### PR TITLE
Show per-line processing status during bulk lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Web: per-input-line status panel during bulk lookups — each card line
+  starts as pending (blue spinner), then transitions to resolved (green
+  check) or error (amber alert) as its first lookup event arrives.
+  New result rows fade in to make streaming visible.
+
 - Web: "Restore defaults" button in the settings drawer footer that resets
   all settings (API key, tag, sort, max price, dedupe, hide images) to
   their initial values.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,6 +16,7 @@ import { bulkLookup, lookupLine } from './api/client'
 import { InputEditor } from './components/InputEditor'
 import { ResultsTable } from './components/ResultsTable'
 import { ExportBar } from './components/ExportBar'
+import { ProcessingQueue } from './components/ProcessingQueue'
 import { SettingsDrawer } from './components/SettingsDrawer'
 import { useAppStore } from './store'
 import type { BulkEvent } from './types'
@@ -29,6 +30,8 @@ function App() {
     isRunning,
     setIsRunning,
     setProgress,
+    setProcessingLines,
+    markLineStatus,
   } = useAppStore()
 
   const abortRef = useRef<AbortController | null>(null)
@@ -55,6 +58,7 @@ function App() {
     if (nonEmpty.length === 0) return
 
     clearRows()
+    setProcessingLines(nonEmpty.map((line) => ({ line, status: 'pending' })))
     setIsRunning(true)
     setProgress({ done: 0, total: nonEmpty.length })
 
@@ -65,6 +69,10 @@ function App() {
 
     function onEvent(event: BulkEvent) {
       if (event.done) return
+
+      // First event for this input line transitions it out of "pending".
+      // Subsequent events (top:N expansions) leave the status alone.
+      markLineStatus(event.index, event.matched ? 'resolved' : 'error')
 
       if (settings.dedupe && event.matched && event.card) {
         const cid = event.card.id as string | undefined
@@ -95,7 +103,17 @@ function App() {
     } catch {
       setIsRunning(false)
     }
-  }, [inputText, settings, isRunning, clearRows, appendRow, setIsRunning, setProgress])
+  }, [
+    inputText,
+    settings,
+    isRunning,
+    clearRows,
+    appendRow,
+    setIsRunning,
+    setProgress,
+    setProcessingLines,
+    markLineStatus,
+  ])
 
   const handleStop = useCallback(() => {
     abortRef.current?.abort()
@@ -148,7 +166,10 @@ function App() {
           <h2 className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-500">
             Results
           </h2>
-          <ResultsTable onRerunLine={handleRerunLine} />
+          <div className="flex flex-col gap-3">
+            <ProcessingQueue />
+            <ResultsTable onRerunLine={handleRerunLine} />
+          </div>
         </section>
       </main>
 

--- a/web/src/components/ProcessingQueue.test.tsx
+++ b/web/src/components/ProcessingQueue.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ProcessingQueue } from './ProcessingQueue'
+
+const { mockState } = vi.hoisted(() => ({
+  mockState: {
+    processingLines: [
+      { line: 'Charizard | Base Set | 4', status: 'resolved' as const },
+      { line: 'Pikachu | Jungle', status: 'error' as const },
+      { line: 'top:5 Mew ex', status: 'pending' as const },
+    ],
+    isRunning: true,
+  },
+}))
+
+vi.mock('../store', () => ({
+  useAppStore: () => mockState,
+}))
+
+describe('ProcessingQueue', () => {
+  it('renders one entry per input line and a done/total count', () => {
+    render(<ProcessingQueue />)
+    expect(screen.getByText(/looking up cards/i)).toBeInTheDocument()
+    expect(screen.getByText(/2 of 3 done/i)).toBeInTheDocument()
+    expect(screen.getByText('Charizard | Base Set | 4')).toBeInTheDocument()
+    expect(screen.getByText('Pikachu | Jungle')).toBeInTheDocument()
+    expect(screen.getByText('top:5 Mew ex')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/ProcessingQueue.tsx
+++ b/web/src/components/ProcessingQueue.tsx
@@ -1,0 +1,55 @@
+/**
+ * ProcessingQueue — per-line status panel shown while a bulk lookup is
+ * in flight. Each input line transitions pending → resolved / error as
+ * its first SSE event arrives. Resolved lines fade out after a short
+ * delay so the user can see the green check before the row settles.
+ */
+import { CheckCircle2, AlertTriangle, Loader2 } from 'lucide-react'
+import { useAppStore } from '../store'
+import type { ProcessingLine } from '../types'
+
+export function ProcessingQueue() {
+  const { processingLines, isRunning } = useAppStore()
+
+  if (processingLines.length === 0) return null
+
+  const done = processingLines.filter((l) => l.status !== 'pending').length
+  const total = processingLines.length
+  // Hide once everything has resolved and the run has finished.
+  if (!isRunning && done === total) return null
+
+  return (
+    <div className="rounded-md border border-zinc-800 bg-zinc-900/60 px-4 py-3">
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-xs font-medium text-zinc-400">
+          Looking up cards…
+        </span>
+        <span className="text-xs tabular-nums text-zinc-500">
+          {done} of {total} done
+        </span>
+      </div>
+      <ul className="grid grid-cols-1 gap-1 sm:grid-cols-2 md:grid-cols-3">
+        {processingLines.map((pl, i) => (
+          <LineStatus key={`${i}:${pl.line}`} line={pl} />
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function LineStatus({ line }: { line: ProcessingLine }) {
+  const icon =
+    line.status === 'pending' ? (
+      <Loader2 size={12} className="flex-shrink-0 animate-spin text-blue-400" />
+    ) : line.status === 'resolved' ? (
+      <CheckCircle2 size={12} className="flex-shrink-0 text-green-400" />
+    ) : (
+      <AlertTriangle size={12} className="flex-shrink-0 text-amber-400" />
+    )
+  return (
+    <li className="flex items-center gap-1.5 text-xs text-zinc-400">
+      {icon}
+      <span className="truncate">{line.line}</span>
+    </li>
+  )
+}

--- a/web/src/components/ProcessingQueue.tsx
+++ b/web/src/components/ProcessingQueue.tsx
@@ -1,8 +1,9 @@
 /**
  * ProcessingQueue — per-line status panel shown while a bulk lookup is
  * in flight. Each input line transitions pending → resolved / error as
- * its first SSE event arrives. Resolved lines fade out after a short
- * delay so the user can see the green check before the row settles.
+ * its first SSE event arrives. The panel unmounts as soon as the run
+ * finishes (whether by completion, Stop, or error) so abandoned
+ * pending entries don't spin indefinitely.
  */
 import { CheckCircle2, AlertTriangle, Loader2 } from 'lucide-react'
 import { useAppStore } from '../store'
@@ -12,11 +13,13 @@ export function ProcessingQueue() {
   const { processingLines, isRunning } = useAppStore()
 
   if (processingLines.length === 0) return null
+  // Hide as soon as the run finishes — covers both the success case
+  // (where every line is already resolved/error) and the abort/error
+  // case (where some lines would otherwise stay pending forever).
+  if (!isRunning) return null
 
   const done = processingLines.filter((l) => l.status !== 'pending').length
   const total = processingLines.length
-  // Hide once everything has resolved and the run has finished.
-  if (!isRunning && done === total) return null
 
   return (
     <div className="rounded-md border border-zinc-800 bg-zinc-900/60 px-4 py-3">

--- a/web/src/components/ResultsTable.tsx
+++ b/web/src/components/ResultsTable.tsx
@@ -148,7 +148,7 @@ function ResultRow({
   return (
     <>
       <tr
-        className={`border-b border-zinc-800 hover:bg-zinc-800/50 transition-colors ${
+        className={`border-b border-zinc-800 hover:bg-zinc-800/50 transition-colors motion-safe:animate-[fadeInRow_220ms_ease-out] ${
           !row.matched ? 'opacity-60' : ''
         } ${isOverCap ? 'bg-amber-950/30' : ''}`}
       >

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,1 +1,12 @@
 @import "tailwindcss";
+
+@keyframes fadeInRow {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/web/src/store/index.test.ts
+++ b/web/src/store/index.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useAppStore } from './index'
+
+describe('store: processingLines', () => {
+  beforeEach(() => useAppStore.setState({ processingLines: [] }))
+
+  it('markLineStatus transitions a pending line to resolved', () => {
+    useAppStore.setState({
+      processingLines: [{ line: 'Charizard', status: 'pending' }],
+    })
+    useAppStore.getState().markLineStatus(0, 'resolved')
+    expect(useAppStore.getState().processingLines[0].status).toBe('resolved')
+  })
+
+  it('markLineStatus is idempotent for already-resolved lines (top:N expansions)', () => {
+    useAppStore.setState({
+      processingLines: [{ line: 'top:5 Mew', status: 'resolved' }],
+    })
+    useAppStore.getState().markLineStatus(0, 'error')
+    expect(useAppStore.getState().processingLines[0].status).toBe('resolved')
+  })
+
+  it('markLineStatus ignores out-of-range indices', () => {
+    useAppStore.setState({
+      processingLines: [{ line: 'a', status: 'pending' }],
+    })
+    useAppStore.getState().markLineStatus(99, 'resolved')
+    expect(useAppStore.getState().processingLines).toHaveLength(1)
+    expect(useAppStore.getState().processingLines[0].status).toBe('pending')
+  })
+})

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import type { Row, Settings } from '../types'
+import type { ProcessingLine, Row, Settings } from '../types'
 
 const DEFAULT_SETTINGS: Settings = {
   apiKey: '',
@@ -30,6 +30,11 @@ interface AppState {
   isRunning: boolean
   setIsRunning: (v: boolean) => void
 
+  /** Per-input-line status tracked across the current bulk lookup. */
+  processingLines: ProcessingLine[]
+  setProcessingLines: (lines: ProcessingLine[]) => void
+  markLineStatus: (index: number, status: ProcessingLine['status']) => void
+
   /** Persistent settings (survives page reload). */
   settings: Settings
   updateSettings: (partial: Partial<Settings>) => void
@@ -52,6 +57,17 @@ export const useAppStore = create<AppState>()(
 
       isRunning: false,
       setIsRunning: (isRunning) => set({ isRunning }),
+
+      processingLines: [],
+      setProcessingLines: (processingLines) => set({ processingLines }),
+      markLineStatus: (index, status) =>
+        set((state) => {
+          const current = state.processingLines[index]
+          if (!current || current.status !== 'pending') return state
+          const next = state.processingLines.slice()
+          next[index] = { ...current, status }
+          return { processingLines: next }
+        }),
 
       settings: { ...DEFAULT_SETTINGS },
       updateSettings: (partial) =>

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,6 +1,28 @@
 import '@testing-library/jest-dom/vitest'
-import { afterEach } from 'vitest'
+import { afterEach, vi } from 'vitest'
 import { cleanup } from '@testing-library/react'
+
+// Zustand's persist middleware reaches for `localStorage` on every state
+// change. jsdom in Node 22 exposes an experimental `localStorage` global
+// that throws on `setItem` unless `--localstorage-file` is passed, so we
+// install a plain in-memory stub before any test code runs.
+const _memory: Record<string, string> = {}
+vi.stubGlobal('localStorage', {
+  getItem: (k: string) => _memory[k] ?? null,
+  setItem: (k: string, v: string) => {
+    _memory[k] = v
+  },
+  removeItem: (k: string) => {
+    delete _memory[k]
+  },
+  clear: () => {
+    for (const k of Object.keys(_memory)) delete _memory[k]
+  },
+  key: (i: number) => Object.keys(_memory)[i] ?? null,
+  get length() {
+    return Object.keys(_memory).length
+  },
+})
 
 afterEach(() => {
   cleanup()

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -84,6 +84,12 @@ export interface Settings {
   sort: SortMode
 }
 
+/** One input line tracked through the bulk lookup lifecycle. */
+export interface ProcessingLine {
+  line: string
+  status: 'pending' | 'resolved' | 'error'
+}
+
 export interface SetInfo {
   id: string
   name: string


### PR DESCRIPTION
Closes #27

## What

- Adds a `ProcessingQueue` panel above the results table that lists every input line with a status icon: blue spinner for pending, green check for resolved, amber alert for error.
- Adds a `processingLines` slice + `markLineStatus` action to the store. The action only flips lines out of pending — top:N expansions emit subsequent events with the same index and leave the status alone.
- Adds a `fadeInRow` keyframe applied to new rows in `ResultsTable`, gated on `motion-safe` to respect `prefers-reduced-motion`.
- Adds a `localStorage` shim to the Vitest setup so Zustand's persist middleware no longer crashes in Node 22's experimental localStorage. Unblocks store-level tests.
- Adds tests for `ProcessingQueue` (renders one entry per line + done/total count) and for `markLineStatus` (pending → resolved, idempotent for top:N, ignores out-of-range).

## Why

During a cold-cache run the API can take 30s. With only a progress bar visible the UI looks frozen — users had no per-card feedback. The processing panel maps each input line to a visible state transition, and the row animation makes streaming inserts feel live.

## How to verify

1. `cd web && npm test` — all 12 tests pass (was 8).
2. `make check && cd web && npm run build` — clean.
3. Run the app, paste 5+ lines, click **Look up**. Above the table you should see a panel listing each line with a spinner; spinners flip to check / alert icons as events arrive. New result rows fade in (unless your OS has reduced-motion enabled).