### PR TITLE
devops: re-enable PEP 740 attestations on PyPI publish

### DIFF
--- a/.github/workflows/release-on-version-bump.yml
+++ b/.github/workflows/release-on-version-bump.yml
@@ -42,10 +42,16 @@ jobs:
     needs: detect
     if: needs.detect.outputs.should_release == 'true'
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
+      # Push the tag with a PAT so that release.yml's `push: tags` trigger
+      # fires as a top-level workflow. Tags pushed with the default
+      # GITHUB_TOKEN do not trigger downstream workflows, and routing the
+      # release through `workflow_call` would make the Sigstore identity
+      # reflect this caller workflow instead of release.yml, breaking
+      # PEP 740 attestation verification against the trusted publisher.
       - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Create and push tag
         run: |
@@ -53,13 +59,3 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a "${{ needs.detect.outputs.tag }}" -m "Release ${{ needs.detect.outputs.tag }}"
           git push origin "${{ needs.detect.outputs.tag }}"
-
-  release:
-    needs: [detect, tag]
-    if: needs.detect.outputs.should_release == 'true'
-    uses: ./.github/workflows/release.yml
-    with:
-      tag: ${{ needs.detect.outputs.tag }}
-    permissions:
-      contents: write
-      id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,6 @@ on:
   push:
     tags:
       - "v*"
-  workflow_call:
-    inputs:
-      tag:
-        description: "Tag to release (e.g. v1.0.1)"
-        required: true
-        type: string
 
 permissions:
   contents: read
@@ -19,8 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ inputs.tag || github.ref }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -63,12 +55,6 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          # Re-enable once PyPI's attestation verifier accepts the
-          # release-on-version-bump.yml trusted-publisher binding
-          # (currently rejects with 400 "Verification failed: Build
-          # Config URI does not match expected Trusted Publisher").
-          attestations: false
 
   github-release:
     name: Publish GitHub Release
@@ -86,13 +72,12 @@ jobs:
       - name: Compute PyPI version
         id: pypi
         run: |
-          REF="${{ inputs.tag || github.ref_name }}"
-          echo "version=${REF#v}" >> "$GITHUB_OUTPUT"
+          echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ inputs.tag || github.ref_name }}
+          tag_name: ${{ github.ref_name }}
           files: dist/*
           generate_release_notes: true
           body: |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -342,11 +342,12 @@ config, internal refactors, and test-only changes.
 
 Releases are driven by `pyproject.toml`. A PR that bumps the version
 **is** the release — once it merges to `main`, the
-`release-on-version-bump` workflow tags the new commit, builds the
-package, runs the test suite, publishes to
-[PyPI](https://pypi.org/project/mgz-pkmn/) via trusted publishing, and
-creates a GitHub Release with the built distribution attached and
-notes linking to the new PyPI version.
+`release-on-version-bump` workflow tags the new commit. The tag push
+triggers `release.yml`, which builds the package, runs the test
+suite, publishes to [PyPI](https://pypi.org/project/mgz-pkmn/) via
+trusted publishing (with PEP 740 attestations), and creates a GitHub
+Release with the built distribution attached and notes linking to the
+new PyPI version.
 
 To cut a release, open a single PR that:
 
@@ -376,11 +377,35 @@ git push origin v0.2.0
 
 The `pypi-publish` job uses [PyPI Trusted
 Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) so the
-workflow uploads to PyPI without a stored API token. The binding —
-owner `mgzwarrior`, repo `mgz-pkmn`, workflow `release.yml`,
-environment `pypi` — and the matching `pypi` GitHub Environment
-(no secrets) are already in place. If either ever needs to be
-rebuilt (project re-owned, environment recreated, etc.), re-add the
-trusted publisher in the PyPI project's **Publishing** settings with
-those same four values and recreate the `pypi` Environment under
-repo Settings → Environments.
+workflow uploads to PyPI without a stored API token, and signs each
+artifact with a [PEP 740](https://peps.python.org/pep-0740/)
+attestation that PyPI verifies against the trusted-publisher binding.
+The binding — owner `mgzwarrior`, repo `mgz-pkmn`, workflow
+`release.yml`, environment `pypi` — and the matching `pypi` GitHub
+Environment (no secrets) are already in place. If either ever needs
+to be rebuilt (project re-owned, environment recreated, etc.), re-add
+the trusted publisher in the PyPI project's **Publishing** settings
+with those same four values and recreate the `pypi` Environment
+under repo Settings → Environments.
+
+Only **one** binding is required because both the auto-release path
+and a manually pushed `v*` tag converge on `release.yml` running as
+a top-level workflow. `release-on-version-bump.yml` deliberately
+pushes the tag (rather than calling `release.yml` via
+`workflow_call`) so the Sigstore certificate's Build Config URI
+matches the binding — attestation verification looks at the
+top-level workflow ref, which differs from the reusable workflow ref
+that OIDC trusted-publisher auth uses.
+
+### `RELEASE_PAT` secret
+
+`release-on-version-bump.yml` pushes the release tag with a
+fine-grained Personal Access Token stored as the repo secret
+`RELEASE_PAT`. A PAT is required because tags pushed with the
+default `GITHUB_TOKEN` do not trigger downstream workflows, and
+`release.yml` needs to fire on the tag push.
+
+Scope the PAT to this repository with **Contents: read and write**.
+Rotate it on the standard cadence and update the
+`RELEASE_PAT` secret under repo Settings → Secrets and variables →
+Actions.


### PR DESCRIPTION
Closes #196

## What

Collapses the auto-release indirection so `release.yml` always runs as a top-level workflow, then re-enables PEP 740 attestations on the PyPI publish step.

- `release-on-version-bump.yml` now just creates and pushes the release tag (using a new `RELEASE_PAT` secret, since tags pushed with the default `GITHUB_TOKEN` don't trigger downstream workflows). It no longer calls `release.yml` via `workflow_call`.
- `release.yml` drops its `workflow_call` entry point and the `inputs.tag` fallbacks, and removes `attestations: false` from the publish step.
- Docs updated to explain the single-binding model and the `RELEASE_PAT` requirement.

## Why

Routing through `workflow_call` made the Sigstore certificate's Build Config URI point at the **caller** workflow (`release-on-version-bump.yml`), while PyPI's trusted-publisher OIDC auth used the **reusable** workflow's filename (`release.yml`). The two checks read different OIDC claims (`workflow_ref` vs. `job_workflow_ref`), so a single binding could never satisfy both — and attestation verification kept rejecting uploads even after a second binding for `release-on-version-bump.yml` was added.

With `release.yml` always running top-level, both the auto-release path and a manually pushed `v*` tag converge on the same identity, and one trusted-publisher binding covers everything.

## How to verify

**Prereq** (before merging): create a fine-grained PAT scoped to this repo with **Contents: read and write**, store it as the repo secret `RELEASE_PAT`. The second trusted-publisher binding for `release-on-version-bump.yml` on PyPI can be removed once this lands — only the `release.yml` binding is needed going forward.

After merge, cut a throwaway release (e.g. bump to a `1.0.2rc1` in `pyproject.toml`) and confirm:

- [x] `release-on-version-bump.yml` pushes the `v1.0.2rc1` tag
- [x] `release.yml` fires on the tag push (top-level run, not a reusable invocation)
- [x] PyPI upload succeeds with **attestations enabled** (no 400 from the verifier)
- [x] GitHub Release is created with the artifacts attached
- [x] Manually pushing a `v*` tag still works the same way