### PR TITLE
Fix Docker build: copy README.md for project install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,10 @@ COPY pyproject.toml uv.lock ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --extra api --no-dev --no-install-project --frozen
 
-# Install the project itself.
+# Install the project itself. README.md is required because pyproject.toml
+# declares it as the package readme — hatchling validates it at build time.
 COPY src/ ./src/
+COPY README.md ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --extra api --no-dev --frozen
 


### PR DESCRIPTION
Closes #32

## What

Adds `COPY README.md ./` to the `Dockerfile` before the project-install `uv sync` step.

## Why

`pyproject.toml` declares `readme = "README.md"`, and hatchling validates that field when `uv sync` builds the project. The Dockerfile only copied `src/`, so the runtime stage failed:

```
OSError: Readme file does not exist: README.md
error: failed to solve: process "/bin/sh -c uv sync --extra api --no-dev --frozen" did not complete successfully: exit code: 1
```

This broke the Docker (and therefore Render) deploy post-restructure.

## How to verify

- `make docker-build` — succeeds (previously failed at the project-install step)
- `make docker-run` then `curl localhost:8000/health` → `{"status":"ok"}` (verified locally)
- `render.yaml` parses; `healthCheckPath: /health` matches the real endpoint in `api/main.py` — no changes needed there

🤖 Generated with [Claude Code](https://claude.com/claude-code)