### PR TITLE
Warn on currency-blind --max-price with mixed EUR/USD input

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -41,7 +41,7 @@ boundary.
 | `--images-dir PATH` | `output/images/` | Where to save downloaded card images. |
 | `--api-key TEXT` | `$POKEMONTCG_IO_API_KEY` | pokemontcg.io API key (raises rate limits). |
 | `--no-images` | off | Skip image downloads + embedding. |
-| `--max-price FLOAT` | (none) | Per-card budget cap. **Bulk** `top:N` / `All …` lookups respect it strictly — candidates above the cap are excluded *before* the top-N cut, so an "affordable top 10" still returns 10. **Single-card** lookups always appear in every artifact even when above the cap, but get a visual flag (amber-fill on the Market cell in xlsx, red `! MP $X` line in the PDF, `over_max_price: true` in JSON). Applied to the raw market figure regardless of currency — keep your input list single-currency for it to mean what you'd expect. |
+| `--max-price FLOAT` | (none) | Per-card budget cap. **Bulk** `top:N` / `All …` lookups respect it strictly — candidates above the cap are excluded *before* the top-N cut, so an "affordable top 10" still returns 10. **Single-card** lookups always appear in every artifact even when above the cap, but get a visual flag (amber-fill on the Market cell in xlsx, red `! MP $X` line in the PDF, `over_max_price: true` in JSON). See the currency-blindness warning below. |
 | `--dedupe` | off | Remove duplicate matched cards across all queries (keyed by card id), keeping the first occurrence in xlsx / PDF / JSON. |
 | `--report-json PATH` | (none) | Also dump a structured JSON report. See [Outputs](outputs.md#json-report). |
 | `--pdf PATH` | (none) | Also write a 3×3 binder-style PDF (9 cards/page) — image-forward, sized to print and slip into 9-pocket pages as physical placeholders. See [PDF binder](binder-pdf.md). |
@@ -54,6 +54,15 @@ boundary.
 | `--print-summary-only` | off | Print the run summary but write no output artifacts — no xlsx, PDFs, checklist, JSON report, or images (image downloads are skipped too). The disk cache still operates normally, so repeated runs stay fast. Useful when iterating on input formatting without regenerating outputs on every run. |
 | `-v, --verbose` | off | Echo each API request URL (cached entries are flagged). |
 | `-h, --help` | | Show usage. |
+
+> **`--max-price` is currency-blind.**
+> The cap is applied to the raw market figure regardless of whether the card is priced
+> in USD (TCGPlayer / PriceCharting) or EUR (Cardmarket). A `--max-price 50` run over
+> a mixed-currency input compares €50 German cards against the $50 threshold as if they
+> were the same number. The CLI prints a warning when this mismatch is detected, but
+> the cap is still enforced as-is. **To keep the cap meaningful, use a single-currency
+> input list** — either all TCGPlayer / PriceCharting sources (USD) or all Cardmarket
+> sources (EUR).
 
 ## `pkmn set-cards` options
 

--- a/docs/input-format.md
+++ b/docs/input-format.md
@@ -126,10 +126,19 @@ cell in the PDF binder.
 
 ## Known limitations
 
-- **Inline price filtering is approximate.** The comparator parser
-  distinguishes strict (`>`, `<`) from inclusive (`>=`, `<=`) and
-  intersects with `--max-price`, but it's currency-blind and silently
-  drops conditions on single-card lookups. A line like
+- **Price filtering (inline and `--max-price`) is currency-blind.**
+  All price comparisons — both `--max-price` and inline bounds like
+  `>= $50` — are applied to the raw market figure regardless of whether
+  the card is priced in USD (TCGPlayer, PriceCharting) or EUR
+  (Cardmarket). A mixed-currency input list produces unintuitive
+  results: a €40 German card and a $40 American card look identical to
+  the filter. The CLI prints a warning when `--max-price` is set and
+  EUR-priced cards are in the results. **Keep your input list
+  single-currency** — all TCGPlayer / PriceCharting (USD) or all
+  Cardmarket (EUR) — to make the cap meaningful. In addition, inline
+  price bounds are approximate in other ways: the comparator parser
+  distinguishes strict (`>`, `<`) from inclusive (`>=`, `<=`) but
+  silently drops conditions on single-card lookups. A line like
   `Charizard | Base | 4 >= $100` parses the bound but doesn't act on
   it. Acceptable for bulk budgeting; not a general-purpose query
   language.

--- a/src/mgz_pkmn/cli.py
+++ b/src/mgz_pkmn/cli.py
@@ -653,6 +653,19 @@ def lookup(
     summary_parts.append(click.style(f"{overall_elapsed:.1f}s total", fg="bright_black"))
     click.echo("  " + "  ·  ".join(summary_parts))
 
+    if max_price is not None:
+        foreign_priced = [
+            r for r in rows if r.pricing.market is not None and r.pricing.currency != "USD"
+        ]
+        if foreign_priced:
+            currencies = "/".join(sorted({r.pricing.currency for r in foreign_priced}))
+            click.secho(
+                f"  ⚠  --max-price is currency-blind: {len(foreign_priced)} card(s) priced in"
+                f" {currencies} are compared against ${max_price:,.2f} as if USD."
+                " Pass a single-currency input list or the cap may not mean what you expect.",
+                fg="yellow",
+            )
+
     if print_summary_only:
         click.echo()
         click.secho(

--- a/src/mgz_pkmn/cli.py
+++ b/src/mgz_pkmn/cli.py
@@ -654,10 +654,13 @@ def lookup(
     click.echo("  " + "  ·  ".join(summary_parts))
 
     if max_price is not None:
-        foreign_priced = [
-            r for r in rows if r.pricing.market is not None and r.pricing.currency != "USD"
-        ]
-        if foreign_priced:
+        priced_rows = [r for r in rows if r.pricing.market is not None]
+        pool_currencies = {r.pricing.currency for r in priced_rows}
+        # Only warn when currencies are genuinely mixed.  An all-EUR or all-USD
+        # run is internally consistent; the mismatch arises only when both appear
+        # in the same result set and the cap treats them as the same unit.
+        if len(pool_currencies) > 1:
+            foreign_priced = [r for r in priced_rows if r.pricing.currency != "USD"]
             currencies = "/".join(sorted({r.pricing.currency for r in foreign_priced}))
             click.secho(
                 f"  ⚠  --max-price is currency-blind: {len(foreign_priced)} card(s) priced in"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -347,5 +347,111 @@ class LookupSummaryCacheTests(unittest.TestCase):
         self.assertNotIn("fetched", result.output)
 
 
+class LookupCurrencyWarningTests(unittest.TestCase):
+    """The ⚠ currency-blind warning should appear only when --max-price is set
+    AND the result set contains a genuine mix of USD and non-USD priced rows."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._old_xdg = os.environ.get("XDG_CACHE_HOME")
+        self._old_warn = os.environ.get(cache._WARN_BYTES_ENV)
+        os.environ["XDG_CACHE_HOME"] = self._tmp.name
+        os.environ[cache._WARN_BYTES_ENV] = "0"
+        cache.reset_api_counters()
+
+    def tearDown(self) -> None:
+        if self._old_xdg is None:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        else:
+            os.environ["XDG_CACHE_HOME"] = self._old_xdg
+        if self._old_warn is None:
+            os.environ.pop(cache._WARN_BYTES_ENV, None)
+        else:
+            os.environ[cache._WARN_BYTES_ENV] = self._old_warn
+
+    def _write_inputs(self, names: list[str]) -> Path:
+        path = Path(self._tmp.name) / "in.txt"
+        path.write_text("\n".join(names) + "\n", encoding="utf-8")
+        return path
+
+    @staticmethod
+    def _mixed_currency_stub(pkmn, tcgdex, pc, q, default_lang=None):
+        """Return USD pricing for 'Mew', EUR pricing for 'Pikachu'."""
+        if q.name == "Pikachu":
+            card = {
+                "id": "pikachu-eur",
+                "name": "Pikachu",
+                "number": "1",
+                "set": {"name": "Test Set"},
+                "_database": "stub",
+                "cardmarket": {
+                    "_currency": "EUR",
+                    "prices": {"averageSellPrice": 15.0},
+                },
+            }
+        else:
+            card = {
+                "id": "mew-usd",
+                "name": "Mew",
+                "number": "1",
+                "set": {"name": "Test Set"},
+                "_database": "stub",
+                "tcgplayer": {"prices": {"holofoil": {"market": 10.0}}},
+            }
+        return MatchResult(card, "matched")
+
+    @staticmethod
+    def _usd_only_stub(pkmn, tcgdex, pc, q, default_lang=None):
+        card = {
+            "id": q.name,
+            "name": q.name,
+            "number": "1",
+            "set": {"name": "Test Set"},
+            "_database": "stub",
+            "tcgplayer": {"prices": {"holofoil": {"market": 10.0}}},
+        }
+        return MatchResult(card, "matched")
+
+    def test_warning_emitted_for_mixed_currencies_with_max_price(self) -> None:
+        input_path = self._write_inputs(["Mew", "Pikachu"])
+        out = Path(self._tmp.name) / "out.xlsx"
+
+        with patch("mgz_pkmn.cli.find_card", side_effect=self._mixed_currency_stub):
+            result = CliRunner().invoke(
+                cli,
+                ["lookup", str(input_path), "-o", str(out), "--no-images", "--max-price", "20"],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("currency-blind", result.output)
+
+    def test_warning_suppressed_for_single_currency_with_max_price(self) -> None:
+        input_path = self._write_inputs(["Mew", "Pikachu"])
+        out = Path(self._tmp.name) / "out.xlsx"
+
+        with patch("mgz_pkmn.cli.find_card", side_effect=self._usd_only_stub):
+            result = CliRunner().invoke(
+                cli,
+                ["lookup", str(input_path), "-o", str(out), "--no-images", "--max-price", "20"],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertNotIn("currency-blind", result.output)
+
+    def test_warning_suppressed_without_max_price(self) -> None:
+        input_path = self._write_inputs(["Mew", "Pikachu"])
+        out = Path(self._tmp.name) / "out.xlsx"
+
+        with patch("mgz_pkmn.cli.find_card", side_effect=self._mixed_currency_stub):
+            result = CliRunner().invoke(
+                cli,
+                ["lookup", str(input_path), "-o", str(out), "--no-images"],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertNotIn("currency-blind", result.output)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -286,6 +286,66 @@ class PriceBoundaryFilterTests(unittest.TestCase):
         self.assertEqual([c["id"] for c in results], ["low"])
 
 
+def _eur_card(card_id: str, name: str, market: float) -> dict:
+    """Build a stub card priced in EUR via Cardmarket (not USD via TCGPlayer)."""
+    return {
+        "id": card_id,
+        "name": name,
+        "number": "1",
+        "set": {"name": "Test Set", "series": "Test Series"},
+        "subtypes": [],
+        "cardmarket": {
+            "_currency": "EUR",
+            "prices": {"averageSellPrice": market},
+        },
+    }
+
+
+class MixedCurrencyFilterTests(unittest.TestCase):
+    """--max-price compares raw market figures regardless of currency.
+
+    A pool containing both USD (TCGPlayer) and EUR (Cardmarket) cards is
+    filtered by the same numeric threshold.  This test documents the current
+    currency-blind behaviour so any future currency-aware change is intentional.
+    """
+
+    @staticmethod
+    def _mixed_client() -> _StubTCGClient:
+        return _StubTCGClient(
+            {
+                "name:Pikachu": [
+                    _card("usd-10", "Pikachu", 10.0),
+                    _card("usd-30", "Pikachu", 30.0),
+                    _eur_card("eur-15", "Pikachu", 15.0),
+                    _eur_card("eur-25", "Pikachu", 25.0),
+                ],
+                "name:Pikachu*": [
+                    _card("usd-10", "Pikachu", 10.0),
+                    _card("usd-30", "Pikachu", 30.0),
+                    _eur_card("eur-15", "Pikachu", 15.0),
+                    _eur_card("eur-25", "Pikachu", 25.0),
+                ],
+            }
+        )
+
+    def test_max_price_drops_eur_cards_above_cap_currency_blind(self) -> None:
+        # Both USD and EUR cards above the $20 cap are dropped, even though the
+        # EUR values are in a different currency.  usd-30 ($30 USD) and
+        # eur-25 (€25 EUR treated as 25) are both excluded.
+        q = CardQuery(raw="x", name="Pikachu", bulk_top=10)
+        results = find_top_cards(self._mixed_client(), q, limit=10, max_price=20.0)
+        ids = {c["id"] for c in results}
+        self.assertIn("usd-10", ids)
+        self.assertIn("eur-15", ids)
+        self.assertNotIn("usd-30", ids)
+        self.assertNotIn("eur-25", ids)
+
+    def test_max_price_passes_all_cards_when_no_cap(self) -> None:
+        q = CardQuery(raw="x", name="Pikachu", bulk_top=10)
+        results = find_top_cards(self._mixed_client(), q, limit=10)
+        self.assertEqual(len(results), 4)
+
+
 class ExpandConceptTests(unittest.TestCase):
     def test_known_concept_returns_slash_string(self) -> None:
         result = _expand_concept("eeveelution")


### PR DESCRIPTION
Closes #8

## What

- Adds a yellow CLI warning when `--max-price` is active and the result set contains EUR-priced cards (from Cardmarket), telling the user how many cards are affected and advising a single-currency input list.
- Expands `docs/cli.md` with a prominent blockquote callout explaining the currency-blind behaviour and linking to it from the `--max-price` row description.
- Expands the "Known limitations" entry in `docs/input-format.md` to loudly explain the limitation with a recommendation.
- Adds two new tests in `tests/test_lookup.py` (`MixedCurrencyFilterTests`) that document and pin the currency-blind filtering contract.

## Why

`--max-price` compared raw market figures regardless of whether a card was priced in USD (TCGPlayer, PriceCharting) or EUR (Cardmarket). On a mixed-currency input list, the cap was silently meaningless — a €40 German card and a $40 US card looked identical to the filter. Nothing warned the user.

## How to verify

1. Create an input file with both a TCGPlayer-sourced card and a Cardmarket-sourced card.
2. Run `pkmn lookup <file> --max-price 30` — you should see the yellow `⚠ --max-price is currency-blind` warning in the summary.
3. Run `pkmn lookup <file>` without `--max-price` — no warning appears.
4. `make check` passes: 191 tests, ruff clean.