### PR TITLE
Disable PEP 740 attestations on PyPI publish to unblock v1.0.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,8 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          attestations: false
 
   github-release:
     name: Publish GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,10 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          # Re-enable once PyPI's attestation verifier accepts the
+          # release-on-version-bump.yml trusted-publisher binding
+          # (currently rejects with 400 "Verification failed: Build
+          # Config URI does not match expected Trusted Publisher").
           attestations: false
 
   github-release:


### PR DESCRIPTION
Unblocks the v1.0.1 release. Related to #192.

## What

Sets `attestations: false` on the `pypa/gh-action-pypi-publish` step in `release.yml`.

## Why

Run [25970752931](https://github.com/mgzwarrior/mgz-pkmn/actions/runs/25970752931) keeps failing at the attestation verification step with:

> Invalid attestations supplied during upload: ... Certificate's Build Config URI (release-on-version-bump.yml@refs/heads/main) does not match expected Trusted Publisher (release.yml @ mgzwarrior/mgz-pkmn)

OIDC trusted-publisher auth itself is succeeding (the upload session opens), so the actual auth boundary is intact. The failure is in the optional PEP 740 supply-chain attestation, which PyPI verifies against trusted-publisher bindings — and PyPI's attestation verifier isn't picking up the second `release-on-version-bump.yml` binding even after it was added.

Disabling attestations sidesteps this and gets v1.0.1 published. Attestations are a *nice-to-have* supply-chain signal, not the auth path; we can re-enable in a follow-up once we understand why the second binding isn't being matched.

## How to verify

- `make check` is green
- Once merged, re-run the failed jobs on [run 25970752931](https://github.com/mgzwarrior/mgz-pkmn/actions/runs/25970752931); the build artifacts are still cached, so it'll resume at `pypi-publish`. Expected: publish succeeds, GitHub Release fires, v1.0.1 appears on https://pypi.org/project/mgz-pkmn/.

## Follow-up

Open a tracking issue to re-enable attestations once PyPI's verifier behavior with multiple bindings is understood (or after the next release if the verifier picks up the binding on its own).