### PR TITLE
Set ID cards: new pkmn set-cards subcommand + UI button

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ docker-run:  ## Run the Docker image on :8000. Reads POKEMONTCG_IO_API_KEY from 
 .PHONY: run-sample
 run-sample:  ## Smoke-run the CLI on sample_cards.txt (override: INPUT=, OUTPUT_DIR=).
 	@mkdir -p $(OUTPUT_DIR)
-	uv run pkmn $(INPUT) -o $(OUTPUT_DIR)/cards.xlsx --pdf $(OUTPUT_DIR)/binder.pdf --report-json $(OUTPUT_DIR)/summary.json
+	uv run pkmn lookup $(INPUT) -o $(OUTPUT_DIR)/cards.xlsx --pdf $(OUTPUT_DIR)/binder.pdf --report-json $(OUTPUT_DIR)/summary.json
 
 .PHONY: cache-clear
 cache-clear:  ## Wipe the on-disk cache (~/.cache/mgz-pkmn) — including URL overrides.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ condensed binder, set-completion checklist, and JSON report alongside.
 
 Two ways to drive it:
 
-- **CLI** — `./pkmn cards.txt` produces xlsx + (optional) PDF + JSON.
+- **CLI** — `./pkmn lookup cards.txt` produces xlsx + (optional) PDF +
+  JSON; `./pkmn set-cards` emits printable set ID cutouts.
 - **Web UI** — FastAPI backend in [api/](api/) and a React + Vite
   frontend in [web/](web/) put the same pipeline behind a live
   in-browser interface with streaming results and one-click export.
@@ -50,12 +51,14 @@ Run `make help` for the full target list.
 ## Quickstart
 
 ```bash
-./pkmn input/ --no-images \
+./pkmn lookup input/ --no-images \
   -o output/cards.xlsx \
   --pdf output/binder.pdf \
   --condensed-pdf output/binder-condensed.pdf \
   --checklist output/checklist.pdf \
   --report-json output/summary.json
+
+./pkmn set-cards -o output/set-cards.pdf   # printable set ID cutouts (no input needed)
 ```
 
 The bundled [`input/`](input/) directory ships three small example lists

