### PR TITLE
Distinguish > from >= (and < from <=) in comparator parser

### DIFF
--- a/docs/input-format.md
+++ b/docs/input-format.md
@@ -127,9 +127,9 @@ cell in the PDF binder.
 ## Known limitations
 
 - **Inline price filtering is approximate.** The comparator parser
-  handles `>=`, `<=`, `>`, `<` correctly and intersects with
-  `--max-price`, but it's currency-blind, treats `>` like `>=`, and
-  silently drops conditions on single-card lookups. A line like
+  distinguishes strict (`>`, `<`) from inclusive (`>=`, `<=`) and
+  intersects with `--max-price`, but it's currency-blind and silently
+  drops conditions on single-card lookups. A line like
   `Charizard | Base | 4 >= $100` parses the bound but doesn't act on
   it. Acceptable for bulk budgeting; not a general-purpose query
   language.

--- a/src/mgz_pkmn/lookup.py
+++ b/src/mgz_pkmn/lookup.py
@@ -450,21 +450,37 @@ def find_top_cards(
 
     # Combine global cap with the per-query inline bounds. Both upper bounds
     # are intersected (most restrictive wins). The lower bound only comes
-    # from the query — there's no global "minimum price" knob.
+    # from the query — there's no global "minimum price" knob. The global
+    # `--max-price` cap is always inclusive; if a strict `<` bound shares
+    # the winning value with the cap, we keep the strict flag.
     effective_max = max_price
+    effective_max_exclusive = False
     if q.price_max is not None:
-        effective_max = q.price_max if effective_max is None else min(effective_max, q.price_max)
+        if effective_max is None or q.price_max < effective_max:
+            effective_max = q.price_max
+            effective_max_exclusive = q.price_max_exclusive
+        elif q.price_max == effective_max and q.price_max_exclusive:
+            effective_max_exclusive = True
     effective_min = q.price_min
+    effective_min_exclusive = q.price_min_exclusive
 
     enriched: list[tuple[float, dict[str, Any]]] = []
     for card in pool:
         pricing = extract_pricing(card, q.variant_hint)
         if pricing.market is None:
             continue
-        if effective_max is not None and pricing.market > effective_max:
-            continue
-        if effective_min is not None and pricing.market < effective_min:
-            continue
+        if effective_max is not None:
+            if effective_max_exclusive:
+                if pricing.market >= effective_max:
+                    continue
+            elif pricing.market > effective_max:
+                continue
+        if effective_min is not None:
+            if effective_min_exclusive:
+                if pricing.market <= effective_min:
+                    continue
+            elif pricing.market < effective_min:
+                continue
         enriched.append((pricing.market, card))
 
     enriched.sort(key=lambda pair: pair[0], reverse=True)

--- a/src/mgz_pkmn/parser.py
+++ b/src/mgz_pkmn/parser.py
@@ -116,6 +116,10 @@ class CardQuery:
     # top-N cut so an "affordable top 10 ≥ $20" still returns 10.
     price_min: float | None = None
     price_max: float | None = None
+    # Whether each bound is strict (`>` / `<`) or inclusive (`>=` / `<=`).
+    # When True, a card whose price exactly equals the bound is excluded.
+    price_min_exclusive: bool = False
+    price_max_exclusive: bool = False
     # Set by "All <subject> cards" lines — return every matching card rather
     # than capping at top-N. Mutually exclusive with bulk_top in practice.
     bulk_all: bool = False
@@ -123,9 +127,11 @@ class CardQuery:
     def __str__(self) -> str:
         bound_bits: list[str] = []
         if self.price_min is not None:
-            bound_bits.append(f">=${self.price_min:g}")
+            op = ">" if self.price_min_exclusive else ">="
+            bound_bits.append(f"{op}${self.price_min:g}")
         if self.price_max is not None:
-            bound_bits.append(f"<=${self.price_max:g}")
+            op = "<" if self.price_max_exclusive else "<="
+            bound_bits.append(f"{op}${self.price_max:g}")
         bound = f" ({' '.join(bound_bits)})" if bound_bits else ""
         if self.bulk_all:
             in_set = f" in {self.set_hint}" if self.set_hint else ""
@@ -179,7 +185,9 @@ def parse_line(line: str) -> CardQuery | None:
     # In-line price conditions (`>= $20`, `<= $50`, `between` via two clauses).
     # Pulled out before bulk-phrase matching because the bulk regex is anchored
     # to end-of-string and would otherwise miss when a price tail is present.
-    body, price_min, price_max = _extract_price_conds(body)
+    body, price_min, price_max, price_min_exclusive, price_max_exclusive = _extract_price_conds(
+        body
+    )
 
     if not body and url_hint:
         return CardQuery(
@@ -191,6 +199,8 @@ def parse_line(line: str) -> CardQuery | None:
             url_hint,
             price_min=price_min,
             price_max=price_max,
+            price_min_exclusive=price_min_exclusive,
+            price_max_exclusive=price_max_exclusive,
         )
 
     # "Top-N chase cards" patterns trump the regular parsing. The user is
@@ -209,6 +219,8 @@ def parse_line(line: str) -> CardQuery | None:
             count,
             price_min=price_min,
             price_max=price_max,
+            price_min_exclusive=price_min_exclusive,
+            price_max_exclusive=price_max_exclusive,
             bulk_all=count is None,
         )
 
