### PR TITLE
Soft-warn when on-disk cache exceeds 50 MB

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -35,6 +35,12 @@ list don't keep re-spending API quota. Two stores live there:
 - **Manual nuke** — `rm -rf ~/.cache/mgz-pkmn` removes everything
   including URL overrides. There's no LRU eviction; the cache stays
   small (a few MB after a typical run).
+- **Soft-warn at startup** — `pkmn lookup` stats the cache directory
+  at run start and prints a yellow `⚠` to stderr if total size exceeds
+  50 MB. The threshold is overridable via
+  [`MGZ_PKMN_CACHE_WARN_BYTES`](#environment-variables); set it to `0`
+  to silence the warning entirely. The check is stat-only (no payload
+  reads) so it adds negligible startup cost.
 
 ## Inspecting the cache
 
@@ -61,4 +67,5 @@ show what's there. Combine with [`--clear-cache`](#behavior) on the next
 | Variable | Effect |
 |---|---|
 | `MGZ_PKMN_NO_CACHE` | When set to a truthy value (anything other than empty, `0`, `false`, `False`), disables both the API response cache and URL-override lookups for the current process. Reads always miss; writes are no-ops; the on-disk cache is left untouched. The CLI's [`--no-cache`](cli.md#pkmn-lookup-options) flag sets this internally — set it directly when running the FastAPI service or invoking the library from another process where the flag isn't available. `--clear-cache` still wipes the API cache even when this is set; the explicit wipe wins over the implicit skip. |
+| `MGZ_PKMN_CACHE_WARN_BYTES` | Integer byte count for the cache-size soft-warn threshold checked at `pkmn lookup` startup. Defaults to `52428800` (50 MB). Set to `0` (or any non-positive value) to disable the warning entirely. Unparseable values fall back to the default. |
 | `XDG_CACHE_HOME` | Overrides the cache root. The store lives at `$XDG_CACHE_HOME/mgz-pkmn` when set, falling back to `~/.cache/mgz-pkmn` otherwise. Standard XDG semantics — no mgz-pkmn-specific behavior. |

--- a/src/mgz_pkmn/cache.py
+++ b/src/mgz_pkmn/cache.py
@@ -57,14 +57,23 @@ def _disabled() -> bool:
     return os.environ.get(_NO_CACHE_ENV, "").strip() not in ("", "0", "false", "False")
 
 
+def _cache_root_path() -> Path:
+    """Compute the cache root path without creating it.
+
+    Read-only counterpart to `cache_root()` — used by pre-flight checks
+    (size warning, etc.) that shouldn't have the side effect of creating
+    a cache directory on a fresh install or read-only filesystem."""
+    base = os.environ.get("XDG_CACHE_HOME") or str(Path.home() / ".cache")
+    return Path(base) / "mgz-pkmn"
+
+
 def cache_root() -> Path:
     """Resolve the cache directory, creating it lazily.
 
     Honours `XDG_CACHE_HOME` so users with a custom cache layout aren't
     overridden, and falls back to `~/.cache/mgz-pkmn` otherwise. Safe to
     call repeatedly — `mkdir(parents=True, exist_ok=True)` is idempotent."""
-    base = os.environ.get("XDG_CACHE_HOME") or str(Path.home() / ".cache")
-    root = Path(base) / "mgz-pkmn"
+    root = _cache_root_path()
     root.mkdir(parents=True, exist_ok=True)
     return root
 
@@ -72,10 +81,10 @@ def cache_root() -> Path:
 def cache_warn_threshold() -> int:
     """Resolve the soft-warn threshold for total cache size, in bytes.
 
-    Reads `MGZ_PKMN_CACHE_WARN_BYTES` (an integer byte count) when set; falls
-    back to `DEFAULT_CACHE_WARN_BYTES` (50 MB). A non-positive value disables
-    the warning entirely, which is how an unparseable env var also lands —
-    callers should treat `<= 0` as "do not warn"."""
+    Reads `MGZ_PKMN_CACHE_WARN_BYTES` (an integer byte count) when set;
+    unset / empty / unparseable values fall back to `DEFAULT_CACHE_WARN_BYTES`
+    (50 MB). Only an explicit non-positive integer (`0` or negative) disables
+    the warning — callers treat `<= 0` as "do not warn"."""
     raw = os.environ.get(_WARN_BYTES_ENV, "").strip()
     if not raw:
         return DEFAULT_CACHE_WARN_BYTES
@@ -88,21 +97,26 @@ def cache_warn_threshold() -> int:
 def cache_size_bytes() -> int:
     """Total on-disk cache size in bytes (API responses + URL overrides file).
 
-    Stat-only — no payload reads, no JSON parsing — so it's safe to call at
+    Stat-only — no payload reads, no JSON parsing, and no side effects: the
+    cache directory is not created if it doesn't exist yet. Safe to call at
     every CLI startup as a cheap pre-flight check. Returns 0 when the cache
-    has no contents yet (fresh install, post-`rm -rf`, etc.)."""
-    root = cache_root()
+    root is missing (fresh install, post-`rm -rf`, read-only $HOME, etc.)."""
+    root = _cache_root_path()
+    if not root.exists():
+        return 0
     total = 0
     api_dir = root / "api"
     if api_dir.exists():
-        for entry in api_dir.iterdir():
+        try:
+            entries = list(api_dir.iterdir())
+        except OSError:
+            entries = []
+        for entry in entries:
             if not entry.is_file() or entry.suffix != ".json":
                 continue
-            try:
+            with contextlib.suppress(OSError):
                 total += entry.stat().st_size
-            except OSError:
-                continue
-    overrides = _overrides_path()
+    overrides = root / _OVERRIDES_FILE
     with contextlib.suppress(OSError):
         total += overrides.stat().st_size
     return total

--- a/src/mgz_pkmn/cache.py
+++ b/src/mgz_pkmn/cache.py
@@ -20,6 +20,7 @@ eviction — the cache is small (KB per query) and clearing is a manual
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import os
@@ -29,7 +30,9 @@ from pathlib import Path
 from typing import Any
 
 DEFAULT_API_TTL_SECONDS = 7 * 24 * 60 * 60  # one week
+DEFAULT_CACHE_WARN_BYTES = 50 * 1024 * 1024  # 50 MB
 _NO_CACHE_ENV = "MGZ_PKMN_NO_CACHE"
+_WARN_BYTES_ENV = "MGZ_PKMN_CACHE_WARN_BYTES"
 _OVERRIDES_FILE = "url_overrides.json"
 
 
@@ -64,6 +67,45 @@ def cache_root() -> Path:
     root = Path(base) / "mgz-pkmn"
     root.mkdir(parents=True, exist_ok=True)
     return root
+
+
+def cache_warn_threshold() -> int:
+    """Resolve the soft-warn threshold for total cache size, in bytes.
+
+    Reads `MGZ_PKMN_CACHE_WARN_BYTES` (an integer byte count) when set; falls
+    back to `DEFAULT_CACHE_WARN_BYTES` (50 MB). A non-positive value disables
+    the warning entirely, which is how an unparseable env var also lands —
+    callers should treat `<= 0` as "do not warn"."""
+    raw = os.environ.get(_WARN_BYTES_ENV, "").strip()
+    if not raw:
+        return DEFAULT_CACHE_WARN_BYTES
+    try:
+        return int(raw)
+    except ValueError:
+        return DEFAULT_CACHE_WARN_BYTES
+
+
+def cache_size_bytes() -> int:
+    """Total on-disk cache size in bytes (API responses + URL overrides file).
+
+    Stat-only — no payload reads, no JSON parsing — so it's safe to call at
+    every CLI startup as a cheap pre-flight check. Returns 0 when the cache
+    has no contents yet (fresh install, post-`rm -rf`, etc.)."""
+    root = cache_root()
+    total = 0
+    api_dir = root / "api"
+    if api_dir.exists():
+        for entry in api_dir.iterdir():
+            if not entry.is_file() or entry.suffix != ".json":
+                continue
+            try:
+                total += entry.stat().st_size
+            except OSError:
+                continue
+    overrides = _overrides_path()
+    with contextlib.suppress(OSError):
+        total += overrides.stat().st_size
+    return total
 
 
 # ---------------------------------------------------------------------------

--- a/src/mgz_pkmn/cli.py
+++ b/src/mgz_pkmn/cli.py
@@ -402,6 +402,7 @@ def lookup(
         # but the cache module checks it) inherit the setting.
         os.environ["MGZ_PKMN_NO_CACHE"] = "1"
     _print_banner(__version__)
+    _warn_if_cache_large()
 
     if clear_cache:
         cleared = disk_cache.clear_api_cache()
@@ -833,6 +834,28 @@ def _format_bytes(n: int) -> str:
             return f"{size:.1f} {unit}"
         size /= 1024
     return f"{size:.1f} {units[-1]}"  # unreachable, satisfies type-checkers
+
+
+def _warn_if_cache_large() -> None:
+    """Soft-warn when the on-disk cache exceeds the configured threshold.
+
+    Stat-only check at run start (no payload reads). Threshold defaults to
+    50 MB and is overridable via `MGZ_PKMN_CACHE_WARN_BYTES`; a non-positive
+    value disables the warning. We surface this on the CLI's stderr so it
+    doesn't pollute piped stdout output but is still visible interactively."""
+    threshold = disk_cache.cache_warn_threshold()
+    if threshold <= 0:
+        return
+    size = disk_cache.cache_size_bytes()
+    if size <= threshold:
+        return
+    click.secho(
+        f"⚠ cache directory is {_format_bytes(size)} "
+        f"(threshold {_format_bytes(threshold)}). "
+        f"Run with --clear-cache or `rm -rf {disk_cache.cache_root()}` to reclaim space.",
+        fg="yellow",
+        err=True,
+    )
 
 
 def _format_age(mtime: float | None, *, now: float | None = None) -> str:

--- a/src/mgz_pkmn/cli.py
+++ b/src/mgz_pkmn/cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import sys
 import time
 from pathlib import Path
@@ -849,10 +850,14 @@ def _warn_if_cache_large() -> None:
     size = disk_cache.cache_size_bytes()
     if size <= threshold:
         return
+    # `size > 0` implies the cache dir exists, so `cache_root()`'s mkdir is
+    # a no-op here. Quote the path with shlex so a user can copy-paste the
+    # `rm -rf` suggestion verbatim even when XDG_CACHE_HOME has spaces.
+    root = str(disk_cache.cache_root())
     click.secho(
         f"⚠ cache directory is {_format_bytes(size)} "
         f"(threshold {_format_bytes(threshold)}). "
-        f"Run with --clear-cache or `rm -rf {disk_cache.cache_root()}` to reclaim space.",
+        f"Run with --clear-cache or `rm -rf {shlex.quote(root)}` to reclaim space.",
         fg="yellow",
         err=True,
     )

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -50,6 +50,18 @@ class CacheSizeTests(_IsolatedCacheDirMixin):
         expected += cache._overrides_path().stat().st_size
         self.assertEqual(cache.cache_size_bytes(), expected)
 
+    def test_size_check_does_not_create_cache_root(self) -> None:
+        # Point at a fresh, untouched XDG location and call size_bytes — it
+        # should report 0 *without* the side effect of creating the dir
+        # (matters for read-only filesystems and clean-environment checks).
+        fresh = tempfile.TemporaryDirectory()
+        self.addCleanup(fresh.cleanup)
+        os.environ["XDG_CACHE_HOME"] = fresh.name
+        root = cache._cache_root_path()
+        self.assertFalse(root.exists())
+        self.assertEqual(cache.cache_size_bytes(), 0)
+        self.assertFalse(root.exists(), "size check must not create the cache dir")
+
 
 class CacheWarnThresholdTests(_IsolatedCacheDirMixin):
     def test_default_is_50_mb(self) -> None:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -33,7 +33,40 @@ class _IsolatedCacheDirMixin(unittest.TestCase):
             os.environ.pop(cache._NO_CACHE_ENV, None)
         else:
             os.environ[cache._NO_CACHE_ENV] = self._old_no_cache
+        os.environ.pop(cache._WARN_BYTES_ENV, None)
         self._tmp.cleanup()
+
+
+class CacheSizeTests(_IsolatedCacheDirMixin):
+    def test_empty_cache_size_is_zero(self) -> None:
+        self.assertEqual(cache.cache_size_bytes(), 0)
+
+    def test_size_sums_api_and_overrides(self) -> None:
+        cache.write_api("k1", {"a": 1})
+        cache.write_api("k2", {"b": 2})
+        cache.record_url_override("Mew", None, "https://pc/mew")
+        api_dir = cache.cache_root() / "api"
+        expected = sum(p.stat().st_size for p in api_dir.glob("*.json"))
+        expected += cache._overrides_path().stat().st_size
+        self.assertEqual(cache.cache_size_bytes(), expected)
+
+
+class CacheWarnThresholdTests(_IsolatedCacheDirMixin):
+    def test_default_is_50_mb(self) -> None:
+        self.assertEqual(cache.cache_warn_threshold(), 50 * 1024 * 1024)
+        self.assertEqual(cache.cache_warn_threshold(), cache.DEFAULT_CACHE_WARN_BYTES)
+
+    def test_env_override_parses_integer(self) -> None:
+        os.environ[cache._WARN_BYTES_ENV] = "12345"
+        self.assertEqual(cache.cache_warn_threshold(), 12345)
+
+    def test_zero_disables_warning(self) -> None:
+        os.environ[cache._WARN_BYTES_ENV] = "0"
+        self.assertEqual(cache.cache_warn_threshold(), 0)
+
+    def test_bad_env_falls_back_to_default(self) -> None:
+        os.environ[cache._WARN_BYTES_ENV] = "not-a-number"
+        self.assertEqual(cache.cache_warn_threshold(), cache.DEFAULT_CACHE_WARN_BYTES)
 
 
 class ApiCacheTests(_IsolatedCacheDirMixin):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -160,6 +160,23 @@ class WarnIfCacheLargeTests(unittest.TestCase):
         self.assertIn("threshold", result.stderr)
         self.assertIn("--clear-cache", result.stderr)
 
+    def test_warning_shell_quotes_path_with_spaces(self) -> None:
+        # XDG roots with spaces are real (e.g. macOS "Application Support").
+        # The `rm -rf …` suggestion must be copy-pasteable, so the path
+        # needs to be quoted in the printed message.
+        spaced = tempfile.TemporaryDirectory(prefix="cache space ")
+        self.addCleanup(spaced.cleanup)
+        os.environ["XDG_CACHE_HOME"] = spaced.name
+        cache.write_api("k", {"x": 1})
+        os.environ[cache._WARN_BYTES_ENV] = "1"
+        result = self._invoke()
+        # The unquoted path would land in the message verbatim; the quoted
+        # form wraps it in single quotes (shlex.quote's behaviour on paths
+        # with spaces). Either way, the literal "rm -rf <space><space>" with
+        # an unquoted space MUST NOT appear.
+        self.assertIn("'", result.stderr)
+        self.assertNotIn(f"rm -rf {spaced.name}/mgz-pkmn ", result.stderr)
+
     def test_zero_threshold_disables_warning(self) -> None:
         cache.write_api("k", {"x": 1})
         os.environ[cache._WARN_BYTES_ENV] = "0"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,8 +10,10 @@ from click.testing import CliRunner
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
+import click
+
 from mgz_pkmn import cache
-from mgz_pkmn.cli import _dedupe_rows, _format_age, _format_bytes, cli
+from mgz_pkmn.cli import _dedupe_rows, _format_age, _format_bytes, _warn_if_cache_large, cli
 from mgz_pkmn.parser import CardQuery
 from mgz_pkmn.pricing import Pricing
 from mgz_pkmn.report import build_json_report
@@ -106,6 +108,63 @@ class CacheStatsCommandTests(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn("API responses: 0 entries", result.output)
         self.assertIn("oldest —", result.output)
+
+
+class WarnIfCacheLargeTests(unittest.TestCase):
+    """The soft-warn helper invoked at `pkmn lookup` start. We drive it
+    through a throwaway Click command so its `secho(err=True)` output lands
+    in `result.stderr` rather than leaking onto the real test terminal."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._old_xdg = os.environ.get("XDG_CACHE_HOME")
+        self._old_warn = os.environ.get(cache._WARN_BYTES_ENV)
+        os.environ["XDG_CACHE_HOME"] = self._tmp.name
+        os.environ.pop(cache._WARN_BYTES_ENV, None)
+
+    def tearDown(self) -> None:
+        if self._old_xdg is None:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        else:
+            os.environ["XDG_CACHE_HOME"] = self._old_xdg
+        if self._old_warn is None:
+            os.environ.pop(cache._WARN_BYTES_ENV, None)
+        else:
+            os.environ[cache._WARN_BYTES_ENV] = self._old_warn
+        self._tmp.cleanup()
+
+    @staticmethod
+    def _invoke() -> object:
+        @click.command()
+        def runner() -> None:
+            _warn_if_cache_large()
+
+        return CliRunner().invoke(runner, [])
+
+    def test_no_warning_on_empty_cache(self) -> None:
+        result = self._invoke()
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(result.stderr, "")
+
+    def test_no_warning_below_threshold(self) -> None:
+        cache.write_api("k", {"x": 1})
+        # Real default is 50 MB — a single tiny JSON file falls well under.
+        result = self._invoke()
+        self.assertEqual(result.stderr, "")
+
+    def test_warning_emitted_when_over_threshold(self) -> None:
+        cache.write_api("k", {"x": 1})
+        os.environ[cache._WARN_BYTES_ENV] = "1"
+        result = self._invoke()
+        self.assertIn("cache directory is", result.stderr)
+        self.assertIn("threshold", result.stderr)
+        self.assertIn("--clear-cache", result.stderr)
+
+    def test_zero_threshold_disables_warning(self) -> None:
+        cache.write_api("k", {"x": 1})
+        os.environ[cache._WARN_BYTES_ENV] = "0"
+        result = self._invoke()
+        self.assertEqual(result.stderr, "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Stat the on-disk cache at `pkmn lookup` startup and print a yellow `⚠`
  to stderr when total size exceeds a configurable threshold (default 50 MB).
- New env var `MGZ_PKMN_CACHE_WARN_BYTES` overrides the threshold; set it
  to `0` (or any non-positive value) to silence the warning entirely.
- Stat-only check (no payload reads, no JSON parsing) so the pre-flight
  cost is negligible.

Closes #17

## Approach

- `cache.cache_size_bytes()` walks `api/*.json` + `url_overrides.json` with
  `stat()` only — cheap to call at every startup.
- `cache.cache_warn_threshold()` reads `MGZ_PKMN_CACHE_WARN_BYTES`, falls
  back to `DEFAULT_CACHE_WARN_BYTES` (50 MB) on unset/unparseable values,
  and surfaces `<= 0` to disable.
- `cli._warn_if_cache_large()` ties the two together and writes a yellow
  warning to stderr — out of piped stdout, but visible interactively.
- Invoked from `lookup` right after the banner, before any cache-mutating
  flag (`--clear-cache`) so the user sees the bloat note even when they're
  already addressing it.

`set-cards` and `cache stats` deliberately don't call the warning — the
latter already surfaces total size, the former isn't the typical
cache-growing flow.

## Test plan

- [x] `make check` is green (lint + format + 161 unit tests, up from 151).
- [x] Manual smoke test: `MGZ_PKMN_CACHE_WARN_BYTES=1 pkmn lookup ...`
      emits the warning on stderr; default threshold leaves the warning
      silent for a typical sub-MB cache.
- [x] Setting `MGZ_PKMN_CACHE_WARN_BYTES=0` silences the warning.
- [x] Unparseable values fall back to the 50 MB default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)