### PR TITLE
ADR-0012 (Proposed): Open-core architecture for a paid Vendor tier

### DIFF
--- a/docs/adr/0012-open-core-architecture.md
+++ b/docs/adr/0012-open-core-architecture.md
@@ -18,10 +18,15 @@ Three forces shape the option space:
 
 1. **The collector ↔ vendor split is a real audience boundary.** A
    solo collector prepping for a card show needs the current CLI plus
-   maybe a hosted convenience layer. A card-shop vendor needs
+   maybe a hosted convenience layer for persistence (saved want-lists,
+   run history, sync across devices). A card-shop vendor needs
    multi-user accounts, persistent inventory, acquisition-cost comps,
    and integrations with paid third-party APIs. These aren't
-   gradations of the same product — they serve different jobs.
+   gradations of the same product — they serve different jobs, and
+   their hosted-infrastructure expectations differ accordingly:
+   collectors are price-sensitive and will share infrastructure with
+   other collectors; vendors expect tenant isolation strong enough to
+   treat their inventory and pricing data as private.
 
 2. **The OSS contributor base is small but growing.** Decisions made
    now about contributor licensing are cheap to change today and
@@ -56,13 +61,32 @@ Adopt an **open-core architecture with three structural commitments**:
    — community contributors can write their own plugins without
    coordination.
 
