### PR TITLE
V1 release prep: promote changelog to 1.0.0, bump version, update roadmap and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-05-15
+
 ### Added
 
 - Web: per-input-line status panel during bulk lookups — each card line
@@ -118,5 +120,6 @@ UI, multi-source card lookup, all output formats, and release infrastructure.
 - Incomplete URL substring sanitization (CodeQL alerts).
 - Workflow permissions hardening (CodeQL alerts).
 
-[Unreleased]: https://github.com/mgzwarrior/mgz-pkmn/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/mgzwarrior/mgz-pkmn/compare/v0.1.0...v1.0.0
 [0.1.0]: https://github.com/mgzwarrior/mgz-pkmn/releases/tag/v0.1.0

--- a/api/README.md
+++ b/api/README.md
@@ -70,6 +70,7 @@ without CORS gymnastics. CORS is also pre-allowed for `localhost:5173` and
 | `GET`  | `/api/v1/sets` | Cached list of Pokémon TCG sets (weekly TTL) |
 | `POST` | `/api/v1/overrides` | Record a sticky PriceCharting URL override |
 | `GET`  | `/api/v1/overrides` | List all recorded URL overrides |
+| `GET`  | `/api/v1/set-cards.pdf` | Printable set identification cards PDF (no input needed) |
 
 The full schema (request models, response shapes) is in Swagger — the
 examples below are just the bits worth calling out.
@@ -176,6 +177,7 @@ api/
 │   ├── lookup.py      # POST /lookup, POST /bulk (SSE)
 │   ├── export.py      # POST /export
 │   ├── sets.py        # GET /sets (with disk cache)
+│   ├── set_cards.py   # GET /set-cards.pdf
 │   └── overrides.py   # POST/GET /overrides
 └── pyproject.toml     # editable-installs `mgz-pkmn` from ../
 ```
@@ -207,9 +209,10 @@ expect each to maintain its own.
 
 ## Dev workflow
 
-The API has no dedicated test suite yet — the underlying `mgz_pkmn` package
-is well-covered by `tests/` at the repo root, and the routes are thin
-wrappers. To smoke-test a route:
+API routes are covered by `tests/test_api_routes.py`, `tests/test_export_api.py`,
+`tests/test_set_cards_api.py`, and `tests/test_spa_mount.py` at the repo root.
+Run them with `make test` or `uv run python -m unittest discover -s tests`.
+To smoke-test a route manually:
 
 ```bash
 # Health

--- a/api/main.py
+++ b/api/main.py
@@ -46,7 +46,7 @@ class SPAStaticFiles(StaticFiles):
 app = FastAPI(
     title="mgz-pkmn API",
     description="Browser-accessible API for the mgz-pkmn Pokémon card lookup tool.",
-    version="0.1.0",
+    version="1.0.0",
 )
 
 # Allow the Vite dev server (and any localhost port) to call the API.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -4,8 +4,8 @@ We take security seriously. Thank you for helping keep `mgz-pkmn` and its users 
 
 ## Supported versions
 
-`mgz-pkmn` is pre-1.0 and ships from `main`. Security fixes land on the latest
-release line — older tagged versions are not patched.
+`mgz-pkmn` ships from `main`. Security fixes land on the latest release
+line — older tagged versions are not patched.
 
 | Version                 | Supported          |
 | ----------------------- | ------------------ |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -151,14 +151,13 @@ the hook with a stable Python path.
 
 ## CI
 
-GitHub Actions runs three parallel jobs on every pull request and push
+GitHub Actions runs two parallel jobs on every pull request and push
 to `main`:
 
 | Job | What it checks |
 |---|---|
-| `lint-and-test` | ruff lint + format check + full test suite, across Python 3.11 / 3.12 / 3.13 |
-| `api-lint` | ruff lint + format check for `api/` (with the `api` extras installed) |
-| `web-lint-and-build` | ESLint + TypeScript build (`tsc -b && vite build`) for `web/` |
+| `api` | ruff lint + format check + full test suite (`src/` and `api/`), across Python 3.11 / 3.12 / 3.13 |
+| `web` | ESLint + Vitest + TypeScript build (`tsc -b && vite build`) for `web/` |
 
 ## Changelog
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,9 +12,9 @@ number for one-click navigation; speculative items don't have issues yet.
 
 ## Versioning policy
 
