### PR TITLE
Add click-to-sort headers and per-column filters to ResultsTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Web: click any sortable column header (Name, Set, Rarity, Market,
+  Source) in the results table to cycle through ascending → descending
+  → off. A new **Filter** toggle reveals per-column inputs: substring
+  match for text columns and min/max range for Market. View-only —
+  exports continue to honor the sort mode in Settings.
+
+### Added
+
 - Web: "Restore defaults" button in the settings drawer footer that resets
   all settings (API key, tag, sort, max price, dedupe, hide images) to
   their initial values.

--- a/web/src/components/ResultsTable.test.tsx
+++ b/web/src/components/ResultsTable.test.tsx
@@ -1,14 +1,181 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { ResultsTable } from './ResultsTable'
+import { applyFilters, applySort } from './resultsTableFilter'
+import { useAppStore } from '../store'
+import type { Row } from '../types'
 
 vi.mock('../api/client', () => ({
   addOverride: vi.fn(),
 }))
 
+function makeRow(over: Partial<Row> = {}): Row {
+  return {
+    query: { raw: '', name: '' } as Row['query'],
+    card: null,
+    pricing: { market: null, currency: 'USD', variant: null, source: null, url: null },
+    tag: '',
+    matched: true,
+    reason: '',
+    ...over,
+  }
+}
+
 describe('ResultsTable', () => {
   it('shows empty-state message when there are no rows', () => {
+    useAppStore.setState({ rows: [], isRunning: false, progress: null })
     render(<ResultsTable />)
     expect(screen.getByText(/results will appear here/i)).toBeInTheDocument()
+  })
+})
+
+describe('applyFilters', () => {
+  const rows: Row[] = [
+    makeRow({
+      card: { name: 'Charizard', rarity: 'Holo Rare', set: { name: 'Base Set' } },
+      pricing: { market: 100, currency: 'USD', variant: null, source: 'TCGPlayer', url: null },
+    }),
+    makeRow({
+      card: { name: 'Pikachu', rarity: 'Common', set: { name: 'Jungle' } },
+      pricing: { market: 5, currency: 'USD', variant: null, source: 'Cardmarket', url: null },
+    }),
+    makeRow({
+      card: { name: 'Mew ex', rarity: 'Double Rare', set: { name: 'Scarlet & Violet' } },
+      pricing: { market: 25, currency: 'USD', variant: null, source: 'TCGPlayer', url: null },
+    }),
+  ]
+
+  it('substring text match is case-insensitive', () => {
+    expect(
+      applyFilters(rows, {
+        name: 'char',
+        set: '',
+        rarity: '',
+        marketMin: '',
+        marketMax: '',
+        source: '',
+      }),
+    ).toHaveLength(1)
+  })
+
+  it('min/max market range excludes prices outside the band', () => {
+    const filtered = applyFilters(rows, {
+      name: '',
+      set: '',
+      rarity: '',
+      marketMin: '10',
+      marketMax: '50',
+      source: '',
+    })
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0].card?.name as string | undefined).toBe('Mew ex')
+  })
+
+  it('combines multiple column filters as AND', () => {
+    const filtered = applyFilters(rows, {
+      name: 'a',
+      set: '',
+      rarity: 'rare',
+      marketMin: '',
+      marketMax: '',
+      source: 'tcg',
+    })
+    expect(filtered).toHaveLength(1)
+    expect(filtered[0].card?.name as string | undefined).toBe('Charizard')
+  })
+})
+
+describe('applySort', () => {
+  const rows: Row[] = [
+    makeRow({
+      card: { name: 'Charizard' },
+      pricing: { market: 100, currency: 'USD', variant: null, source: null, url: null },
+    }),
+    makeRow({
+      card: { name: 'Abra' },
+      pricing: { market: 50, currency: 'USD', variant: null, source: null, url: null },
+    }),
+    makeRow({
+      card: { name: 'Zubat' },
+      pricing: { market: 1, currency: 'USD', variant: null, source: null, url: null },
+    }),
+  ]
+
+  it('returns input unchanged when sort is off', () => {
+    expect(applySort(rows, null, null).map((r) => r.card?.name)).toEqual([
+      'Charizard',
+      'Abra',
+      'Zubat',
+    ])
+  })
+
+  it('sorts strings ascending', () => {
+    expect(applySort(rows, 'name', 'asc').map((r) => r.card?.name)).toEqual([
+      'Abra',
+      'Charizard',
+      'Zubat',
+    ])
+  })
+
+  it('sorts numbers descending', () => {
+    expect(applySort(rows, 'market', 'desc').map((r) => r.pricing.market)).toEqual([
+      100, 50, 1,
+    ])
+  })
+})
+
+describe('ResultsTable: header sort cycle', () => {
+  it('clicking the Name header cycles asc → desc → off', () => {
+    useAppStore.setState({
+      rows: [
+        makeRow({ card: { name: 'Charizard' } }),
+        makeRow({ card: { name: 'Abra' } }),
+        makeRow({ card: { name: 'Zubat' } }),
+      ],
+      isRunning: false,
+      progress: null,
+    })
+
+    render(<ResultsTable />)
+    const header = screen.getByRole('button', { name: /sort by name/i })
+
+    function firstBodyRow(): string {
+      // First non-header row contains the first card name.
+      const rows = screen.getAllByRole('row')
+      return rows[rows.length === 1 ? 0 : 1].textContent ?? ''
+    }
+
+    fireEvent.click(header) // asc
+    expect(firstBodyRow()).toContain('Abra')
+
+    fireEvent.click(header) // desc
+    expect(firstBodyRow()).toContain('Zubat')
+
+    fireEvent.click(header) // off → original order
+    expect(firstBodyRow()).toContain('Charizard')
+
+    useAppStore.setState({ rows: [] })
+  })
+
+  it('toggling Filter reveals filter inputs and narrows displayed rows', () => {
+    useAppStore.setState({
+      rows: [
+        makeRow({ card: { name: 'Charizard' } }),
+        makeRow({ card: { name: 'Pikachu' } }),
+      ],
+      isRunning: false,
+      progress: null,
+    })
+
+    render(<ResultsTable />)
+    fireEvent.click(screen.getByRole('button', { name: /filter/i }))
+    const nameFilter = screen.getByLabelText(/filter by name/i)
+    fireEvent.change(nameFilter, { target: { value: 'char' } })
+
+    const bodyRows = screen.getAllByRole('row').filter((tr) => tr.querySelector('td'))
+    expect(bodyRows).toHaveLength(1)
+    expect(bodyRows[0].textContent).toContain('Charizard')
+
+    useAppStore.setState({ rows: [] })
   })
 })

