### PR TITLE
Wire mgz-pkmn.com as the canonical project home

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,7 +5,7 @@ authors:
   - family-names: "Grant"
     given-names: "Matt"
     email: "mattgrant33@gmail.com"
-url: "https://github.com/mgzwarrior/mgz-pkmn"
+url: "https://mgz-pkmn.com"
 repository-code: "https://github.com/mgzwarrior/mgz-pkmn"
 license: "MIT"
 version: "1.0.0"

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,6 +10,9 @@ Items live on GitHub as issues, labels, milestones, and projects — this
 document is the navigator. Every committed item below carries its issue
 number for one-click navigation; speculative items don't have issues yet.
 
+For the end-user-facing project overview (features, "how it works",
+live demo), see <https://mgz-pkmn.com>.
+
 ## Versioning policy
 
 - **V1** (`1.0.0`) — **shipped**. A defensible 1.0 with no obvious

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ api = [
 pkmn = "mgz_pkmn.cli:cli"
 
 [project.urls]
-Homepage = "https://github.com/mgzwarrior/mgz-pkmn"
+Homepage = "https://mgz-pkmn.com"
 Repository = "https://github.com/mgzwarrior/mgz-pkmn"
 Issues = "https://github.com/mgzwarrior/mgz-pkmn/issues"
 Documentation = "https://github.com/mgzwarrior/mgz-pkmn/tree/main/docs"

--- a/site/README.md
+++ b/site/README.md
@@ -1,8 +1,10 @@
 # mgz-pkmn marketing site
 
-Astro 5 + Tailwind 4 static site. Deployed to Cloudflare Pages on a custom
-domain. Lives alongside the source so site copy can ship atomically with
-the features it describes.
+Live at <https://mgz-pkmn.com>.
+
+Astro 5 + Tailwind 4 static site deployed to Cloudflare Pages. Lives
+alongside the source so site copy can ship atomically with the features
+it describes — a push to `main` that touches `site/**` triggers a redeploy.
 
 ## Dev
 
@@ -65,12 +67,15 @@ automatically.
 
 ## Custom domain
 
-Register one (e.g. via [Cloudflare
-Registrar](https://www.cloudflare.com/products/registrar/) at-cost or
-[Porkbun](https://porkbun.com)) and add it via the Cloudflare Pages
-project's Custom domains panel. Update `site.url` in
-[`astro.config.mjs`](astro.config.mjs) so canonical URLs and OG meta
-tags resolve correctly.
+Live at [`mgz-pkmn.com`](https://mgz-pkmn.com), registered through
+Cloudflare Registrar (at-cost) and wired to the Pages project via
+Custom domains. Canonical URL is set in
+[`astro.config.mjs`](astro.config.mjs) so OG meta tags and the
+generated sitemap resolve correctly.
+
+To change the domain later: update `site.url` in `astro.config.mjs`,
+swap the Custom domain in the Pages project, and update the references
+in `README.md`, `CITATION.cff`, and `pyproject.toml`.
 
 ## Assets
 


### PR DESCRIPTION
Closes #149

## What

The marketing site is live at [\`mgz-pkmn.com\`](https://mgz-pkmn.com) (Cloudflare Pages, auto-deploys from \`main\` on changes to \`site/**\`). This PR points repo metadata and a handful of docs at it.

| File | Change |
|---|---|
| [\`pyproject.toml\`](pyproject.toml) | \`[project.urls] Homepage\` → \`https://mgz-pkmn.com\` (Repository / Issues / Documentation correctly still point at GitHub) |
| [\`CITATION.cff\`](CITATION.cff) | \`url:\` → \`https://mgz-pkmn.com\` (\`repository-code:\` still GitHub) |
| [\`site/README.md\`](site/README.md) | Present-tense the domain in the intro; rewrite the "Custom domain" section to describe the live setup; add a rename runbook for future domain changes |
| [\`docs/roadmap.md\`](docs/roadmap.md) | Short pointer to \`mgz-pkmn.com\` for end-user-facing context near the doc intro |

## Why

The marketing site is now the right entry point for non-developer audiences and the canonical project URL for citation and packaging metadata. The GitHub repo remains the source / contribution surface — it's still referenced everywhere it should be.

## How to verify

- \`grep -r "mgz-pkmn.com" pyproject.toml CITATION.cff site/README.md docs/roadmap.md\` — non-empty match in each
- \`make check\` passes (verified locally)
- The site itself (already deployed) reads \`https://mgz-pkmn.com\` as its canonical URL via [\`site/astro.config.mjs\`](site/astro.config.mjs)

## Not in this PR (external actions)

- GitHub repo \`homepage\` field — being set via the API alongside this PR (not a code change)
- Discussion #132 (1.0 announcement) — getting a "Try it: mgz-pkmn.com" link at the top alongside this PR