### PR TITLE
Add long-name truncation tests for the checklist PDF

### DIFF
--- a/tests/test_checklist.py
+++ b/tests/test_checklist.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import sys
 import tempfile
 import unittest
@@ -7,10 +8,24 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
-from mgz_pkmn.checklist import _build_sections, _format_mp, write_checklist_pdf
+from reportlab.pdfgen import canvas
+
+from mgz_pkmn.checklist import (
+    _build_sections,
+    _format_mp,
+    _truncate_to_width,
+    write_checklist_pdf,
+)
 from mgz_pkmn.parser import CardQuery
 from mgz_pkmn.pricing import Pricing
 from mgz_pkmn.spreadsheet import Row
+
+# Names long enough to exercise the condensed checklist's truncation boundary.
+LONG_NAMES = [
+    "Special Illustration Rare V-UNION",
+    "Iron Valiant ex (Special Illustration Rare)",
+    "Charizard ex — Obsidian Flames Ultra Premium Collection",
+]
 
 
 def _make_row(
@@ -95,6 +110,57 @@ class WritePdfTests(unittest.TestCase):
             written = write_checklist_pdf(rows, out)
             self.assertEqual(written, 0)
             self.assertFalse(out.exists())
+
+    def test_long_names_across_pages_keep_all_rows(self) -> None:
+        # Long names must not drop rows — every matched row survives into the
+        # section, even when the section spills onto multiple pages.
+        rows = [
+            _make_row(
+                tag="long-names",
+                card=_card(
+                    cid=f"sv8-{i}",
+                    number=str(i),
+                    name=LONG_NAMES[i % len(LONG_NAMES)],
+                ),
+                market=1234.56,
+            )
+            for i in range(200)
+        ]
+        sections = _build_sections(rows)
+        self.assertEqual(len(sections[0]["rows"]), 200)
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "checklist.pdf"
+            written = write_checklist_pdf(rows, out)
+            self.assertEqual(written, 1)
+            self.assertTrue(out.exists())
+            self.assertGreater(out.stat().st_size, 0)
+
+
+class TruncateToWidthTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.c = canvas.Canvas(io.BytesIO())
+
+    def test_long_name_truncated_within_max_width(self) -> None:
+        # No horizontal overflow: the truncated string fits the column budget.
+        max_w = 80.0
+        for name in LONG_NAMES:
+            result = _truncate_to_width(self.c, name, "Helvetica", 8, max_w)
+            self.assertLessEqual(self.c.stringWidth(result, "Helvetica", 8), max_w)
+            self.assertTrue(result.endswith("…"))
+
+    def test_short_name_returned_unchanged(self) -> None:
+        result = _truncate_to_width(self.c, "Pikachu", "Helvetica", 8, 200.0)
+        self.assertEqual(result, "Pikachu")
+
+    def test_nonpositive_max_width_returns_empty(self) -> None:
+        self.assertEqual(_truncate_to_width(self.c, "Charizard", "Helvetica", 8, 0.0), "")
+        self.assertEqual(_truncate_to_width(self.c, "Charizard", "Helvetica", 8, -5.0), "")
+
+    def test_tiny_max_width_stops_at_floor(self) -> None:
+        # The loop guard keeps len(text) > 3, so even a sliver column yields a
+        # short stub rather than looping forever or returning nothing.
+        result = _truncate_to_width(self.c, LONG_NAMES[0], "Helvetica", 8, 1.0)
+        self.assertGreaterEqual(len(result), 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds test coverage for the condensed checklist PDF's long-name handling — previously there was no fixture exercising the truncation boundary.

- New `TruncateToWidthTests` covering `_truncate_to_width`: long names fit within the column budget (no horizontal overflow), short names pass through unchanged, non-positive widths return `""`, and a sliver-width column stops at the length floor instead of looping forever.
- New `WritePdfTests.test_long_names_across_pages_keep_all_rows`: 200 rows with long names (`Special Illustration Rare V-UNION` and similar) — asserts every matched row survives into the section and the multi-page PDF still writes.
- Adds a shared `LONG_NAMES` fixture.

## Approach / notes

- Tests target the actual implementation (`COLUMNS = 3`). The roadmap text describes a "6-column" checklist, but the current code is 3-column; the truncation logic under test is column-count-agnostic.
- `_truncate_to_width` is private but imported the same way the existing tests already import `_build_sections` / `_format_mp`.
- "No missing rows" is asserted via `_build_sections` row-count preservation plus a successful multi-page write, since the rendered PDF binary can't be cheaply row-counted.

## Verify

- `make check` — ruff lint + format check + full test suite (183 tests, 5 new) all green.

Closes #13