### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/mgzwarrior/mgz-pkmn/security/code-scanning/6](https://github.com/mgzwarrior/mgz-pkmn/security/code-scanning/6)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root (top-level, alongside `name` and `on`) so it applies to all jobs unless overridden.  
Best minimal fix here is:

- `contents: read`

This preserves existing behavior (checkout and CI tasks continue to work) while constraining token scope and satisfying CodeQL. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
