### PR TITLE
Add MIT LICENSE; document branch naming convention

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Matt Grant
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ the FastAPI server. Swagger UI lives at <http://localhost:8000/docs>.
 For deeper docs (endpoint reference, troubleshooting, architecture),
 see [api/README.md](api/README.md) and [web/README.md](web/README.md).
 
+## License
+
+Released under the [MIT License](LICENSE).
+
 ## Documentation
 
 Reference docs live under [`docs/`](docs/) and are mirrored to the

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -46,6 +46,41 @@ records an explicit link.
 If there is no tracking issue, open one first — every change should be
 traceable back to an issue.
 
+## Opening a PR
+
+When opening a PR for an issue, mirror the issue's labels, milestone,
+and project assignment onto the PR so the issue and PR move through
+the project board together. None of this is automatic — branch name
+prefix and closing keywords don't copy metadata.
+
+`gh pr create` accepts these directly. Pull the values from the issue
+first:
+
+```bash
+ISSUE=28
+REPO=mgzwarrior/mgz-pkmn
+gh issue view $ISSUE --repo $REPO --json labels,milestone,projectItems
+```
+
+Then pass them at create time:
+
+```bash
+gh pr create \
+  --title "..." \
+  --body  "...Resolves #$ISSUE..." \
+  --label    "area:devops,version:v1,type:chore" \
+  --milestone "v1.0" \
+  --project   "DevOps & release"
+```
+
+If you've already opened the PR, sync after the fact with `gh pr edit
+<PR> --add-label ... --milestone ...` and `gh project item-add <project-number>
+--owner mgzwarrior --url <pr-url>`.
+
+The PR body must still include a closing keyword (`Fixes #N`, `Closes
+#N`, `Resolves #N`) — that's what GitHub uses for the issue/PR link
+and for auto-closing the issue on merge.
+
 ## Development
 
 The Makefile at the repo root wraps the common dev commands. Run

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -34,9 +34,14 @@ that returns the normalized card shape, then adding it to
 ## Branch naming
 
 Name feature/fix branches `<issueNumber>-<shortDescription>` (e.g.
-`28-add-license-file`). GitHub auto-links any PR opened from such a
-branch to the matching issue, so the issue page surfaces the in-flight
-PR without manual cross-referencing.
+`28-add-license-file`). The number prefix makes the related issue easy
+to spot in `git branch` output and in the PR list at a glance.
+
+The branch name alone does **not** make GitHub link the PR to the
+issue — for that, either reference the issue in the PR body with a
+closing keyword (`Fixes #28`, `Closes #28`, `Resolves #28`), or create
+the branch from the issue's "Development" panel in the GitHub UI, which
+records an explicit link.
 
 If there is no tracking issue, open one first — every change should be
 traceable back to an issue.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -73,9 +73,12 @@ gh pr create \
   --project   "DevOps & release"
 ```
 
-If you've already opened the PR, sync after the fact with `gh pr edit
-<PR> --add-label ... --milestone ...` and `gh project item-add <project-number>
---owner mgzwarrior --url <pr-url>`.
+If you've already opened the PR, sync after the fact:
+
+```bash
+gh pr edit <PR> --add-label "..." --milestone "..."
+gh project item-add <project-number> --owner mgzwarrior --url <pr-url>
+```
 
 The PR body must still include a closing keyword (`Fixes #N`, `Closes
 #N`, `Resolves #N`) — that's what GitHub uses for the issue/PR link

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -31,6 +31,16 @@ Adding a new source is a matter of dropping a module under `sources/`
 that returns the normalized card shape, then adding it to
 `lookup.find_card`.
 
+## Branch naming
+
+Name feature/fix branches `<issueNumber>-<shortDescription>` (e.g.
+`28-add-license-file`). GitHub auto-links any PR opened from such a
+branch to the matching issue, so the issue page surfaces the in-flight
+PR without manual cross-referencing.
+
+If there is no tracking issue, open one first — every change should be
+traceable back to an issue.
+
 ## Development
 
 The Makefile at the repo root wraps the common dev commands. Run

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,8 @@
 name = "mgz-pkmn"
 version = "0.1.0"
 description = "CLI to look up Pokemon cards, fetch images and prices, and emit an .xlsx for card-show prep."
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.11"
 dependencies = [
     "click>=8.1",


### PR DESCRIPTION
## Summary

- Add `LICENSE` (MIT, © 2026 Matt Grant) at the repo root — unblocks PyPI / Hatch release.
- Add PEP 639 SPDX metadata to `pyproject.toml` (`license = "MIT"`, `license-files = ["LICENSE"]`).
- New "License" section in `README.md` linking to the file.
- Document the `<issueNumber>-<shortDescription>` branch naming convention in `docs/contributing.md` so PRs auto-link to their issues.

Resolves #28.

## Test plan

- [x] `uv build --wheel` succeeds; built wheel `METADATA` shows `License-Expression: MIT` and bundles `licenses/LICENSE` in the dist-info.
- [x] CI (`lint-and-test`, `api-lint`, `web-lint-and-build`) passes on this branch.
- [ ] GitHub renders the new "License" section in the README and shows the MIT badge in the repo sidebar once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)