### PR TITLE
Bump version to 1.0.2rc1 for attestations smoke test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mgz-pkmn"
-version = "1.0.1"
+version = "1.0.2rc1"
 description = "CLI and web app to look up Pokemon cards across open data sources, fetch images and prices, and emit an .xlsx, PDF binder, set-completion checklist, and JSON report for card-show prep."
 readme = "README.md"
 license = "MIT"

--- a/src/mgz_pkmn/__init__.py
+++ b/src/mgz_pkmn/__init__.py
@@ -1,6 +1,6 @@
 """Pokemon card list -> spreadsheet for card shows."""
 
-__version__ = "1.0.1"
+__version__ = "1.0.2rc1"
 
 from mgz_pkmn.parser import CardQuery, parse_lines
 

--- a/uv.lock
+++ b/uv.lock
@@ -261,7 +261,7 @@ wheels = [
 
 [[package]]
 name = "mgz-pkmn"
-version = "1.0.1"
+version = "1.0.2rc1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Bumps the project version to `1.0.2rc1` (PEP 440 release candidate). No other changes.

## Why

End-to-end smoke test of the rewired release path from #197. Confirms:

- `release-on-version-bump.yml` pushes the `v1.0.2rc1` tag using `RELEASE_PAT`
- `release.yml` fires as a top-level workflow on the tag push (not via `workflow_call`)
- PyPI upload succeeds with **PEP 740 attestations enabled** — verified against the single trusted-publisher binding
- GitHub Release is created with the built sdist + wheel attached

Pre-release versions are excluded from `pip install mgz-pkmn` by default, so this won't affect users on stable. The changelog will be rotated when 1.0.2 stable ships with real entries.

## How to verify

After merge, watch the Actions tab:

- [x] `release-on-version-bump` succeeds and the `v1.0.2rc1` tag appears
- [x] `release.yml` fires (top-level run, not a reusable invocation)
- [x] `pypi-publish` step succeeds with attestations on (no 400 from the verifier)
- [x] [pypi.org/project/mgz-pkmn/1.0.2rc1/](https://pypi.org/project/mgz-pkmn/1.0.2rc1/) shows the artifacts and an attestation badge
- [x] GitHub Release v1.0.2rc1 has the sdist + wheel attached