### PR TITLE
Show cache hit rate in the CLI summary

### DIFF
--- a/src/mgz_pkmn/cache.py
+++ b/src/mgz_pkmn/cache.py
@@ -35,6 +35,12 @@ _NO_CACHE_ENV = "MGZ_PKMN_NO_CACHE"
 _WARN_BYTES_ENV = "MGZ_PKMN_CACHE_WARN_BYTES"
 _OVERRIDES_FILE = "url_overrides.json"
 
+# Per-run counters for the API response cache: hits = served from disk,
+# fetches = written after a successful network call. Reset at the start of
+# each `pkmn lookup` invocation so the summary line reflects only that run.
+_api_hits = 0
+_api_fetches = 0
+
 
 @dataclass(frozen=True)
 class CacheStats:
@@ -139,7 +145,8 @@ def read_api(key: str, ttl_seconds: float = DEFAULT_API_TTL_SECONDS) -> Any | No
 
     `key` is expected to be a fully-qualified request URL — same URL hashes
     to the same path. Returns None on miss, expiry, or any I/O / JSON error
-    (caller falls through to a network fetch)."""
+    (caller falls through to a network fetch). A successful return bumps the
+    per-run hit counter (see `api_counters()`)."""
     if _disabled():
         return None
     p = _api_path(key)
@@ -148,9 +155,12 @@ def read_api(key: str, ttl_seconds: float = DEFAULT_API_TTL_SECONDS) -> Any | No
     if time.time() - p.stat().st_mtime > ttl_seconds:
         return None
     try:
