### PR TITLE
Seed CHANGELOG.md for 0.1.0 → 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,101 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versions follow [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-05-08
+
+Foundation release. Establishes the full CLI pipeline, a FastAPI/React web
+UI, multi-source card lookup, all output formats, and release infrastructure.
+
+### Added
+
+#### CLI
+- `pkmn lookup` command: parses a card list, looks up each card across open
+  data sources, downloads images, and writes an `.xlsx` with embedded
+  thumbnails, market price, and 80/85/90/95% negotiation comps.
+- `pkmn set-cards` command: generates printable set ID cutouts (no input
+  list needed).
+- `--pdf` / `--condensed-pdf` flags for standard 3×3 and condensed 6×4
+  PDF binder layouts.
+- `--checklist` flag for a printable per-tag checklist PDF.
+- `--report-json` flag for a structured JSON report (summary, per-tag
+  aggregates, highlights, full row data).
+- `--dedupe` flag to collapse duplicate input lines before lookup.
+- `--max-price` filter with per-currency awareness and amber highlight for
+  above-cap rows in the spreadsheet.
+- `--sort` flag with multiple sort modes applied before any output is written.
+- `--print-summary-only` mode to emit the run summary without writing output
+  files.
+- Inline per-card price conditions on bulk lookups (`>=`, `<=`, `>`, `<`).
+- Bulk / "top-N" lookup syntax: `top:5 Charizard cards`,
+  `all Pikachu prints`.
+- Multi-language card support via language tokens (`japanese`, `korean`, etc.)
+  in input lines.
+- Disk cache (`DiskCache`) for API responses; `pkmn cache stats` subcommand.
+- `MGZ_PKMN_NO_CACHE` env var to bypass cache for a run.
+- Cache soft-warn when on-disk size exceeds 50 MB; hit-rate shown in
+  CLI summary.
+- Versioned schema for `url_overrides.json`.
+- Public `parse_lines()` API and `CardQuery` export from the package.
+
+#### Multi-source lookup
+- **pokemontcg.io** (primary): English/international cards with TCGPlayer
+  (USD) and Cardmarket (EUR) prices.
+- **TCGdex** (multilingual fallback): `en`, `ja`, `ko`, `zh-tw`, `zh-cn`,
+  `de`, `fr`, `es`, `it`, `pt`, and more; includes Cardmarket prices.
+- **PriceCharting** (opt-in via URL): region-exclusive products; returns USD
+  loose/new/graded prices.
+- Set-overlap scoring and name-clause heuristics for candidate ranking.
+- `MatchResult` wraps scrape failures so callers get structured error info
+  rather than bare exceptions.
+
+#### Web UI
+- FastAPI backend (`api/`) with `/lookup`, `/parse`, `/sets`, and
+  `/overrides` routes; full test coverage for all routes.
+- React + Vite frontend (`web/`) with streaming results, settings drawer,
+  one-click export, and an `ErrorBoundary` around the SPA root.
+- SPA served with `Cache-Control: no-cache` to prevent stale asset delivery.
+
+#### Outputs
+- `.xlsx` with frozen header row, per-column widths, embedded card thumbnails,
+  currency-aware number formatting, and a totals footer row.
+- Summary `sort_mode` field included in the JSON report.
+- `make refresh-examples` target to regenerate tracked output artifacts.
+
+#### Infrastructure
+- GitHub Actions CI: lint + format check + full test suite on Python 3.11,
+  3.12, and 3.13; ESLint + TypeScript build for `web/`; ruff lint for `api/`.
+- Docker image with README copied into the build context.
+- Render auto-deploy configuration (`render.yaml`).
+- Dependabot config for Python, JS, and GitHub Actions dependencies.
+- `SECURITY.md` and CodeQL scanning.
+- MIT `LICENSE`.
+- Pre-commit hooks: `ruff check --fix` + `ruff format` on every staged file.
+- `pyproject.toml` metadata polished for future PyPI publish.
+- GitHub Sponsors `FUNDING.yml`.
+
+#### Documentation
+- `README.md` with install, quickstart, API key setup, and feature overview.
+- `docs/cli.md` with full CLI reference and worked examples.
+- `docs/contributing.md` with project layout, branch naming, PR process,
+  and CI/release notes.
+- `AGENTS.md` with code conventions and invariants for AI coding agents.
+- `CLAUDE.md` with contributor workflow guidance for Claude Code.
+- `SECURITY.md` with vulnerability disclosure policy.
+- ADR index under `docs/adr/` capturing key architectural decisions.
+- Roadmap in `docs/roadmap.md` linked to GitHub issues.
+- Issue and PR templates.
+
+### Fixed
+- ReDoS vulnerabilities in parser regexes (polynomial backtracking on
+  adversarial input eliminated across multiple passes).
+- Incomplete URL substring sanitization (CodeQL alerts).
+- Workflow permissions hardening (CodeQL alerts).
+
+[Unreleased]: https://github.com/mgzwarrior/mgz-pkmn/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/mgzwarrior/mgz-pkmn/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,10 @@ No other format is acceptable. Keep the description short (2–4 words, kebab-ca
 
 - Match existing patterns and style. Don't introduce new dependencies without a strong reason.
 - Keep the change **focused**: one issue, one PR.
+- For **user-facing** changes (features, fixes, behavior changes, deprecations,
+  removals), add a bullet under the matching subsection of `[Unreleased]` in
+  [CHANGELOG.md](CHANGELOG.md). Skip it for dependency bumps, CI tweaks,
+  internal refactors, and test-only changes.
 - Run `make fix` before committing to auto-apply lint/formatting fixes:
 
 ```bash

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -160,9 +160,25 @@ to `main`:
 | `api-lint` | ruff lint + format check for `api/` (with the `api` extras installed) |
 | `web-lint-and-build` | ESLint + TypeScript build (`tsc -b && vite build`) for `web/` |
 
+## Changelog
+
+[CHANGELOG.md](../CHANGELOG.md) follows the [Keep a
+Changelog](https://keepachangelog.com/en/1.1.0/) format. A PR with a
+**user-facing** change — a new feature, bug fix, behaviour change,
+deprecation, or removal — adds a bullet under the matching subsection
+(`Added` / `Changed` / `Fixed` / `Deprecated` / `Removed`) of the
+`[Unreleased]` section at the top of the file.
+
+Skip the changelog for changes users never see: dependency bumps, CI
+config, internal refactors, and test-only changes.
+
 ## Releasing
 
-Push a `v*` tag to trigger the release workflow:
+First, rotate the changelog: rename the `[Unreleased]` section to the
+new version with today's date, add a fresh empty `[Unreleased]` above
+it, and update the compare links at the bottom of the file.
+
+Then push a `v*` tag to trigger the release workflow:
 
 ```bash
 git tag v0.2.0


### PR DESCRIPTION
Closes #30

## What

Adds `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
conventions with:

- An empty `[Unreleased]` section — the landing zone for every future PR going forward
- A retroactive `[0.1.0] - 2026-05-08` entry covering the full foundation: CLI pipeline,
  multi-source lookup, all output formats (xlsx, PDF binder, checklist, JSON report),
  web UI, infrastructure, and docs
- Comparison links at the bottom for both sections

Also wires the changelog into the contributor workflow so it actually gets maintained:

- `CLAUDE.md` Step 4 now tells contributors to add an `[Unreleased]` bullet for
  user-facing changes (and to skip it for dep bumps, CI tweaks, refactors, test-only changes)
- `docs/contributing.md` gains a **Changelog** section with the same guidance, and the
  **Releasing** section now starts with rotating `[Unreleased]` → the new version

## Why

No CHANGELOG means no clear record of what changed between versions. Establishing this
now gives contributors a place to document changes as they land, and gives users a
human-readable release summary when 1.0.0 is cut. Documenting the update step in the
workflow ensures the file is actually kept current rather than going stale.

## How to verify

1. `cat CHANGELOG.md` — confirm Keep a Changelog structure: `[Unreleased]` at the top,
   `[0.1.0]` with Added/Fixed sections below, comparison links at the bottom.
2. `grep -A2 "user-facing" CLAUDE.md docs/contributing.md` — confirm the workflow docs
   reference the changelog step.
3. `make check` — no regressions (docs-only change).