### PR TITLE
Fix duplicate permissions key in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,5 @@
 name: CI
 
-permissions:
-  contents: read
-
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary
- Two CodeQL autofix passes each added a top-level `permissions: { contents: read }` block to `.github/workflows/ci.yml`, producing a duplicate YAML key.
- GitHub Actions rejected the workflow with a "workflow file issue" so CI hasn't been running on `main` or PRs (e.g. [run 25838777325](https://github.com/mgzwarrior/mgz-pkmn/actions/runs/25838777325)).
- Collapsed the two identical blocks into one (kept the one between `on:` and `jobs:`).

Resolves #96

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` parses successfully
- [x] CI run on this PR completes (api + web jobs) instead of failing as "workflow file issue"

🤖 Generated with [Claude Code](https://claude.com/claude-code)