-3. **A hosted offering can be added later as a separate delivery
-   layer over the same plugin surface.** "Vendor Cloud" runs the OSS
-   CLI plus the vendor plugin on infrastructure operated by the
-   maintainer, adds multi-user state, scheduled jobs, and paid-API
-   integrations. It does not replace the locally-installable vendor
-   package; the two coexist because customers split on trust /
-   connectivity / data-residency lines that aren't going away.
+3. **Hosted offerings are additional delivery layers over the same
+   plugin surface — not a single product, but a small family,
+   matched to the audience.** Two distinct hosted shapes are
+   anticipated:
+
+   - **Cloud (for collectors)** — multi-tenant on shared
+     infrastructure operated by the maintainer. Adds the persistence
+     features collectors will plausibly pay a few dollars a month for
+     (saved want-lists, run history, scheduled re-pricing, email /
+     Discord delivery of generated outputs), without any of the
+     vendor-only machinery. Economically only viable as multi-tenant
+     at the collector price point, which is itself an architectural
+     constraint: every query is scoped to a user, no per-customer
+     infra footprint.
+   - **Vendor Cloud (for vendors)** — runs the OSS CLI plus the
+     vendor plugin with stronger tenant isolation than Cloud — at
+     minimum strict per-tenant data segregation, plausibly dedicated
+     compute for larger customers. Adds the vendor-only capabilities
+     (multi-user, inventory state, acquisition-cost comps,
+     paid-third-party-API integrations).
+
+   Neither hosted layer replaces a locally-installable equivalent:
+   collectors keep the free OSS CLI, vendors keep the locally
+   installable `mgz-pkmn-vendor` package. Customers split on trust /
+   connectivity / data-residency lines that aren't going away, and
+   the architecture preserves that optionality on both sides.
 
 Adopt **DCO (Developer Certificate of Origin)** sign-off as the
 licensing posture for OSS contributions (tracked separately in #170).
@@ -94,9 +118,10 @@ until they're real.
   repo beyond the plugin surface (which is justified on its own).
   Decoupling the two codebases means the paid product can iterate
   on its own cadence without forcing OSS releases.
-- "Vendor Cloud" as a future hosted layer is additive, not
-  exclusive — it does not foreclose on serving customers who insist
-  on local install for data-residency or trust reasons.
+- Both hosted layers (Cloud for collectors, Vendor Cloud for
+  vendors) are additive, not exclusive — they don't foreclose on
+  serving customers who insist on the locally-installable
+  equivalent for data-residency, trust, or offline-use reasons.
 - DCO sign-off makes downstream commercial reuse unambiguous
   without imposing CLA friction or key-management burden on
   contributors.
@@ -116,16 +141,26 @@ until they're real.
   -s`) but non-zero, particularly for web-edits and contributors
   unfamiliar with the convention. Mitigated by docs and an optional
   `commit-msg` hook.
+- Operating two hosted shapes with different isolation guarantees
+  (multi-tenant Cloud, more isolated Vendor Cloud) is genuinely
+  more work than operating one. The architecture preserves the
+  option to defer either indefinitely — but if both ship, the
+  application layer must enforce tenant scoping correctly on
+  every query in Cloud, and the deploy story for Vendor Cloud
+  needs to make per-tenant separation cheap. Both are real costs
+  worth flagging before commitment.
 
 **Neutral.**
 
 - This ADR documents the architectural commitment; commercial
   details (tier names, pricing, feature gating) are intentionally
   excluded and live in private planning artifacts until launch.
-- "Vendor Cloud" being a separate delivery layer means the
-  maintainer must decide separately whether to be in the
-  infrastructure-operation business. The architecture doesn't force
-  the decision; it preserves the option.
+- Both hosted layers being separate delivery layers means the
+  maintainer can decide independently per audience whether to be
+  in the infrastructure-operation business — ship Cloud without
+  Vendor Cloud, ship neither, ship both, in any order. The
+  architecture doesn't force any of those decisions; it preserves
+  the optionality.
 
 ## Alternatives considered
 
@@ -152,6 +187,15 @@ until they're real.
   install (vendors with sensitive inventory data, offline shows,
   data-residency requirements). Retained as an *additional* delivery
   layer per the third decision point above.
+
+- **Single hosted tier serving both collectors and vendors.** One
+  hosted product, isolation good enough for vendors, priced low
+  enough for collectors. Rejected because the two ends of that
+  range are economically incompatible: collector-grade pricing only
+  works on shared infrastructure, vendor-grade isolation only works
+  on per-tenant separation. Trying to bridge them collapses to
+  serving one audience badly. Two distinct hosted shapes is the
+  honest split.
 
 - **CLA instead of DCO.** Contributors sign a one-time agreement
   (typically out-of-band, via a bot) granting the project broader

--- a/docs/adr/0012-open-core-architecture.md
+++ b/docs/adr/0012-open-core-architecture.md
@@ -1,0 +1,162 @@
+# ADR 0012: Open-core architecture for a paid Vendor tier
+
+- **Status:** Proposed
+- **Date:** 2026-05-16
+- **Tags:** open-core, monetization, governance
+
+## Context
+
+The project's roadmap commits to a free/paid separation at V2.x
+([`docs/roadmap.md`](../roadmap.md)): "Free features stay free forever;
+paid features expand the vendor / power-user surface." That's a stance,
+not yet an architecture. Before any paid code lands, the *shape* of
+the open-core split needs a load-bearing decision so contributors can
+reason about what code goes where, and so a future paid product
+doesn't retroactively distort the OSS codebase.
+
+Three forces shape the option space:
+
+1. **The collector ↔ vendor split is a real audience boundary.** A
+   solo collector prepping for a card show needs the current CLI plus
+   maybe a hosted convenience layer. A card-shop vendor needs
+   multi-user accounts, persistent inventory, acquisition-cost comps,
+   and integrations with paid third-party APIs. These aren't
+   gradations of the same product — they serve different jobs.
+
+2. **The OSS contributor base is small but growing.** Decisions made
+   now about contributor licensing are cheap to change today and
+   expensive to change later (every accumulated contributor either
+   re-asserts past commits or is grandfathered, which weakens any
+   downstream legal cleanup). The right time to set up the rails is
+   before there's much rolling stock on them.
+
+3. **Open-core projects fail predictably when the line wanders.**
+   The recurring failure mode: features start free, drift into a
+   paid tier, contributors discover they shipped free labor into a
+   paywalled product, trust erodes. The defense is structural — the
+   paid surface lives somewhere the OSS contributor cannot
+   accidentally land — not procedural.
+
+## Decision
+
+Adopt an **open-core architecture with three structural commitments**:
+
+1. **The paid surface lives in a separate private repository**
+   (`mgz-pkmn-vendor`) under a future `mgz-pkmn` GitHub organization.
+   It is *not* a paid-features branch, feature flag, or `paid/`
+   subdirectory inside this repo. The physical separation is the
+   defense against scope drift and accidental contribution.
+
+2. **The OSS CLI exposes a deliberate plugin surface** (entry-point
+   discovery for subcommands, output writers, and lookup sources).
+   The vendor package depends on `mgz-pkmn` as an ordinary pip
+   dependency and registers against those entry points. `pkmn vendor
+   <subcommand>` becomes available if-and-only-if `mgz-pkmn-vendor`
+   is installed alongside. The plugin surface is independently useful
+   — community contributors can write their own plugins without
+   coordination.
+
+3. **A hosted offering can be added later as a separate delivery
+   layer over the same plugin surface.** "Vendor Cloud" runs the OSS
+   CLI plus the vendor plugin on infrastructure operated by the
+   maintainer, adds multi-user state, scheduled jobs, and paid-API
+   integrations. It does not replace the locally-installable vendor
+   package; the two coexist because customers split on trust /
+   connectivity / data-residency lines that aren't going away.
+
+Adopt **DCO (Developer Certificate of Origin)** sign-off as the
+licensing posture for OSS contributions (tracked separately in #170).
+DCO is the lightest-weight option that gives clear per-commit
+assertions that contributors had the right to license their
+contributions under MIT — the same MIT that the paid tier relies on
+when it reuses OSS code. Distinct from cryptographic commit signing
+(intentionally dropped in #153 / [ADR-0010 era](0010-unified-project-with-area-views.md));
+DCO solves a different problem.
+
+**Explicitly out of scope of this ADR**: specific paid-tier names,
+pricing, feature lists, hosted-vs-local SKU packaging, support
+policies. Those are commercial decisions that change frequently
+before launch and don't belong in a public architectural record
+until they're real.
+
+## Consequences
+
+**Positive.**
+
+- The OSS contributor base never sees, depends on, or accidentally
+  ships into the paid codebase. The free product stays whole and
+  independently useful — anyone can run the full CLI without ever
+  knowing the paid tier exists.
+- The plugin surface added for the paid tier is a generally useful
+  capability — community plugins for custom outputs, sources, or
+  workflows can use the same entry points.
+- Adding `mgz-pkmn-vendor` later requires no changes to the OSS
+  repo beyond the plugin surface (which is justified on its own).
+  Decoupling the two codebases means the paid product can iterate
+  on its own cadence without forcing OSS releases.
+- "Vendor Cloud" as a future hosted layer is additive, not
+  exclusive — it does not foreclose on serving customers who insist
+  on local install for data-residency or trust reasons.
+- DCO sign-off makes downstream commercial reuse unambiguous
+  without imposing CLA friction or key-management burden on
+  contributors.
+
+**Negative.**
+
+- The plugin surface is a public API the OSS project must
+  maintain. Breaking it is a downstream-impact event, even if no
+  community plugins exist yet.
+- Two repos means two release cadences, two CI pipelines, two issue
+  trackers, two sets of branch protection rules. The split is
+  load-bearing but not free.
+- Some OSS contributors may want to work on Vendor features and
+  cannot; that's a known cost of the boundary and the right tradeoff
+  given the alternative.
+- DCO adds one CI gate to every PR. Friction is small (`git commit
+  -s`) but non-zero, particularly for web-edits and contributors
+  unfamiliar with the convention. Mitigated by docs and an optional
+  `commit-msg` hook.
+
+**Neutral.**
+
+- This ADR documents the architectural commitment; commercial
+  details (tier names, pricing, feature gating) are intentionally
+  excluded and live in private planning artifacts until launch.
+- "Vendor Cloud" being a separate delivery layer means the
+  maintainer must decide separately whether to be in the
+  infrastructure-operation business. The architecture doesn't force
+  the decision; it preserves the option.
+
+## Alternatives considered
+
+- **Monorepo with paid-feature flags.** Paid features live in this
+  repo behind build flags or an `enterprise/` directory; OSS users
+  build without the flag. Rejected: continuous risk that
+  well-meaning OSS contributors land on paid-tier code,
+  continuous contributor-trust tax explaining why some directories
+  are off-limits, license complexity (dual-licensing inside a single
+  source tree is a known footgun). GitLab CE/EE is the canonical
+  cautionary tale.
+
+- **Fork-and-extend.** The paid repo is a private fork of the OSS
+  repo that merges from upstream periodically. Rejected: produces
+  compounding merge conflicts, requires the paid fork to track
+  every OSS refactor, and lets the two codebases diverge until
+  upstreaming gets impossible. Worse on every dimension than the
+  plugin-surface approach.
+
+- **Hosted-only paid surface, no client-side paid package.** The
+  OSS CLI is the entire local product; paid features exist only on
+  servers operated by the maintainer. Rejected as the *exclusive*
+  approach because it forecloses on customers who require local
+  install (vendors with sensitive inventory data, offline shows,
+  data-residency requirements). Retained as an *additional* delivery
+  layer per the third decision point above.
+
+- **CLA instead of DCO.** Contributors sign a one-time agreement
+  (typically out-of-band, via a bot) granting the project broader
+  rights than the project license. Rejected for now: adds friction
+  contributors notice (must sign something before first contribution),
+  and the broader rights aren't needed when MIT already permits
+  commercial reuse. Reconsider if the project ever needs to relicense
+  or accept corporate contributors who require a CLA.

--- a/docs/adr/0012-open-core-architecture.md
+++ b/docs/adr/0012-open-core-architecture.md
@@ -16,17 +16,24 @@ doesn't retroactively distort the OSS codebase.
 
 Three forces shape the option space:
 
-1. **The collector ↔ vendor split is a real audience boundary.** A
-   solo collector prepping for a card show needs the current CLI plus
-   maybe a hosted convenience layer for persistence (saved want-lists,
-   run history, sync across devices). A card-shop vendor needs
-   multi-user accounts, persistent inventory, acquisition-cost comps,
-   and integrations with paid third-party APIs. These aren't
-   gradations of the same product — they serve different jobs, and
-   their hosted-infrastructure expectations differ accordingly:
-   collectors are price-sensitive and will share infrastructure with
-   other collectors; vendors expect tenant isolation strong enough to
-   treat their inventory and pricing data as private.
+1. **The collector ↔ vendor split is a real audience boundary, but
+   not necessarily an infrastructure boundary.** A solo collector
+   prepping for a card show needs the current CLI plus maybe a
+   hosted convenience layer for persistence (saved want-lists, run
+   history, sync across devices). A card-shop vendor needs
+   multi-user accounts, persistent inventory, acquisition-cost
+   comps, and integrations with paid third-party APIs. These aren't
+   gradations of the same product — they serve different jobs.
+   Hosted-infrastructure expectations, however, mostly do *not*
+   split along this boundary: most vendors will accept shared
+   infrastructure with application-layer tenant scoping (the same
+   model collectors get), provided their inventory and pricing data
+   are private from other tenants. A subset of vendors — those
+   with prior data-leak trauma, an internal compliance posture, or
+   workloads heavy enough to justify dedicated compute — will
+   require dedicated hosting. The architecture should preserve
+   that as an upgrade path, not force it as a separate product
+   from day one.
 
 2. **The OSS contributor base is small but growing.** Decisions made
    now about contributor licensing are cheap to change today and
@@ -62,31 +69,40 @@ Adopt an **open-core architecture with three structural commitments**:
    coordination.
 
 3. **Hosted offerings are additional delivery layers over the same
-   plugin surface — not a single product, but a small family,
-   matched to the audience.** Two distinct hosted shapes are
-   anticipated:
+   plugin surface. Ship one hosted product (Cloud) with multiple
+   plans on shared multi-tenant infrastructure; offer dedicated
+   hosting as an opt-in upgrade for vendors who require it.**
 
-   - **Cloud (for collectors)** — multi-tenant on shared
-     infrastructure operated by the maintainer. Adds the persistence
-     features collectors will plausibly pay a few dollars a month for
-     (saved want-lists, run history, scheduled re-pricing, email /
-     Discord delivery of generated outputs), without any of the
-     vendor-only machinery. Economically only viable as multi-tenant
-     at the collector price point, which is itself an architectural
-     constraint: every query is scoped to a user, no per-customer
-     infra footprint.
-   - **Vendor Cloud (for vendors)** — runs the OSS CLI plus the
-     vendor plugin with stronger tenant isolation than Cloud — at
-     minimum strict per-tenant data segregation, plausibly dedicated
-     compute for larger customers. Adds the vendor-only capabilities
-     (multi-user, inventory state, acquisition-cost comps,
-     paid-third-party-API integrations).
+   - **Cloud (default hosted product)** — multi-tenant on shared
+     infrastructure operated by the maintainer. Two plans on the
+     same infrastructure, differing only in feature surface,
+     quotas, and price:
+     - *Collector plan* — persistence features (saved want-lists,
+       run history, scheduled re-pricing, email / Discord delivery
+       of generated outputs). Price-sensitive; the
+       few-dollars-a-month anchor is what makes multi-tenant the
+       only viable model.
+     - *Vendor plan* — the vendor-only capabilities (multi-user
+       accounts, inventory state, acquisition-cost comps,
+       paid-third-party-API integrations). Same isolation
+       guarantees as the Collector plan; what differs is the
+       feature surface above and the quotas / rate limits sized
+       for vendor workloads.
+   - **Vendor Cloud Pro (opt-in dedicated upgrade)** — runs the
+     OSS CLI plus the vendor plugin on dedicated per-tenant
+     infrastructure. Targeted at vendors who specifically require
+     it (compliance posture, prior trust events, workloads heavy
+     enough to justify the cost). *Not a launch-day commitment*:
+     ships when there's evidence of demand and willingness to pay
+     for it. The architecture must preserve the upgrade path
+     (shared-infra schema is the same as, or trivially convertible
+     to, the dedicated-infra schema) from the start.
 
-   Neither hosted layer replaces a locally-installable equivalent:
+   No hosted layer replaces a locally-installable equivalent:
    collectors keep the free OSS CLI, vendors keep the locally
    installable `mgz-pkmn-vendor` package. Customers split on trust /
    connectivity / data-residency lines that aren't going away, and
-   the architecture preserves that optionality on both sides.
+   the architecture preserves that optionality.
 
 Adopt **DCO (Developer Certificate of Origin)** sign-off as the
 licensing posture for OSS contributions (tracked separately in #170).
@@ -118,10 +134,16 @@ until they're real.
   repo beyond the plugin surface (which is justified on its own).
   Decoupling the two codebases means the paid product can iterate
   on its own cadence without forcing OSS releases.
-- Both hosted layers (Cloud for collectors, Vendor Cloud for
-  vendors) are additive, not exclusive — they don't foreclose on
-  serving customers who insist on the locally-installable
-  equivalent for data-residency, trust, or offline-use reasons.
+- All hosted layers (Cloud's Collector and Vendor plans, plus the
+  deferred Vendor Cloud Pro upgrade) are additive, not exclusive —
+  they don't foreclose on serving customers who insist on the
+  locally-installable equivalent for data-residency, trust, or
+  offline-use reasons.
+- Starting with a single multi-tenant Cloud (rather than two
+  parallel hosted products from day one) defers the operational
+  cost of running a second production system until there's evidence
+  of demand for dedicated tenancy. Cheaper to launch, easier to
+  evolve.
 - DCO sign-off makes downstream commercial reuse unambiguous
   without imposing CLA friction or key-management burden on
   contributors.
@@ -141,26 +163,45 @@ until they're real.
   -s`) but non-zero, particularly for web-edits and contributors
   unfamiliar with the convention. Mitigated by docs and an optional
   `commit-msg` hook.
