### PR TITLE
Update roadmap and add ADR-0010 for unified project structure

### DIFF
--- a/docs/adr/0010-unified-project-with-area-views.md
+++ b/docs/adr/0010-unified-project-with-area-views.md
@@ -1,0 +1,115 @@
+# ADR 0010: Single unified GitHub Project with per-area views
+
+- **Status:** Accepted
+- **Date:** 2026-05-12
+- **Tags:** project-management, planning
+
+## Context
+
+The roadmap originally split tracking work across five area-specific
+GitHub Projects v2, one per `area:*` label:
+
+- [#6 Lookup engine](https://github.com/users/mgzwarrior/projects/6)
+- [#7 Output artifacts](https://github.com/users/mgzwarrior/projects/7)
+- [#8 Cache & persistence](https://github.com/users/mgzwarrior/projects/8)
+- [#9 Web UI / API](https://github.com/users/mgzwarrior/projects/9)
+- [#10 DevOps & release](https://github.com/users/mgzwarrior/projects/10)
+
+The split was a direct translation of the codebase's area boundaries
+into project boundaries. Each project had its own Status field, its
+own items, and (mostly default-off) workflows. The premise was that
+per-area ownership would scale better than one board for everything —
+each area lead could curate their own board without stepping on the
+others.
+
+In practice, the layout made cross-area views impossible. Projects v2
+has no native "merge multiple projects" mechanism: an item lives in
+exactly one project, fields don't compose across projects, and any
+Kanban that spans areas can only be reconstructed by hand. The pain
+showed up everywhere a question naturally cut across areas: release
+planning (a V1 milestone has work in every area), day-to-day
+"what's open across the whole repo," and PR triage for work that
+touched more than one area.
+
+Beyond the cross-cutting blind spot, the five-board layout multiplied
+small maintenance costs: five workflow configurations to keep in sync,
+five auto-add rules, five Status fields with slightly different
+ordering. Each was cheap; the aggregate wasn't.
+
+This ADR was filed after the migration completed, not before. The
+original five-board layout was never itself recorded in an ADR; this
+ADR documents both the new structure and — for posterity — what came
+before.
+
+## Decision
+
+Consolidate the five area-specific projects into a single
+[`mgz-pkmn`](https://github.com/users/mgzwarrior/projects/11) project.
+Recover per-area focus through saved board views filtered by the
+existing `area:*` labels:
+
+- **All** (board, no filter, group by Status) — the cross-area Kanban
+  the old layout couldn't produce.
+- **Lookup / Outputs / Cache / Web / API / DevOps** (board, filter
+  `label:"area:<name>"`, group by Status) — functionally equivalent
+  to the five old per-area boards.
+- **Milestones** (table) for release planning.
+- **Roadmap** (roadmap layout) for time-on-axis views.
+
+Use the existing `area:*` labels rather than introducing a custom
+`Area` single-select project field. The labels were already
+universally applied (verified all 68 migrated items carried one),
+they work outside the Project view (issue search, README badges,
+GitHub's native label filter), and a redundant single-select field
+would have created drift risk for no capability the views couldn't
+deliver.
+
+Project workflows on the unified project:
+
+- Auto-add `repo:mgzwarrior/mgz-pkmn is:open` items.
+- Item closed → Status `Done`.
+- PR merged → Status `Done`.
+- Item reopened → Status `Todo`.
+- Auto-archive items closed > 2 weeks.
+
+The five old projects are closed (not deleted) to preserve history.
+
+## Consequences
+
+- Cross-area views become first-class. The default "All" board shows
+  every open item in the repo; release planning uses the Milestones
+  table without reconciling five sources.
+- Per-area focus is preserved via saved views, with the same
+  Status-grouped Kanban shape contributors are used to.
+- A single set of workflow rules to maintain. Auto-add + auto-archive
+  apply uniformly.
+- Adding a new area is now "add an `area:*` label + a saved view,"
+  not "spin up a new project and rewire automation."
+- The unified project mixes work at different lifecycle stages (V1
+  polish + V2 architectural items). Filtering relies on the
+  `version:*` label being applied consistently — a discipline the
+  old layout didn't enforce. The roadmap doc already requires it.
+- The `area:*` label remains load-bearing: items without one fall
+  through every area view. Worth a CI check or periodic audit if
+  drift starts to show up.
+- View URLs changed. Any external link to the old project boards
+  (#6–#10) resolves to a closed project.
+  [`docs/roadmap.md`](../roadmap.md) is the canonical entry point and
+  has been updated; ad-hoc links elsewhere will need rewriting as
+  they surface.
+
+## Alternatives considered
+
+- **Keep the five-project layout.** Preserves the per-area mental
+  model but leaves the cross-area gap unsolved and pays the
+  five-workflows tax forever.
+- **Custom `Area` single-select project field instead of `area:*`
+  labels.** Tighter coupling between Project state and the field,
+  and supports project-only automations keyed on the field. Loses
+  the label's reach outside Projects (issue search, badges, native
+  label filter) and adds a second source of truth to keep in sync.
+  Not worth the cost when labels already cover every view we need.
+- **One project per milestone (`v1.0`, `v2.0`, …).** Solves
+  release-planning cross-area views but reintroduces the original
+  problem for everyday "what's open in area X" questions. Strictly
+  worse than the chosen layout.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,7 @@ not just the shape.
 | [0007](0007-fastapi-and-sse-for-streaming-results.md) | FastAPI backend + Server-Sent Events for streaming lookup results | Accepted | 2026-05-09 |
 | [0008](0008-two-pass-stable-sort-for-row-ordering.md) | Two-pass stable sort for compound row ordering | Accepted | 2026-05-09 |
 | [0009](0009-docs-as-source-with-wiki-sync.md) | `docs/` is the source of truth; the GitHub Wiki is a mirror | Accepted | 2026-05-09 |
+| [0010](0010-unified-project-with-area-views.md) | Single unified GitHub Project with per-area views | Accepted | 2026-05-12 |
 
 ## Adding a new ADR
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,7 +19,8 @@ number for one-click navigation; speculative items don't have issues yet.
   the 1.0 cut (the announcement, the contributor-comms refresh, set
   identification cards) rather than blocking it.
 - **V2** — **committed**. Deeper development per area. Tracked per-area
-  on GitHub Projects (links below).
+  on the unified [`mgz-pkmn`](https://github.com/users/mgzwarrior/projects/11)
+  project (per-area views linked below).
 - **V2.x / Post-V2** — **committed but later**. Currently themed around
   the **free / paid separation and monetization work** — once V2 is
   shipped, the project is mature enough to consider sustainable funding
@@ -31,17 +32,21 @@ number for one-click navigation; speculative items don't have issues yet.
 
 ## Project areas
 
-The codebase splits cleanly into five areas. Each has its own GitHub
-Project for tracking V1 + V2 work, plus an auto-updating open-issues
-badge below.
+The codebase splits cleanly into five areas. All work tracks on the
+unified [`mgz-pkmn`](https://github.com/users/mgzwarrior/projects/11)
+project, with a saved board view per area filtered by the matching
+`area:*` label. Each row below links to that area's view, plus an
+auto-updating open-issues badge. See
+[ADR-0010](adr/0010-unified-project-with-area-views.md) for the
+rationale behind the single-project structure.
 
-| Area | Owns | Project | Open |
+| Area | Owns | View | Open |
 |---|---|---|---|
-| **Lookup engine** | Parse user input, resolve cards across data sources, attach pricing. ([`parser.py`](../src/mgz_pkmn/parser.py), [`lookup.py`](../src/mgz_pkmn/lookup.py), [`sources/`](../src/mgz_pkmn/sources/), [`pricing.py`](../src/mgz_pkmn/pricing.py)) | [#6](https://github.com/users/mgzwarrior/projects/6) | [![](https://img.shields.io/github/issues/mgzwarrior/mgz-pkmn/area%3Alookup?label=)](https://github.com/mgzwarrior/mgz-pkmn/issues?q=is%3Aopen+label%3Aarea%3Alookup) |
-| **Output artifacts** | Render rows into spreadsheet / PDFs / checklist / JSON. ([`spreadsheet.py`](../src/mgz_pkmn/spreadsheet.py), [`binder.py`](../src/mgz_pkmn/binder.py), [`checklist.py`](../src/mgz_pkmn/checklist.py), [`report.py`](../src/mgz_pkmn/report.py)) | [#7](https://github.com/users/mgzwarrior/projects/7) | [![](https://img.shields.io/github/issues/mgzwarrior/mgz-pkmn/area%3Aoutputs?label=)](https://github.com/mgzwarrior/mgz-pkmn/issues?q=is%3Aopen+label%3Aarea%3Aoutputs) |
-| **Cache & persistence** | Disk cache for API responses + URL overrides; (V2) multi-user storage. ([`cache.py`](../src/mgz_pkmn/cache.py)) | [#8](https://github.com/users/mgzwarrior/projects/8) | [![](https://img.shields.io/github/issues/mgzwarrior/mgz-pkmn/area%3Acache?label=)](https://github.com/mgzwarrior/mgz-pkmn/issues?q=is%3Aopen+label%3Aarea%3Acache) |
-| **Web UI / API** | FastAPI service + React SPA. ([`api/`](../api/), [`web/`](../web/)) | [#9](https://github.com/users/mgzwarrior/projects/9) | [![](https://img.shields.io/github/issues/mgzwarrior/mgz-pkmn/area%3Aweb?label=)](https://github.com/mgzwarrior/mgz-pkmn/issues?q=is%3Aopen+label%3Aarea%3Aweb) |
-| **DevOps & release** | CI, deployment, packaging, distribution, security, governance. | [#10](https://github.com/users/mgzwarrior/projects/10) | [![](https://img.shields.io/github/issues/mgzwarrior/mgz-pkmn/area%3Adevops?label=)](https://github.com/mgzwarrior/mgz-pkmn/issues?q=is%3Aopen+label%3Aarea%3Adevops) |
+| **Lookup engine** | Parse user input, resolve cards across data sources, attach pricing. ([`parser.py`](../src/mgz_pkmn/parser.py), [`lookup.py`](../src/mgz_pkmn/lookup.py), [`sources/`](../src/mgz_pkmn/sources/), [`pricing.py`](../src/mgz_pkmn/pricing.py)) | [Lookup](https://github.com/users/mgzwarrior/projects/11/views/3) | [![](https://img.shields.io/github/issues/mgzwarrior/mgz-pkmn/area%3Alookup?label=)](https://github.com/mgzwarrior/mgz-pkmn/issues?q=is%3Aopen+label%3Aarea%3Alookup) |
+| **Output artifacts** | Render rows into spreadsheet / PDFs / checklist / JSON. ([`spreadsheet.py`](../src/mgz_pkmn/spreadsheet.py), [`binder.py`](../src/mgz_pkmn/binder.py), [`checklist.py`](../src/mgz_pkmn/checklist.py), [`report.py`](../src/mgz_pkmn/report.py)) | [Outputs](https://github.com/users/mgzwarrior/projects/11/views/4) | [![](https://img.shields.io/github/issues/mgzwarrior/mgz-pkmn/area%3Aoutputs?label=)](https://github.com/mgzwarrior/mgz-pkmn/issues?q=is%3Aopen+label%3Aarea%3Aoutputs) |
+| **Cache & persistence** | Disk cache for API responses + URL overrides; (V2) multi-user storage. ([`cache.py`](../src/mgz_pkmn/cache.py)) | [Cache](https://github.com/users/mgzwarrior/projects/11/views/5) | [![](https://img.shields.io/github/issues/mgzwarrior/mgz-pkmn/area%3Acache?label=)](https://github.com/mgzwarrior/mgz-pkmn/issues?q=is%3Aopen+label%3Aarea%3Acache) |
+| **Web UI / API** | FastAPI service + React SPA. ([`api/`](../api/), [`web/`](../web/)) | [Web / API](https://github.com/users/mgzwarrior/projects/11/views/6) | [![](https://img.shields.io/github/issues/mgzwarrior/mgz-pkmn/area%3Aweb?label=)](https://github.com/mgzwarrior/mgz-pkmn/issues?q=is%3Aopen+label%3Aarea%3Aweb) |
+| **DevOps & release** | CI, deployment, packaging, distribution, security, governance. | [DevOps](https://github.com/users/mgzwarrior/projects/11/views/7) | [![](https://img.shields.io/github/issues/mgzwarrior/mgz-pkmn/area%3Adevops?label=)](https://github.com/mgzwarrior/mgz-pkmn/issues?q=is%3Aopen+label%3Aarea%3Adevops) |
 
 ---
 
@@ -308,10 +313,12 @@ number of **opt-in power features** also live behind a fair price for
 end users who want them, so the project can monetize its largest
 audience without breaking the free-forever promise on core flows.
 
-V2.x has its own GitHub Project so the policy work, infra changes,
-and feature gating land coherently. Issues for these items will be
-filed once V1 ships — leaving them un-numbered keeps the doc honest
-about what's open vs. just intended.
+V2.x items track on the unified
+[`mgz-pkmn`](https://github.com/users/mgzwarrior/projects/11) project
+alongside the rest of the roadmap; once issues are filed they get the
+`version:v2.x` label so the policy work, infra changes, and feature
+gating land coherently. Leaving them un-numbered until V1 ships keeps
+the doc honest about what's open vs. just intended.
 
 ### Monetization
 


### PR DESCRIPTION
## Summary

- Update `docs/roadmap.md` Project areas section: replace the five closed area-project links (#6–#10) with per-area board views on the unified [`mgz-pkmn`](https://github.com/users/mgzwarrior/projects/11) project, and refresh surrounding prose (V2 and V2.x sections) to match the single-project structure.
- Add [ADR-0010](docs/adr/0010-unified-project-with-area-views.md) recording the consolidation decision: Context covers the original five-board layout and why it was structured that way; Decision documents the unified project with `area:*`-filtered views, label-vs-field choice, and workflows; Consequences + Alternatives follow the template.
- Add the ADR row to [`docs/adr/README.md`](docs/adr/README.md).

Resolves #74

## Test plan

- [x] `docs/roadmap.md` Project areas table links each area to its view on project 11 (Lookup → view 3, Outputs → view 4, Cache → view 5, Web / API → view 6, DevOps → view 7).
- [x] V2 + V2.x prose no longer references "five GitHub Projects" or a separate V2.x project.
- [x] `docs/adr/0010-unified-project-with-area-views.md` renders cleanly and links to the prior projects (#6–#10), the unified project (#11), and the roadmap.
- [x] `docs/adr/README.md` index includes the ADR-0010 row in numeric order.
- [x] No broken intra-doc links (manual click-through on the changed pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)