### PR TITLE
Apply inline price filters to single-card lookups

### DIFF
--- a/src/mgz_pkmn/cli.py
+++ b/src/mgz_pkmn/cli.py
@@ -562,6 +562,11 @@ def lookup(
                     f"      ✗ PriceCharting fetch failed for {result.url}",
                     fg="yellow",
                 )
+            elif result.reason == "price_mismatch":
+                click.secho(
+                    f"      ✗ {q.name!r} found but price is outside the requested bound",
+                    fg="yellow",
+                )
             else:
                 click.secho(
                     "      ✗ no match in pokemontcg.io or TCGdex",

--- a/src/mgz_pkmn/lookup.py
+++ b/src/mgz_pkmn/lookup.py
@@ -118,6 +118,40 @@ def _is_pricecharting_url(url: str) -> bool:
     return host == "pricecharting.com" or host.endswith(".pricecharting.com")
 
 
+def _apply_price_bounds(result: MatchResult, q: CardQuery) -> MatchResult:
+    """Return a price_mismatch MatchResult when the card violates inline bounds.
+
+    Both `price_min` and `price_max` on the query are checked. Cards with no
+    pricing data pass through — filtering on an unknown price would silently
+    swallow valid matches."""
+    if result.card is None:
+        return result
+    if q.price_min is None and q.price_max is None:
+        return result
+
+    pricing = extract_pricing(result.card, q.variant_hint)
+    if pricing.market is None:
+        return result
+
+    if q.price_min is not None:
+        if q.price_min_exclusive:
+            if pricing.market <= q.price_min:
+                return MatchResult(None, "price_mismatch")
+        else:
+            if pricing.market < q.price_min:
+                return MatchResult(None, "price_mismatch")
+
+    if q.price_max is not None:
+        if q.price_max_exclusive:
+            if pricing.market >= q.price_max:
+                return MatchResult(None, "price_mismatch")
+        else:
+            if pricing.market > q.price_max:
+                return MatchResult(None, "price_mismatch")
+
+    return result
+
+
 def find_card(
     pkmn: TCGClient,
     tcgdex: TCGDexClient,
@@ -147,6 +181,7 @@ def find_card(
         result = pc.fetch(q.url_hint)
         if result.card:
             disk_cache.record_url_override(q.name, q.set_hint, q.url_hint)
+            result = _apply_price_bounds(result, q)
         return result
     # Other URL hosts: not yet supported; fall through to DB search.
 
@@ -159,12 +194,12 @@ def find_card(
     if override and _is_pricecharting_url(override):
         override_result = pc.fetch(override)
         if override_result.card:
-            return override_result
+            return _apply_price_bounds(override_result, q)
 
     # 3. pokemontcg.io — best for English / international English releases.
     primary = search_pokemontcg(pkmn, q)
     if primary.card:
-        return primary
+        return _apply_price_bounds(primary, q)
 
     # 3. TCGdex — fall back through any languages hinted in the input, then EN.
     langs = detect_languages(q.name) or []
@@ -180,7 +215,7 @@ def find_card(
     for lang in langs:
         result = search_tcgdex(tcgdex, q, lang)
         if result.card:
-            return result
+            return _apply_price_bounds(result, q)
         if result.reason == "set_mismatch":
             saw_set_mismatch = True
 

--- a/src/mgz_pkmn/sources/base.py
+++ b/src/mgz_pkmn/sources/base.py
@@ -12,7 +12,8 @@ from ..parser import CardQuery
 class MatchResult:
     card: dict[str, Any] | None
     # Core reasons emitted by the lookup module:
-    #   "matched" | "no_candidates" | "set_mismatch" | "scrape_failed"
+    #   "matched" | "no_candidates" | "set_mismatch" | "scrape_failed" |
+    #   "price_mismatch"
     # Higher layers (API routes) may synthesize their own values
     # (e.g. "error", "unparseable") when surfacing results to clients, so the
     # set is non-exhaustive.

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -10,6 +10,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from mgz_pkmn import cache
 from mgz_pkmn.lookup import (
+    _apply_price_bounds,
     _expand_concept,
     _name_token_match,
     _split_evolution_line,
@@ -300,6 +301,139 @@ class ExpandConceptTests(unittest.TestCase):
 
     def test_concept_lookup_is_case_insensitive(self) -> None:
         self.assertEqual(_expand_concept("PUPPY"), _expand_concept("puppy"))
+
+
+class ApplyPriceBoundsTests(unittest.TestCase):
+    """Unit tests for _apply_price_bounds — the helper that enforces inline price
+    conditions on single-card lookup results."""
+
+    def _priced_card(self, market: float) -> dict:
+        return {
+            "id": "test-1",
+            "name": "Charizard",
+            "number": "4",
+            "set": {"name": "Base Set", "series": "Base"},
+            "tcgplayer": {"prices": {"holofoil": {"market": market}}},
+        }
+
+    def _q(self, **kwargs) -> CardQuery:
+        return CardQuery(raw="test", name="Charizard", **kwargs)
+
+    def test_no_bounds_passes_through(self) -> None:
+        card = self._priced_card(50.0)
+        result = _apply_price_bounds(MatchResult(card, "matched"), self._q())
+        self.assertIs(result.card, card)
+
+    def test_inclusive_min_passes_equal(self) -> None:
+        card = self._priced_card(100.0)
+        q = self._q(price_min=100.0, price_min_exclusive=False)
+        result = _apply_price_bounds(MatchResult(card, "matched"), q)
+        self.assertIs(result.card, card)
+
+    def test_inclusive_min_drops_below(self) -> None:
+        card = self._priced_card(80.0)
+        q = self._q(price_min=100.0, price_min_exclusive=False)
+        result = _apply_price_bounds(MatchResult(card, "matched"), q)
+        self.assertIsNone(result.card)
+        self.assertEqual(result.reason, "price_mismatch")
+
+    def test_strict_min_drops_equal(self) -> None:
+        card = self._priced_card(100.0)
+        q = self._q(price_min=100.0, price_min_exclusive=True)
+        result = _apply_price_bounds(MatchResult(card, "matched"), q)
+        self.assertIsNone(result.card)
+        self.assertEqual(result.reason, "price_mismatch")
+
+    def test_strict_min_passes_above(self) -> None:
+        card = self._priced_card(100.01)
+        q = self._q(price_min=100.0, price_min_exclusive=True)
+        result = _apply_price_bounds(MatchResult(card, "matched"), q)
+        self.assertIs(result.card, card)
+
+    def test_inclusive_max_passes_equal(self) -> None:
+        card = self._priced_card(50.0)
+        q = self._q(price_max=50.0, price_max_exclusive=False)
+        result = _apply_price_bounds(MatchResult(card, "matched"), q)
+        self.assertIs(result.card, card)
+
+    def test_inclusive_max_drops_above(self) -> None:
+        card = self._priced_card(60.0)
+        q = self._q(price_max=50.0, price_max_exclusive=False)
+        result = _apply_price_bounds(MatchResult(card, "matched"), q)
+        self.assertIsNone(result.card)
+        self.assertEqual(result.reason, "price_mismatch")
+
+    def test_strict_max_drops_equal(self) -> None:
+        card = self._priced_card(50.0)
+        q = self._q(price_max=50.0, price_max_exclusive=True)
+        result = _apply_price_bounds(MatchResult(card, "matched"), q)
+        self.assertIsNone(result.card)
+        self.assertEqual(result.reason, "price_mismatch")
+
+    def test_no_pricing_data_passes_through(self) -> None:
+        card = {
+            "id": "test-1",
+            "name": "Charizard",
+            "number": "4",
+            "set": {"name": "Base Set", "series": "Base"},
+        }
+        q = self._q(price_min=100.0)
+        result = _apply_price_bounds(MatchResult(card, "matched"), q)
+        self.assertIs(result.card, card)
+
+    def test_none_card_passes_through(self) -> None:
+        q = self._q(price_min=100.0)
+        result = _apply_price_bounds(MatchResult(None, "no_candidates"), q)
+        self.assertIsNone(result.card)
+        self.assertEqual(result.reason, "no_candidates")
+
+
+class FindCardPriceBoundsTests(unittest.TestCase):
+    """Integration tests: find_card() enforces inline price bounds end-to-end."""
+
+    def _charizard(self, market: float) -> dict:
+        return {
+            "id": "base1-4",
+            "name": "Charizard",
+            "number": "4",
+            "set": {"name": "Base Set", "series": "Base"},
+            "tcgplayer": {"prices": {"holofoil": {"market": market}}},
+        }
+
+    def test_find_card_drops_when_price_below_min(self) -> None:
+        card = self._charizard(80.0)
+        client = _StubTCGClient({"name:Charizard": [card]})
+        q = CardQuery(
+            raw="Charizard >= $100", name="Charizard", price_min=100.0, price_min_exclusive=False
+        )
+        result = find_card(
+            client, _NullTCGDexClient(), _StubPCClient(MatchResult(None, "no_candidates")), q
+        )
+        self.assertIsNone(result.card)
+        self.assertEqual(result.reason, "price_mismatch")
+
+    def test_find_card_passes_when_price_meets_min(self) -> None:
+        card = self._charizard(120.0)
+        client = _StubTCGClient({"name:Charizard": [card]})
+        q = CardQuery(
+            raw="Charizard >= $100", name="Charizard", price_min=100.0, price_min_exclusive=False
+        )
+        result = find_card(
+            client, _NullTCGDexClient(), _StubPCClient(MatchResult(None, "no_candidates")), q
+        )
+        self.assertIsNotNone(result.card)
+
+    def test_find_card_drops_when_price_above_max(self) -> None:
+        card = self._charizard(200.0)
+        client = _StubTCGClient({"name:Charizard": [card]})
+        q = CardQuery(
+            raw="Charizard <= $100", name="Charizard", price_max=100.0, price_max_exclusive=False
+        )
+        result = find_card(
+            client, _NullTCGDexClient(), _StubPCClient(MatchResult(None, "no_candidates")), q
+        )
+        self.assertIsNone(result.card)
+        self.assertEqual(result.reason, "price_mismatch")
 
 
 class _StubPCClient:


### PR DESCRIPTION
Closes #6

## What

- Added `_apply_price_bounds(result, q)` helper in `lookup.py` that checks `q.price_min` / `q.price_max` against the matched card's market price and returns `MatchResult(None, "price_mismatch")` when violated.
- Called this helper at every point in `find_card()` where a successful match is about to be returned (PriceCharting URL, sticky URL override, pokemontcg.io, TCGdex).
- Cards with no pricing data pass through unchanged — filtering on an unknown price would silently swallow valid matches.
- Added `"price_mismatch"` to the documented reason values in `MatchResult`.
- CLI now shows a distinct yellow message when a card is dropped by a price bound (`✗ found but price is outside the requested bound`).

## Why

`Charizard | Base | 4/102 >= $100` previously parsed the bound but silently discarded it — the card was returned regardless of whether its price met the constraint. Users had no feedback that their filter was being ignored.

## How to verify

```bash
# Should now report price_mismatch instead of returning the card
# (assuming Charizard Base 4/102 is priced below $10,000)
echo "Charizard | Base Set | 4/102 >= $10000" | pkmn run -

# Happy path — should still match when price is within bounds
echo "Charizard | Base Set | 4/102 >= $1" | pkmn run -

# Run the test suite
make check
```