### PR TITLE
Serve SPA index.html with Cache-Control: no-cache

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -9,13 +9,39 @@ Or from inside the api/ directory:
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from typing import Any
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
+from starlette.responses import Response
 
 from .routes import export, lookup, overrides, parse, set_cards, sets
+
+
+class SPAStaticFiles(StaticFiles):
+    """StaticFiles that disables browser caching for ``index.html``.
+
+    Vite emits content-hashed filenames for JS/CSS, so those are safe to cache
+    aggressively. But ``index.html`` points at the current hashed bundle names,
+    and a stale copy will load the old assets after a redeploy. Forcing
+    revalidation on ``index.html`` keeps deploys visible without a hard reload.
+    """
+
+    def file_response(
+        self,
+        full_path: Any,
+        stat_result: os.stat_result,
+        scope: Any,
+        status_code: int = 200,
+    ) -> Response:
+        response = super().file_response(full_path, stat_result, scope, status_code)
+        if os.path.basename(os.fspath(full_path)) == "index.html":
+            response.headers["Cache-Control"] = "no-cache"
+        return response
+
 
 app = FastAPI(
     title="mgz-pkmn API",
@@ -55,4 +81,4 @@ def health() -> dict:
 # lives below the API routes so /api/* and /health continue to win.
 _web_dist = Path(__file__).resolve().parent.parent / "web" / "dist"
 if _web_dist.is_dir():
-    app.mount("/", StaticFiles(directory=_web_dist, html=True), name="web")
+    app.mount("/", SPAStaticFiles(directory=_web_dist, html=True), name="web")

--- a/tests/test_spa_mount.py
+++ b/tests/test_spa_mount.py
@@ -1,0 +1,59 @@
+"""Tests for the SPA mount's caching behavior.
+
+The mount must serve ``index.html`` with ``Cache-Control: no-cache`` so a fresh
+deploy is visible after a normal refresh. Hashed assets in ``assets/`` must
+keep their default caching behavior so they remain long-cacheable.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.main import SPAStaticFiles
+
+
+class SPAStaticFilesTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        dist = Path(self._tmp.name)
+        (dist / "index.html").write_text("<!doctype html><html></html>")
+        (dist / "assets").mkdir()
+        (dist / "assets" / "index-abc123.js").write_text("console.log(1);")
+
+        app = FastAPI()
+        app.mount("/", SPAStaticFiles(directory=dist, html=True), name="web")
+        self.client = TestClient(app)
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def test_index_html_has_no_cache(self) -> None:
+        resp = self.client.get("/index.html")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.headers.get("cache-control"), "no-cache")
+
+    def test_root_serves_index_with_no_cache(self) -> None:
+        resp = self.client.get("/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.headers.get("cache-control"), "no-cache")
+
+    def test_hashed_asset_is_not_marked_no_cache(self) -> None:
+        resp = self.client.get("/assets/index-abc123.js")
+        self.assertEqual(resp.status_code, 200)
+        # The hashed asset must not inherit the index.html override; whatever
+        # default Starlette sets (none today) is fine, but it must not be
+        # "no-cache".
+        self.assertNotEqual(resp.headers.get("cache-control"), "no-cache")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Subclass `StaticFiles` as `SPAStaticFiles` so the SPA mount stamps `Cache-Control: no-cache` onto `index.html` only.
- Hashed assets under `assets/` keep their existing (long-cache-friendly) headers — no regression for content-hashed bundles.
- Add `tests/test_spa_mount.py` covering `/index.html`, `/` (directory fallback to `index.html`), and a hashed asset (must not inherit `no-cache`).

## Why
Per #70, the deployed SPA's `index.html` was being served with default `StaticFiles` headers, letting browsers and intermediate caches keep stale copies. A fresh Render deploy could keep showing the old UI until a hard refresh, because the stale `index.html` pointed at the old bundle filenames. Forcing revalidation on the shell alone is the minimal fix.

## Test plan
- [x] `make test` — 136 tests pass (new SPA mount tests included)
- [x] `make check` — ruff + format + tests + web eslint all green
- [x] Manual: redeploy and confirm a normal refresh picks up the new shell without `Cmd+Shift+R`

Resolves #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)