-        return json.loads(p.read_text(encoding="utf-8"))
+        payload = json.loads(p.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
+    global _api_hits
+    _api_hits += 1
+    return payload
 
 
 def clear_api_cache() -> int:
@@ -183,7 +193,9 @@ def write_api(key: str, data: Any) -> None:
 
     Atomic write: payload goes to a sibling `.tmp` file and then renames.
     A failed serialisation or rename is silently ignored — caching is best
-    effort, never a hard requirement."""
+    effort, never a hard requirement. A successful write bumps the per-run
+    fetch counter (see `api_counters()`); callers only invoke this after a
+    successful network fetch, so it doubles as the fetch tally."""
     if _disabled():
         return
     try:
@@ -193,6 +205,27 @@ def write_api(key: str, data: Any) -> None:
         tmp.replace(p)
     except (OSError, TypeError, ValueError):
         return
+    global _api_fetches
+    _api_fetches += 1
+
+
+def reset_api_counters() -> None:
+    """Zero the per-run hit/fetch counters. Called at `pkmn lookup` start so
+    the summary reflects only the current run, not any prior in-process state
+    (matters for the test suite, where many runs share an interpreter)."""
+    global _api_hits, _api_fetches
+    _api_hits = 0
+    _api_fetches = 0
+
+
+def api_counters() -> tuple[int, int]:
+    """Return `(hits, fetches)` accumulated since the last `reset_api_counters`.
+
+    `hits` is the number of `read_api` calls that served a cached payload;
+    `fetches` is the number of `write_api` calls that successfully persisted
+    a freshly-fetched payload. The CLI summary reads this snapshot to render
+    the `· N cached / M fetched` tail."""
+    return (_api_hits, _api_fetches)
 
 
 # ---------------------------------------------------------------------------

--- a/src/mgz_pkmn/cli.py
+++ b/src/mgz_pkmn/cli.py
@@ -404,6 +404,7 @@ def lookup(
         os.environ["MGZ_PKMN_NO_CACHE"] = "1"
     _print_banner(__version__)
     _warn_if_cache_large()
+    disk_cache.reset_api_counters()
 
     if clear_cache:
         cleared = disk_cache.clear_api_cache()
@@ -625,6 +626,14 @@ def lookup(
     )
     if non_en:
         summary_parts.append(click.style(f"⚑ {non_en} non-English", fg="bright_red"))
+    cache_hits, cache_fetches = disk_cache.api_counters()
+    if cache_hits:
+        # Only surface when caching actually helped this run — zero-hit runs
+        # (first invocation, --no-cache, or an all-miss TTL refresh) would
+        # just clutter the line without adding signal.
+        summary_parts.append(
+            click.style(f"{cache_hits} cached / {cache_fetches} fetched", fg="cyan")
+        )
     summary_parts.append(click.style(f"{overall_elapsed:.1f}s total", fg="bright_black"))
     click.echo("  " + "  ·  ".join(summary_parts))
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -199,6 +199,57 @@ class CacheStatsTests(_IsolatedCacheDirMixin):
         self.assertEqual(s.override_count, 1)
 
 
+class ApiCounterTests(_IsolatedCacheDirMixin):
+    def setUp(self) -> None:
+        super().setUp()
+        cache.reset_api_counters()
+
+    def test_reset_zeroes_counters(self) -> None:
+        cache.write_api("k", {"x": 1})
+        cache.read_api("k")
+        self.assertNotEqual(cache.api_counters(), (0, 0))
+        cache.reset_api_counters()
+        self.assertEqual(cache.api_counters(), (0, 0))
+
+    def test_write_increments_fetches(self) -> None:
+        cache.write_api("k1", {"a": 1})
+        cache.write_api("k2", {"b": 2})
+        hits, fetches = cache.api_counters()
+        self.assertEqual(hits, 0)
+        self.assertEqual(fetches, 2)
+
+    def test_read_hit_increments_hits(self) -> None:
+        cache.write_api("k", {"x": 1})
+        cache.reset_api_counters()
+        self.assertEqual(cache.read_api("k"), {"x": 1})
+        self.assertEqual(cache.read_api("k"), {"x": 1})
+        hits, fetches = cache.api_counters()
+        self.assertEqual(hits, 2)
+        self.assertEqual(fetches, 0)
+
+    def test_read_miss_does_not_increment_hits(self) -> None:
+        self.assertIsNone(cache.read_api("never-written"))
+        self.assertEqual(cache.api_counters(), (0, 0))
+
+    def test_ttl_expiry_is_not_a_hit(self) -> None:
+        key = "expired"
+        cache.write_api(key, {"x": 1})
+        cache.reset_api_counters()
+        path = cache._api_path(key)
+        old = time.time() - (cache.DEFAULT_API_TTL_SECONDS + 100)
+        os.utime(path, (old, old))
+        self.assertIsNone(cache.read_api(key))
+        self.assertEqual(cache.api_counters(), (0, 0))
+
+    def test_no_cache_env_suppresses_both_counters(self) -> None:
+        cache.write_api("k", {"x": 1})
+        cache.reset_api_counters()
+        os.environ[cache._NO_CACHE_ENV] = "1"
+        self.assertIsNone(cache.read_api("k"))
+        cache.write_api("k2", {"y": 2})
+        self.assertEqual(cache.api_counters(), (0, 0))
+
+
 class UrlOverrideTests(_IsolatedCacheDirMixin):
     def test_record_and_find_round_trip(self) -> None:
         cache.record_url_override(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from click.testing import CliRunner
 
@@ -17,6 +18,7 @@ from mgz_pkmn.cli import _dedupe_rows, _format_age, _format_bytes, _warn_if_cach
 from mgz_pkmn.parser import CardQuery
 from mgz_pkmn.pricing import Pricing
 from mgz_pkmn.report import build_json_report
+from mgz_pkmn.sources.base import MatchResult
 from mgz_pkmn.spreadsheet import Row
 
 
@@ -182,6 +184,97 @@ class WarnIfCacheLargeTests(unittest.TestCase):
         os.environ[cache._WARN_BYTES_ENV] = "0"
         result = self._invoke()
         self.assertEqual(result.stderr, "")
+
+
+class LookupSummaryCacheTests(unittest.TestCase):
+    """End-to-end check that `· N cached / M fetched` appears in the summary
+    when the run produced cache hits — and is suppressed when it didn't.
+
+    We stub `find_card` so the test stays hermetic, but drive real disk-cache
+    reads/writes from inside the stub so the counters increment for the same
+    reason they would in production."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._old_xdg = os.environ.get("XDG_CACHE_HOME")
+        self._old_warn = os.environ.get(cache._WARN_BYTES_ENV)
+        os.environ["XDG_CACHE_HOME"] = self._tmp.name
+        # Silence the size-warn helper so it doesn't pollute the captured
+        # output we're asserting against.
+        os.environ[cache._WARN_BYTES_ENV] = "0"
+        cache.reset_api_counters()
+
+    def tearDown(self) -> None:
+        if self._old_xdg is None:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        else:
+            os.environ["XDG_CACHE_HOME"] = self._old_xdg
+        if self._old_warn is None:
+            os.environ.pop(cache._WARN_BYTES_ENV, None)
+        else:
+            os.environ[cache._WARN_BYTES_ENV] = self._old_warn
+
+    def _write_inputs(self, names: list[str]) -> Path:
+        path = Path(self._tmp.name) / "in.txt"
+        path.write_text("\n".join(names) + "\n", encoding="utf-8")
+        return path
+
+    def _make_stub(self) -> object:
+        """Return a `find_card` replacement that simulates cache traffic.
+
+        Each call reads a per-query URL from disk; if absent, performs a
+        write (the production `_fetch_page` does the same). Pre-seeding
+        keys before invoking the CLI lets the test force a specific
+        hit/fetch mix."""
+
+        def stub(pkmn, tcgdex, pc, q, default_lang=None):
+            url = f"https://example.test/q={q.name}"
+            if cache.read_api(url) is None:
+                cache.write_api(url, {"id": q.name, "name": q.name})
+            card = {
+                "id": q.name,
+                "name": q.name,
+                "number": "1",
+                "set": {"name": "Test Set"},
+                "rarity": "Common",
+                "_database": "stub",
+            }
+            return MatchResult(card, "matched")
+
+        return stub
+
+    def test_summary_includes_cached_and_fetched_counts(self) -> None:
+        # Pre-seed one URL so the first query is a hit; the second query
+        # writes a fresh entry (a "fetch"). Expected: 1 cached / 1 fetched.
+        cache.write_api("https://example.test/q=Mew", {"id": "Mew", "name": "Mew"})
+        input_path = self._write_inputs(["Mew", "Pikachu"])
+        out = Path(self._tmp.name) / "out.xlsx"
+
+        with patch("mgz_pkmn.cli.find_card", side_effect=self._make_stub()):
+            result = CliRunner().invoke(
+                cli,
+                ["lookup", str(input_path), "-o", str(out), "--no-images"],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("1 cached / 1 fetched", result.output)
+
+    def test_summary_omits_cache_counts_when_no_hits(self) -> None:
+        # Fresh cache → every query is a fetch, no hits. The summary tail
+        # should be suppressed entirely on a zero-hit run.
+        input_path = self._write_inputs(["Pikachu"])
+        out = Path(self._tmp.name) / "out.xlsx"
+
+        with patch("mgz_pkmn.cli.find_card", side_effect=self._make_stub()):
+            result = CliRunner().invoke(
+                cli,
+                ["lookup", str(input_path), "-o", str(out), "--no-images"],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertNotIn("cached", result.output)
+        self.assertNotIn("fetched", result.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Track per-run API cache hits and fetches and surface them on the
`pkmn lookup` Summary line as `· N cached / M fetched` whenever the
run produced at least one cache hit.

Closes #16

## Approach

- Added module-level counters (`_api_hits`, `_api_fetches`) in
  `src/mgz_pkmn/cache.py`, plus `reset_api_counters()` and an
  `api_counters() -> (hits, fetches)` getter.
- `read_api` increments hits whenever it returns a cached payload;
  `write_api` increments fetches on every successful persist. Callers
  only call `write_api` after a successful network fetch, so the
  fetch tally lines up with real upstream traffic.
- `pkmn lookup` calls `reset_api_counters()` at run start and appends
  the cyan `N cached / M fetched` segment to the Summary line when
  `hits > 0`. Zero-hit runs (first invocation, `--no-cache`, all-miss
  TTL refresh) keep the existing summary unchanged so we don't add
  visual noise without signal.

## Test plan

- [x] `make check` (ruff + format + 171 tests passing, was 163)
- [x] New unit tests in `tests/test_cache.py` cover the counters:
  reset zeroes them, writes bump fetches, hits bump on real reads,
  misses / TTL expiry / `MGZ_PKMN_NO_CACHE=1` do not.
- [x] New end-to-end tests in `tests/test_cli.py` drive the lookup
  command with a stubbed `find_card` that performs real disk-cache
  traffic, asserting `1 cached / 1 fetched` appears in the summary
  for a pre-seeded mix and that the tail is suppressed on a fresh
  cache.
- [x] `cd web && npm run build` and `npm run lint` both green.