### PR TITLE
Add `make refresh-examples` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,16 @@ run-sample:  ## Smoke-run the CLI on sample_cards.txt (override: INPUT=, OUTPUT_
 	@mkdir -p $(OUTPUT_DIR)
 	uv run pkmn lookup $(INPUT) -o $(OUTPUT_DIR)/cards.xlsx --pdf $(OUTPUT_DIR)/binder.pdf --report-json $(OUTPUT_DIR)/summary.json
 
+.PHONY: refresh-examples
+refresh-examples:  ## Regenerate all tracked output/ examples from sample_cards.txt. Run before tagging a release (requires network).
+	@mkdir -p $(OUTPUT_DIR)
+	uv run pkmn lookup $(INPUT) \
+	  -o $(OUTPUT_DIR)/cards.xlsx \
+	  --pdf $(OUTPUT_DIR)/binder.pdf \
+	  --condensed-pdf $(OUTPUT_DIR)/binder-condensed.pdf \
+	  --checklist $(OUTPUT_DIR)/checklist.pdf \
+	  --report-json $(OUTPUT_DIR)/summary.json
+
 .PHONY: cache-clear
 cache-clear:  ## Wipe the on-disk cache (~/.cache/mgz-pkmn) — including URL overrides.
 	rm -rf $${XDG_CACHE_HOME:-$$HOME/.cache}/mgz-pkmn


### PR DESCRIPTION
Closes #15

## What

Adds a `refresh-examples` Makefile target in the `## CLI / cache` section that regenerates all five tracked artifacts in `output/` from `sample_cards.txt` in a single command:

```
make refresh-examples
```

Generates:
- `output/cards.xlsx`
- `output/binder.pdf`
- `output/binder-condensed.pdf`  ← missing from `run-sample`
- `output/checklist.pdf`         ← missing from `run-sample`
- `output/summary.json`

Accepts the same `INPUT=` and `OUTPUT_DIR=` overrides as `run-sample`.

## Why

The existing `run-sample` target only generated three of the five tracked artifacts; the condensed binder and checklist PDFs had to be regenerated manually. Without a single regen command, `output/` examples drift from the current code between releases.

## How to verify

```bash
make refresh-examples
ls -la output/
# binder-condensed.pdf, binder.pdf, cards.xlsx, checklist.pdf, summary.json all updated
```