### PR TITLE
docs: document two PyPI trusted publisher bindings

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -376,11 +376,20 @@ git push origin v0.2.0
 
 The `pypi-publish` job uses [PyPI Trusted
 Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) so the
-workflow uploads to PyPI without a stored API token. The binding —
-owner `mgzwarrior`, repo `mgz-pkmn`, workflow `release.yml`,
-environment `pypi` — and the matching `pypi` GitHub Environment
-(no secrets) are already in place. If either ever needs to be
+workflow uploads to PyPI without a stored API token. PyPI verifies
+against the **entry workflow** that started the run (not the reusable
+workflow that actually performs the upload), so each release path
+needs its own trusted publisher binding. Two are configured:
+
+| Path | Entry workflow | When it fires |
+|---|---|---|
+| Auto | `release-on-version-bump.yml` | A merged PR bumps the version in `pyproject.toml` |
+| Manual fallback | `release.yml` | A maintainer pushes a `v*` tag from their laptop |
+
+Both bindings share: owner `mgzwarrior`, repo `mgz-pkmn`,
+environment `pypi`. The matching `pypi` GitHub Environment
+(no secrets) is also in place. If any of this ever needs to be
 rebuilt (project re-owned, environment recreated, etc.), re-add the
-trusted publisher in the PyPI project's **Publishing** settings with
-those same four values and recreate the `pypi` Environment under
-repo Settings → Environments.
+trusted publishers in the PyPI project's **Publishing** settings
+with those values and recreate the `pypi` Environment under repo
+Settings → Environments.


### PR DESCRIPTION
Follow-up to #192 / #193.

## What

Updates the **PyPI trusted publisher wiring** section in [docs/contributing.md](https://github.com/mgzwarrior/mgz-pkmn/blob/192-document-second-pypi-binding/docs/contributing.md#pypi-trusted-publisher-wiring) to explain that two bindings are required (one per release path) and to call out the underlying entry-workflow rule.

## Why

The first attempted v1.0.1 release ([run 25970752931](https://github.com/mgzwarrior/mgz-pkmn/actions/runs/25970752931)) failed with `400 Invalid attestations supplied during upload` because PyPI matches the trusted publisher against the **entry workflow** that started the run — `release-on-version-bump.yml` — not the reusable `release.yml` it calls. Only `release.yml` had a binding configured.

A second binding for `release-on-version-bump.yml` is being added on the PyPI side. This PR makes that fact discoverable in the contributing docs so the next maintainer doesn't trip over the same rule.

## How to verify

- `make check` is green
- Read the updated section in [docs/contributing.md](https://github.com/mgzwarrior/mgz-pkmn/blob/192-document-second-pypi-binding/docs/contributing.md#pypi-trusted-publisher-wiring)