### PR TITLE
docs: add CITATION.cff metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,12 @@
+cff-version: 1.2.0
+message: "If you use mgz-pkmn, please cite it using the metadata below."
+title: "mgz-pkmn"
+authors:
+  - family-names: "Grant"
+    given-names: "Matt"
+    email: "mattgrant33@gmail.com"
+url: "https://github.com/mgzwarrior/mgz-pkmn"
+repository-code: "https://github.com/mgzwarrior/mgz-pkmn"
+license: "MIT"
+version: "1.0.0"
+date-released: "2026-05-15"


### PR DESCRIPTION
Closes #134

## What

Add a root `CITATION.cff` file with the maintainer, release, repository, and license metadata GitHub needs to surface the citation UI.

## Why

This gives readers a first-class way to cite the project instead of reconstructing the metadata by hand.

## How to verify

- Confirm `CITATION.cff` exists at the repo root
- Check the file includes the required `cff-version`, title, author, repo URL, license, version, and release date fields
- Ran `python3` field-presence validation for the expected CFF keys
- Ran `git diff --check`