### PR TITLE
Embed card images in API exports, matching CLI behavior

### DIFF
--- a/api/routes/export.py
+++ b/api/routes/export.py
@@ -4,16 +4,20 @@ binder PDF, or set-completion checklist PDF."""
 from __future__ import annotations
 
 import io
+import re
 import tempfile
 from pathlib import Path
 from typing import Any
 
+import requests
 from fastapi import APIRouter, HTTPException
+from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from mgz_pkmn.binder import CONDENSED_LAYOUT, STANDARD_LAYOUT, write_binder_pdf
 from mgz_pkmn.checklist import write_checklist_pdf
+from mgz_pkmn.images import download_image
 from mgz_pkmn.parser import CardQuery
 from mgz_pkmn.pricing import Pricing
 from mgz_pkmn.sorting import DEFAULT_SORT, SORT_MODES, sort_rows
@@ -61,6 +65,7 @@ class ExportRequest(BaseModel):
     sort: str = DEFAULT_SORT
     max_price: float | None = None
     title: str = "cards"
+    no_images: bool = True  # mirrors the lookup Settings default
 
 
 # Valid formats and the (filename, media-type) each maps to.
@@ -74,6 +79,9 @@ _FORMAT_MAP: dict[str, tuple[str, str]] = {
     "checklist": ("checklist.pdf", "application/pdf"),
 }
 
+# Formats whose writers embed card art. The checklist is text-only.
+_IMAGE_FORMATS = frozenset({"xlsx", "pdf", "condensed-pdf"})
+
 
 # ---------------------------------------------------------------------------
 # Route
@@ -86,9 +94,9 @@ async def export_file(req: ExportRequest) -> StreamingResponse:
 
     `format` is one of `xlsx`, `pdf`, `condensed-pdf`, `checklist`.
     `sort` controls row ordering (see `mgz_pkmn.sorting.SORT_MODES`).
-    Images are not embedded during API export — the export is intentionally
-    fast and dependency-free on the server side. Use the CLI for
-    image-embedded spreadsheets.
+    When `no_images` is false, each matched card's art is downloaded and
+    embedded into the xlsx / binder PDFs, mirroring the CLI. The default
+    (`no_images: true`) skips downloads for a faster, smaller export.
     """
     if req.format not in _FORMAT_MAP:
         raise HTTPException(
@@ -101,13 +109,33 @@ async def export_file(req: ExportRequest) -> StreamingResponse:
             detail=f"sort must be one of {list(SORT_MODES)}",
         )
 
-    rows = [_to_row(r) for r in req.rows]
-    sort_rows(rows, req.sort)
-
     filename, media_type = _FORMAT_MAP[req.format]
+    # Image downloads + document rendering are blocking; keep them off the
+    # event loop.
+    content = await run_in_threadpool(_render, req, filename)
 
