### PR TITLE
Add GitHub Sponsors FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [mgzwarrior]


### PR DESCRIPTION
Closes #33

## What

Adds `.github/FUNDING.yml` pointing at the `mgzwarrior` GitHub Sponsors account.

## Why

Last item before the V1 release — surfaces a Sponsor button on the repo home page.

## How to verify

- GitHub renders a "Sponsor" button on the repo home once this lands on the default branch (visibility depends on the `mgzwarrior` account having GitHub Sponsors enabled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)