-- Operating two hosted shapes with different isolation guarantees
-  (multi-tenant Cloud, more isolated Vendor Cloud) is genuinely
-  more work than operating one. The architecture preserves the
-  option to defer either indefinitely — but if both ship, the
-  application layer must enforce tenant scoping correctly on
-  every query in Cloud, and the deploy story for Vendor Cloud
-  needs to make per-tenant separation cheap. Both are real costs
-  worth flagging before commitment.
+- **Noisy-neighbor risk.** Vendor-plan workloads (scheduled
+  re-pricing, bulk imports, paid-API integrations) running
+  alongside Collector-plan workloads on shared infrastructure will
+  need quota management, rate limiting, and ideally an async job
+  queue so one tenant's heavy run doesn't degrade another's. None
+  of this is hard, but all of it has to actually be there from the
+  first vendor onboarded.
+- **Cloud → Vendor Cloud Pro migration is a known problem to
+  design for, not against.** Moving an existing tenant's data from
+  shared to dedicated infrastructure is non-trivial and needs to
+  be cheap before the first customer asks. The shared-infra schema
+  and the dedicated-infra schema need to be the same (or trivially
+  convertible) from the start; designing them as if they'll always
+  diverge would be a foreclosure.
+- **Launching with shared-only Cloud foregoes the largest
+  vendors** — those who require dedicated infrastructure from day
+  one. Likely the right tradeoff (those vendors are rarely early
+  customers anyway), but worth being honest about: those are
+  deferred-revenue customers, not lost ones, as long as the
+  upgrade path is preserved.
+- **Tenant scoping must be correct everywhere, every time.** In a
+  multi-tenant Cloud that serves both audiences, every query must
+  be scoped to the requesting tenant; a single missed scope is a
+  cross-tenant leak. Mitigated by ORM-level discipline (a base
+  query that always filters by tenant) and a per-PR review checklist,
+  but it's a continuous obligation.
 
 **Neutral.**
 
 - This ADR documents the architectural commitment; commercial
   details (tier names, pricing, feature gating) are intentionally
   excluded and live in private planning artifacts until launch.
