### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,8 @@ concurrency:
   group: deploy
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mgzwarrior/mgz-pkmn/security/code-scanning/2](https://github.com/mgzwarrior/mgz-pkmn/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so the token is minimally scoped regardless of repo/org defaults.  
Best fix here: define workflow-level permissions as empty (`{}`), since this job does not need any GitHub API/resource access via `GITHUB_TOKEN`. This is the least-privileged, behavior-preserving change.

**Where to change**
- File: `.github/workflows/deploy.yml`
- Region: after the `concurrency` block and before `jobs:`
- Add:
  - `permissions: {}`

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