@@ -229,6 +241,8 @@ def parse_line(line: str) -> CardQuery | None:
                         url_hint,
                         price_min=price_min,
                         price_max=price_max,
+                        price_min_exclusive=price_min_exclusive,
+                        price_max_exclusive=price_max_exclusive,
                     )
                 return CardQuery(
                     raw,
@@ -239,6 +253,8 @@ def parse_line(line: str) -> CardQuery | None:
                     url_hint,
                     price_min=price_min,
                     price_max=price_max,
+                    price_min_exclusive=price_min_exclusive,
+                    price_max_exclusive=price_max_exclusive,
                 )
             if len(parts) == 2:
                 if NUMBER_RE.match(parts[1].replace(" ", "")):
@@ -251,6 +267,8 @@ def parse_line(line: str) -> CardQuery | None:
                         url_hint,
                         price_min=price_min,
                         price_max=price_max,
+                        price_min_exclusive=price_min_exclusive,
+                        price_max_exclusive=price_max_exclusive,
                     )
                 return CardQuery(
                     raw,
@@ -261,6 +279,8 @@ def parse_line(line: str) -> CardQuery | None:
                     url_hint,
                     price_min=price_min,
                     price_max=price_max,
+                    price_min_exclusive=price_min_exclusive,
+                    price_max_exclusive=price_max_exclusive,
                 )
 
     # Positional fallback. Find a number-shaped token; everything else is name+set.
@@ -285,28 +305,45 @@ def parse_line(line: str) -> CardQuery | None:
         url_hint,
         price_min=price_min,
         price_max=price_max,
+        price_min_exclusive=price_min_exclusive,
+        price_max_exclusive=price_max_exclusive,
     )
 
 