+    return StreamingResponse(
+        io.BytesIO(content),
+        media_type=media_type,
+        headers={"Content-Disposition": f"attachment; filename={filename}"},
+    )
+
+
+def _render(req: ExportRequest, filename: str) -> bytes:
+    """Build the requested file and return its bytes. Runs in a worker thread."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        out_path = Path(tmpdir) / filename
+        tmp = Path(tmpdir)
+
+        embed_images = not req.no_images and req.format in _IMAGE_FORMATS
+        if embed_images:
+            images_dir = tmp / "images"
+            with requests.Session() as session:
+                rows = [_to_row(r, images_dir, session) for r in req.rows]
+        else:
+            rows = [_to_row(r, None, None) for r in req.rows]
+        sort_rows(rows, req.sort)
+
+        out_path = tmp / filename
         if req.format == "xlsx":
             write_spreadsheet(rows, out_path, max_price=req.max_price)
         elif req.format == "pdf":
@@ -125,17 +153,20 @@ async def export_file(req: ExportRequest) -> StreamingResponse:
                     status_code=400,
                     detail="checklist has no matched rows to render",
                 )
-        content = out_path.read_bytes()
-
-    return StreamingResponse(
-        io.BytesIO(content),
-        media_type=media_type,
-        headers={"Content-Disposition": f"attachment; filename={filename}"},
-    )
+        return out_path.read_bytes()
 
 
-def _to_row(r: RowIn) -> Row:
-    """Reconstruct an internal Row from the wire payload."""
+def _to_row(
+    r: RowIn,
+    images_dir: Path | None,
+    session: requests.Session | None,
+) -> Row:
+    """Reconstruct an internal Row from the wire payload.
+
+    When `images_dir` and `session` are provided, the matched card's art is
+    downloaded into `images_dir` so the writers can embed it — mirroring the
+    CLI. Otherwise `image_path` is left None.
+    """
     q = CardQuery(
         raw=r.query.raw,
         name=r.query.name,
@@ -155,4 +186,28 @@ def _to_row(r: RowIn) -> Row:
         url=r.pricing.url,
         currency=r.pricing.currency,
     )
-    return Row(query=q, card=r.card, pricing=pricing, image_path=None, tag=r.tag)
+    image_path = _download_card_image(r.card, images_dir, session)
+    return Row(query=q, card=r.card, pricing=pricing, image_path=image_path, tag=r.tag)
+
+
+def _download_card_image(
+    card: dict[str, Any] | None,
+    images_dir: Path | None,
+    session: requests.Session | None,
+) -> Path | None:
+    """Download a matched card's art into `images_dir`, mirroring the CLI.
+
+    Returns the local path, or None when image embedding is off, the card has
+    no art, or the download failed.
+    """
+    if images_dir is None or session is None or not card:
+        return None
+    images = card.get("images") or {}
+    img_url = images.get("large") or images.get("small")
+    if not img_url:
+        return None
+    ext = Path(img_url).suffix or ".png"
+    safe = re.sub(r"[^a-zA-Z0-9_-]+", "_", f"{card.get('id')}")
+    dest = images_dir / f"{safe}{ext}"
+    download_image(img_url, dest, session)
+    return dest if dest.exists() else None

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -8,7 +8,7 @@ checklist live in their own pages — see [PDF binder](binder-pdf.md) and
 
 | Column | Notes |
 |---|---|
-| Image | Embedded 96 × 134 thumbnail (CLI exports only — see note below). |
+| Image | Embedded 96 × 134 thumbnail. |
 | **Source** | The input file's stem — groups rows by which list they came from. |
 | Input | Your original line. |
 | Name / Set / Series / Number / Rarity | From the matched card. |
@@ -26,14 +26,6 @@ a number looks off.
 
 Full-resolution PNGs land in `output/images/` by default (named after
 the matched card id).
-
-**Images and the web app:** only CLI runs embed thumbnails in the
-spreadsheet. The web app's `/api/v1/export` endpoint never embeds
-images — the export is intentionally kept fast and dependency-free on
-the server side, so it skips downloading and thumbnailing card art
-regardless of the "Hide images in results" setting (which only affects
-the on-screen results table). For an image-embedded spreadsheet, use
-the CLI.
 
 ## JSON report (`--report-json`)
 

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -8,7 +8,7 @@ checklist live in their own pages — see [PDF binder](binder-pdf.md) and
 
 | Column | Notes |
 |---|---|
-| Image | Embedded 96 × 134 thumbnail. |
+| Image | Embedded 96 × 134 thumbnail (CLI exports only — see note below). |
 | **Source** | The input file's stem — groups rows by which list they came from. |
 | Input | Your original line. |
 | Name / Set / Series / Number / Rarity | From the matched card. |
@@ -26,6 +26,14 @@ a number looks off.
 
 Full-resolution PNGs land in `output/images/` by default (named after
 the matched card id).
+
+**Images and the web app:** only CLI runs embed thumbnails in the
+spreadsheet. The web app's `/api/v1/export` endpoint never embeds
+images — the export is intentionally kept fast and dependency-free on
+the server side, so it skips downloading and thumbnailing card art
+regardless of the "Hide images in results" setting (which only affects
+the on-screen results table). For an image-embedded spreadsheet, use
+the CLI.
 
 ## JSON report (`--report-json`)
 

--- a/tests/test_export_api.py
+++ b/tests/test_export_api.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import sys
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from fastapi.testclient import TestClient
+from PIL import Image as PILImage
 
 from api.main import app
 
@@ -22,20 +24,31 @@ def _row_payload(
     set_name: str = "Surging Sparks",
     market: float | None = 12.5,
     tag: str = "test",
+    images: dict | None = None,
 ) -> dict:
+    card = {
+        "id": cid,
+        "name": name,
+        "number": number,
+        "set": {"id": "sv8", "name": set_name, "printedTotal": 191, "total": 252},
+        "_database": "pokemontcg.io",
+        "language": "en",
+    }
+    if images is not None:
+        card["images"] = images
     return {
         "query": {"raw": name, "name": name},
-        "card": {
-            "id": cid,
-            "name": name,
-            "number": number,
-            "set": {"id": "sv8", "name": set_name, "printedTotal": 191, "total": 252},
-            "_database": "pokemontcg.io",
-            "language": "en",
-        },
+        "card": card,
         "pricing": {"market": market, "currency": "USD"},
         "tag": tag,
     }
+
+
+def _fake_download(url, dest, session) -> bool:
+    """Stand-in for images.download_image — writes a tiny valid PNG."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    PILImage.new("RGB", (10, 14), "white").save(dest, format="PNG")
+    return True
 
 
 class ExportApiTests(unittest.TestCase):