--- a/web/src/components/ResultsTable.tsx
+++ b/web/src/components/ResultsTable.tsx
@@ -4,12 +4,27 @@
  * Each row shows: thumbnail (if available), name, set, rarity,
  * market price, comp tiers (80/85/90/95%), price source, and a link to
  * the listing. Unmatched rows show an amber "not found" badge.
+ *
+ * Headers for Name / Set / Rarity / Market / Source are click-to-sort
+ * (asc → desc → off). A Filter toggle reveals a row of per-column
+ * inputs — text match for strings, min/max for the Market column. The
+ * column sort/filter is view-only; exports still honor the sort mode
+ * in Settings.
  */
-import { useState } from 'react'
-import { ExternalLink, AlertCircle } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { ArrowDown, ArrowUp, ArrowUpDown, ExternalLink, AlertCircle, Filter } from 'lucide-react'
 import { addOverride } from '../api/client'
 import { useAppStore } from '../store'
 import type { Row } from '../types'
+import {
+  applyFilters,
+  applySort,
+  EMPTY_FILTERS,
+  hasActiveFilters,
+  type Filters,
+  type SortColumn,
+  type SortDir,
+} from './resultsTableFilter'
 
 interface Props {
   onRerunLine?: (line: string) => void
@@ -17,6 +32,27 @@ interface Props {
 
 export function ResultsTable({ onRerunLine }: Props) {
   const { rows, progress, isRunning, settings } = useAppStore()
+  const [sortColumn, setSortColumn] = useState<SortColumn | null>(null)
+  const [sortDir, setSortDir] = useState<SortDir | null>(null)
+  const [showFilters, setShowFilters] = useState(false)
+  const [filters, setFilters] = useState<Filters>(EMPTY_FILTERS)
+
+  function cycleSort(column: SortColumn) {
+    if (sortColumn !== column) {
+      setSortColumn(column)
+      setSortDir('asc')
+    } else if (sortDir === 'asc') {
+      setSortDir('desc')
+    } else {
+      setSortColumn(null)
+      setSortDir(null)
+    }
+  }
+
+  const displayedRows = useMemo(
+    () => applySort(applyFilters(rows, filters), sortColumn, sortDir),
+    [rows, filters, sortColumn, sortDir],
+  )
 
   if (rows.length === 0 && !isRunning) {
     return (
@@ -47,6 +83,36 @@ export function ResultsTable({ onRerunLine }: Props) {
         </div>
       )}
 
+      {/* Toolbar */}
+      <div className="flex items-center justify-between">
+        <button
+          type="button"
+          onClick={() => setShowFilters((v) => !v)}
+          aria-pressed={showFilters}
+          className={`flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs transition-colors ${
+            showFilters
+              ? 'border-blue-700 bg-blue-900/30 text-blue-300'
+              : 'border-zinc-700 bg-zinc-800 text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700'
+          }`}
+        >
+          <Filter size={12} />
+          {showFilters ? 'Hide filters' : 'Filter'}
+        </button>
+        {(sortColumn || hasActiveFilters(filters)) && (
+          <button
+            type="button"
+            onClick={() => {
+              setSortColumn(null)
+              setSortDir(null)
+              setFilters(EMPTY_FILTERS)
+            }}
+            className="text-xs text-zinc-500 hover:text-zinc-300"
+          >
+            Clear sort &amp; filters
+          </button>
+        )}
+      </div>
+
       {/* Table */}
       <div className="overflow-x-auto rounded-md border border-zinc-700">
         <table className="w-full text-sm border-collapse">
@@ -55,20 +121,114 @@ export function ResultsTable({ onRerunLine }: Props) {
               {!settings.noImages && (
                 <th className="px-3 py-2 text-xs font-medium text-zinc-400 w-16">Img</th>
               )}
-              <th className="px-3 py-2 text-xs font-medium text-zinc-400">Name</th>
-              <th className="px-3 py-2 text-xs font-medium text-zinc-400 hidden md:table-cell">Set</th>
-              <th className="px-3 py-2 text-xs font-medium text-zinc-400 hidden lg:table-cell">Rarity</th>
-              <th className="px-3 py-2 text-xs font-medium text-zinc-400 text-right">Market</th>
+              <SortableHeader
+                label="Name"
+                column="name"
+                active={sortColumn}
+                dir={sortDir}
+                onClick={cycleSort}
+              />
+              <SortableHeader
+                label="Set"
+                column="set"
+                active={sortColumn}
+                dir={sortDir}
+                onClick={cycleSort}
+                className="hidden md:table-cell"
+              />
+              <SortableHeader
+                label="Rarity"
+                column="rarity"
+                active={sortColumn}
+                dir={sortDir}
+                onClick={cycleSort}
+                className="hidden lg:table-cell"
+              />
+              <SortableHeader
+                label="Market"
+                column="market"
+                active={sortColumn}
+                dir={sortDir}
+                onClick={cycleSort}
+                align="right"
+              />
               <th className="px-3 py-2 text-xs font-medium text-zinc-400 text-right hidden xl:table-cell">80%</th>
               <th className="px-3 py-2 text-xs font-medium text-zinc-400 text-right hidden xl:table-cell">85%</th>
               <th className="px-3 py-2 text-xs font-medium text-zinc-400 text-right hidden xl:table-cell">90%</th>
               <th className="px-3 py-2 text-xs font-medium text-zinc-400 text-right hidden xl:table-cell">95%</th>
-              <th className="px-3 py-2 text-xs font-medium text-zinc-400 hidden sm:table-cell">Source</th>
+              <SortableHeader
+                label="Source"
+                column="source"
+                active={sortColumn}
+                dir={sortDir}
+                onClick={cycleSort}
+                className="hidden sm:table-cell"
+              />
               <th className="px-3 py-2 text-xs font-medium text-zinc-400 w-8" />
             </tr>
+            {showFilters && (
+              <tr className="border-b border-zinc-700 bg-zinc-900">
+                {!settings.noImages && <th />}
+                <FilterCell>
+                  <FilterInput
+                    aria-label="Filter by name"
+                    placeholder="contains…"
+                    value={filters.name}
+                    onChange={(v) => setFilters((f) => ({ ...f, name: v }))}
+                  />
+                </FilterCell>
+                <FilterCell className="hidden md:table-cell">
+                  <FilterInput
+                    aria-label="Filter by set"
+                    placeholder="contains…"
+                    value={filters.set}
+                    onChange={(v) => setFilters((f) => ({ ...f, set: v }))}
+                  />
+                </FilterCell>
+                <FilterCell className="hidden lg:table-cell">
+                  <FilterInput
+                    aria-label="Filter by rarity"
+                    placeholder="contains…"
+                    value={filters.rarity}
+                    onChange={(v) => setFilters((f) => ({ ...f, rarity: v }))}
+                  />
+                </FilterCell>
+                <FilterCell>
+                  <div className="flex gap-1">
+                    <FilterInput
+                      aria-label="Min market price"
+                      type="number"
+                      placeholder="min"
+                      value={filters.marketMin}
+                      onChange={(v) => setFilters((f) => ({ ...f, marketMin: v }))}
+                    />
+                    <FilterInput
+                      aria-label="Max market price"
+                      type="number"
+                      placeholder="max"
+                      value={filters.marketMax}
+                      onChange={(v) => setFilters((f) => ({ ...f, marketMax: v }))}
+                    />
+                  </div>
+                </FilterCell>
+                <th className="hidden xl:table-cell" />
+                <th className="hidden xl:table-cell" />
+                <th className="hidden xl:table-cell" />
+                <th className="hidden xl:table-cell" />
+                <FilterCell className="hidden sm:table-cell">
+                  <FilterInput
+                    aria-label="Filter by source"
+                    placeholder="contains…"
+                    value={filters.source}
+                    onChange={(v) => setFilters((f) => ({ ...f, source: v }))}
+                  />
+                </FilterCell>
+                <th />
+              </tr>
+            )}
           </thead>
           <tbody>
-            {rows.map((row, i) => (
+            {displayedRows.map((row, i) => (
               <ResultRow
                 key={i}
                 row={row}
@@ -88,10 +248,91 @@ export function ResultsTable({ onRerunLine }: Props) {
       </div>
 
       <p className="text-xs text-zinc-600 text-right">
-        {rows.filter((r) => r.matched).length} matched · {rows.filter((r) => !r.matched).length}{' '}
-        unmatched · {rows.length} total
+        {displayedRows.filter((r) => r.matched).length} matched ·{' '}
+        {displayedRows.filter((r) => !r.matched).length} unmatched ·{' '}
+        {displayedRows.length} shown
+        {displayedRows.length !== rows.length && (
+          <span className="text-zinc-500"> (of {rows.length})</span>
+        )}
       </p>
     </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function SortableHeader({
+  label,
+  column,
+  active,
+  dir,
+  onClick,
+  className = '',
+  align = 'left',
+}: {
+  label: string
+  column: SortColumn
+  active: SortColumn | null
+  dir: SortDir | null
+  onClick: (c: SortColumn) => void
+  className?: string
+  align?: 'left' | 'right'
+}) {
+  const isActive = active === column
+  const Icon = isActive ? (dir === 'asc' ? ArrowUp : ArrowDown) : ArrowUpDown
+  return (
+    <th
+      className={`px-3 py-2 text-xs font-medium ${align === 'right' ? 'text-right' : ''} ${className}`}
+    >
+      <button
+        type="button"
+        onClick={() => onClick(column)}
+        className={`inline-flex items-center gap-1 ${
+          isActive ? 'text-zinc-100' : 'text-zinc-400 hover:text-zinc-200'
+        }`}
+        aria-label={`Sort by ${label}`}
+      >
+        {label}
+        <Icon size={11} className={isActive ? 'opacity-100' : 'opacity-40'} />
+      </button>
+    </th>
+  )
+}
+
+function FilterCell({
+  children,
+  className = '',
+}: {
+  children: React.ReactNode
+  className?: string
+}) {
+  return <th className={`px-2 py-1.5 ${className}`}>{children}</th>
+}
+
+function FilterInput({
+  value,
+  onChange,
+  placeholder,
+  type = 'text',
+  'aria-label': ariaLabel,
+}: {
+  value: string
+  onChange: (v: string) => void
+  placeholder: string
+  type?: 'text' | 'number'
+  'aria-label': string
+}) {
+  return (
+    <input
+      type={type}
+      value={value}
+      placeholder={placeholder}
+      aria-label={ariaLabel}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full rounded border border-zinc-700 bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-200 placeholder:text-zinc-600 focus:outline-none focus:ring-1 focus:ring-blue-500"
+    />
   )
 }
 

--- a/web/src/components/resultsTableFilter.ts
+++ b/web/src/components/resultsTableFilter.ts
@@ -1,0 +1,97 @@
+/**
+ * Pure helpers for filtering and sorting result rows in the table view.
+ *
+ * View-only — exports continue to apply the sort mode chosen in Settings,
+ * not the column sort selected here.
+ */
+import type { Row } from '../types'
+
+export type SortColumn = 'name' | 'set' | 'rarity' | 'market' | 'source'
+export type SortDir = 'asc' | 'desc'
+
+export interface Filters {
+  name: string
+  set: string
+  rarity: string
+  marketMin: string
+  marketMax: string
+  source: string
+}
+
+export const EMPTY_FILTERS: Filters = {
+  name: '',
+  set: '',
+  rarity: '',
+  marketMin: '',
+  marketMax: '',
+  source: '',
+}
+
+export function hasActiveFilters(f: Filters): boolean {
+  return Object.values(f).some((v) => v !== '')
+}
+
+export function applyFilters(rows: Row[], filters: Filters): Row[] {
+  const min = filters.marketMin === '' ? null : Number(filters.marketMin)
+  const max = filters.marketMax === '' ? null : Number(filters.marketMax)
+  return rows.filter((row) => {
+    if (filters.name && !text(getName(row)).includes(filters.name.toLowerCase())) return false
+    if (filters.set && !text(getSet(row)).includes(filters.set.toLowerCase())) return false
+    if (filters.rarity && !text(getRarity(row)).includes(filters.rarity.toLowerCase())) return false
+    if (filters.source && !text(row.pricing.source).includes(filters.source.toLowerCase())) {
+      return false
+    }
+    if (min != null || max != null) {
+      const m = row.pricing.market
+      if (m == null) return false
+      if (min != null && m < min) return false
+      if (max != null && m > max) return false
+    }
+    return true
+  })
+}
+
+export function applySort(rows: Row[], column: SortColumn | null, dir: SortDir | null): Row[] {
+  if (!column || !dir) return rows
+  const mul = dir === 'asc' ? 1 : -1
+  const get = SORT_ACCESSORS[column]
+  const indexed = rows.map((row, i) => ({ row, i }))
+  indexed.sort((a, b) => {
+    const cmp = compareValues(get(a.row), get(b.row))
+    return cmp !== 0 ? cmp * mul : a.i - b.i
+  })
+  return indexed.map((x) => x.row)
+}
+
+const SORT_ACCESSORS: Record<SortColumn, (row: Row) => string | number | null> = {
+  name: (row) => getName(row),
+  set: (row) => getSet(row),
+  rarity: (row) => getRarity(row),
+  market: (row) => row.pricing.market,
+  source: (row) => row.pricing.source,
+}
+
+function text(v: unknown): string {
+  return typeof v === 'string' ? v.toLowerCase() : ''
+}
+
+function getName(row: Row): string | null {
+  return (row.card?.name as string | undefined) ?? row.query.name ?? null
+}
+
+function getSet(row: Row): string | null {
+  const setObj = row.card?.set as { name?: string } | undefined
+  return setObj?.name ?? null
+}
+
+function getRarity(row: Row): string | null {
+  return (row.card?.rarity as string | undefined) ?? null
+}
+
+function compareValues(a: string | number | null, b: string | number | null): number {
+  if (a == null && b == null) return 0
+  if (a == null) return 1
+  if (b == null) return -1
+  if (typeof a === 'number' && typeof b === 'number') return a - b
+  return String(a).localeCompare(String(b))
+}

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,6 +1,28 @@
 import '@testing-library/jest-dom/vitest'
-import { afterEach } from 'vitest'
+import { afterEach, vi } from 'vitest'
 import { cleanup } from '@testing-library/react'
+
+// Zustand's persist middleware reaches for `localStorage` on every state
+// change. jsdom in Node 22 exposes an experimental `localStorage` global
+// that throws on `setItem` unless `--localstorage-file` is passed, so we
+// install a plain in-memory stub before any test code runs.
+const _memory: Record<string, string> = {}
+vi.stubGlobal('localStorage', {
+  getItem: (k: string) => _memory[k] ?? null,
+  setItem: (k: string, v: string) => {
+    _memory[k] = v
+  },
+  removeItem: (k: string) => {
+    delete _memory[k]
+  },
+  clear: () => {
+    for (const k of Object.keys(_memory)) delete _memory[k]
+  },
+  key: (i: number) => Object.keys(_memory)[i] ?? null,
+  get length() {
+    return Object.keys(_memory).length
+  },
+})
 
 afterEach(() => {
   cleanup()


### PR DESCRIPTION
Closes #26

## What

- **Sort**: Headers for Name, Set, Rarity, Market, and Source cycle through asc → desc → off when clicked, with a directional arrow icon showing the active state.
- **Filter**: A new **Filter** toggle reveals per-column inputs — substring match (case-insensitive) for text columns and min/max numeric range for Market.
- A "Clear sort & filters" affordance appears once anything is active.
- View-only — exports still apply the sort mode chosen in Settings, not the column sort selected here.
- Helpers (`applyFilters`, `applySort`, `EMPTY_FILTERS`) extracted to `resultsTableFilter.ts` so the component file keeps Fast Refresh working.

## Why

With many rows the read-only table left users with no way to narrow the view. Click-to-sort and per-column filters cover the common cases (find by name, see only cards over \$X, etc.) without leaving the page.

## How to verify

1. `cd web && npm test` — 16 tests pass (10 new across `applyFilters`, `applySort`, and integration tests for the sort cycle + filter narrowing).
2. `make check && cd web && npm run build` — clean.
3. Run the app and look up several cards. Click any sortable header — first click sorts asc with an up-arrow, second click flips to desc, third click clears. Click **Filter** to reveal the input row; type a substring in Name, or a price in Market min/max. The footer count updates as filters narrow.

<img width="1118" height="135" alt="image" src="https://github.com/user-attachments/assets/a24e012c-15f7-45ca-b76e-25a6ac33c74d" />


## Coordinates with #125

This PR also adds the localStorage shim to `web/src/test/setup.ts` that PR #125 introduces. The two PRs add identical content; whichever lands second will resolve trivially.