-- Both hosted layers being separate delivery layers means the
-  maintainer can decide independently per audience whether to be
-  in the infrastructure-operation business — ship Cloud without
-  Vendor Cloud, ship neither, ship both, in any order. The
-  architecture doesn't force any of those decisions; it preserves
-  the optionality.
+- **Vendor Cloud Pro is a deferred commitment, not a launch-day
+  product.** The architecture preserves the option to ship it
+  whenever demand justifies; nothing about Cloud's design
+  forecloses on adding dedicated tenancy as an upgrade. The
+  maintainer can also choose to never ship Vendor Cloud Pro at
+  all — Cloud with strong application-layer isolation may suffice
+  for the available market.
 
 ## Alternatives considered
 
@@ -188,14 +229,16 @@ until they're real.
   data-residency requirements). Retained as an *additional* delivery
   layer per the third decision point above.
 
-- **Single hosted tier serving both collectors and vendors.** One
-  hosted product, isolation good enough for vendors, priced low
-  enough for collectors. Rejected because the two ends of that
-  range are economically incompatible: collector-grade pricing only
-  works on shared infrastructure, vendor-grade isolation only works
-  on per-tenant separation. Trying to bridge them collapses to
-  serving one audience badly. Two distinct hosted shapes is the
-  honest split.
+- **Two parallel hosted products from day one (Cloud for
+  collectors, Vendor Cloud for vendors).** Build distinct hosted
+  shapes for each audience from the start, with Vendor Cloud
+  running on stronger isolation than Cloud. Rejected for now:
+  doubles the operational surface area before there's evidence
+  vendors need dedicated infrastructure on day one. Tier-up from a
+  single multi-tenant Cloud is the cheaper, evidence-driven path;
+  dedicated upgrades land via Vendor Cloud Pro when a customer
+  specifically asks. Reconsider if a pattern of
+  vendors-asking-for-dedicated appears before launch.
 
 - **CLA instead of DCO.** Contributors sign a one-time agreement
   (typically out-of-band, via a bot) granting the project broader

