### PR TITLE
Auto-release to PyPI on pyproject.toml version bump

### DIFF
--- a/.github/workflows/release-on-version-bump.yml
+++ b/.github/workflows/release-on-version-bump.yml
@@ -1,0 +1,65 @@
+name: Release on version bump
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.check.outputs.tag }}
+      should_release: ${{ steps.check.outputs.should_release }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect version and tag state
+        id: check
+        run: |
+          VERSION=$(grep -E '^version = ' pyproject.toml | head -1 | sed -E 's/version = "(.+)"/\1/')
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not parse version from pyproject.toml"
+            exit 1
+          fi
+          TAG="v$VERSION"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          if git rev-parse "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists; nothing to release."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Tagging $TAG and triggering release."
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  tag:
+    needs: detect
+    if: needs.detect.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ needs.detect.outputs.tag }}" -m "Release ${{ needs.detect.outputs.tag }}"
+          git push origin "${{ needs.detect.outputs.tag }}"
+
+  release:
+    needs: [detect, tag]
+    if: needs.detect.outputs.should_release == 'true'
+    uses: ./.github/workflows/release.yml
+    with:
+      tag: ${{ needs.detect.outputs.tag }}
+    permissions:
+      contents: write
+      id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_call:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v1.0.1)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -13,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.tag || github.ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -71,11 +79,14 @@ jobs:
 
       - name: Compute PyPI version
         id: pypi
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+        run: |
+          REF="${{ inputs.tag || github.ref_name }}"
+          echo "version=${REF#v}" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ inputs.tag || github.ref_name }}
           files: dist/*
           generate_release_notes: true
           body: |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -340,22 +340,37 @@ config, internal refactors, and test-only changes.
 
 ## Releasing
 
-First, rotate the changelog: rename the `[Unreleased]` section to the
-new version with today's date, add a fresh empty `[Unreleased]` above
-it, and update the compare links at the bottom of the file.
+Releases are driven by `pyproject.toml`. A PR that bumps the version
+**is** the release — once it merges to `main`, the
+`release-on-version-bump` workflow tags the new commit, builds the
+package, runs the test suite, publishes to
+[PyPI](https://pypi.org/project/mgz-pkmn/) via trusted publishing, and
+creates a GitHub Release with the built distribution attached and
+notes linking to the new PyPI version.
 
-Then push a `v*` tag to trigger the release workflow:
+To cut a release, open a single PR that:
+
+1. Rotates the changelog: rename the `[Unreleased]` section to the new
+   version with today's date, add a fresh empty `[Unreleased]` above
+   it, and update the compare links at the bottom of the file.
+2. Bumps the version string in `pyproject.toml`,
+   `src/mgz_pkmn/__init__.py`, and `uv.lock` (run `uv lock` after
+   editing `pyproject.toml` to update the lockfile).
+
+Merge the PR — the rest is automatic. The
+`release-on-version-bump` workflow no-ops if the `v<version>` tag
+already exists, so unrelated `pyproject.toml` edits (dependency
+bumps, metadata tweaks) don't trigger spurious releases.
+
+### Emergency manual release
+
+If automation is unavailable, the underlying `release.yml` workflow
+still accepts a manually pushed tag:
 
 ```bash
 git tag v0.2.0
 git push origin v0.2.0
 ```
-
-The workflow builds the package, runs the test suite, publishes the
-built distribution to [PyPI](https://pypi.org/project/mgz-pkmn/) via
-trusted publishing, and creates a GitHub Release with the same
-distribution files attached. The Release notes link to the new PyPI
-version.
 
 ### PyPI trusted publisher wiring
 


### PR DESCRIPTION
Closes #192

## What

Adds `.github/workflows/release-on-version-bump.yml`:

- Fires on `push: branches: [main], paths: [pyproject.toml]`
- Reads `version` from `pyproject.toml`
- **Idempotent guard:** no-ops if the `v<version>` tag already exists, so dependency bumps and other non-version `pyproject.toml` edits don't trigger spurious releases
- Otherwise: creates and pushes `v<version>` tag, then invokes `release.yml` via `workflow_call` — build, PyPI publish, and GitHub Release all happen in the same run, visible in the Actions tab

Refactors `release.yml` to accept both triggers:

- `on: push: tags: v*` — preserved as an emergency manual-push fallback (works because the maintainer's local git auth, not `GITHUB_TOKEN`, pushes the tag)
- `on: workflow_call:` with a `tag` input — invoked by `release-on-version-bump.yml`

Updates the **Releasing** section in [docs/contributing.md](https://github.com/mgzwarrior/mgz-pkmn/blob/192-auto-release-on-version-bump/docs/contributing.md#releasing) to describe the new "version bump PR is the release" flow.

## Why

The version-bump PR review already serves as the deliberate human gate. Pushing the tag from a laptop afterward is a separate manual step that's easy to forget and invisible to anyone but the maintainer. With this in place, merging the PR is the release — single source of truth (`pyproject.toml`), single event (merge to main), one Actions run from end to end.

This also dodges the `GITHUB_TOKEN` tag-trigger gotcha (tags pushed by the workflow token don't fire other workflows) by reusing `release.yml` via `workflow_call` instead of relying on the tag push to chain workflows.

## How to verify

Full end-to-end verification requires merging this PR and then merging [#191](https://github.com/mgzwarrior/mgz-pkmn/pull/191) (which bumps to `1.0.1`). The expected sequence on #191 merge:

1. `release-on-version-bump` workflow fires on the merge commit
2. `detect` job reads `1.0.1` from `pyproject.toml`, confirms `v1.0.1` doesn't exist, sets `should_release=true`
3. `tag` job pushes the `v1.0.1` annotated tag
4. `release` job calls `release.yml`, which builds, publishes to PyPI, and creates the GitHub Release linking to `https://pypi.org/project/mgz-pkmn/1.0.1/`

Pre-merge sanity:

- `make check` is green
- Workflow YAML parses (CI green on this PR)

## Suggested merge order

This should land **before** #191 so that merging #191 is the first real test of the auto-release flow.