### PR TITLE
Add /site to dependabot.yml for grouped weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@
 #     out-of-sync lockfile would break the image)
 #   - Python under api/ (FastAPI service, separate pyproject, no lockfile)
 #   - npm under web/ (React SPA)
+#   - npm under site/ (Astro marketing site)
 #   - GitHub Actions used by our workflows
 #
 # Grouping minor + patch bumps into a single weekly PR cuts review churn;
@@ -51,6 +52,20 @@ updates:
       - "type:chore"
     groups:
       web-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/site"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "area:devops"
+      - "type:chore"
+    groups:
+      site-minor-and-patch:
         update-types:
           - "minor"
           - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,6 +69,15 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # Astro 6 ships Vite 7 while @tailwindcss/vite@4.x bundles Vite 8.
+      # The version mismatch breaks the build (see PR #148). Re-enable
+      # by removing this ignore block once @tailwindcss/vite ships a
+      # release compatible with Astro 6's bundled Vite, or once Astro 6
+      # itself moves to Vite 8.
+      - dependency-name: "astro"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Closes #154

## What

Two related additions to [\`.github/dependabot.yml\`](.github/dependabot.yml):

1. **New \`/site\` \`npm\` entry**, modeled on the existing \`/web\` block:
   - Weekly schedule, grouped \`site-minor-and-patch\` (minor + patch in one PR; majors come through individually)
   - \`area:devops\` + \`type:chore\` labels (no \`area:web\` — the marketing site is a separate surface from the React SPA)
   - \`open-pull-requests-limit: 5\`
2. **Narrowly-scoped \`ignore\` block** for \`astro\` major bumps only. Patch and minor astro updates still flow through; only major-version proposals (e.g. the Astro 5→6 bump in [#148](https://github.com/mgzwarrior/mgz-pkmn/pull/148)) are blocked. Inline comment documents the re-enable trigger condition.

File header comment updated to note the new \`/site\` coverage.

## Why

\`/site\` was the only npm directory not in dependabot config. Without an entry, site updates only surfaced as ungrouped, unlabelled security-alert PRs — exactly the situation that produced [#148](https://github.com/mgzwarrior/mgz-pkmn/pull/148) (closed; ecosystem-incompatible Astro 6 bump).

[Dependabot's own follow-up comment](https://github.com/mgzwarrior/mgz-pkmn/pull/148#issuecomment-4465751614) on the closed PR explicitly notes that closing alone won't prevent the same proposal from reappearing next weekly run. The narrow \`ignore\` block addresses that without blocking the patch/minor flow we actually want.

## How to verify

- \`grep -A 20 '/site' .github/dependabot.yml\` shows the new block with the \`ignore\` clause
- File-header comment lists site/ alongside the other covered directories
- Next Dependabot run produces a grouped PR for any pending site minor/patch deps, and does NOT re-propose Astro 6