--- a/docs/adr/0012-open-core-architecture.md
+++ b/docs/adr/0012-open-core-architecture.md
@@ -69,34 +69,28 @@ Adopt an **open-core architecture with three structural commitments**:
    coordination.
 
 3. **Hosted offerings are additional delivery layers over the same
-   plugin surface. Ship one hosted product (Cloud) with multiple
-   plans on shared multi-tenant infrastructure; offer dedicated
-   hosting as an opt-in upgrade for vendors who require it.**
+   plugin surface. Ship one default multi-tenant hosted product
+   that serves both audiences on shared infrastructure; preserve a
+   deferred opt-in upgrade path to dedicated tenancy for customers
+   who require it.**
 
-   - **Cloud (default hosted product)** — multi-tenant on shared
-     infrastructure operated by the maintainer. Two plans on the
-     same infrastructure, differing only in feature surface,
-     quotas, and price:
-     - *Collector plan* — persistence features (saved want-lists,
-       run history, scheduled re-pricing, email / Discord delivery
-       of generated outputs). Price-sensitive; the
-       few-dollars-a-month anchor is what makes multi-tenant the
-       only viable model.
-     - *Vendor plan* — the vendor-only capabilities (multi-user
-       accounts, inventory state, acquisition-cost comps,
-       paid-third-party-API integrations). Same isolation
-       guarantees as the Collector plan; what differs is the
-       feature surface above and the quotas / rate limits sized
-       for vendor workloads.
-   - **Vendor Cloud Pro (opt-in dedicated upgrade)** — runs the
-     OSS CLI plus the vendor plugin on dedicated per-tenant
-     infrastructure. Targeted at vendors who specifically require
-     it (compliance posture, prior trust events, workloads heavy
-     enough to justify the cost). *Not a launch-day commitment*:
-     ships when there's evidence of demand and willingness to pay
-     for it. The architecture must preserve the upgrade path
-     (shared-infra schema is the same as, or trivially convertible
-     to, the dedicated-infra schema) from the start.
+   - The **default hosted product** is multi-tenant on shared
+     infrastructure operated by the maintainer. The same
+     infrastructure serves collectors and vendors via plans that
+     differ in feature surface, quotas, and price, but share the
+     same isolation guarantees enforced at the application layer.
+     Multi-tenancy is itself an architectural constraint: every
+     query is scoped to the requesting tenant, no per-customer
+     infra footprint.
+   - A **dedicated-tenancy upgrade** is preserved as an opt-in
+     path for the subset of customers who require it (compliance
+     posture, prior trust events, workloads heavy enough to
+     justify the cost). *Not a launch-day commitment*: ships
+     when there's evidence of demand and willingness to pay for
+     it. The architecture must preserve the upgrade path —
+     shared-infra and dedicated-infra schemas must be the same,
+     or trivially convertible, from the start — so the upgrade
+     can land without rework when justified.
 
    No hosted layer replaces a locally-installable equivalent:
    collectors keep the free OSS CLI, vendors keep the locally
