### PR TITLE
Add --all-extras to release workflow uv sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install dependencies
-        run: uv sync --all-groups
+        run: uv sync --all-groups --all-extras
 
       - name: Lint (ruff check)
         run: uv run ruff check src/


### PR DESCRIPTION
Closes #130

## What

One-line fix: \`release.yml\` now runs \`uv sync --all-groups --all-extras\` (was missing \`--all-extras\`), matching \`ci.yml\`.

## Why

The optional \`api\` extra brings in \`fastapi\` and \`uvicorn\`. Without it, the four API test modules (\`test_api_routes.py\`, \`test_export_api.py\`, \`test_set_cards_api.py\`, \`test_spa_mount.py\`) fail to import during the release-time test gate with:

\`\`\`
ModuleNotFoundError: No module named 'fastapi'
\`\`\`

This is what broke the \`v1.0.0\` tag run. The tag is on remote but no GitHub Release was created.

## How to verify

- \`grep "uv sync" .github/workflows/release.yml .github/workflows/ci.yml\` — both should now read \`uv sync --all-groups --all-extras\`.
- After this merges, re-tag and re-push \`v1.0.0\` to confirm the workflow runs cleanly through to \`Create GitHub Release\`.