### PR TITLE
Add "Restore defaults" button to SettingsDrawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Web: "Restore defaults" button in the settings drawer footer that resets
+  all settings (API key, tag, sort, max price, dedupe, hide images) to
+  their initial values.
+
 ## [0.1.0] - 2026-05-08
 
 Foundation release. Establishes the full CLI pipeline, a FastAPI/React web

--- a/web/src/components/SettingsDrawer.test.tsx
+++ b/web/src/components/SettingsDrawer.test.tsx
@@ -2,8 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { SettingsDrawer } from './SettingsDrawer'
 
-const mockResetSettings = vi.fn()
-const mockUpdateSettings = vi.fn()
+const { mockResetSettings, mockUpdateSettings } = vi.hoisted(() => ({
+  mockResetSettings: vi.fn(),
+  mockUpdateSettings: vi.fn(),
+}))
 
 vi.mock('../store', () => ({
   useAppStore: () => ({

--- a/web/src/components/SettingsDrawer.test.tsx
+++ b/web/src/components/SettingsDrawer.test.tsx
@@ -1,10 +1,40 @@
-import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { SettingsDrawer } from './SettingsDrawer'
 
+const mockResetSettings = vi.fn()
+const mockUpdateSettings = vi.fn()
+
+vi.mock('../store', () => ({
+  useAppStore: () => ({
+    settings: {
+      apiKey: '',
+      maxPrice: null,
+      noImages: true,
+      tag: '',
+      dedupe: false,
+      sort: 'number',
+    },
+    updateSettings: mockUpdateSettings,
+    resetSettings: mockResetSettings,
+  }),
+}))
+
 describe('SettingsDrawer', () => {
+  beforeEach(() => {
+    mockResetSettings.mockClear()
+    mockUpdateSettings.mockClear()
+  })
+
   it('renders the settings trigger button', () => {
     render(<SettingsDrawer />)
     expect(screen.getByRole('button', { name: /settings/i })).toBeInTheDocument()
+  })
+
+  it('"Restore defaults" button calls resetSettings', () => {
+    render(<SettingsDrawer />)
+    fireEvent.click(screen.getByRole('button', { name: /settings/i }))
+    fireEvent.click(screen.getByRole('button', { name: /restore defaults/i }))
+    expect(mockResetSettings).toHaveBeenCalledOnce()
   })
 })

--- a/web/src/components/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer.tsx
@@ -18,7 +18,7 @@ const SORT_OPTIONS: { value: SortMode; label: string }[] = [
 ]
 
 export function SettingsDrawer() {
-  const { settings, updateSettings } = useAppStore()
+  const { settings, updateSettings, resetSettings } = useAppStore()
 
   return (
     <Dialog.Root>
@@ -132,6 +132,16 @@ export function SettingsDrawer() {
                 onChange={(v) => updateSettings({ noImages: v })}
               />
             </div>
+          </div>
+
+          {/* Footer */}
+          <div className="border-t border-zinc-700 px-5 py-4">
+            <button
+              onClick={resetSettings}
+              className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700 transition-colors"
+            >
+              Restore defaults
+            </button>
           </div>
         </Dialog.Content>
       </Dialog.Portal>

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -2,6 +2,15 @@ import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import type { Row, Settings } from '../types'
 
+const DEFAULT_SETTINGS: Settings = {
+  apiKey: '',
+  maxPrice: null,
+  noImages: true,
+  tag: '',
+  dedupe: false,
+  sort: 'number',
+}
+
 interface AppState {
   /** The raw multi-line card-list text typed by the user. */
   inputText: string
@@ -24,6 +33,7 @@ interface AppState {
   /** Persistent settings (survives page reload). */
   settings: Settings
   updateSettings: (partial: Partial<Settings>) => void
+  resetSettings: () => void
 }
 
 export const useAppStore = create<AppState>()(
@@ -43,16 +53,10 @@ export const useAppStore = create<AppState>()(
       isRunning: false,
       setIsRunning: (isRunning) => set({ isRunning }),
 
-      settings: {
-        apiKey: '',
-        maxPrice: null,
-        noImages: true,
-        tag: '',
-        dedupe: false,
-        sort: 'number',
-      },
+      settings: { ...DEFAULT_SETTINGS },
       updateSettings: (partial) =>
         set((state) => ({ settings: { ...state.settings, ...partial } })),
+      resetSettings: () => set({ settings: { ...DEFAULT_SETTINGS } }),
     }),
     {
       name: 'mgz-pkmn-settings',

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,1 +1,7 @@
 import '@testing-library/jest-dom/vitest'
+import { afterEach } from 'vitest'
+import { cleanup } from '@testing-library/react'
+
+afterEach(() => {
+  cleanup()
+})


### PR DESCRIPTION
Closes #24

## What

- Adds a `resetSettings` action to the Zustand store (extracts `DEFAULT_SETTINGS` as the canonical source for both initial state and reset).
- Renders a **Restore defaults** button in the SettingsDrawer footer that restores every setting (API key, tag, sort order, max price cap, dedupe, hide images) to its initial value.
- Wires `cleanup()` into the Vitest setup so multiple `render` calls in the same file don't leak DOM into adjacent tests.
- Adds a behavior test that asserts the button calls `resetSettings`.

## Why

Issue #24: "No escape hatch from a weird settings state." If a user mis-toggles or pastes a stale API key, they had to manually re-edit every field — now one click puts everything back.

## How to verify

1. `cd web && npm run dev`
2. Click **Settings**, change a few values (e.g. set a price cap, toggle dedupe on, type something in the API key field).
3. Scroll to the bottom of the drawer and click **Restore defaults**.
4. All fields revert to their original defaults.

<img width="1145" height="628" alt="image" src="https://github.com/user-attachments/assets/b761d86c-5294-49f2-87ca-03495a04cf5f" />


Tests: `cd web && npm test` — 5 passing.