--- a/api/main.py
+++ b/api/main.py
@@ -15,7 +15,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
-from .routes import export, lookup, overrides, parse, sets
+from .routes import export, lookup, overrides, parse, set_cards, sets
 
 app = FastAPI(
     title="mgz-pkmn API",
@@ -42,6 +42,7 @@ app.include_router(parse.router, prefix="/api/v1", tags=["parse"])
 app.include_router(lookup.router, prefix="/api/v1", tags=["lookup"])
 app.include_router(export.router, prefix="/api/v1", tags=["export"])
 app.include_router(sets.router, prefix="/api/v1", tags=["sets"])
+app.include_router(set_cards.router, prefix="/api/v1", tags=["set-cards"])
 app.include_router(overrides.router, prefix="/api/v1", tags=["overrides"])
 
 

--- a/api/routes/set_cards.py
+++ b/api/routes/set_cards.py
@@ -1,0 +1,51 @@
+"""GET /api/v1/set-cards.pdf — printable set identification cards.
+
+Fetches every Pokémon TCG set from pokemontcg.io, renders one card-sized
+cutout per set (3x3 grid on Letter, sized for a 9-pocket binder sheet),
+and streams the PDF back."""
+
+from __future__ import annotations
+
+import io
+import tempfile
+from pathlib import Path
+
+import requests
+from fastapi import APIRouter, HTTPException
+from fastapi.concurrency import run_in_threadpool
+from fastapi.responses import StreamingResponse
+
+from mgz_pkmn.set_cards import fetch_all_sets, write_set_cards_pdf
+from mgz_pkmn.sources import TCGClient
+
+router = APIRouter()
+
+
+@router.get("/set-cards.pdf")
+async def get_set_cards_pdf(api_key: str | None = None) -> StreamingResponse:
+    """Return a PDF of printable set identification cutouts.
+
+    Pass `api_key` as a query parameter to authenticate the upstream
+    pokemontcg.io request (otherwise the public rate limit applies)."""
+    content = await run_in_threadpool(_render, api_key)
+    return StreamingResponse(
+        io.BytesIO(content),
+        media_type="application/pdf",
+        headers={"Content-Disposition": "attachment; filename=set-cards.pdf"},
+    )
+
+
+def _render(api_key: str | None) -> bytes:
+    client = TCGClient(api_key=api_key)
+    try:
+        sets = fetch_all_sets(client)
+    except requests.RequestException as exc:
+        raise HTTPException(status_code=502, detail=f"upstream fetch failed: {exc}") from exc
+    if not sets:
+        raise HTTPException(status_code=502, detail="pokemontcg.io returned no sets")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        out_path = tmp / "set-cards.pdf"
+        logos_dir = tmp / "logos"
+        write_set_cards_pdf(sets, out_path, logos_dir=logos_dir, session=client.session)
+        return out_path.read_bytes()

--- a/api/routes/set_cards.py
+++ b/api/routes/set_cards.py
@@ -20,14 +20,25 @@ from mgz_pkmn.sources import TCGClient
 
 router = APIRouter()
 
+# Logos are cached on disk across requests so we don't re-download the entire
+# set catalog every time someone hits this endpoint. Shared with the CLI's
+# default `--logos-dir` only when the API runs as the same user — otherwise
+# each gets its own cache, which is fine.
+_LOGOS_CACHE_DIR = Path("~/.cache/mgz-pkmn/set-logos").expanduser()
+
 
 @router.get("/set-cards.pdf")
-async def get_set_cards_pdf(api_key: str | None = None) -> StreamingResponse:
+async def get_set_cards_pdf(
+    api_key: str | None = None,
+    no_images: bool = False,
+) -> StreamingResponse:
     """Return a PDF of printable set identification cutouts.
 
     Pass `api_key` as a query parameter to authenticate the upstream
-    pokemontcg.io request (otherwise the public rate limit applies)."""
-    content = await run_in_threadpool(_render, api_key)
+    pokemontcg.io request (otherwise the public rate limit applies).
+    Pass `no_images=true` to skip logo downloads and render text-only
+    cutouts — much faster on a cold cache."""
+    content = await run_in_threadpool(_render, api_key, no_images)
     return StreamingResponse(
         io.BytesIO(content),
         media_type="application/pdf",
@@ -35,7 +46,7 @@ async def get_set_cards_pdf(api_key: str | None = None) -> StreamingResponse:
     )
 
 
-def _render(api_key: str | None) -> bytes:
+def _render(api_key: str | None, no_images: bool) -> bytes:
     client = TCGClient(api_key=api_key)
     try:
         sets = fetch_all_sets(client)
@@ -43,9 +54,9 @@ def _render(api_key: str | None) -> bytes:
         raise HTTPException(status_code=502, detail=f"upstream fetch failed: {exc}") from exc
     if not sets:
         raise HTTPException(status_code=502, detail="pokemontcg.io returned no sets")
+    logos_dir = None if no_images else _LOGOS_CACHE_DIR
+    session = None if no_images else client.session
     with tempfile.TemporaryDirectory() as tmpdir:
-        tmp = Path(tmpdir)
-        out_path = tmp / "set-cards.pdf"
-        logos_dir = tmp / "logos"
-        write_set_cards_pdf(sets, out_path, logos_dir=logos_dir, session=client.session)
+        out_path = Path(tmpdir) / "set-cards.pdf"
+        write_set_cards_pdf(sets, out_path, logos_dir=logos_dir, session=session)
         return out_path.read_bytes()

--- a/docs/binder-pdf.md
+++ b/docs/binder-pdf.md
@@ -56,6 +56,37 @@ as `STANDARD_LAYOUT` and `CONDENSED_LAYOUT` instances of the
 one — every drawing function reads its constants from the layout
 object, so adding a new size is a single dataclass call away.
 
+## Set identification cards (`pkmn set-cards`)
+
+`pkmn set-cards` is a **standalone subcommand** — it takes no positional
+arguments and is unrelated to the lookup/checklist flow above. It fetches
+every Pokémon TCG set from pokemontcg.io and emits one card-sized cutout
+per set, laid out **3×3 on Letter** so a printed page slots straight into
+a 9-pocket binder sheet. Cut out the set you want and drop it into the
+first pocket of that section.
+
+Each cutout shows:
+
+- The **set logo** (when the set's API payload provides one)
+- **Set name** and **series**
+- **Release year**
+- **N cards** — the set's printed total
+- The **generation date** in small print at the bottom
+
+```bash
+./pkmn set-cards                                 # → ./set-cards.pdf
+./pkmn set-cards -o output/set-cards.pdf         # custom path
+./pkmn set-cards --no-images                     # skip logo downloads
+POKEMONTCG_IO_API_KEY=xxx ./pkmn set-cards       # authenticated upstream
+```
+
+Set logos are downloaded into `output/images/set-logos/` (configurable
+with `--logos-dir`) and reused on subsequent runs.
+
+In the web UI, the **Set ID cards** button in the header downloads the
+same PDF on demand. The button is always enabled — it doesn't depend on
+the card list in the editor.
+
 ## Non-English cards
 
 Non-English cards get a full-width dark-red banner above the card image

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,17 +1,27 @@
 # CLI reference
 
-`pkmn` is a single Click command. All artifacts are optional — pass the
-flag for each one you want.
+`pkmn` is a Click group exposing two subcommands:
+
+- **`pkmn lookup INPUTS...`** — the original card-lookup pipeline (xlsx,
+  binder PDFs, checklist, JSON report). Documented below.
+- **`pkmn set-cards`** — generate printable set identification cutouts
+  for binder section dividers; takes no positional arguments. See
+  [PDF binder → Set identification cards](binder-pdf.md#set-identification-cards-pkmn-set-cards).
+
+For backward compatibility, **invoking `pkmn` with input paths and no
+subcommand is forwarded to `lookup`** — `./pkmn cards.txt` and
+`./pkmn lookup cards.txt` are equivalent.
 
 ## Invocation patterns
 
 ```bash
-./pkmn sample_cards.txt                      # one file
-./pkmn list-a.txt list-b.txt                 # multiple files
-./pkmn input/                                # a directory of *.txt files
-./pkmn input/ extras.txt                     # mix of dirs + files
-uv run pkmn input/ -o output/cards.xlsx --pdf output/binder.pdf
-python -m mgz_pkmn input/
+./pkmn sample_cards.txt                      # one file (forwards to lookup)
+./pkmn lookup list-a.txt list-b.txt          # explicit, multiple files
+./pkmn lookup input/                         # a directory of *.txt files
+./pkmn lookup input/ extras.txt              # mix of dirs + files
+./pkmn set-cards                             # all-sets cutout PDF, no args
+uv run pkmn lookup input/ -o output/cards.xlsx --pdf output/binder.pdf
+python -m mgz_pkmn lookup input/
 ```
 
 Each input file's stem becomes a **Source tag** — every row in the
@@ -19,7 +29,7 @@ spreadsheet records its source list, and the PDF binder starts a new
 section (with a banner showing the tag + card count) at each file
 boundary.
 
-## Options
+## `pkmn lookup` options
 
 | Flag | Default | Purpose |
 |---|---|---|
@@ -41,17 +51,29 @@ boundary.
 | `-v, --verbose` | off | Echo each API request URL (cached entries are flagged). |
 | `-h, --help` | | Show usage. |
 
+## `pkmn set-cards` options
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `-o, --output PATH` | `set-cards.pdf` | PDF output path. |
+| `--api-key TEXT` | `$POKEMONTCG_IO_API_KEY` | pokemontcg.io API key. |
+| `--logos-dir PATH` | `output/images/set-logos/` | Where to cache downloaded set logos. |
+| `--no-images` | off | Skip logo downloads and render text-only cutouts. |
+| `-v, --verbose` | off | Echo each API request URL. |
+| `-h, --help` | | Show usage. |
+
 ## Examples
 
 ```bash
-./pkmn cards.txt
-./pkmn cards.txt --no-images -o quick.xlsx
-POKEMONTCG_IO_API_KEY=xxx ./pkmn cards.txt -v
-./pkmn cards.txt -o show.xlsx --report-json show.json
-./pkmn cards.txt -o show.xlsx --pdf binder.pdf       # spreadsheet + PDF binder
-./pkmn cards.txt --max-price 50 --pdf binder.pdf     # only show cards ≤ $50
-./pkmn input/ --pdf binder.pdf --checklist checklist.pdf   # binder + front-of-binder checklist
-./pkmn input/ --pdf binder.pdf --sort price-desc           # restore old "priciest first" ordering
+./pkmn cards.txt                                     # forwards to lookup
+./pkmn lookup cards.txt --no-images -o quick.xlsx
+POKEMONTCG_IO_API_KEY=xxx ./pkmn lookup cards.txt -v
+./pkmn lookup cards.txt -o show.xlsx --report-json show.json
+./pkmn lookup cards.txt -o show.xlsx --pdf binder.pdf       # spreadsheet + PDF binder
+./pkmn lookup cards.txt --max-price 50 --pdf binder.pdf     # only show cards ≤ $50
+./pkmn lookup input/ --pdf binder.pdf --checklist checklist.pdf
+./pkmn set-cards                                            # all-sets ID cutouts
+./pkmn set-cards -o output/set-cards.pdf
 ```
 
 ## Worked examples
@@ -68,7 +90,7 @@ together cover every input syntax and lookup mode the tool supports:
 Run all three at once and produce every artifact:
 
 ```bash
-./pkmn input/ --no-images \
+./pkmn lookup input/ --no-images \
   -o output/cards.xlsx \
   --pdf output/binder.pdf \
   --condensed-pdf output/binder-condensed.pdf \

--- a/src/mgz_pkmn/cli.py
+++ b/src/mgz_pkmn/cli.py
@@ -21,6 +21,7 @@ from .lookup import find_card, find_top_cards
 from .parser import CardQuery, read_input
 from .pricing import Pricing, extract_pricing
 from .report import build_json_report
+from .set_cards import fetch_all_sets, write_set_cards_pdf
 from .sorting import DEFAULT_SORT, SORT_MODES, sort_rows
 from .sources import PriceChartingClient, TCGClient, TCGDexClient
 from .sources.base import MatchResult
@@ -191,7 +192,30 @@ def _exeggutor_checkpoint() -> None:
     click.echo()
 
 
-@click.command(context_settings={"help_option_names": ["-h", "--help"]})
+class FallbackGroup(click.Group):
+    """A Click group that forwards unknown subcommands to `lookup`.
+
+    Lets `pkmn cards.txt` keep working alongside `pkmn lookup cards.txt`
+    and `pkmn set-cards` — preserves the historical, no-subcommand CLI
+    while still surfacing real subcommands in `--help`."""
+
+    def resolve_command(
+        self, ctx: click.Context, args: list[str]
+    ) -> tuple[str | None, click.Command | None, list[str]]:
+        try:
+            return super().resolve_command(ctx, args)
+        except click.UsageError:
+            lookup_cmd = self.commands.get("lookup")
+            if lookup_cmd is None:
+                raise
+            return "lookup", lookup_cmd, args
+
+
+@click.group(
+    cls=FallbackGroup,
+    context_settings={"help_option_names": ["-h", "--help"]},
+    invoke_without_command=True,
+)
 @click.version_option(__version__, "-V", "--version", prog_name="pkmn")
 @click.option(
     "--exeggutor",
@@ -201,6 +225,18 @@ def _exeggutor_checkpoint() -> None:
     expose_value=False,
     callback=_print_exeggutor_egg,
 )
+@click.pass_context
+def cli(ctx: click.Context) -> None:
+    """Pokémon card lookup, pricing, and binder/PDF output tools.
+
+    Without a subcommand, behaves like `pkmn lookup ...` for backward
+    compatibility — pass input files as positional arguments. Use
+    `pkmn set-cards` to generate printable set identification cutouts."""
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+
+
+@cli.command(name="lookup", context_settings={"help_option_names": ["-h", "--help"]})
 @click.argument(
     "input_paths",
     metavar="INPUTS...",
@@ -334,7 +370,7 @@ def _exeggutor_checkpoint() -> None:
     ),
 )
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output.")
-def cli(
+def lookup(
     input_paths: tuple[Path, ...],
     output: Path,
     images_dir: Path,
@@ -697,6 +733,78 @@ def _expand_inputs(paths: tuple[Path, ...]) -> list[Path]:
             seen.add(resolved)
             out.append(c)
     return out
+
+
+@cli.command(name="set-cards", context_settings={"help_option_names": ["-h", "--help"]})
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(dir_okay=False, writable=True, path_type=Path),
+    default=Path("set-cards.pdf"),
+    show_default=True,
+    help="Where to write the PDF.",
+)
+@click.option(
+    "--api-key",
+    envvar="POKEMONTCG_IO_API_KEY",
+    default=None,
+    help="pokemontcg.io API key (or set POKEMONTCG_IO_API_KEY).",
+)
+@click.option(
+    "--logos-dir",
+    type=click.Path(file_okay=False, path_type=Path),
+    default=Path("output/images/set-logos"),
+    show_default=True,
+    help="Where to cache downloaded set logos.",
+)
+@click.option(
+    "--no-images",
+    is_flag=True,
+    help="Skip logo downloads and render text-only cutouts.",
+)
+@click.option("-v", "--verbose", is_flag=True, help="Verbose output.")
+def set_cards_command(
+    output: Path,
+    api_key: str | None,
+    logos_dir: Path,
+    no_images: bool,
+    verbose: bool,
+) -> None:
+    """Generate printable set ID cards for binder section dividers.
+
+    Fetches every Pokémon TCG set from pokemontcg.io and emits one
+    card-sized cutout per set, laid out 3x3 on Letter so a printed page
+    drops straight into a 9-pocket binder sheet. Takes no positional
+    arguments."""
+    _print_banner(__version__)
+
+    _print_section("Fetching set catalog from pokemontcg.io")
+    client = TCGClient(api_key=api_key, verbose=verbose)
+    try:
+        sets = fetch_all_sets(client)
+    except requests.RequestException as exc:
+        raise click.ClickException(f"set fetch failed: {exc}") from exc
+    click.secho("  ✓ ", fg="green", nl=False)
+    click.echo(f"{len(sets)} set{'s' if len(sets) != 1 else ''}")
+
+    _print_section("Writing outputs")
+    logos = None if no_images else logos_dir
+    session = None if no_images else client.session
+    written = write_set_cards_pdf(sets, output, logos_dir=logos, session=session)
+    click.secho("  ✓ ", fg="green", nl=False)
+    click.echo(
+        f"{output}  "
+        + click.style(
+            f"({written} cutout{'s' if written != 1 else ''})",
+            fg="bright_black",
+        )
+    )
+    if not no_images:
+        click.secho("  ✓ ", fg="green", nl=False)
+        click.echo(f"logos cached in {logos_dir}/")
+
+    click.echo()
+    click.secho("Done!", fg="green", bold=True)
 
 
 if __name__ == "__main__":

--- a/src/mgz_pkmn/cli.py
+++ b/src/mgz_pkmn/cli.py
@@ -784,6 +784,8 @@ def set_cards_command(
         sets = fetch_all_sets(client)
     except requests.RequestException as exc:
         raise click.ClickException(f"set fetch failed: {exc}") from exc
+    if not sets:
+        raise click.ClickException("pokemontcg.io returned no sets")
     click.secho("  ✓ ", fg="green", nl=False)
     click.echo(f"{len(sets)} set{'s' if len(sets) != 1 else ''}")
 

--- a/src/mgz_pkmn/set_cards.py
+++ b/src/mgz_pkmn/set_cards.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import datetime as _dt
 import re
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -182,8 +183,20 @@ def _draw_logo(c: canvas.Canvas, path: Path | None, x: float, y: float, w: float
             preserveAspectRatio=True,
             mask="auto",
         )
-    except Exception:
-        return
+    except Exception as exc:
+        print(f"  ! logo render failed for {path}: {exc}", file=sys.stderr)
+        _draw_placeholder(c, x, y, w, h, "image error")
+
+
+def _draw_placeholder(c: canvas.Canvas, x: float, y: float, w: float, h: float, label: str) -> None:
+    c.saveState()
+    c.setFillColorRGB(0.95, 0.95, 0.95)
+    c.setStrokeColorRGB(0.85, 0.85, 0.85)
+    c.rect(x, y, w, h, stroke=1, fill=1)
+    c.setFillColorRGB(0.55, 0.55, 0.55)
+    c.setFont("Helvetica-Oblique", 9)
+    c.drawCentredString(x + w / 2, y + h / 2 - 3, label)
+    c.restoreState()
 
 
 def _draw_text_block(

--- a/src/mgz_pkmn/set_cards.py
+++ b/src/mgz_pkmn/set_cards.py
@@ -1,0 +1,250 @@
+"""Render printable set identification cards for binder section dividers.
+
+Each set in the input list becomes one card-sized cutout (2.5"x3.5"), laid
+out 3x3 on a Letter page — i.e. one full 9-pocket binder sheet per page.
+Cut a row out, slot it into the first pocket of that set's section, and the
+binder is self-labelling.
+
+The CLI subcommand `pkmn set-cards` fetches the full set catalog from
+pokemontcg.io and emits a cutout for every one of them. The API route
+`GET /api/v1/set-cards.pdf` uses the same code path.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import re
+from pathlib import Path
+from typing import Any
+
+import requests
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.units import inch
+from reportlab.lib.utils import ImageReader
+from reportlab.pdfgen import canvas
+
+from .images import download_image
+from .sources import TCGClient
+
+PAGE_W, PAGE_H = letter  # 612 x 792 pt
+CARD_W = 2.5 * inch
+CARD_H = 3.5 * inch
+COLS = 3
+ROWS = 3
+GRID_W = COLS * CARD_W
+GRID_H = ROWS * CARD_H
+MARGIN_X = (PAGE_W - GRID_W) / 2
+MARGIN_Y = (PAGE_H - GRID_H) / 2
+CUTOUTS_PER_PAGE = COLS * ROWS
+
+CELL_PADDING = 10
+LOGO_BOX_RATIO = 0.50  # share of cell height reserved for logo art
+TEXT_BLOCK_GAP = 8
+
+
+def fetch_all_sets(client: TCGClient) -> list[dict[str, Any]]:
+    """Return every Pokémon TCG set on pokemontcg.io, sorted oldest → newest.
+
+    Each dict has at minimum: id, name. Optionally: series, total,
+    printedTotal, releaseDate, images.{logo,symbol}."""
+    url = "https://api.pokemontcg.io/v2/sets?orderBy=releaseDate&pageSize=250"
+    resp = client.session.get(url, timeout=30)
+    resp.raise_for_status()
+    raw = resp.json().get("data", [])
+    return [
+        {
+            "id": s.get("id"),
+            "name": s.get("name"),
+            "series": s.get("series"),
+            "total": s.get("total"),
+            "printedTotal": s.get("printedTotal"),
+            "releaseDate": s.get("releaseDate"),
+            "images": s.get("images") or {},
+        }
+        for s in raw
+        if s.get("id") and s.get("name")
+    ]
+
+
+def write_set_cards_pdf(
+    sets: list[dict[str, Any]],
+    out_path: Path,
+    *,
+    logos_dir: Path | None = None,
+    session: requests.Session | None = None,
+    today: _dt.date | None = None,
+) -> int:
+    """Render one cutout per set to a PDF. Returns the count written.
+
+    `logos_dir` + `session` enable set-logo downloading & caching to disk.
+    Pass both as None to render the cutouts text-only (used in tests, and
+    by the CLI's `--no-images` mode)."""
+    if not sets:
+        return 0
+
+    today = today or _dt.date.today()
+    cutouts = [_normalize(s, today) for s in sets]
+
+    if logos_dir is not None and session is not None:
+        for co in cutouts:
+            co["logo_path"] = _fetch_logo(co["logo_url"], co["set_id"], logos_dir, session)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    c = canvas.Canvas(str(out_path), pagesize=letter)
+    c.setTitle(out_path.stem)
+
+    for page_start in range(0, len(cutouts), CUTOUTS_PER_PAGE):
+        if page_start > 0:
+            c.showPage()
+        page = cutouts[page_start : page_start + CUTOUTS_PER_PAGE]
+        for i, co in enumerate(page):
+            col = i % COLS
+            row = i // COLS
+            x = MARGIN_X + col * CARD_W
+            y = PAGE_H - MARGIN_Y - (row + 1) * CARD_H
+            _draw_cutout(c, x, y, co)
+
+    c.save()
+    return len(cutouts)
+
+
+def _normalize(set_obj: dict[str, Any], today: _dt.date) -> dict[str, Any]:
+    images = set_obj.get("images") or {}
+    total = set_obj.get("printedTotal") or set_obj.get("total")
+    return {
+        "set_id": set_obj.get("id") or set_obj.get("name") or "?",
+        "set_name": set_obj.get("name") or "?",
+        "series": set_obj.get("series"),
+        "release_year": _release_year(set_obj.get("releaseDate")),
+        "total": total,
+        "logo_url": images.get("logo") or images.get("symbol"),
+        "logo_path": None,
+        "generated": today.isoformat(),
+    }
+
+
+def _release_year(release_date: str | None) -> str | None:
+    if not release_date:
+        return None
+    m = re.match(r"(\d{4})", release_date)
+    return m.group(1) if m else None
+
+
+def _fetch_logo(
+    url: str | None, set_id: str, logos_dir: Path, session: requests.Session
+) -> Path | None:
+    if not url:
+        return None
+    safe = re.sub(r"[^a-zA-Z0-9_-]+", "_", set_id) or "set"
+    ext = Path(url).suffix or ".png"
+    dest = logos_dir / f"{safe}{ext}"
+    if download_image(url, dest, session):
+        return dest
+    return None
+
+
+def _draw_cutout(c: canvas.Canvas, x: float, y: float, co: dict[str, Any]) -> None:
+    """Render one cutout in the cell whose bottom-left is (x, y).
+
+    Dashed cell border = cut line. Logo on top half, text block underneath."""
+    c.saveState()
+    c.setStrokeColorRGB(0.6, 0.6, 0.6)
+    c.setLineWidth(0.4)
+    c.setDash(2, 2)
+    c.rect(x, y, CARD_W, CARD_H, stroke=1, fill=0)
+    c.setDash()
+    c.restoreState()
+
+    inner_x = x + CELL_PADDING
+    inner_y = y + CELL_PADDING
+    inner_w = CARD_W - 2 * CELL_PADDING
+    inner_h = CARD_H - 2 * CELL_PADDING
+
+    logo_h = inner_h * LOGO_BOX_RATIO
+    logo_bottom = inner_y + inner_h - logo_h
+    _draw_logo(c, co.get("logo_path"), inner_x, logo_bottom, inner_w, logo_h)
+
+    text_top = logo_bottom - TEXT_BLOCK_GAP
+    text_bottom = inner_y
+    _draw_text_block(c, co, inner_x, text_bottom, inner_w, text_top - text_bottom)
+
+
+def _draw_logo(c: canvas.Canvas, path: Path | None, x: float, y: float, w: float, h: float) -> None:
+    if not path or not path.exists():
+        return
+    try:
+        c.drawImage(
+            ImageReader(str(path)),
+            x,
+            y,
+            w,
+            h,
+            preserveAspectRatio=True,
+            mask="auto",
+        )
+    except Exception:
+        return
+
+
+def _draw_text_block(
+    c: canvas.Canvas, co: dict[str, Any], x: float, y: float, w: float, h: float
+) -> None:
+    """Set name (wrapped, up to 2 lines), series, year, total cards, gen date."""
+    name = co["set_name"]
+    series = co.get("series")
+    year = co.get("release_year")
+    total = co.get("total")
+    generated = co["generated"]
+
+    name_lines = _wrap_two_lines(c, name, "Helvetica-Bold", 13, w)
+    name_size = 13
+    cur_y = y + h - name_size
+    c.setFont("Helvetica-Bold", name_size)
+    c.setFillColorRGB(0.1, 0.1, 0.1)
+    for line in name_lines:
+        c.drawCentredString(x + w / 2, cur_y, line)
+        cur_y -= name_size + 1
+
+    if series:
+        c.setFont("Helvetica", 9)
+        c.setFillColorRGB(0.35, 0.35, 0.35)
+        cur_y -= 2
+        c.drawCentredString(x + w / 2, cur_y, series)
+        cur_y -= 11
+
+    if year:
+        c.setFont("Helvetica", 9)
+        c.setFillColorRGB(0.5, 0.5, 0.5)
+        c.drawCentredString(x + w / 2, cur_y, year)
+        cur_y -= 11
+
+    if total:
+        cur_y -= 4
+        c.setFont("Helvetica-Bold", 11)
+        c.setFillColorRGB(0.16, 0.21, 0.30)
+        c.drawCentredString(x + w / 2, cur_y, f"{total} cards")
+
+    c.setFont("Helvetica", 7)
+    c.setFillColorRGB(0.55, 0.55, 0.55)
+    c.drawCentredString(x + w / 2, y + 2, f"generated {generated}")
+
+
+def _wrap_two_lines(c: canvas.Canvas, text: str, font: str, size: float, max_w: float) -> list[str]:
+    """Greedy word-wrap to at most two lines, ellipsizing the tail if needed."""
+    if c.stringWidth(text, font, size) <= max_w:
+        return [text]
+    words = text.split()
+    line1_words: list[str] = []
+    rest = words[:]
+    while rest:
+        candidate = " ".join([*line1_words, rest[0]])
+        if c.stringWidth(candidate, font, size) > max_w and line1_words:
+            break
+        line1_words.append(rest.pop(0))
+    line1 = " ".join(line1_words) if line1_words else words[0]
+    if not rest:
+        return [line1]
+    line2 = " ".join(rest)
+    while c.stringWidth(line2, font, size) > max_w and len(line2) > 3:
+        line2 = line2[:-2] + "…"
+    return [line1, line2]

--- a/tests/test_set_cards.py
+++ b/tests/test_set_cards.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import datetime as _dt
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from mgz_pkmn.set_cards import (
+    _release_year,
+    fetch_all_sets,
+    write_set_cards_pdf,
+)
+
+
+def _set(
+    *,
+    sid: str = "sv8",
+    name: str = "Surging Sparks",
+    series: str | None = "Scarlet & Violet",
+    total: int | None = 252,
+    printed: int | None = 191,
+    release: str | None = "2024/11/08",
+    logo: str | None = "https://images.pokemontcg.io/sv8/logo.png",
+) -> dict:
+    out: dict = {
+        "id": sid,
+        "name": name,
+        "series": series,
+        "total": total,
+        "printedTotal": printed,
+        "releaseDate": release,
+    }
+    if logo is not None:
+        out["images"] = {"logo": logo, "symbol": logo.replace("logo", "symbol")}
+    return out
+
+
+class ReleaseYearTests(unittest.TestCase):
+    def test_parses_iso_like_date(self) -> None:
+        self.assertEqual(_release_year("2024/11/08"), "2024")
+
+    def test_handles_year_only(self) -> None:
+        self.assertEqual(_release_year("1999"), "1999")
+
+    def test_none_when_missing(self) -> None:
+        self.assertIsNone(_release_year(None))
+        self.assertIsNone(_release_year(""))
+
+
+class FetchAllSetsTests(unittest.TestCase):
+    def test_normalizes_pokemontcg_payload(self) -> None:
+        client = MagicMock()
+        response = MagicMock()
+        response.json.return_value = {
+            "data": [
+                {
+                    "id": "sv8",
+                    "name": "Surging Sparks",
+                    "series": "Scarlet & Violet",
+                    "printedTotal": 191,
+                    "total": 252,
+                    "releaseDate": "2024/11/08",
+                    "images": {
+                        "logo": "https://images.pokemontcg.io/sv8/logo.png",
+                        "symbol": "https://images.pokemontcg.io/sv8/symbol.png",
+                    },
+                },
+                # Skipped — no id.
+                {"name": "Bogus"},
+            ]
+        }
+        client.session.get.return_value = response
+
+        sets = fetch_all_sets(client)
+        self.assertEqual(len(sets), 1)
+        self.assertEqual(sets[0]["id"], "sv8")
+        self.assertEqual(sets[0]["images"]["logo"], "https://images.pokemontcg.io/sv8/logo.png")
+
+
+class WritePdfTests(unittest.TestCase):
+    def test_renders_pdf_without_network(self) -> None:
+        sets = [_set(), _set(sid="sv7", name="Stellar Crown", printed=142, total=175)]
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "set-cards.pdf"
+            written = write_set_cards_pdf(sets, out)
+            self.assertEqual(written, 2)
+            self.assertTrue(out.exists())
+            self.assertGreater(out.stat().st_size, 0)
+
+    def test_zero_when_no_sets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "set-cards.pdf"
+            self.assertEqual(write_set_cards_pdf([], out), 0)
+            self.assertFalse(out.exists())
+
+    def test_paginates_when_more_than_nine_sets(self) -> None:
+        sets = [_set(sid=f"set-{i}", name=f"Set {i}") for i in range(11)]
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "set-cards.pdf"
+            written = write_set_cards_pdf(sets, out)
+            self.assertEqual(written, 11)
+            self.assertTrue(out.exists())
+
+    def test_handles_missing_optional_fields(self) -> None:
+        # Cards with no release date / total / logo still render.
+        sets = [_set(release=None, total=None, printed=None, logo=None, series=None)]
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "set-cards.pdf"
+            written = write_set_cards_pdf(sets, out)
+            self.assertEqual(written, 1)
+            self.assertTrue(out.exists())
+
+    def test_today_override(self) -> None:
+        # The `today` knob is mostly for snapshot tests; just verify it
+        # accepts a date and doesn't blow up.
+        sets = [_set()]
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "set-cards.pdf"
+            written = write_set_cards_pdf(sets, out, today=_dt.date(2026, 5, 10))
+            self.assertEqual(written, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_set_cards.py
+++ b/tests/test_set_cards.py
@@ -1,15 +1,21 @@
 from __future__ import annotations
 
 import datetime as _dt
+import io
 import sys
 import tempfile
 import unittest
+from contextlib import redirect_stderr
 from pathlib import Path
 from unittest.mock import MagicMock
+
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from mgz_pkmn.set_cards import (
+    _draw_logo,
     _release_year,
     fetch_all_sets,
     write_set_cards_pdf,
@@ -122,6 +128,27 @@ class WritePdfTests(unittest.TestCase):
             out = Path(tmp) / "set-cards.pdf"
             written = write_set_cards_pdf(sets, out, today=_dt.date(2026, 5, 10))
             self.assertEqual(written, 1)
+
+
+class DrawLogoTests(unittest.TestCase):
+    def test_corrupt_file_logs_and_draws_placeholder(self) -> None:
+        # A path that exists but isn't a valid image used to silently fail.
+        # Now it should log to stderr and render an "image error" placeholder
+        # instead of leaving an invisible gap.
+        with tempfile.TemporaryDirectory() as tmp:
+            bad = Path(tmp) / "broken.png"
+            bad.write_bytes(b"not a real image")
+            out = Path(tmp) / "out.pdf"
+            c = canvas.Canvas(str(out), pagesize=letter)
+
+            err = io.StringIO()
+            with redirect_stderr(err):
+                _draw_logo(c, bad, 100, 100, 100, 50)
+            c.save()
+
+            self.assertIn("logo render failed", err.getvalue())
+            self.assertTrue(out.exists())
+            self.assertGreater(out.stat().st_size, 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_set_cards_api.py
+++ b/tests/test_set_cards_api.py
@@ -51,6 +51,46 @@ class SetCardsEndpointTests(unittest.TestCase):
             resp = client.get("/api/v1/set-cards.pdf")
         self.assertEqual(resp.status_code, 502)
 
+    def test_no_images_flag_skips_write_set_cards_pdf_session(self) -> None:
+        # `no_images=true` must wire `logos_dir=None`/`session=None` through
+        # to write_set_cards_pdf — otherwise every API hit would re-download
+        # the full set logo catalog.
+        captured: dict = {}
+
+        def _fake_writer(sets, out_path, *, logos_dir=None, session=None, today=None):
+            captured["logos_dir"] = logos_dir
+            captured["session"] = session
+            out_path.write_bytes(b"%PDF-1.4\n%fake\n")
+            return len(sets)
+
+        with (
+            patch("api.routes.set_cards.fetch_all_sets", return_value=SAMPLE_SETS),
+            patch("api.routes.set_cards.write_set_cards_pdf", side_effect=_fake_writer),
+        ):
+            resp = client.get("/api/v1/set-cards.pdf?no_images=true")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIsNone(captured["logos_dir"])
+        self.assertIsNone(captured["session"])
+
+    def test_default_uses_persistent_logo_cache(self) -> None:
+        # Default request must pass a persistent on-disk cache dir (not a
+        # per-request TemporaryDirectory) so logos survive across calls.
+        captured: dict = {}
+
+        def _fake_writer(sets, out_path, *, logos_dir=None, session=None, today=None):
+            captured["logos_dir"] = logos_dir
+            out_path.write_bytes(b"%PDF-1.4\n%fake\n")
+            return len(sets)
+
+        with (
+            patch("api.routes.set_cards.fetch_all_sets", return_value=SAMPLE_SETS),
+            patch("api.routes.set_cards.write_set_cards_pdf", side_effect=_fake_writer),
+        ):
+            resp = client.get("/api/v1/set-cards.pdf")
+        self.assertEqual(resp.status_code, 200)
+        self.assertIsNotNone(captured["logos_dir"])
+        self.assertIn(".cache/mgz-pkmn", str(captured["logos_dir"]))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_set_cards_api.py
+++ b/tests/test_set_cards_api.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+client = TestClient(app)
+
+
+SAMPLE_SETS = [
+    {
+        "id": "sv8",
+        "name": "Surging Sparks",
+        "series": "Scarlet & Violet",
+        "total": 252,
+        "printedTotal": 191,
+        "releaseDate": "2024/11/08",
+        "images": {},  # no logo URL → no network call from set_cards renderer
+    },
+    {
+        "id": "sv7",
+        "name": "Stellar Crown",
+        "series": "Scarlet & Violet",
+        "total": 175,
+        "printedTotal": 142,
+        "releaseDate": "2024/09/13",
+        "images": {},
+    },
+]
+
+
+class SetCardsEndpointTests(unittest.TestCase):
+    def test_returns_pdf(self) -> None:
+        with patch("api.routes.set_cards.fetch_all_sets", return_value=SAMPLE_SETS):
+            resp = client.get("/api/v1/set-cards.pdf")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.headers["content-type"], "application/pdf")
+        self.assertIn("attachment", resp.headers["content-disposition"])
+        self.assertTrue(resp.content.startswith(b"%PDF"))
+
+    def test_502_when_upstream_returns_empty(self) -> None:
+        with patch("api.routes.set_cards.fetch_all_sets", return_value=[]):
+            resp = client.get("/api/v1/set-cards.pdf")
+        self.assertEqual(resp.status_code, 502)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -175,6 +175,37 @@ export async function exportFile(
 }
 
 // ---------------------------------------------------------------------------
+// set identification cards
+// ---------------------------------------------------------------------------
+
+/**
+ * Download the printable set-identification-cards PDF. Triggers a save in
+ * the browser; no rows or settings are required — the server fetches the
+ * full set catalog itself.
+ */
+export async function downloadSetCardsPdf(apiKey?: string): Promise<void> {
+  const params = apiKey ? `?api_key=${encodeURIComponent(apiKey)}` : ''
+  const res = await fetch(`${BASE}/set-cards.pdf${params}`)
+  if (!res.ok) {
+    let detail = `set-cards failed: ${res.status}`
+    try {
+      const body = await res.json()
+      if (body?.detail) detail = body.detail
+    } catch {
+      /* fall through */
+    }
+    throw new Error(detail)
+  }
+  const blob = await res.blob()
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = 'set-cards.pdf'
+  a.click()
+  setTimeout(() => URL.revokeObjectURL(url), 0)
+}
+
+// ---------------------------------------------------------------------------
 // sets
 // ---------------------------------------------------------------------------
 

--- a/web/src/components/ExportBar.tsx
+++ b/web/src/components/ExportBar.tsx
@@ -1,13 +1,23 @@
 /**
  * ExportBar — download buttons for xlsx, standard PDF binder, condensed PDF
- * binder, and the per-tag checklist PDF.
+ * binder, the per-tag checklist PDF, and the set identification cards PDF.
  *
- * Disabled until at least one matched row is available.
+ * Row-dependent buttons (xlsx/pdf/condensed-pdf/checklist) are disabled
+ * until at least one matched row is available. The Set ID cards button
+ * is always enabled — it fetches the full set catalog server-side and
+ * doesn't require any input rows.
  */
 import { useState } from 'react'
 import type { ReactNode } from 'react'
-import { FileSpreadsheet, BookOpen, LayoutGrid, ListChecks, Loader2 } from 'lucide-react'
-import { exportFile } from '../api/client'
+import {
+  FileSpreadsheet,
+  BookOpen,
+  LayoutGrid,
+  ListChecks,
+  Tags,
+  Loader2,
+} from 'lucide-react'
+import { downloadSetCardsPdf, exportFile } from '../api/client'
 import { useAppStore } from '../store'
 import type { ExportFormat } from '../types'
 
@@ -20,7 +30,7 @@ const BUTTONS: { format: ExportFormat; label: string; icon: ReactNode }[] = [
 
 export function ExportBar() {
   const { rows, settings } = useAppStore()
-  const [loading, setLoading] = useState<ExportFormat | null>(null)
+  const [loading, setLoading] = useState<ExportFormat | 'set-cards' | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   const matchedRows = rows.filter((r) => r.matched)
@@ -43,6 +53,18 @@ export function ExportBar() {
     }
   }
 
+  async function handleSetCards() {
+    setLoading('set-cards')
+    setError(null)
+    try {
+      await downloadSetCardsPdf(settings.apiKey || undefined)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setLoading(null)
+    }
+  }
+
   return (
     <div className="flex items-center gap-2 flex-wrap">
       {BUTTONS.map((b) => (
@@ -55,6 +77,13 @@ export function ExportBar() {
           onClick={() => handleExport(b.format)}
         />
       ))}
+      <ExportButton
+        label="Set ID cards"
+        icon={<Tags size={14} />}
+        loading={loading === 'set-cards'}
+        disabled={loading !== null}
+        onClick={handleSetCards}
+      />
       {matchedRows.length > 0 && !disabled && (
         <span className="text-xs text-zinc-500 ml-1">
           {matchedRows.length} row{matchedRows.length !== 1 ? 's' : ''}


### PR DESCRIPTION
## Summary

- New `pkmn set-cards` subcommand: fetches every Pokémon TCG set from pokemontcg.io and emits one card-sized cutout per set, 3x3 on Letter, sized to slot into a 9-pocket binder sheet. Each cutout shows logo, set name, series, release year, total card count, and generation date. Takes no positional arguments.
- `pkmn` is now a Click group with `lookup` (existing pipeline) + `set-cards` subcommands. A `FallbackGroup` keeps `pkmn cards.txt` working — unknown subcommands forward to `lookup`.
- New `GET /api/v1/set-cards.pdf` endpoint and a **Set ID cards** download button in the web UI header (always enabled, independent of the input list).

## Reviewer notes

- The previous design (per-tag dominant set, attached as a `--checklist`-style flag) was scrapped after design feedback — this PR ships the corrected design: one cutout per set, dedicated subcommand, no required input.
- Backward compat: `./pkmn cards.txt` still routes to `lookup`. The `Makefile` `run-sample` target was updated to use explicit `pkmn lookup` for clarity.
- Logo art is downloaded lazily into `output/images/set-logos/` (configurable). `--no-images` skips the download and renders text-only cutouts.
- Docs updated: docs/binder-pdf.md, docs/cli.md, README.md.

## Test plan

- [x] \`uv run python -m unittest discover -s tests\` — 115 tests pass (9 new in tests/test_set_cards.py, 2 new in tests/test_set_cards_api.py)
- [x] \`uv run ruff check src/ tests/ api/\` — clean
- [x] Web: \`tsc -b && vite build\` — clean
- [x] \`pkmn --help\` / \`pkmn set-cards --help\` / \`pkmn lookup --help\` — all wired
- [x] Manual: run \`pkmn set-cards\` and verify the PDF is printable / cuts to size
- [x] Manual: hit \"Set ID cards\" button in the web UI and confirm the file downloads

Resolves #71