### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   api:
     name: api (py${{ matrix.python-version }})


### PR DESCRIPTION
Potential fix for [https://github.com/mgzwarrior/mgz-pkmn/security/code-scanning/1](https://github.com/mgzwarrior/mgz-pkmn/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege token access unless overridden.  
Best minimal fix for current functionality is:

- `contents: read`

This supports `actions/checkout` and typical read-only CI operations while preventing unnecessary write scopes.  
Change location: near the top of the workflow, after `on:` (or before `jobs:`), so it applies globally to both `api` and `web` jobs without duplicating config.

No imports, methods, or dependencies are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