@@ -104,6 +117,38 @@ class ExportApiTests(unittest.TestCase):
             json={"rows": [_row_payload()], "format": "xlsx", "sort": "bogus"},
         )
         self.assertEqual(resp.status_code, 400)
+
+    def test_xlsx_export_skips_images_by_default(self) -> None:
+        payload = _row_payload(images={"large": "https://img.example/pikachu.png"})
+        with patch("api.routes.export.download_image") as mock_dl:
+            resp = client.post(
+                "/api/v1/export",
+                json={"rows": [payload], "format": "xlsx"},
+            )
+        self.assertEqual(resp.status_code, 200)
+        mock_dl.assert_not_called()
+
+    def test_xlsx_export_embeds_images_when_enabled(self) -> None:
+        payload = _row_payload(images={"large": "https://img.example/pikachu.png"})
+        with patch("api.routes.export.download_image", side_effect=_fake_download) as mock_dl:
+            resp = client.post(
+                "/api/v1/export",
+                json={"rows": [payload], "format": "xlsx", "no_images": False},
+            )
+        self.assertEqual(resp.status_code, 200)
+        self.assertGreater(len(resp.content), 0)
+        mock_dl.assert_called_once()
+
+    def test_checklist_export_never_downloads_images(self) -> None:
+        # The checklist is text-only — even with images enabled, no downloads.
+        payload = _row_payload(images={"large": "https://img.example/pikachu.png"})
+        with patch("api.routes.export.download_image") as mock_dl:
+            resp = client.post(
+                "/api/v1/export",
+                json={"rows": [payload], "format": "checklist", "no_images": False},
+            )
+        self.assertEqual(resp.status_code, 200)
+        mock_dl.assert_not_called()
 
     def test_sort_accepts_documented_modes(self) -> None:
         for mode in ("number", "number-desc", "price-asc", "price-desc", "release-date", "alpha"):

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -138,6 +138,7 @@ export async function exportFile(
     maxPrice?: number | null
     title?: string
     sort?: SortMode
+    noImages?: boolean
   } = {},
 ): Promise<void> {
   const res = await fetch(`${BASE}/export`, {
@@ -149,6 +150,7 @@ export async function exportFile(
       sort: options.sort ?? 'number',
       max_price: options.maxPrice ?? null,
       title: options.title ?? 'cards',
+      no_images: options.noImages ?? true,
     }),
   })
 

--- a/web/src/components/ExportBar.tsx
+++ b/web/src/components/ExportBar.tsx
@@ -45,6 +45,7 @@ export function ExportBar() {
         maxPrice: settings.maxPrice,
         title: settings.tag || 'cards',
         sort: settings.sort,
+        noImages: settings.noImages,
       })
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))

--- a/web/src/components/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer.tsx
@@ -126,8 +126,8 @@ export function SettingsDrawer() {
               />
               <Toggle
                 id="noImages"
-                label="Hide images in results"
-                description="Speeds up the table but hides thumbnails"
+                label="Hide images"
+                description="Skips thumbnails in the table and image embedding in exports — faster and smaller"
                 checked={settings.noImages}
                 onChange={(v) => updateSettings({ noImages: v })}
               />


### PR DESCRIPTION
Closes #12

## What

Aligns the web/API export with CLI behavior so it embeds card art:

- `api/routes/export.py` now accepts a `no_images` flag (default `true`,
  mirroring the lookup `Settings` default). When `false`, each matched
  card's art is downloaded into a temp dir and embedded by the xlsx /
  binder-PDF writers — the same path the CLI uses.
- Image download + document rendering moved into `run_in_threadpool`
  so the new network I/O stays off the event loop.
- The web client forwards the existing "Hide images" setting
  (`settings.noImages`) to the export endpoint; the setting's label and
  description were updated since it now also governs exports.

## Why

The `/api/v1/export` route hard-coded `image_path=None`, so web-driven
xlsx and binder-PDF exports never embedded thumbnails regardless of
settings — while the CLI embeds images unless `--no-images` is passed.
Issue #12 asked to either embed images or document the limitation; this
takes the first path so CLI and Web exports behave identically.

## How to verify

- `make check` — full lint + 186 tests (3 new export-API tests covering
  images-on, images-off default, and the text-only checklist).
- `cd web && npm run build` — web typecheck/build passes.
- Manual: in the web app, leave "Hide images" off, run a lookup, and
  download the `.xlsx` / PDF binder — card thumbnails are now embedded.
  Toggle "Hide images" on and re-export to confirm the fast, image-free
  path still works.