### PR TITLE
Adopt DCO sign-off via CI workflow + contributor docs

### DIFF
--- a/.githooks/dco-signoff
+++ b/.githooks/dco-signoff
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# pre-commit commit-msg hook: auto-append DCO Signed-off-by trailer if missing.
+# Invoked by pre-commit; $1 is the commit message file.
+set -euo pipefail
+
+name=$(git config user.name)
+email=$(git config user.email)
+
+if [ -z "$name" ] || [ -z "$email" ]; then
+  echo "error: git config user.name and user.email must be set for DCO sign-off" >&2
+  exit 1
+fi
+
+git interpret-trailers \
+  --if-exists doNothing \
+  --trailer "Signed-off-by: $name <$email>" \
+  --in-place \
+  "$1"

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,43 @@
+name: DCO
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  dco:
+    name: DCO sign-off check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Check Signed-off-by trailer on every commit
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          missing=0
+          while IFS= read -r sha; do
+            [ -z "$sha" ] && continue
+            author=$(git log -1 --format='%an <%ae>' "$sha")
+            if ! git log -1 --format='%B' "$sha" | grep -qE '^Signed-off-by: '; then
+              echo "::error::Commit $sha by $author is missing 'Signed-off-by:' trailer"
+              missing=$((missing + 1))
+            fi
+          done < <(git rev-list --no-merges "$BASE_SHA..$HEAD_SHA")
+          if [ "$missing" -gt 0 ]; then
+            echo ""
+            echo "$missing commit(s) missing DCO sign-off."
+            echo "Fix the last commit with:  git commit --amend -s"
+            echo "Fix all PR commits with:   git rebase --signoff $BASE_SHA"
+            echo "Then force-push. See docs/contributing.md for the full guide."
+            exit 1
+          fi
+          echo "All commits carry Signed-off-by."

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -21,14 +21,25 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        # Merge commits are excluded via --no-merges, matching the convention
+        # used by Linux, Kubernetes, and most CNCF projects. Merge commits
+        # generally represent integration rather than new authored content;
+        # contributors should resolve conflicts in a separate signed commit
+        # rather than in a merge commit.
         run: |
           set -euo pipefail
           missing=0
           while IFS= read -r sha; do
             [ -z "$sha" ] && continue
             author=$(git log -1 --format='%an <%ae>' "$sha")
-            if ! git log -1 --format='%B' "$sha" | grep -qE '^Signed-off-by: '; then
-              echo "::error::Commit $sha by $author is missing 'Signed-off-by:' trailer"
+            # Use git's trailer parser so we match only well-formed trailers
+            # in the last paragraph, not arbitrary "Signed-off-by:" mentions
+            # in the commit body.
+            trailer=$(git log -1 --format='%B' "$sha" \
+              | git interpret-trailers --parse \
+              | grep -E '^Signed-off-by: .+ <.+@.+>$' || true)
+            if [ -z "$trailer" ]; then
+              echo "::error::Commit $sha by $author is missing a well-formed 'Signed-off-by:' trailer"
               missing=$((missing + 1))
             fi
           done < <(git rev-list --no-merges "$BASE_SHA..$HEAD_SHA")
@@ -40,4 +51,4 @@ jobs:
             echo "Then force-push. See docs/contributing.md for the full guide."
             exit 1
           fi
-          echo "All commits carry Signed-off-by."
+          echo "All commits carry a well-formed Signed-off-by trailer."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,8 @@ repos:
         entry: bash -c 'cd web && npx tsc -b'
         files: ^web/.*\.(ts|tsx)$
         pass_filenames: false
+      - id: dco-signoff
+        name: DCO sign-off (auto-append if missing)
+        language: system
+        stages: [commit-msg]
+        entry: .githooks/dco-signoff

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,7 +115,9 @@ When adding or changing a public-facing behaviour:
 - Do not add print statements inside library code; use `logging` or surface
   errors through return values.
 - Do not bypass pre-commit hooks (`--no-verify`).
