### PR TITLE
Add Code of Conduct and document contributor path

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions or general discussion
+    url: https://github.com/mgzwarrior/mgz-pkmn/discussions
+    about: Ask a question or start a conversation in Discussions.
+  - name: Introduce yourself
+    url: https://github.com/mgzwarrior/mgz-pkmn/discussions/160
+    about: Say hello and meet the community.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,10 +2,14 @@
 
 ## Our Pledge
 
-We as contributors and maintainers pledge to make participation in this project a
-harassment-free experience for everyone, regardless of age, body size, disability,
-ethnicity, gender identity and expression, level of experience, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our community
+a harassment-free experience for everyone, regardless of age, body size, visible or
+invisible disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal appearance,
+race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that promote an open, welcoming, diverse,
+inclusive, and healthy community.
 
 ## Our Standards
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,36 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as contributors and maintainers pledge to make participation in this project a
+harassment-free experience for everyone, regardless of age, body size, disability,
+ethnicity, gender identity and expression, level of experience, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experience
+- Gracefully accepting constructive feedback
+- Focusing on what is best for the community
+- Showing empathy toward other community members
+
+Examples of unacceptable behavior:
+
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by
+contacting the maintainer at **mattgrant33@gmail.com**. All complaints will be reviewed
+and investigated promptly and fairly. The maintainer is obligated to maintain
+confidentiality with regard to the reporter.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -41,6 +41,13 @@ Stuck on scope or design? Open a [GitHub
 Discussion](https://github.com/mgzwarrior/mgz-pkmn/discussions/new?category=general)
 before writing code — it's cheaper to align early than to redo a PR.
 
+## Opening an issue
+
+Blank issues are disabled — the "New Issue" button shows structured templates
+and contact links instead. If you want to ask a question or start a discussion
+rather than file a bug or feature request, use [GitHub
+Discussions](https://github.com/mgzwarrior/mgz-pkmn/discussions) directly.
+
 ## Claiming an issue
 
 Comment on the issue saying you'd like to take it — something as

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -11,7 +11,16 @@ end-user installation and usage, see the [README](../README.md).
 New here? Welcome — contributions are explicitly invited, including
 AI-assisted ones. [AGENTS.md](../AGENTS.md) is there to make
 agent-driven contributions supportable, not exotic; humans benefit
-from the same conventions.
+from the same conventions. All contributors are expected to follow the
+[Code of Conduct](../CODE_OF_CONDUCT.md).
+
+Before or after your first PR, feel free to pop into the
+[Introduce yourself 👋](https://github.com/mgzwarrior/mgz-pkmn/discussions/160)
+discussion and say hello — it's a nice place to meet the community.
+For the full picture on contributing (including AI-assisted PRs and
+current priorities), see the
+[Contributing to mgz-pkmn](https://github.com/mgzwarrior/mgz-pkmn/discussions/141)
+discussion.
 
 The fastest way in:
 
@@ -31,6 +40,26 @@ The fastest way in:
 Stuck on scope or design? Open a [GitHub
 Discussion](https://github.com/mgzwarrior/mgz-pkmn/discussions/new?category=general)
 before writing code — it's cheaper to align early than to redo a PR.
+
+## Claiming an issue
+
+Comment on the issue saying you'd like to take it — something as
+simple as "I'd like to work on this" is enough. The maintainer will
+assign it to you.
+
+Claimed issues that have seen no activity for **two weeks** are
+reopened for others to pick up. If life gets in the way, just say so
+in the thread — it won't be reassigned without notice.
+
+## Contributor ladder
+
+| Level | How you get there |
+|---|---|
+| **Contributor** | Any merged PR. Your name is in the commit history. |
+| **Collaborator** | Invited by the maintainer after a merged PR — grants write access to branches and the ability to self-assign issues. |
+
+No formal process — if you've shipped something and want to stay
+involved, say so and the invite will follow.
 
 ## Curated starter issues
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -56,7 +56,7 @@ in the thread — it won't be reassigned without notice.
 | Level | How you get there |
 |---|---|
 | **Contributor** | Any merged PR. Your name is in the commit history. |
-| **Collaborator** | Invited by the maintainer after a merged PR — grants write access to branches and the ability to self-assign issues. |
+| **Collaborator** | Invited by the maintainer after a merged PR — grants write access to the repository (subject to branch protection rules) and the ability to self-assign issues. |
 
 No formal process — if you've shipped something and want to stay
 involved, say so and the invite will follow.


### PR DESCRIPTION
Closes #161

## What

- Adds `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1, enforcement contact: mattgrant33@gmail.com)
- Documents the issue-claiming convention in `docs/contributing.md`: comment to claim, maintainer assigns, two-week inactivity policy
- Adds a contributor ladder table: Contributor (any merged PR) → Collaborator (maintainer invite)
- Links to the [Introduce yourself 👋](https://github.com/mgzwarrior/mgz-pkmn/discussions/160) and [Contributing to mgz-pkmn](https://github.com/mgzwarrior/mgz-pkmn/discussions/141) discussions from the contributing guide

## Why

New contributors had no written guidance on how to claim an issue, what the inactivity policy is, or what comes after a first merged PR. The missing Code of Conduct also kept GitHub's community health score at 85%. These changes close that gap and make the contributor path explicit end-to-end.

## How to verify

1. Visit the repo root — `CODE_OF_CONDUCT.md` should be present and linked in the GitHub community health checklist
2. Read `docs/contributing.md` — "Claiming an issue" and "Contributor ladder" sections should appear between "Getting started" and "Curated starter issues"
3. Confirm both discussion links appear in the "Getting started" section
4. `make check` passes (verified locally)