### PR TITLE
Add CODEOWNERS for required-review branch protection

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Code owners for mgz-pkmn.
+#
+# Used by the "Require review from Code Owners" branch protection rule
+# on `main`. Order matters: later, more-specific rules win.
+#
+# Reference: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner — every file in the repo unless overridden below.
+* @mgzwarrior


### PR DESCRIPTION
Closes #144

## What

Adds \`.github/CODEOWNERS\` with a single blanket rule: every file is owned by \`@mgzwarrior\`.

## Why

This unlocks the **Require review from Code Owners** branch protection rule on \`main\`. Once enabled in repo settings, PRs from forks (or anywhere) can't be merged without an explicit maintainer approval, regardless of who opened them. Pairs with the existing required status checks (\`api\`, \`web\`, CodeQL) to make the merge bar uniform for everyone.

Future per-area splits (\`web/* @web-team\`, \`docs/* @doc-triagers\`) are one-line additions to this file as the contributor base grows.

## How to verify

- The file appears under [Settings → Code security → Code owners](https://github.com/mgzwarrior/mgz-pkmn/settings/code_security_and_analysis) with no syntax errors.
- After merge: flip on **Settings → Branches → main → Require a pull request before merging → Require review from Code Owners** to enforce it.