@@ -134,16 +128,16 @@ until they're real.
   repo beyond the plugin surface (which is justified on its own).
   Decoupling the two codebases means the paid product can iterate
   on its own cadence without forcing OSS releases.
-- All hosted layers (Cloud's Collector and Vendor plans, plus the
-  deferred Vendor Cloud Pro upgrade) are additive, not exclusive —
-  they don't foreclose on serving customers who insist on the
+- The default multi-tenant hosted product and the deferred
+  dedicated-tenancy upgrade are additive, not exclusive — they
+  don't foreclose on serving customers who insist on the
   locally-installable equivalent for data-residency, trust, or
   offline-use reasons.
-- Starting with a single multi-tenant Cloud (rather than two
-  parallel hosted products from day one) defers the operational
-  cost of running a second production system until there's evidence
-  of demand for dedicated tenancy. Cheaper to launch, easier to
-  evolve.
+- Starting with a single multi-tenant hosted product (rather than
+  two parallel hosted products from day one) defers the
+  operational cost of running a second production system until
+  there's evidence of demand for dedicated tenancy. Cheaper to
+  launch, easier to evolve.
 - DCO sign-off makes downstream commercial reuse unambiguous
   without imposing CLA friction or key-management burden on
   contributors.
@@ -163,45 +157,45 @@ until they're real.
   -s`) but non-zero, particularly for web-edits and contributors
   unfamiliar with the convention. Mitigated by docs and an optional
   `commit-msg` hook.
-- **Noisy-neighbor risk.** Vendor-plan workloads (scheduled
-  re-pricing, bulk imports, paid-API integrations) running
-  alongside Collector-plan workloads on shared infrastructure will
-  need quota management, rate limiting, and ideally an async job
-  queue so one tenant's heavy run doesn't degrade another's. None
-  of this is hard, but all of it has to actually be there from the
-  first vendor onboarded.
-- **Cloud → Vendor Cloud Pro migration is a known problem to
-  design for, not against.** Moving an existing tenant's data from
+- **Noisy-neighbor risk.** Heavier workloads (scheduled jobs,
+  bulk imports, integrations with paid external APIs) running
+  alongside lighter ones on shared infrastructure will need quota
+  management, rate limiting, and ideally an async job queue so
+  one tenant's heavy run doesn't degrade another's. None of this
+  is hard, but all of it has to actually be there from the first
+  heavy-workload tenant onboarded.
+- **Shared-to-dedicated migration is a known problem to design
+  for, not against.** Moving an existing tenant's data from
   shared to dedicated infrastructure is non-trivial and needs to
-  be cheap before the first customer asks. The shared-infra schema
-  and the dedicated-infra schema need to be the same (or trivially
-  convertible) from the start; designing them as if they'll always
-  diverge would be a foreclosure.
-- **Launching with shared-only Cloud foregoes the largest
-  vendors** — those who require dedicated infrastructure from day
-  one. Likely the right tradeoff (those vendors are rarely early
-  customers anyway), but worth being honest about: those are
+  be cheap before the first customer asks. The shared-infra
+  schema and the dedicated-infra schema need to be the same (or
+  trivially convertible) from the start; designing them as if
+  they'll always diverge would be a foreclosure.
+- **Launching with shared-only hosting foregoes the customers
+  who require dedicated infrastructure from day one.** Likely
+  the right tradeoff (those customers are rarely early adopters
+  anyway), but worth being honest about: they're
   deferred-revenue customers, not lost ones, as long as the
   upgrade path is preserved.
 - **Tenant scoping must be correct everywhere, every time.** In a
-  multi-tenant Cloud that serves both audiences, every query must
-  be scoped to the requesting tenant; a single missed scope is a
-  cross-tenant leak. Mitigated by ORM-level discipline (a base
-  query that always filters by tenant) and a per-PR review checklist,
-  but it's a continuous obligation.
+  multi-tenant hosted product that serves multiple audiences,
+  every query must be scoped to the requesting tenant; a single
+  missed scope is a cross-tenant leak. Mitigated by ORM-level
+  discipline (a base query that always filters by tenant) and a
+  per-PR review checklist, but it's a continuous obligation.
 
 **Neutral.**
 
 - This ADR documents the architectural commitment; commercial
   details (tier names, pricing, feature gating) are intentionally
   excluded and live in private planning artifacts until launch.
-- **Vendor Cloud Pro is a deferred commitment, not a launch-day
-  product.** The architecture preserves the option to ship it
-  whenever demand justifies; nothing about Cloud's design
-  forecloses on adding dedicated tenancy as an upgrade. The
-  maintainer can also choose to never ship Vendor Cloud Pro at
-  all — Cloud with strong application-layer isolation may suffice
-  for the available market.
+- **The dedicated-tenancy upgrade is a deferred commitment, not a
+  launch-day product.** The architecture preserves the option to
+  ship it whenever demand justifies; nothing about the
+  multi-tenant product's design forecloses on adding dedicated
+  tenancy as an upgrade. The maintainer can also choose to never
+  ship dedicated tenancy at all — multi-tenant hosting with strong
+  application-layer isolation may suffice for the available market.
 
 ## Alternatives considered
 
@@ -229,15 +223,15 @@ until they're real.
   data-residency requirements). Retained as an *additional* delivery
   layer per the third decision point above.
 
-- **Two parallel hosted products from day one (Cloud for
-  collectors, Vendor Cloud for vendors).** Build distinct hosted
-  shapes for each audience from the start, with Vendor Cloud
-  running on stronger isolation than Cloud. Rejected for now:
+- **Two parallel hosted products from day one — a multi-tenant
+  one for collectors and a dedicated-tenancy one for vendors.**
+  Build distinct hosted products for each audience from the
+  start, with different isolation guarantees. Rejected for now:
   doubles the operational surface area before there's evidence
-  vendors need dedicated infrastructure on day one. Tier-up from a
-  single multi-tenant Cloud is the cheaper, evidence-driven path;
-  dedicated upgrades land via Vendor Cloud Pro when a customer
-  specifically asks. Reconsider if a pattern of
+  the vendor audience needs dedicated infrastructure on day one.
+  A tier-up from a single multi-tenant product (with a dedicated
+  upgrade path for customers who specifically ask) is the
+  cheaper, evidence-driven path. Reconsider if a pattern of
   vendors-asking-for-dedicated appears before launch.
 
 - **CLA instead of DCO.** Contributors sign a one-time agreement

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,6 +22,7 @@ not just the shape.
 | [0009](0009-docs-as-source-with-wiki-sync.md) | `docs/` is the source of truth; the GitHub Wiki is a mirror | Accepted | 2026-05-09 |
 | [0010](0010-unified-project-with-area-views.md) | Single unified GitHub Project with per-area views | Accepted | 2026-05-12 |
 | [0011](0011-marketing-site-stack.md) | Marketing site under `site/` (Astro + Tailwind, Cloudflare Pages) | Accepted | 2026-05-16 |
+| [0012](0012-open-core-architecture.md) | Open-core architecture for a paid Vendor tier | Proposed | 2026-05-16 |
 
 ## Adding a new ADR
 


### PR DESCRIPTION
Resolves #171

## What

Adds [`docs/adr/0012-open-core-architecture.md`](https://github.com/mgzwarrior/mgz-pkmn/blob/171-adr-0012-open-core-architecture/docs/adr/0012-open-core-architecture.md) with `Status: Proposed`, and indexes it in `docs/adr/README.md`.

The ADR records the load-bearing structural commitments for the planned free/paid separation:

1. **Separate private repo** (`mgz-pkmn-vendor` under a future `mgz-pkmn` GitHub org) for the paid surface. Not a flag, branch, or subdirectory in this repo.
2. **OSS CLI exposes a plugin surface** (entry-point discovery for subcommands, output writers, sources). Vendor package depends on `mgz-pkmn` as an ordinary pip dependency and registers against the entry points.
3. **One default multi-tenant hosted product** that serves both audiences on shared infrastructure, with **a deferred opt-in upgrade path to dedicated tenancy** for customers who require it. Schemas must stay shared-or-trivially-convertible from the start so the upgrade path isn't foreclosed.

DCO sign-off is adopted as the contributor licensing posture (implementation tracked in #170, PR #173).

The ADR is intentionally written in structural terms throughout the Decision and Consequences sections — it commits to *shapes* (one multi-tenant product, an upgrade path to dedicated), not to *commercial details* (specific tier names, pricing, packaging, feature lists). Commercial details remain in private planning until launch.

## Why

The roadmap commits to a free/paid separation at V2.x but the *architecture* isn't yet documented. Recording the shape before any paid code lands means:

- Contributors can reason about what code goes where without surprises.
- The plugin surface gets justified on its own merits (community plugins benefit too), not retrofitted later.
- The contributor-licensing posture (DCO) is settled before the contributor base grows much further — adding it later is increasingly expensive.
- The "open-core feature drift" failure mode is structurally prevented (separate repo), not procedurally avoided.
- The hosted-offering shape (one multi-tenant product with a deferred dedicated upgrade) is settled before any infrastructure code is written that would foreclose on it.

## Proposed-first

This ADR uses the **Proposed-first** pattern that the ADR template explicitly supports (see [`docs/adr/README.md`](https://github.com/mgzwarrior/mgz-pkmn/blob/171-adr-0012-open-core-architecture/docs/adr/README.md#L38)). Existing ADRs in this repo (-0010, -0011) were filed post-decision; this is the first one inviting review *before* the decision is locked.

Plan:
1. Open this PR as `Status: Proposed`.
2. Open a linked GitHub Discussion thread to gather async feedback alongside the PR review.
3. After a reasonable feedback window (suggest ~1 week), flip `Status:` to `Accepted` in a follow-up commit on this same PR and merge.

If feedback materially changes the decision, fold it into the ADR or — if the change is large enough — close this PR and file a fresh one.

## Review feedback incorporated

- **Two-vs-one hosted shape**: the initial draft committed to two parallel hosted products (one for collectors, one for vendors) from day one. Revised to one multi-tenant product with a deferred dedicated upgrade path, on the rationale that most vendors will accept shared infrastructure with strong application-layer tenant scoping; only a subset requires dedicated. This defers a real operational cost (running a second production system) until evidence justifies it.
- **Commercial vs architectural language**: an earlier revision used specific tier names ("Cloud", "Collector plan", "Vendor plan", "Vendor Cloud Pro"), enumerated features, and gave a price anchor. That contradicted the ADR's own out-of-scope statement. Revised to use structural terminology throughout Decision and Consequences. Working names for these tiers remain in private planning.

## How to verify

- `docs/adr/0012-open-core-architecture.md` is present, follows the template, status is `Proposed`.
- `docs/adr/README.md` index includes the new row in numeric order, status `Proposed`.
- `make check` passes (verified locally).
- No code changes — purely documentation.

## Explicitly out of scope

- Specific paid-tier names, pricing, feature lists, packaging.
- Implementation of the plugin surface itself (separate future issue once this ADR is Accepted).
- Implementation of DCO enforcement (tracked in #170, PR #173).