### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/src/mgz_pkmn/lookup.py
+++ b/src/mgz_pkmn/lookup.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from typing import Any
+from urllib.parse import urlparse
 
 from . import cache as disk_cache
 from .parser import CardQuery, detect_card_language, detect_languages, strip_noise
@@ -105,6 +106,14 @@ _CONCEPT_KEYWORDS: dict[str, str] = {
 }
 
 
+def _is_pricecharting_url(url: str) -> bool:
+    host = urlparse(url).hostname
+    if not host:
+        return False
+    host = host.lower()
+    return host == "pricecharting.com" or host.endswith(".pricecharting.com")
+
+
 def find_card(
     pkmn: TCGClient,
     tcgdex: TCGDexClient,
@@ -130,7 +139,7 @@ def find_card(
     #    nothing matched. The override is recorded ONLY on success so a bad
     #    URL the user pastes once doesn't get pinned as a sticky override
     #    that quietly fails on every subsequent run.
-    if q.url_hint and "pricecharting.com" in q.url_hint:
+    if q.url_hint and _is_pricecharting_url(q.url_hint):
         result = pc.fetch(q.url_hint)
         if result.card:
             disk_cache.record_url_override(q.name, q.set_hint, q.url_hint)
@@ -143,7 +152,7 @@ def find_card(
     #    is stale or the scrape fails, fall through to DB sources rather than
     #    failing the lookup — the user didn't paste it this run.
     override = disk_cache.find_url_override(q.name, q.set_hint)
-    if override and "pricecharting.com" in override:
+    if override and _is_pricecharting_url(override):
         override_result = pc.fetch(override)
         if override_result.card:
             return override_result


### PR DESCRIPTION
Potential fix for [https://github.com/mgzwarrior/mgz-pkmn/security/code-scanning/5](https://github.com/mgzwarrior/mgz-pkmn/security/code-scanning/5)

Use URL parsing and host-based validation instead of substring checks.

Best fix in this file:
1. Add `urlparse` import from `urllib.parse`.
2. Add a small helper (e.g., `_is_pricecharting_url`) that:
   - Parses the URL.
   - Extracts `hostname`.
   - Returns `True` only for exact `pricecharting.com` or subdomains ending in `.pricecharting.com`.
3. Replace both substring checks in `find_card` (line 133 and line 146 region) with this helper.

This keeps functionality (accepting PriceCharting links) while preventing bypasses from arbitrary string placement.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
