### PR TITLE
Publish to PyPI on v* tag via trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,10 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -37,8 +37,50 @@ jobs:
           name: dist
           path: dist/
 
+  pypi-publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mgz-pkmn
+    permissions:
+      id-token: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Publish GitHub Release
+    needs: pypi-publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: dist
+          path: dist/
+
+      - name: Compute PyPI version
+        id: pypi
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
           files: dist/*
           generate_release_notes: true
+          body: |
+            **Install from PyPI:** https://pypi.org/project/mgz-pkmn/${{ steps.pypi.outputs.version }}/
+
+            ```bash
+            pip install mgz-pkmn==${{ steps.pypi.outputs.version }}
+            ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
   [PyPI](https://pypi.org/project/mgz-pkmn/) on every `v*` tag using
   trusted publishing (OIDC, no stored token). The GitHub Release notes
   link to the newly published PyPI version. One-time PyPI-side setup
-  documented in [docs/contributing.md](docs/contributing.md#one-time-pypi-trusted-publisher-setup).
+  documented in [docs/contributing.md](docs/contributing.md#pypi-trusted-publisher-wiring).
 - Marketing site under `site/`: Astro 5 + Tailwind 4, single landing
   page (hero, features, how-it-works, roadmap teaser, footer),
   designed to deploy to Cloudflare Pages on a custom domain. New

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Release workflow now publishes the built sdist + wheel to
+  [PyPI](https://pypi.org/project/mgz-pkmn/) on every `v*` tag using
+  trusted publishing (OIDC, no stored token). The GitHub Release notes
+  link to the newly published PyPI version. One-time PyPI-side setup
+  documented in [docs/contributing.md](docs/contributing.md#one-time-pypi-trusted-publisher-setup).
 - Marketing site under `site/`: Astro 5 + Tailwind 4, single landing
   page (hero, features, how-it-works, roadmap teaser, footer),
   designed to deploy to Cloudflare Pages on a custom domain. New

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -357,29 +357,15 @@ trusted publishing, and creates a GitHub Release with the same
 distribution files attached. The Release notes link to the new PyPI
 version.
 
-### One-time PyPI trusted publisher setup
+### PyPI trusted publisher wiring
 
 The `pypi-publish` job uses [PyPI Trusted
 Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) so the
-workflow can upload to PyPI without storing an API token. This needs to
-be configured once on the PyPI side:
-
-1. Sign in to PyPI as a maintainer of `mgz-pkmn` (or, for the very
-   first release, use the [pending publisher
-   flow](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/)
-   to claim the name).
-2. Open the project's **Publishing** settings and add a new GitHub
-   trusted publisher with these values:
-   - **Owner:** `mgzwarrior`
-   - **Repository:** `mgz-pkmn`
-   - **Workflow filename:** `release.yml`
-   - **Environment name:** `pypi`
-3. In this repo, create a GitHub Environment named `pypi`
-   (Settings → Environments → New environment). No secrets are needed;
-   the environment exists so PyPI's trusted-publisher binding has
-   something to match against, and so production deploys get the
-   environment's protection rules (required reviewers, branch/tag
-   filters) if you choose to add them.
-
-Once the binding is in place, every `v*` tag push will publish to PyPI
-automatically.
+workflow uploads to PyPI without a stored API token. The binding —
+owner `mgzwarrior`, repo `mgz-pkmn`, workflow `release.yml`,
+environment `pypi` — and the matching `pypi` GitHub Environment
+(no secrets) are already in place. If either ever needs to be
+rebuilt (project re-owned, environment recreated, etc.), re-add the
+trusted publisher in the PyPI project's **Publishing** settings with
+those same four values and recreate the `pypi` Environment under
+repo Settings → Environments.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -351,5 +351,35 @@ git tag v0.2.0
 git push origin v0.2.0
 ```
 
-The workflow builds the package, runs the test suite, and publishes a
-GitHub Release with the built distribution files attached.
+The workflow builds the package, runs the test suite, publishes the
+built distribution to [PyPI](https://pypi.org/project/mgz-pkmn/) via
+trusted publishing, and creates a GitHub Release with the same
+distribution files attached. The Release notes link to the new PyPI
+version.
+
+### One-time PyPI trusted publisher setup
+
+The `pypi-publish` job uses [PyPI Trusted
+Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) so the
+workflow can upload to PyPI without storing an API token. This needs to
+be configured once on the PyPI side:
+
+1. Sign in to PyPI as a maintainer of `mgz-pkmn` (or, for the very
+   first release, use the [pending publisher
+   flow](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/)
+   to claim the name).
+2. Open the project's **Publishing** settings and add a new GitHub
+   trusted publisher with these values:
+   - **Owner:** `mgzwarrior`
+   - **Repository:** `mgz-pkmn`
+   - **Workflow filename:** `release.yml`
+   - **Environment name:** `pypi`
+3. In this repo, create a GitHub Environment named `pypi`
+   (Settings → Environments → New environment). No secrets are needed;
+   the environment exists so PyPI's trusted-publisher binding has
+   something to match against, and so production deploys get the
+   environment's protection rules (required reviewers, branch/tag
+   filters) if you choose to add them.
+
+Once the binding is in place, every `v*` tag push will publish to PyPI
+automatically.


### PR DESCRIPTION
Closes #64

## What

Splits `.github/workflows/release.yml` into three jobs and adds PyPI publishing:

- **build** — checkout, lint, test, `uv build`, upload `dist/` artifact (unchanged from before)
- **pypi-publish** *(new)* — downloads `dist/` and publishes via [`pypa/gh-action-pypi-publish`](https://github.com/pypa/gh-action-pypi-publish) using OIDC trusted publishing. Runs under a `pypi` GitHub Environment with `id-token: write`; no stored API token
- **github-release** — same `softprops/action-gh-release` step as before, but the release body now leads with a PyPI install link for the new version

Also:

- Documented the trusted-publisher wiring in [docs/contributing.md](https://github.com/mgzwarrior/mgz-pkmn/blob/64-pypi-publish-on-tag/docs/contributing.md#pypi-trusted-publisher-wiring) as a one-paragraph reference (the binding and the `pypi` Environment are already configured; docs exist for disaster-recovery)
- Changelog bullet under `[Unreleased] → Added`

## Why

The roadmap and issue #64 both call for `pip install mgz-pkmn` to Just Work on every release. Trusted publishing was the explicit ask — it removes the operational risk of a long-lived PyPI API token in repo secrets.

## How to verify

End-to-end verification requires a real `v*` tag, which will be done in a follow-up PR that rotates the changelog and bumps `pyproject.toml` to `1.0.1`. Until then:

- Workflow YAML parses (CI green)
- `make check` is green
- Maintainer has already configured the PyPI trusted-publisher binding and the `pypi` Environment

## Acceptance criteria

- [x] Workflow on push tag matching `v*` (already existed; preserved)
- [x] Trusted Publisher configured (workflow side + PyPI side both done)
- [x] Release notes link to PyPI