### PR TITLE
Add summary.sort_mode to the JSON report

### DIFF
--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -35,8 +35,8 @@ alongside the spreadsheet.
 | Key | Contents |
 |---|---|
 | `generated_at`, `version`, `elapsed_seconds` | Run metadata. |
-| `summary` | `sort_mode` (the `--sort` value used for the run, so consumers can reproduce the ordering), counts (rows / matched / missed / priced / bulk-expanded), `totals_by_currency` (sum of market + each comp tier), `stats_by_currency` (avg / median / min / max), and frequency tables for `by_database`, `by_price_source`, `by_rarity`. |
-| `tags` | Same shape as `summary` but per input file (per "Source" tag), plus the `highest_value_card` in that section. |
+| `summary` | Run-level metadata `sort_mode` (the `--sort` value used, so consumers can reproduce the ordering), plus the aggregate fields: counts (rows / matched / missed / priced / bulk-expanded), `totals_by_currency` (sum of market + each comp tier), `stats_by_currency` (avg / median / min / max), and frequency tables for `by_database`, `by_price_source`, `by_rarity`. |
+| `tags` | The same aggregate fields as `summary`, but per input file (per "Source" tag), plus the `highest_value_card` in that section. Run-level metadata like `sort_mode` is not repeated per tag. |
 | `highlights.most_valuable` | Top 5 priced cards across the whole run. |
 | `highlights.missing` | Every unmatched line + its tag, so you can iterate the input. |
 | `rows` | The full per-row payload (input, matched card, pricing, comps, image path). |

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -35,7 +35,7 @@ alongside the spreadsheet.
 | Key | Contents |
 |---|---|
 | `generated_at`, `version`, `elapsed_seconds` | Run metadata. |
-| `summary` | Counts (rows / matched / missed / priced / bulk-expanded), `totals_by_currency` (sum of market + each comp tier), `stats_by_currency` (avg / median / min / max), and frequency tables for `by_database`, `by_price_source`, `by_rarity`. |
+| `summary` | `sort_mode` (the `--sort` value used for the run, so consumers can reproduce the ordering), counts (rows / matched / missed / priced / bulk-expanded), `totals_by_currency` (sum of market + each comp tier), `stats_by_currency` (avg / median / min / max), and frequency tables for `by_database`, `by_price_source`, `by_rarity`. |
 | `tags` | Same shape as `summary` but per input file (per "Source" tag), plus the `highest_value_card` in that section. |
 | `highlights.most_valuable` | Top 5 priced cards across the whole run. |
 | `highlights.missing` | Every unmatched line + its tag, so you can iterate the input. |

--- a/src/mgz_pkmn/cli.py
+++ b/src/mgz_pkmn/cli.py
@@ -705,6 +705,7 @@ def lookup(
             elapsed=overall_elapsed,
             max_price=max_price,
             deduped_rows=deduped_rows,
+            sort_mode=sort_mode,
         )
         report_json.parent.mkdir(parents=True, exist_ok=True)
         report_json.write_text(json.dumps(payload, indent=2), encoding="utf-8")

--- a/src/mgz_pkmn/report.py
+++ b/src/mgz_pkmn/report.py
@@ -104,6 +104,7 @@ def build_json_report(
     elapsed: float,
     max_price: float | None = None,
     deduped_rows: int = 0,
+    sort_mode: str | None = None,
 ) -> dict[str, Any]:
     """Assemble the full report payload.
 
@@ -140,6 +141,7 @@ def build_json_report(
         )
 
     summary = {
+        "sort_mode": sort_mode,
         "input_lines": input_lines,
         "rows_total": len(rows),
         "rows_deduped": deduped_rows,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,6 +55,17 @@ class CliHelpersTests(unittest.TestCase):
         self.assertEqual(payload["summary"]["rows_total"], 1)
         self.assertEqual(payload["summary"]["rows_bulk_expanded"], 3)
 
+    def test_json_report_includes_sort_mode(self) -> None:
+        rows = [_make_row("a", 10)]
+        payload = build_json_report(
+            rows=rows,
+            counters={},
+            input_lines=1,
+            elapsed=1.0,
+            sort_mode="price-desc",
+        )
+        self.assertEqual(payload["summary"]["sort_mode"], "price-desc")
+
 
 class FormatHelpersTests(unittest.TestCase):
     def test_format_bytes_renders_each_unit(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import sys
 import tempfile
@@ -270,6 +271,33 @@ class LookupSummaryCacheTests(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn("1 cached / 1 fetched", result.output)
+
+    def test_report_json_records_sort_mode_from_cli(self) -> None:
+        # Drives the full CLI wiring: `--sort` must reach `summary.sort_mode`
+        # in the written report, not just `build_json_report`'s argument.
+        input_path = self._write_inputs(["Mew"])
+        out = Path(self._tmp.name) / "out.xlsx"
+        report_path = Path(self._tmp.name) / "summary.json"
+
+        with patch("mgz_pkmn.cli.find_card", side_effect=self._make_stub()):
+            result = CliRunner().invoke(
+                cli,
+                [
+                    "lookup",
+                    str(input_path),
+                    "-o",
+                    str(out),
+                    "--no-images",
+                    "--report-json",
+                    str(report_path),
+                    "--sort",
+                    "price-desc",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(report_path.read_text(encoding="utf-8"))
+        self.assertEqual(payload["summary"]["sort_mode"], "price-desc")
 
     def test_summary_omits_cache_counts_when_no_hits(self) -> None:
         # Fresh cache → every query is a fetch, no hits. The summary tail


### PR DESCRIPTION
Closes #11

## What

Adds `report.summary.sort_mode` to the JSON report — the `--sort` value used for the run. `build_json_report` takes a new optional `sort_mode` argument, the CLI passes the resolved sort mode through, and `docs/outputs.md` documents the field.

## Why

JSON consumers couldn't reproduce a run's row ordering without knowing which `--sort` mode produced it. Recording it in the report makes the output self-describing.

## How to verify

- `make check` (new test `test_json_report_includes_sort_mode` asserts the field is present with the correct value)
- Run a lookup with `--report-json output/summary.json --sort price-desc` and confirm `summary.sort_mode` is `"price-desc"` in the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)