### PR TITLE
Drop stale 'signed commits' reference; document skip-labels in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,11 @@ Select the **single highest-value issue** using this priority order:
 2. Smaller, well-scoped issues before large ones
 3. Issues whose `area:*` label is consistent with the current milestone
 
-Skip anything labelled `wip`, `blocked`, or `needs-discussion`.
+Skip anything labelled:
+
+- [`wip`](https://github.com/mgzwarrior/mgz-pkmn/labels/wip) — already being worked on; don't pick up
+- [`blocked`](https://github.com/mgzwarrior/mgz-pkmn/labels/blocked) — waiting on an external dependency or decision
+- [`needs-discussion`](https://github.com/mgzwarrior/mgz-pkmn/labels/needs-discussion) — scope or design not yet aligned; raise the question in the issue or [Discussions](https://github.com/mgzwarrior/mgz-pkmn/discussions) rather than starting work
 
 If an issue is ambiguous and intent can't be inferred from context, **leave a clarifying
 comment and move to the next best issue**. Every change must be traceable to an issue — if

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -24,7 +24,7 @@ The fastest way in:
    touch.
 2. **Skim [AGENTS.md](../AGENTS.md)** for the project's invariants
    (single `Row` shape, pure-function writers, dataclass-driven
-   layouts, signed commits).
+   layouts).
 3. **Open a PR** following the [branch naming](#branch-naming) and
    [opening a PR](#opening-a-pr) sections below.
 


### PR DESCRIPTION
Closes #152

## What

- **\`docs/contributing.md\`** — remove "signed commits" from the AGENTS.md invariants list in the "Getting started" section. It was the only doc mention left after the ruleset change.
- **\`CLAUDE.md\`** — expand the one-line skip-labels callout into a definition list: what \`wip\` / \`blocked\` / \`needs-discussion\` each *mean*, not just that they should be skipped. Now that all three labels exist as real repo labels, the next maintainer triaging knows when to *apply* them too.

## Why

The \`required_signatures\` rule was removed from the \`main\` branch ruleset on 2026-05-16 after the first external contributor experience confirmed the requirement added friction without enforcement value at the project's current scale. Leaving the stale reference would set incorrect expectations for the next contributor.

The CLAUDE.md update follows from creating the \`wip\` and \`blocked\` labels (they were referenced in the workflow but didn't exist as real labels until today).

## How to verify

- \`grep -rn -i "sign.*commit\|signed commit" docs/ AGENTS.md CONTRIBUTING.md README.md CLAUDE.md\` — returns no hits
- CLAUDE.md "Step 1" section lists all three skip-labels with one-line descriptions and links
- \`make check\` passes (verified locally)