-- **V1** (`1.0.0`) — **committed**. A defensible 1.0 with no obvious
-  gaps. Polish, tests, docs, basic release engineering. Tracked on the
-  [v1.0 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/1).
+- **V1** (`1.0.0`) — **shipped**. A defensible 1.0 with no obvious
+  gaps. Polish, tests, docs, basic release engineering. Released
+  2026-05-15; see the [v1.0 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/1).
 - **V1.x / Post-V1** — **committed but later**. Items best done *after*
   the 1.0 cut (the announcement, the contributor-comms refresh, set
   identification cards) rather than blocking it.
@@ -50,10 +50,10 @@ rationale behind the single-project structure.
 
 ---
 
-## V1 — committed
+## V1 — complete
 
-What needs to land before tagging `1.0.0`. Most are polish or filling
-known gaps. The goal of V1 is *defensible*, not *new*.
+All items shipped in **1.0.0** (2026-05-15). See the
+[CHANGELOG](../CHANGELOG.md) for the full list.
 
 ### Lookup engine
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -138,8 +138,7 @@ All items shipped in **1.0.0** (2026-05-15). See the
   feature, docs, plus a generic PR template).
   ([#29](https://github.com/mgzwarrior/mgz-pkmn/issues/29))
 - `CHANGELOG.md` seeded with entries for everything between `0.1.0`
-  and the upcoming `1.0.0`. Going forward, every PR adds an
-  `[Unreleased]` entry.
+  and `1.0.0`. Going forward, every PR adds an `[Unreleased]` entry.
   ([#30](https://github.com/mgzwarrior/mgz-pkmn/issues/30))
 - Polish `pyproject.toml` metadata for PyPI release (`description`,
   `keywords`, `classifiers`, `urls` — current description doesn't

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mgz-pkmn"
-version = "0.1.0"
+version = "1.0.0"
 description = "CLI and web app to look up Pokemon cards across open data sources, fetch images and prices, and emit an .xlsx, PDF binder, set-completion checklist, and JSON report for card-show prep."
 readme = "README.md"
 license = "MIT"
@@ -18,7 +18,7 @@ keywords = [
     "cli",
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Environment :: Web Environment",
     "Intended Audience :: End Users/Desktop",

--- a/src/mgz_pkmn/__init__.py
+++ b/src/mgz_pkmn/__init__.py
@@ -1,6 +1,6 @@
 """Pokemon card list -> spreadsheet for card shows."""
 
-__version__ = "0.1.0"
+__version__ = "1.0.0"
 
 from mgz_pkmn.parser import CardQuery, parse_lines
 

--- a/uv.lock
+++ b/uv.lock
@@ -261,7 +261,7 @@ wheels = [
 
 [[package]]
 name = "mgz-pkmn"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Closes #128

## What

Four mechanical changes to bring the repo metadata in sync with the fact that all V1 milestone issues are closed:

- **`CHANGELOG.md`** — `[Unreleased]` promoted to `[1.0.0] - 2026-05-15`; fresh empty `[Unreleased]` section added; compare links updated.
- **`pyproject.toml`** — `version` bumped from `0.1.0` to `1.0.0`; `Development Status` classifier updated from `4 - Beta` to `5 - Production/Stable`.
- **`docs/roadmap.md`** — "V1 — committed" section renamed to "V1 — complete"; intro paragraph replaced with a one-liner noting all items shipped in 1.0.0; versioning policy entry updated from "committed" to "shipped".
- **`docs/contributing.md`** — CI job table fixed (was listing three stale job names; actual `ci.yml` has two: `api` and `web`).

## Why

All V1 milestone issues are closed and the related PRs are merged. The version field, PyPI classifier, CHANGELOG, and docs still reflected pre-release state. This is the last step before tagging `v1.0.0`.

## How to verify

- `pyproject.toml` shows `version = "1.0.0"` and `Development Status :: 5 - Production/Stable`.
- `CHANGELOG.md` top section is a blank `[Unreleased]` followed by `[1.0.0] - 2026-05-15` with the full list of shipped features.
- `docs/roadmap.md` V1 section reads "V1 — complete" with a one-liner referencing 1.0.0; versioning policy row says "shipped".
- `docs/contributing.md` CI table shows two rows: `api` and `web`.
- `make check` passes (verified locally).