-- Do not commit without `-s`. The DCO check blocks any PR with a commit missing
-  the `Signed-off-by:` trailer. Always `git commit -s -m "..."`. See
-  [docs/contributing.md](docs/contributing.md#signing-off-your-commits) for the
-  recovery commands if you forget.
+- Do not commit without `-s`. The `DCO` CI job fails on any non-merge commit
+  missing the `Signed-off-by:` trailer (and will block merge once required in
+  branch protection). The `commit-msg` pre-commit hook auto-appends the
+  sign-off if installed, but always `git commit -s -m "..."` to be safe. See
+  [docs/contributing.md](docs/contributing.md#signing-off-your-commits) for
+  recovery commands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,3 +115,7 @@ When adding or changing a public-facing behaviour:
 - Do not add print statements inside library code; use `logging` or surface
   errors through return values.
 - Do not bypass pre-commit hooks (`--no-verify`).
+- Do not commit without `-s`. The DCO check blocks any PR with a commit missing
+  the `Signed-off-by:` trailer. Always `git commit -s -m "..."`. See
+  [docs/contributing.md](docs/contributing.md#signing-off-your-commits) for the
+  recovery commands if you forget.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,11 +73,15 @@ make fix
 Pre-commit hooks run `ruff check --fix` and `ruff format` automatically — make sure they
 pass.
 
-**Sign off every commit with `-s`.** This project enforces DCO sign-off via the `DCO`
-check on every PR. Commits without a `Signed-off-by:` trailer block merge. Always commit
-with `git commit -s -m "..."`; if you forget, recover with `git commit --amend --no-edit -s`
-(last commit) or `git rebase --signoff origin/main` (all PR commits), then force-push.
-See [docs/contributing.md](docs/contributing.md#signing-off-your-commits).
+**Sign off every commit with `-s`.** This project runs a DCO check on every PR; the
+`DCO` job fails when any non-merge commit is missing a `Signed-off-by:` trailer (the
+check becomes merge-blocking once the maintainer adds it to branch protection's
+required-checks list). Always commit with `git commit -s -m "..."`; if you forget,
+recover with `git commit --amend --no-edit -s` (last commit) or
+`git rebase --signoff origin/main` (all PR commits), then force-push. If `make install`
+or `make install-hooks` has been run, the `commit-msg` pre-commit hook auto-appends the
+sign-off so `-s` becomes optional locally. See
+[docs/contributing.md](docs/contributing.md#signing-off-your-commits).
 
 Before opening the PR, run the local gate:
 
@@ -154,7 +158,7 @@ You're done when the PR is open and CI is green. The `CI` workflow
 | `api` | ruff lint + format check (`src/`, `api/`) + full test suite, on Python 3.11, 3.12, and 3.13 |
 | `web` | ESLint + TypeScript typecheck/build (`npm run build`) for `web/` |
 | `site` | Astro build for the marketing site (`site/`) |
-| `DCO` | Every PR commit carries a `Signed-off-by:` trailer |
+| `DCO` | Every non-merge PR commit carries a well-formed `Signed-off-by:` trailer (advisory until added to branch protection's required-checks list) |
 
 CodeQL (`Analyze`) also runs on every PR — wait for those checks to pass too.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,15 @@ make fix
 ```
 
 Pre-commit hooks run `ruff check --fix` and `ruff format` automatically — make sure they
-pass. Before opening the PR, run the local gate:
+pass.
+
+**Sign off every commit with `-s`.** This project enforces DCO sign-off via the `DCO`
+check on every PR. Commits without a `Signed-off-by:` trailer block merge. Always commit
+with `git commit -s -m "..."`; if you forget, recover with `git commit --amend --no-edit -s`
+(last commit) or `git rebase --signoff origin/main` (all PR commits), then force-push.
+See [docs/contributing.md](docs/contributing.md#signing-off-your-commits).
+
+Before opening the PR, run the local gate:
 
 ```bash
 make check   # ruff lint + format check + Python tests + web ESLint
@@ -138,12 +146,15 @@ gh project item-add <project-number> --owner mgzwarrior --url <pr-url>
 ## Step 6 — Confirm CI is green
 
 You're done when the PR is open and CI is green. The `CI` workflow
-(`.github/workflows/ci.yml`) defines two jobs:
+(`.github/workflows/ci.yml`) defines three jobs, and `DCO`
+(`.github/workflows/dco.yml`) runs separately on PRs:
 
 | Job | What it checks |
 |-----|---------------|
 | `api` | ruff lint + format check (`src/`, `api/`) + full test suite, on Python 3.11, 3.12, and 3.13 |
 | `web` | ESLint + TypeScript typecheck/build (`npm run build`) for `web/` |
+| `site` | Astro build for the marketing site (`site/`) |
+| `DCO` | Every PR commit carries a `Signed-off-by:` trailer |
 
 CodeQL (`Analyze`) also runs on every PR — wait for those checks to pass too.
 

--- a/Makefile
+++ b/Makefile
@@ -51,9 +51,10 @@ install-site:  ## Marketing site dependencies (`npm install` in site/).
 	cd site && npm install
 
 .PHONY: install-hooks
-install-hooks:  ## Install pre-commit as a uv tool and register the git hook.
+install-hooks:  ## Install pre-commit as a uv tool and register the git hooks (pre-commit + commit-msg).
 	uv tool install pre-commit
 	uv tool run pre-commit install
+	uv tool run pre-commit install --hook-type commit-msg
 
 ## Dev servers
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -226,18 +226,22 @@ Ruff config lives in [pyproject.toml](../pyproject.toml) under
 make install-hooks
 ```
 
-That runs `uv tool install pre-commit` and registers the git hook so
-lint and format checks fire automatically before every commit.
-Equivalent manual flow:
+That runs `uv tool install pre-commit` and registers the git hooks
+(both the `pre-commit` stage for lint/format/typecheck and the
+`commit-msg` stage for DCO sign-off auto-append) so checks fire
+automatically before every commit. Equivalent manual flow:
 
 ```bash
 uv tool install pre-commit
 pre-commit install
+pre-commit install --hook-type commit-msg
 ```
 
 The hooks are defined in
 [.pre-commit-config.yaml](../.pre-commit-config.yaml) and run
-`ruff check --fix` and `ruff format` on every staged file.
+`ruff check --fix` and `ruff format` on every staged file, plus the
+DCO sign-off auto-append on every commit message (see
+[Signing off your commits](#signing-off-your-commits)).
 
 > **Why `uv tool install` and not `uv run --with pre-commit`?**
 > `uv run --with` drops pre-commit into an ephemeral environment under
@@ -254,13 +258,31 @@ the hook with a stable Python path.
 
 ## Signing off your commits
 
-Every commit on a PR needs a [DCO](https://developercertificate.org/)
+Every non-merge commit on a PR needs a [DCO](https://developercertificate.org/)
 sign-off — a `Signed-off-by: Name <email>` trailer in the commit
 message that asserts you have the right to license your contribution
-under MIT. CI blocks merges where any PR commit is missing the trailer.
-See [ADR-0012](adr/0012-open-core-architecture.md) for the rationale.
+under MIT. The `DCO` CI job fails when any non-merge commit is missing
+the trailer; merges are blocked once the maintainer adds the check to
+branch protection's required-checks list (until then the check is
+advisory). Merge commits are exempted to match the convention used by
+Linux, Kubernetes, and most CNCF projects — resolve conflicts in a
+separate signed commit rather than in a merge commit.
 
-Add it automatically by passing `-s` to `git commit`:
+See [ADR-0012](adr/0012-open-core-architecture.md) for the rationale
+behind the DCO posture.
+
+### The easy path: the pre-commit hook auto-appends sign-off
+
+`make install-hooks` (or the full `make install`) registers a
+`commit-msg`-stage pre-commit hook that auto-appends the sign-off
+trailer to every commit using your `git config user.name` and
+`user.email`. With the hook installed you don't have to remember
+`-s` — every local commit is signed off automatically.
+
+### Manual sign-off
+
+If you don't use the hook (or are committing on a machine without the
+pre-commit framework installed), pass `-s` explicitly:
 
 ```bash
 git commit -s -m "your message"
@@ -302,7 +324,7 @@ to `main`, plus a DCO check on PRs:
 | `api` | ruff lint + format check + full test suite (`src/` and `api/`), across Python 3.11 / 3.12 / 3.13 |
 | `web` | ESLint + Vitest + TypeScript build (`tsc -b && vite build`) for `web/` |
 | `site` | Astro build for the marketing site (`site/`) |
-| `DCO` | Every PR commit carries a `Signed-off-by:` trailer (PRs only) |
+| `DCO` | Every non-merge PR commit carries a well-formed `Signed-off-by:` trailer (PRs only; advisory until added to branch protection's required-checks list) |
 
 ## Changelog
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -252,15 +252,57 @@ If you already hit that error, the fix is the same two commands above
 — `uv tool install pre-commit` then `pre-commit install` regenerates
 the hook with a stable Python path.
 
+## Signing off your commits
+
+Every commit on a PR needs a [DCO](https://developercertificate.org/)
+sign-off — a `Signed-off-by: Name <email>` trailer in the commit
+message that asserts you have the right to license your contribution
+under MIT. CI blocks merges where any PR commit is missing the trailer.
+See [ADR-0012](adr/0012-open-core-architecture.md) for the rationale.
+
+Add it automatically by passing `-s` to `git commit`:
+
+```bash
+git commit -s -m "your message"
+```
+
+The trailer uses the name and email from your `git config user.*` —
+no extra setup required, no cryptographic keys, no documents to sign.
+This is *not* the same as GPG/SSH commit signing (this project does
+not enforce signed commits — see [#153](https://github.com/mgzwarrior/mgz-pkmn/pull/153)).
+
+**Forgot `-s` on the last commit:**
+
+```bash
+git commit --amend --no-edit -s
+git push --force-with-lease
+```
+
+**Forgot `-s` on every commit of a PR:**
+
+```bash
+git rebase --signoff origin/main
+git push --force-with-lease
+```
+
+**Editing on github.com:** the web UI doesn't add the trailer
+automatically. After saving, pull the commit locally and amend it with
+`git commit --amend --no-edit -s` before pushing.
+
+Dependabot's commits include the sign-off automatically, so its PRs
+require no special handling.
+
 ## CI
 
-GitHub Actions runs two parallel jobs on every pull request and push
-to `main`:
+GitHub Actions runs three parallel jobs on every pull request and push
+to `main`, plus a DCO check on PRs:
 
 | Job | What it checks |
 |---|---|
 | `api` | ruff lint + format check + full test suite (`src/` and `api/`), across Python 3.11 / 3.12 / 3.13 |
 | `web` | ESLint + Vitest + TypeScript build (`tsc -b && vite build`) for `web/` |
+| `site` | Astro build for the marketing site (`site/`) |
+| `DCO` | Every PR commit carries a `Signed-off-by:` trailer (PRs only) |
 
 ## Changelog
 


### PR DESCRIPTION
Resolves #170

## What

Adopts the [Developer Certificate of Origin](https://developercertificate.org/) sign-off requirement for every non-merge commit on every PR. CI enforces it via a new workflow; a `commit-msg`-stage pre-commit hook auto-appends the sign-off locally so contributors don't have to remember `-s`; docs cover the rationale and recovery flows.

Files touched:

- **`.github/workflows/dco.yml`** (new) — runs on PR `opened` / `synchronize` / `reopened`. Iterates non-merge commits between the PR base and head, uses `git interpret-trailers --parse` plus a `^Signed-off-by: .+ <.+@.+>$` regex to verify each carries a well-formed sign-off trailer (not just an arbitrary body mention). Output includes actionable recovery commands (amend, rebase) when the check fails. Merge commits are exempted to match the Linux/Kubernetes/CNCF convention — resolve conflicts in a separate signed commit rather than in a merge commit.
- **`.githooks/dco-signoff`** (new, executable) — small shell script invoked by the `commit-msg` pre-commit stage. Uses `git interpret-trailers --if-exists doNothing --trailer ...` to auto-append the sign-off using `git config user.*` if not already present. Extracted to a script file rather than inlined in `.pre-commit-config.yaml` because the trailer contains a colon and angle brackets that don't quote cleanly in YAML.
- **`.pre-commit-config.yaml`** — registers the new hook at the `commit-msg` stage. The existing `pre-commit`-stage hooks (ruff, ESLint, typecheck) are unchanged.
- **`Makefile`** — `install-hooks` now also runs `pre-commit install --hook-type commit-msg` so the new stage actually fires after `make install`.
- **`docs/contributing.md`** — new "Signing off your commits" section explaining DCO, the rationale, how to sign with `-s`, the auto-append hook (the easy path), recovery flows for forgotten sign-offs, and the web-edit workaround. CI table updated to include `site` and `DCO` jobs. Pre-commit-hooks section updated to mention both hook stages.
- **`CLAUDE.md`** — Step 4 documents `git commit -s`. Step 6 CI table matches the new contributing.md table. Wording distinguishes between the CI job failing and the merge gate (the gate is added later via branch protection).
- **`AGENTS.md`** — adds DCO sign-off to "What to avoid" alongside the existing `--no-verify` rule, with a pointer to recovery commands and the auto-append hook.

## Why

The free OSS CLI is permissively licensed (MIT), but commits don't currently carry any per-contribution assertion that the contributor had the right to license the code that way. As the project grows — and especially as code is reused in a planned paid Vendor surface (see [ADR-0012](docs/adr/0012-open-core-architecture.md), now merged on main) — we want a clean per-commit legal record.

DCO is the lightest-weight option:
- No documents to sign, no key management.
- Distinct from cryptographic commit signing (which was [explicitly dropped](https://github.com/mgzwarrior/mgz-pkmn/pull/153)) — different problem, different tradeoff.
- Dependabot's commits include sign-off automatically, so its PRs continue to pass.
- With the `commit-msg` hook installed, contributors don't have to remember `-s` at all.

## Why the inline workflow vs. the GitHub App

The issue called out two implementation paths: the [`dcoapp/app`](https://github.com/dcoapp/app) GitHub App or a self-contained Actions workflow. This PR ships the **workflow** because:

- Self-contained — no out-of-repo install step required to make it active.
- Small surface to audit (~30 lines of bash).
- Easy to swap for the App later if the maintainer prefers; the App and the workflow can also coexist with one as a fallback.

If the maintainer wants the App instead, deleting `.github/workflows/dco.yml` and installing `dcoapp/app` is a 30-second swap. No docs would need to change.

## Review feedback incorporated

Copilot raised six comments in the first review pass; all addressed in `ed460fd`:

- **Trailer parsing**: replaced `grep '^Signed-off-by: '` with `git interpret-trailers --parse | grep -E '^Signed-off-by: .+ <.+@.+>$'`. The trailer parser only emits well-formed trailers in the commit-message tail, and the stricter regex requires the `Name <email>` shape. Verified locally that body-only mentions and malformed trailers are correctly rejected.
- **Merge commits**: kept `--no-merges` (matches Linux/Kubernetes/CNCF convention) and documented the choice inline in the workflow + in the contributor docs. The docs now say "every non-merge commit" to match the actual enforcement, removing the apparent contradiction.
- **Advisory wording**: revised all three docs (contributing.md, CLAUDE.md, AGENTS.md) to distinguish between "CI fails" (what this PR enforces) and "merge is blocked" (what happens after the maintainer adds the check to branch protection's required-checks list).
- **Broken ADR link**: ADR-0012 PR #172 merged to main just before this update, so the relative link in `docs/contributing.md` now resolves.

Additionally added the **`commit-msg` pre-commit hook** per maintainer request, so `-s` becomes optional locally once `make install-hooks` has been run.

## How to verify

- Open this PR; the new `DCO sign-off check` should appear in the checks list and pass (this PR's own commits are signed off).
- Push a test branch with a commit *missing* `-s` and open a draft PR; the check should fail with the recovery commands printed in the log.
- Locally, `make install-hooks` should register both the `pre-commit` and `commit-msg` stages; a `git commit` without `-s` should still produce a signed-off commit because the hook auto-appends.

## Required follow-up (out of scope)

The check is **advisory** until added to branch protection's required-checks list. To make it actually block merges:

1. **Repo Settings → Branches → main → Edit protection rule.**
2. Under "Require status checks to pass before merging," add `DCO sign-off check`.
3. Save.

That UI step is required and can't be done from the CLI.

## Context

See [ADR-0012](docs/adr/0012-open-core-architecture.md) for the open-core architecture decision that motivates the DCO posture. This PR is the first implementation consequence of that ADR; it can land independently (DCO is useful even if the paid surface never materializes).