### PR TITLE
Honor settings.dedupe in export requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Web: exports now honor the **Deduplicate by card ID** setting — toggling
+  it before clicking an export button drops matched rows that share a card
+  ID with an earlier row, matching the CLI's `--dedupe` behavior.
+
 ## [0.1.0] - 2026-05-08
 
 Foundation release. Establishes the full CLI pipeline, a FastAPI/React web

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { dedupeRows } from './client'
+import type { Row } from '../types'
+
+function makeRow(over: Partial<Row> = {}): Row {
+  return {
+    query: { raw: '', name: '' } as Row['query'],
+    card: null,
+    pricing: { market: null, currency: 'USD', variant: null, source: null, url: null },
+    tag: '',
+    matched: true,
+    reason: '',
+    ...over,
+  }
+}
+
+describe('dedupeRows', () => {
+  it('removes matched rows sharing a card id, keeping the first occurrence', () => {
+    const rows: Row[] = [
+      makeRow({ card: { id: 'a', name: 'Charizard' } }),
+      makeRow({ card: { id: 'b', name: 'Pikachu' } }),
+      makeRow({ card: { id: 'a', name: 'Charizard' } }),
+    ]
+    const deduped = dedupeRows(rows)
+    expect(deduped).toHaveLength(2)
+    expect((deduped[0].card as { id: string }).id).toBe('a')
+    expect((deduped[1].card as { id: string }).id).toBe('b')
+  })
+
+  it('preserves unmatched rows and rows missing a card id', () => {
+    const rows: Row[] = [
+      makeRow({ matched: false, card: null }),
+      makeRow({ matched: false, card: null }),
+      makeRow({ card: { name: 'Mystery' } }),
+      makeRow({ card: { name: 'Mystery' } }),
+    ]
+    expect(dedupeRows(rows)).toHaveLength(4)
+  })
+
+  it('returns the same row count when there are no duplicates', () => {
+    const rows: Row[] = [
+      makeRow({ card: { id: 'a' } }),
+      makeRow({ card: { id: 'b' } }),
+      makeRow({ card: { id: 'c' } }),
+    ]
+    expect(dedupeRows(rows)).toHaveLength(3)
+  })
+})

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -131,6 +131,24 @@ const DOWNLOAD_FILENAMES: Record<ExportFormat, string> = {
   checklist: 'checklist.pdf',
 }
 
+/**
+ * Drop matched rows that share a card ID with an earlier row. Unmatched rows
+ * and rows without a card ID are always preserved (we can't tell duplicates
+ * apart without an ID). Mirrors the CLI's `--dedupe` and the bulk-lookup
+ * client-side dedupe in `App.tsx`.
+ */
+export function dedupeRows(rows: Row[]): Row[] {
+  const seen = new Set<string>()
+  return rows.filter((row) => {
+    if (!row.matched) return true
+    const cid = (row.card?.id as string | undefined) ?? null
+    if (!cid) return true
+    if (seen.has(cid)) return false
+    seen.add(cid)
+    return true
+  })
+}
+
 export async function exportFile(
   rows: Row[],
   format: ExportFormat,
@@ -139,13 +157,15 @@ export async function exportFile(
     title?: string
     sort?: SortMode
     noImages?: boolean
+    dedupe?: boolean
   } = {},
 ): Promise<void> {
+  const effectiveRows = options.dedupe ? dedupeRows(rows) : rows
   const res = await fetch(`${BASE}/export`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      rows,
+      rows: effectiveRows,
       format,
       sort: options.sort ?? 'number',
       max_price: options.maxPrice ?? null,

--- a/web/src/components/ExportBar.tsx
+++ b/web/src/components/ExportBar.tsx
@@ -46,6 +46,7 @@ export function ExportBar() {
         title: settings.tag || 'cards',
         sort: settings.sort,
         noImages: settings.noImages,
+        dedupe: settings.dedupe,
       })
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))


### PR DESCRIPTION
Closes #25

## What

- Adds a `dedupeRows` helper in `web/src/api/client.ts` that drops matched rows sharing a card ID with an earlier row. Unmatched rows and rows without a card ID are always preserved.
- `exportFile` now accepts a `dedupe` option and applies the helper before posting to `/api/v1/export`.
- `ExportBar` passes `settings.dedupe` from the store into every export call.
- Unit tests for `dedupeRows` covering duplicates, unmatched, missing IDs, and no-op cases.

## Why

Issue #25: "`settings.dedupe` exists in the type but no control flips it." The toggle in SettingsDrawer was wired into client-side bulk-lookup streaming (see `App.tsx`), but the export path ignored it — so toggling dedupe **after** a non-deduped run produced an export with duplicates anyway. With this PR every export honors whatever the toggle is set to at click time, matching the CLI's `--dedupe` semantics.

## How to verify

1. `cd web && npm test` — `dedupeRows` tests pass.
2. Run the app, paste a list with duplicate card lines (e.g. `Charizard | Base Set | 4` twice). Run lookup with **Deduplicate by card ID** off → results table shows both rows.
3. Toggle dedupe **on**, click any export — the resulting file contains a single Charizard row.
4. Toggle dedupe **off**, re-export — both rows appear.