### PR TITLE
Bump version to 1.0.1 and rotate changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-05-16
+
 ### Added
 
 - Release workflow now publishes the built sdist + wheel to
   [PyPI](https://pypi.org/project/mgz-pkmn/) on every `v*` tag using
   trusted publishing (OIDC, no stored token). The GitHub Release notes
-  link to the newly published PyPI version. One-time PyPI-side setup
+  link to the newly published PyPI version. Trusted-publisher wiring
   documented in [docs/contributing.md](docs/contributing.md#pypi-trusted-publisher-wiring).
 - Marketing site under `site/`: Astro 5 + Tailwind 4, single landing
   page (hero, features, how-it-works, roadmap teaser, footer),
@@ -134,6 +136,7 @@ UI, multi-source card lookup, all output formats, and release infrastructure.
 - Incomplete URL substring sanitization (CodeQL alerts).
 - Workflow permissions hardening (CodeQL alerts).
 
-[Unreleased]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/mgzwarrior/mgz-pkmn/compare/v0.1.0...v1.0.0
 [0.1.0]: https://github.com/mgzwarrior/mgz-pkmn/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mgz-pkmn"
-version = "1.0.0"
+version = "1.0.1"
 description = "CLI and web app to look up Pokemon cards across open data sources, fetch images and prices, and emit an .xlsx, PDF binder, set-completion checklist, and JSON report for card-show prep."
 readme = "README.md"
 license = "MIT"

--- a/src/mgz_pkmn/__init__.py
+++ b/src/mgz_pkmn/__init__.py
@@ -1,6 +1,6 @@
 """Pokemon card list -> spreadsheet for card shows."""
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 from mgz_pkmn.parser import CardQuery, parse_lines
 

--- a/uv.lock
+++ b/uv.lock
@@ -261,7 +261,7 @@ wheels = [
 
 [[package]]
 name = "mgz-pkmn"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Follow-up to #190 / closes the verification half of #64.

> **Base note:** this PR is stacked on `64-pypi-publish-on-tag`. Once [#190](https://github.com/mgzwarrior/mgz-pkmn/pull/190) merges, GitHub will auto-retarget this PR to `main`.

## What

- Rotates the two `[Unreleased]` bullets (PyPI publish workflow + marketing site) into a `[1.0.1]` section dated 2026-05-16
- Bumps the version to `1.0.1` in `pyproject.toml`, `src/mgz_pkmn/__init__.py`, and `uv.lock`
- Updates the compare links at the bottom of `CHANGELOG.md`

## Why

After [#190](https://github.com/mgzwarrior/mgz-pkmn/pull/190) merges, the release workflow can publish to PyPI on a `v*` tag — but only a real tag exercises the new `pypi-publish` job end-to-end. `v1.0.1` is the smallest sensible release that lets us verify the path.

## How to verify

After both PRs merge:

```bash
git tag v1.0.1
git push origin v1.0.1
```

Then watch the Actions tab: `build` → `pypi-publish` → `github-release` should run in sequence, and the new version should appear on https://pypi.org/project/mgz-pkmn/ with the GitHub Release notes linking to it.