### PR TITLE
docs: add Discussions links across the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,7 @@ push to `main`.
 | Disk cache + URL overrides | [Cache](docs/cache.md) |
 | Render / Docker / production recipe | [Deployment](docs/deployment.md) |
 | Project layout, dev workflow, CI, release | [Contributing](docs/contributing.md) |
+
+## Community
+
+Questions, ideas, or want to share what you built? Open a thread in [GitHub Discussions](https://github.com/mgzwarrior/mgz-pkmn/discussions).

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,3 +36,5 @@ point — start there, then drill into a topic below.
 
 See [contributing.md](contributing.md) for project layout, dev workflow,
 pre-commit hooks, CI, and the release process.
+
+Questions before you open an issue or PR? Start a thread in [GitHub Discussions](https://github.com/mgzwarrior/mgz-pkmn/discussions) so the conversation is easy for future contributors to find.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -133,6 +133,8 @@ The PR body must still include a closing keyword (`Fixes #N`, `Closes
 #N`, `Resolves #N`) — that's what GitHub uses for the issue/PR link
 and for auto-closing the issue on merge.
 
+If you have a question before you open the PR, use [GitHub Discussions](https://github.com/mgzwarrior/mgz-pkmn/discussions) for that first-pass conversation — it keeps exploratory design talk out of the issue tracker until there is a concrete change to make.
+
 ## Development
 
 The Makefile at the repo root wraps the common dev commands. Run


### PR DESCRIPTION
Closes #137

## What

Add short GitHub Discussions entry points in the root README, the docs landing page, and the contributing guide so visitors can find the community path without hunting for it.

## Why

Discussions is enabled, but the repository did not surface it anywhere obvious for questions or idea threads.

## How to verify

- Check the new `## Community` section in `README.md`
- Confirm `docs/README.md` and `docs/contributing.md` both point readers to Discussions
- Ran `grep` checks for the new Discussions links
- Ran `git diff --check`