### PR TITLE
Document MGZ_PKMN_NO_CACHE env var

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -23,9 +23,9 @@ list don't keep re-spending API quota. Two stores live there:
   explicit-URL path and the pokemontcg.io path so a saved override
   behaves exactly like a re-pasted URL would.
 - **`--no-cache`** disables both stores for the run (sets
-  `MGZ_PKMN_NO_CACHE=1` internally). Reads miss, writes are no-ops; the
-  on-disk cache is unchanged. Use it for an ephemeral clean run that
-  shouldn't pollute or refresh the cache.
+  `MGZ_PKMN_NO_CACHE=1` internally — see [Environment variables](#environment-variables)).
+  Reads miss, writes are no-ops; the on-disk cache is unchanged. Use it
+  for an ephemeral clean run that shouldn't pollute or refresh the cache.
 - **`--clear-cache`** wipes the API response cache *before* the run,
   then proceeds normally so fresh data is fetched and re-cached. URL
   overrides are preserved (they take real effort to set; API responses
@@ -35,3 +35,10 @@ list don't keep re-spending API quota. Two stores live there:
 - **Manual nuke** — `rm -rf ~/.cache/mgz-pkmn` removes everything
   including URL overrides. There's no LRU eviction; the cache stays
   small (a few MB after a typical run).
+
+## Environment variables
+
+| Variable | Effect |
+|---|---|
+| `MGZ_PKMN_NO_CACHE` | When set to a truthy value (anything other than empty, `0`, `false`, `False`), disables both the API response cache and URL-override lookups for the current process. Reads always miss; writes are no-ops; the on-disk cache is left untouched. The CLI's [`--no-cache`](cli.md#pkmn-lookup-options) flag sets this internally — set it directly when running the FastAPI service or invoking the library from another process where the flag isn't available. `--clear-cache` still wipes the API cache even when this is set; the explicit wipe wins over the implicit skip. |
+| `XDG_CACHE_HOME` | Overrides the cache root. The store lives at `$XDG_CACHE_HOME/mgz-pkmn` when set, falling back to `~/.cache/mgz-pkmn` otherwise. Standard XDG semantics — no mgz-pkmn-specific behavior. |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,7 +44,7 @@ boundary.
 | `--pdf PATH` | (none) | Also write a 3×3 binder-style PDF (9 cards/page) — image-forward, sized to print and slip into 9-pocket pages as physical placeholders. See [PDF binder](binder-pdf.md). |
 | `--condensed-pdf PATH` | (none) | Also write a denser binder PDF (6×4 grid, 24 cards/page) with the same caption block as `--pdf`. See [PDF binder](binder-pdf.md#condensed-binder). |
 | `--checklist PATH` | (none) | Also write a printable checklist PDF (one section per input file). See [Checklist PDF](checklist.md). |
-| `--no-cache` | off | Skip the disk cache; force every lookup to hit the network and don't write back. See [Cache](cache.md). |
+| `--no-cache` | off | Skip the disk cache; force every lookup to hit the network and don't write back. Equivalent to exporting `MGZ_PKMN_NO_CACHE=1` for non-CLI callers (FastAPI service, library use). See [Cache → Environment variables](cache.md#environment-variables). |
 | `--clear-cache` | off | Wipe the API response cache before the run, then continue normally so fresh data is re-cached. URL overrides preserved. |
 | `--lang CODE` | (none) | Default TCGdex language for lines that don't name one. Per-line keywords (`japanese`, `chinese`, …) still take priority. See [Languages](languages.md). |
 | `--sort MODE` | `number` | Row order applied to xlsx, binder, and checklist. Tag is always the outermost group; this changes order WITHIN each tag. Choices: `number` (group by set then card # asc — default), `number-desc`, `price-asc`, `price-desc`, `release-date` (chronological by set release date), `alpha` (by card name). |


### PR DESCRIPTION
## Summary

Closes #20.

The `MGZ_PKMN_NO_CACHE` env var has been respected by `src/mgz_pkmn/cache.py` since the disk cache landed (the CLI's `--no-cache` flag sets it internally), but until now it was undocumented. Non-CLI callers — the FastAPI service in `api/`, library use via `mgz_pkmn` as a module — had no visible way to disable the cache.

## Changes

- **`docs/cache.md`** — new "Environment variables" section with a table covering `MGZ_PKMN_NO_CACHE` (truthy/falsy rules, `--clear-cache` interaction, intended use case) and `XDG_CACHE_HOME` (cache-root override).
- **`docs/cli.md`** — the `--no-cache` option row now notes the env-var equivalence and links to the new section, matching how `--sort`, `--max-price`, and other rows cross-link to deeper docs.

## Approach notes

- Documented the existing behavior verbatim — `_disabled()` in `cache.py` treats empty, `"0"`, `"false"`, `"False"` as off, anything else as on. The table reflects exactly that.
- Also documented the `--clear-cache` precedence (cache wipe still happens when `MGZ_PKMN_NO_CACHE=1` is set) because it's a non-obvious corner the docstring already calls out and users reaching for the env var are the ones who care.
- Added `XDG_CACHE_HOME` to the same section since `cache_root()` honors it and that's the natural place to look.

## Test plan

- [x] `make check` — ruff lint + format + 142 unit tests pass.
- [x] Visually proofread the rendered tables in the GitHub diff.
- [x] Anchor link `cache.md#environment-variables` resolves to the new section.