-def _extract_price_conds(body: str) -> tuple[str, float | None, float | None]:
+def _extract_price_conds(
+    body: str,
+) -> tuple[str, float | None, float | None, bool, bool]:
     """Pull `>=`, `<=`, `>`, `<` numeric conditions out of a line and return
-    the cleaned body plus the resolved (min, max) bounds.
+    the cleaned body plus the resolved (min, max) bounds and their strict /
+    inclusive flags.
 
     Multiple conditions on the same side narrow toward the more restrictive
-    bound (`>= 20 >= 30` → min=30; `<= 100 <= 50` → max=50). Inclusive vs
-    strict is collapsed — `>` is treated like `>=` and `<` like `<=` for
-    simplicity since "exactly $20" isn't a useful budget filter."""
+    bound (`>= 20 >= 30` → min=30; `<= 100 <= 50` → max=50). Strict (`>`,
+    `<`) and inclusive (`>=`, `<=`) are tracked distinctly: when two bounds
+    name the same value, the strict form wins (it admits a smaller set).
+    """
     price_min: float | None = None
     price_max: float | None = None
+    price_min_exclusive = False
+    price_max_exclusive = False
 
     def _capture(m: re.Match) -> str:
-        nonlocal price_min, price_max
+        nonlocal price_min, price_max, price_min_exclusive, price_max_exclusive
         op, raw_val = m.group(1), m.group(2)
         val = float(raw_val)
+        strict = op in (">", "<")
         if op in (">=", ">"):
-            price_min = val if price_min is None else max(price_min, val)
+            if price_min is None or val > price_min:
+                price_min = val
+                price_min_exclusive = strict
+            elif val == price_min and strict:
+                price_min_exclusive = True
         else:
-            price_max = val if price_max is None else min(price_max, val)
+            if price_max is None or val < price_max:
+                price_max = val
+                price_max_exclusive = strict
+            elif val == price_max and strict:
+                price_max_exclusive = True
         return ""
 
     cleaned = PRICE_COND_RE.sub(_capture, body)
@@ -316,7 +353,7 @@ def _extract_price_conds(body: str) -> tuple[str, float | None, float | None]:
     # (e.g. "X cards >= $20" → "X cards", or "X | >= $20" → "X").
     # str.rstrip() is O(n) with no backtracking.
     cleaned = cleaned.rstrip(" ,;|-—")
-    return cleaned, price_min, price_max
+    return cleaned, price_min, price_max, price_min_exclusive, price_max_exclusive
 
 
 def _normalize_number(raw: str) -> str:

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -193,6 +193,94 @@ class FindTopCardsTests(unittest.TestCase):
         self.assertEqual(by_id["sv8-3"]["language"], "en")
 
 
+class PriceBoundaryFilterTests(unittest.TestCase):
+    """`>` / `<` are exclusive: a card whose price exactly equals the bound
+    must be dropped. `>=` / `<=` are inclusive: the boundary value is kept.
+    These tests pin that contract through `find_top_cards` so the parser
+    flags are wired all the way to the filter."""
+
+    @staticmethod
+    def _client_with_boundary_cards() -> _StubTCGClient:
+        # Three cards at $10, $20, $30 — covers both sides of a $20 bound.
+        return _StubTCGClient(
+            {
+                "name:Charizard": [
+                    _card("low", "Charizard", 10.0),
+                    _card("at", "Charizard", 20.0),
+                    _card("high", "Charizard", 30.0),
+                ],
+                "name:Charizard*": [
+                    _card("low", "Charizard", 10.0),
+                    _card("at", "Charizard", 20.0),
+                    _card("high", "Charizard", 30.0),
+                ],
+            }
+        )
+
+    def test_inclusive_min_keeps_boundary(self) -> None:
+        # `>= 20` admits the card priced exactly at $20.
+        q = CardQuery(raw="x", name="Charizard", bulk_top=5, price_min=20.0)
+        results = find_top_cards(self._client_with_boundary_cards(), q, limit=5)
+        self.assertEqual(sorted(c["id"] for c in results), ["at", "high"])
+
+    def test_strict_min_drops_boundary(self) -> None:
+        # `> 20` excludes the card priced exactly at $20.
+        q = CardQuery(
+            raw="x",
+            name="Charizard",
+            bulk_top=5,
+            price_min=20.0,
+            price_min_exclusive=True,
+        )
+        results = find_top_cards(self._client_with_boundary_cards(), q, limit=5)
+        self.assertEqual([c["id"] for c in results], ["high"])
+
+    def test_inclusive_max_keeps_boundary(self) -> None:
+        # `<= 20` admits the card priced exactly at $20.
+        q = CardQuery(raw="x", name="Charizard", bulk_top=5, price_max=20.0)
+        results = find_top_cards(self._client_with_boundary_cards(), q, limit=5)
+        self.assertEqual(sorted(c["id"] for c in results), ["at", "low"])
+
+    def test_strict_max_drops_boundary(self) -> None:
+        # `< 20` excludes the card priced exactly at $20.
+        q = CardQuery(
+            raw="x",
+            name="Charizard",
+            bulk_top=5,
+            price_max=20.0,
+            price_max_exclusive=True,
+        )
+        results = find_top_cards(self._client_with_boundary_cards(), q, limit=5)
+        self.assertEqual([c["id"] for c in results], ["low"])
+
+    def test_strict_band_drops_both_boundaries(self) -> None:
+        # `> 10 < 30` keeps only the card at $20 (strict on both sides).
+        q = CardQuery(
+            raw="x",
+            name="Charizard",
+            bulk_top=5,
+            price_min=10.0,
+            price_min_exclusive=True,
+            price_max=30.0,
+            price_max_exclusive=True,
+        )
+        results = find_top_cards(self._client_with_boundary_cards(), q, limit=5)
+        self.assertEqual([c["id"] for c in results], ["at"])
+
+    def test_strict_max_wins_over_inclusive_global_cap_at_same_value(self) -> None:
+        # `--max-price 20` (inclusive) AND inline `< 20` (strict) → strict wins
+        # because it's the more restrictive at the same value.
+        q = CardQuery(
+            raw="x",
+            name="Charizard",
+            bulk_top=5,
+            price_max=20.0,
+            price_max_exclusive=True,
+        )
+        results = find_top_cards(self._client_with_boundary_cards(), q, limit=5, max_price=20.0)
+        self.assertEqual([c["id"] for c in results], ["low"])
+
+
 class ExpandConceptTests(unittest.TestCase):
     def test_known_concept_returns_slash_string(self) -> None:
         result = _expand_concept("eeveelution")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -155,6 +155,74 @@ class BulkDetectionTests(unittest.TestCase):
         self.assertLess(elapsed, 0.5, f"parse_line was too slow: {elapsed:.3f}s")
 
 
+class PriceComparatorTests(unittest.TestCase):
+    """`>` / `<` are strict; `>=` / `<=` are inclusive. The parser must
+    preserve that distinction so the lookup filter can drop the boundary
+    value when the user wrote a strict comparator."""
+
+    def test_inclusive_min(self) -> None:
+        q = parse_line("Charizard >= $20")
+        assert q is not None
+        self.assertEqual(q.price_min, 20.0)
+        self.assertFalse(q.price_min_exclusive)
+
+    def test_strict_min(self) -> None:
+        q = parse_line("Charizard > $20")
+        assert q is not None
+        self.assertEqual(q.price_min, 20.0)
+        self.assertTrue(q.price_min_exclusive)
+
+    def test_inclusive_max(self) -> None:
+        q = parse_line("top 10 Charizard cards <= $50")
+        assert q is not None
+        self.assertEqual(q.price_max, 50.0)
+        self.assertFalse(q.price_max_exclusive)
+
+    def test_strict_max(self) -> None:
+        q = parse_line("top 10 Charizard cards < $50")
+        assert q is not None
+        self.assertEqual(q.price_max, 50.0)
+        self.assertTrue(q.price_max_exclusive)
+
+    def test_two_min_bounds_narrow_to_higher_value(self) -> None:
+        # `>= 20 > 30` → the strict 30 wins (it's the more restrictive).
+        q = parse_line("Charizard >= $20 > $30")
+        assert q is not None
+        self.assertEqual(q.price_min, 30.0)
+        self.assertTrue(q.price_min_exclusive)
+
+    def test_same_value_strict_wins_over_inclusive_min(self) -> None:
+        # When both bounds name the same value, the strict one excludes the
+        # boundary — strictly stricter, so it wins.
+        q = parse_line("Charizard >= $20 > $20")
+        assert q is not None
+        self.assertEqual(q.price_min, 20.0)
+        self.assertTrue(q.price_min_exclusive)
+
+    def test_same_value_strict_wins_over_inclusive_max(self) -> None:
+        q = parse_line("top 10 Charizard cards <= $50 < $50")
+        assert q is not None
+        self.assertEqual(q.price_max, 50.0)
+        self.assertTrue(q.price_max_exclusive)
+
+    def test_str_renders_strict_comparators(self) -> None:
+        q = parse_line("top 5 Charizard cards > $20 < $50")
+        assert q is not None
+        rendered = str(q)
+        self.assertIn(">$20", rendered)
+        self.assertIn("<$50", rendered)
+        # Should not have rendered as inclusive.
+        self.assertNotIn(">=$20", rendered)
+        self.assertNotIn("<=$50", rendered)
+
+    def test_str_renders_inclusive_comparators(self) -> None:
+        q = parse_line("top 5 Charizard cards >= $20 <= $50")
+        assert q is not None
+        rendered = str(q)
+        self.assertIn(">=$20", rendered)
+        self.assertIn("<=$50", rendered)
+
+
 class DetectCardLanguageTests(unittest.TestCase):
     def test_japanese_katakana_in_name(self) -> None:
         # The real motivating case: pokemontcg.io card xy12-109 returns


### PR DESCRIPTION
## Summary

- The inline price comparator parser previously collapsed `>` into `>=` and `<` into `<=`, so `top 5 Charizard > $20` would silently admit a $20 card.
- Track strict-vs-inclusive on `CardQuery` (`price_min_exclusive` / `price_max_exclusive`) and honor the flag in the lookup filter so boundary cards drop when the user wrote a strict comparator.
- When two bounds on the same side share a value, the strict one wins (it admits a smaller set). The global `--max-price` cap stays inclusive, but a strict inline `<` at the same value carries through.

## Test plan

- [x] `make check` — ruff lint + format + Python tests (`unittest discover`) + web eslint, all green
- [x] New `PriceComparatorTests` in [tests/test_parser.py](tests/test_parser.py) cover `>`, `>=`, `<`, `<=`, narrowing across two bounds, same-value strict wins, and `__str__` rendering
- [x] New `PriceBoundaryFilterTests` in [tests/test_lookup.py](tests/test_lookup.py) pin the end-to-end filter behavior via `find_top_cards`, including the `--max-price` × inline-bound intersection at the same value
- [x] 133 tests pass (was 118)

Resolves #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)