### PR TITLE
web: guided empty-state with example query chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Web: empty-state under the card-list input now shows a row of
+  example query chips covering the parser's main formats (explicit
+  set + number, name + set, bulk `top:N`, `All …` bulk, variant
+  hint, price bounds, etc.). Clicking a chip inserts the example
+  and runs the lookup so first-time users get an immediate
+  on-ramp.
+
 ## [1.0.1] - 2026-05-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Web: onboarding help surface. A new **Help** button in the header
+  opens a modal covering what the tool does, how to write queries
+  (with copyable examples), each setting, each export format, and
+  keyboard shortcuts. First-time visitors see a subtle pulse on the
+  button, dismissed once the modal is opened. The modal also offers
+  an optional interactive **tour** that walks through the five main
+  UI sections (card list, look-up button, settings, results, exports)
+  with a glowing ring on each step's target.
 - Web: empty-state under the card-list input now shows a row of
   example query chips covering the parser's main formats (explicit
   set + number, name + set, bulk `top:N`, `All …` bulk, variant

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -52,9 +52,10 @@ function App() {
     }
   }, [])
 
-  const handleRun = useCallback(async () => {
+  const handleRun = useCallback(async (overrideText?: string) => {
     if (isRunning) return
-    const lines = inputText.split('\n')
+    const text = overrideText ?? inputText
+    const lines = text.split('\n')
     const nonEmpty = lines.filter((l) => l.trim() && !l.trim().startsWith('#'))
     if (nonEmpty.length === 0) return
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,6 +18,8 @@ import { ResultsTable } from './components/ResultsTable'
 import { ExportBar } from './components/ExportBar'
 import { ProcessingQueue } from './components/ProcessingQueue'
 import { SettingsDrawer } from './components/SettingsDrawer'
+import { HelpModal } from './components/HelpModal'
+import { Tour } from './components/Tour'
 import { useAppStore } from './store'
 import type { BulkEvent } from './types'
 import logoUrl from './assets/logo.svg'
@@ -36,6 +38,7 @@ function App() {
   } = useAppStore()
 
   const abortRef = useRef<AbortController | null>(null)
+  const [tourOpen, setTourOpen] = useState(false)
 
   // Easter egg: 5 clicks on the brand reveals Exeggutor + claim code
   // EGG-EXEGGCUTE (referencing the six-egg pre-evolution). Reset on
@@ -148,22 +151,27 @@ function App() {
             <span className="text-xs text-zinc-500 hidden sm:inline">card lookup</span>
           </button>
           <div className="flex items-center gap-2">
-            <ExportBar />
-            <SettingsDrawer />
+            <div data-tour="exports">
+              <ExportBar />
+            </div>
+            <HelpModal onStartTour={() => setTourOpen(true)} />
+            <div data-tour="settings">
+              <SettingsDrawer />
+            </div>
           </div>
         </div>
       </header>
 
       {/* Main content */}
       <main className="mx-auto max-w-7xl px-4 py-6 space-y-6">
-        <section>
+        <section data-tour="input">
           <h2 className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-500">
             Card list
           </h2>
           <InputEditor onRun={handleRun} onStop={handleStop} />
         </section>
 
-        <section>
+        <section data-tour="results">
           <h2 className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-500">
             Results
           </h2>
@@ -173,6 +181,8 @@ function App() {
           </div>
         </section>
       </main>
+
+      {tourOpen && <Tour onClose={() => setTourOpen(false)} />}
 
       {/* Easter egg overlay — see handleBrandClick. */}
       {showEgg && (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -182,7 +182,7 @@ function App() {
         </section>
       </main>
 
-      {tourOpen && <Tour onClose={() => setTourOpen(false)} />}
+      {tourOpen && <Tour onClose={() => setTourOpen(false)} onRun={handleRun} />}
 
       {/* Easter egg overlay — see handleBrandClick. */}
       {showEgg && (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -182,7 +182,9 @@ function App() {
         </section>
       </main>
 
-      {tourOpen && <Tour onClose={() => setTourOpen(false)} onRun={handleRun} />}
+      {tourOpen && (
+        <Tour onClose={() => setTourOpen(false)} onRun={handleRun} onStop={handleStop} />
+      )}
 
       {/* Easter egg overlay — see handleBrandClick. */}
       {showEgg && (

--- a/web/src/components/HelpModal.tsx
+++ b/web/src/components/HelpModal.tsx
@@ -123,7 +123,7 @@ export function HelpModal({ onStartTour }: Props) {
             <Section title="Shortcuts">
               <Definitions
                 rows={[
-                  [<Kbd key="run">⌘ Enter</Kbd>, 'Run the lookup'],
+                  [<Kbd key="run">Ctrl/Cmd + Enter</Kbd>, 'Run the lookup'],
                   [<Kbd key="brand">Brand × 5</Kbd>, 'Click the logo five times for a surprise'],
                 ]}
               />

--- a/web/src/components/HelpModal.tsx
+++ b/web/src/components/HelpModal.tsx
@@ -89,7 +89,7 @@ export function HelpModal({ onStartTour }: Props) {
                   ['Mew ex', 'Name only — best match wins'],
                   ['Charizard [holo]', 'Variant hint in brackets'],
                   ['top:5 Charizard cards', 'Bulk: top N by price'],
-                  ['All Energy Removal cards | Base Set', 'Bulk: every match in a set'],
+                  ['All Charizard cards | Base Set', 'Bulk: every match in a set'],
                   ['Pikachu >=20 <=50', 'Price-bound filter'],
                 ]}
               />

--- a/web/src/components/HelpModal.tsx
+++ b/web/src/components/HelpModal.tsx
@@ -1,0 +1,196 @@
+/**
+ * HelpModal — onboarding/help dialog with sections covering queries,
+ * settings, exports, and shortcuts. Includes a "Take the tour" button
+ * that hands control off to the Tour component.
+ */
+import * as Dialog from '@radix-ui/react-dialog'
+import { CircleHelp, X } from 'lucide-react'
+import { useState } from 'react'
+
+const FIRST_VISIT_KEY = 'mgz-pkmn:seen-help'
+
+interface Props {
+  onStartTour: () => void
+}
+
+export function HelpModal({ onStartTour }: Props) {
+  const [open, setOpen] = useState(false)
+  const [hint, setHint] = useState(
+    () => typeof window !== 'undefined' && !window.localStorage.getItem(FIRST_VISIT_KEY),
+  )
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next)
+    if (next && hint) {
+      setHint(false)
+      window.localStorage.setItem(FIRST_VISIT_KEY, '1')
+    }
+  }
+
+  function handleTakeTour() {
+    setOpen(false)
+    onStartTour()
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={handleOpenChange}>
+      <Dialog.Trigger asChild>
+        <button
+          className={`relative flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-200 hover:bg-zinc-700 transition-colors ${
+            hint ? 'ring-2 ring-blue-500 animate-pulse' : ''
+          }`}
+          title="Help"
+          aria-label="Open help"
+        >
+          <CircleHelp size={15} />
+          Help
+        </button>
+      </Dialog.Trigger>
+
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 flex max-h-[90vh] w-[min(640px,92vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-zinc-700 bg-zinc-900 shadow-2xl">
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-zinc-700 px-5 py-4">
+            <Dialog.Title className="text-base font-semibold text-zinc-100">
+              How to use mgz-pkmn
+            </Dialog.Title>
+            <Dialog.Close asChild>
+              <button
+                className="rounded p-1 text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700 transition-colors"
+                aria-label="Close"
+              >
+                <X size={16} />
+              </button>
+            </Dialog.Close>
+          </div>
+
+          {/* Body */}
+          <div className="flex-1 overflow-y-auto px-5 py-4 space-y-6 text-sm text-zinc-300">
+            <Section title="What this does">
+              <p>
+                Paste a list of Pokémon cards (one per line), click{' '}
+                <Kbd>Look up</Kbd>, and get matched cards with current market
+                prices and negotiation comps. Then download an .xlsx, PDF
+                binder, condensed PDF, or checklist for the table.
+              </p>
+            </Section>
+
+            <Section title="Writing queries">
+              <p className="mb-2 text-zinc-400">
+                One card per line. Blank lines and <code>#</code> comments are
+                skipped. Common formats:
+              </p>
+              <Examples
+                rows={[
+                  ['Charizard | Base Set | 4/102', 'Most precise: name, set, number'],
+                  ['Pikachu | Jungle', 'Name + set'],
+                  ['Squirtle | 7/102', 'Name + card number'],
+                  ['Mew ex', 'Name only — best match wins'],
+                  ['Charizard [holo]', 'Variant hint in brackets'],
+                  ['top:5 Charizard cards', 'Bulk: top N by price'],
+                  ['All Energy Removal cards | Base Set', 'Bulk: every match in a set'],
+                  ['Pikachu >=20 <=50', 'Price-bound filter'],
+                ]}
+              />
+            </Section>
+
+            <Section title="Settings">
+              <Definitions
+                rows={[
+                  ['API key', 'Optional pokemontcg.io key — raises the rate limit on bursty lookups.'],
+                  ['Source tag', 'Labels every row in the export (e.g. "binder1") so multiple runs can be merged downstream.'],
+                  ['Sort order', 'Applied within each tag group in every export — card number, price, release date, or alphabetical.'],
+                  ['Max price cap', 'Drops bulk top-N results above the cap. Single-card lookups always show through (flagged amber).'],
+                  ['Deduplicate by card ID', 'Removes duplicates across queries when the same card matched more than once.'],
+                  ['Hide images', 'Skip thumbnails — faster table, smaller exports.'],
+                ]}
+              />
+            </Section>
+
+            <Section title="Exports">
+              <Definitions
+                rows={[
+                  ['Download .xlsx', 'Spreadsheet with embedded thumbnails, market price, and 80/85/90/95% negotiation comps.'],
+                  ['PDF binder', 'Printable binder pages, one card per cell with image + price.'],
+                  ['Condensed PDF', 'Same data, denser layout for quick reference.'],
+                  ['Checklist', 'Per-tag printable checklist PDF.'],
+                  ['Set ID cards', 'Printable set identifier cutouts — no input rows needed.'],
+                ]}
+              />
+            </Section>
+
+            <Section title="Shortcuts">
+              <Definitions
+                rows={[
+                  [<Kbd key="run">⌘ Enter</Kbd>, 'Run the lookup'],
+                  [<Kbd key="brand">Brand × 5</Kbd>, 'Click the logo five times for a surprise'],
+                ]}
+              />
+            </Section>
+          </div>
+
+          {/* Footer */}
+          <div className="flex items-center justify-between border-t border-zinc-700 px-5 py-4">
+            <span className="text-xs text-zinc-500">
+              New here? Take the interactive tour.
+            </span>
+            <button
+              onClick={handleTakeTour}
+              className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-500 transition-colors"
+            >
+              Take the tour
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section>
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-500">
+        {title}
+      </h3>
+      {children}
+    </section>
+  )
+}
+
+function Kbd({ children }: { children: React.ReactNode }) {
+  return (
+    <kbd className="rounded border border-zinc-700 bg-zinc-800 px-1.5 py-0.5 font-mono text-xs text-zinc-200">
+      {children}
+    </kbd>
+  )
+}
+
+function Examples({ rows }: { rows: [string, string][] }) {
+  return (
+    <ul className="space-y-1.5">
+      {rows.map(([query, desc]) => (
+        <li key={query} className="flex flex-col gap-0.5 sm:flex-row sm:items-baseline sm:gap-3">
+          <code className="rounded bg-zinc-800 px-2 py-0.5 font-mono text-xs text-zinc-100">
+            {query}
+          </code>
+          <span className="text-xs text-zinc-500">{desc}</span>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function Definitions({ rows }: { rows: [React.ReactNode, string][] }) {
+  return (
+    <dl className="space-y-2">
+      {rows.map(([term, desc], i) => (
+        <div key={i} className="flex flex-col gap-0.5 sm:flex-row sm:gap-3">
+          <dt className="font-medium text-zinc-200 sm:min-w-[140px]">{term}</dt>
+          <dd className="text-xs text-zinc-400 sm:flex-1 sm:text-sm">{desc}</dd>
+        </div>
+      ))}
+    </dl>
+  )
+}

--- a/web/src/components/HelpModal.tsx
+++ b/web/src/components/HelpModal.tsx
@@ -9,21 +9,40 @@ import { useState } from 'react'
 
 const FIRST_VISIT_KEY = 'mgz-pkmn:seen-help'
 
+// localStorage access can throw in some browsers/contexts (Safari private
+// mode, embedded webviews with storage disabled, quota exhaustion). Wrap so
+// the onboarding hint quietly degrades to "no hint" instead of crashing the
+// SPA on first render.
+function readSeenHelp(): boolean {
+  if (typeof window === 'undefined') return true
+  try {
+    return !!window.localStorage.getItem(FIRST_VISIT_KEY)
+  } catch {
+    return true
+  }
+}
+
+function markSeenHelp(): void {
+  try {
+    window.localStorage.setItem(FIRST_VISIT_KEY, '1')
+  } catch {
+    // ignore — losing the hint dismissal is a fine fallback
+  }
+}
+
 interface Props {
   onStartTour: () => void
 }
 
 export function HelpModal({ onStartTour }: Props) {
   const [open, setOpen] = useState(false)
-  const [hint, setHint] = useState(
-    () => typeof window !== 'undefined' && !window.localStorage.getItem(FIRST_VISIT_KEY),
-  )
+  const [hint, setHint] = useState(() => !readSeenHelp())
 
   function handleOpenChange(next: boolean) {
     setOpen(next)
     if (next && hint) {
       setHint(false)
-      window.localStorage.setItem(FIRST_VISIT_KEY, '1')
+      markSeenHelp()
     }
   }
 

--- a/web/src/components/InputEditor.test.tsx
+++ b/web/src/components/InputEditor.test.tsx
@@ -1,15 +1,75 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { InputEditor } from './InputEditor'
 
 vi.mock('../api/client', () => ({
   parseLine: vi.fn(),
 }))
 
+const { mockSetInputText, mockClearRows, storeState } = vi.hoisted(() => ({
+  mockSetInputText: vi.fn(),
+  mockClearRows: vi.fn(),
+  storeState: {
+    inputText: '',
+    isRunning: false,
+  },
+}))
+
+vi.mock('../store', () => ({
+  useAppStore: () => ({
+    inputText: storeState.inputText,
+    setInputText: mockSetInputText,
+    isRunning: storeState.isRunning,
+    clearRows: mockClearRows,
+  }),
+}))
+
 describe('InputEditor', () => {
+  beforeEach(() => {
+    mockSetInputText.mockClear()
+    mockClearRows.mockClear()
+    storeState.inputText = ''
+    storeState.isRunning = false
+  })
+
   it('renders the textarea and run button', () => {
     render(<InputEditor onRun={vi.fn()} onStop={vi.fn()} />)
     expect(screen.getByRole('textbox')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /look up/i })).toBeInTheDocument()
+  })
+
+  describe('example chips', () => {
+    it('renders the chip panel when inputText is empty', () => {
+      render(<InputEditor onRun={vi.fn()} onStop={vi.fn()} />)
+      expect(screen.getByText('Try one of these')).toBeInTheDocument()
+      // At least one of the known chip examples is present.
+      expect(screen.getByRole('button', { name: 'Pikachu | Jungle' })).toBeInTheDocument()
+    })
+
+    it('hides the chip panel when inputText has content', () => {
+      storeState.inputText = 'Charizard'
+      render(<InputEditor onRun={vi.fn()} onStop={vi.fn()} />)
+      expect(screen.queryByText('Try one of these')).not.toBeInTheDocument()
+    })
+
+    it('treats whitespace-only input as empty and still renders chips', () => {
+      storeState.inputText = '   \n  '
+      render(<InputEditor onRun={vi.fn()} onStop={vi.fn()} />)
+      expect(screen.getByText('Try one of these')).toBeInTheDocument()
+    })
+
+    it('hides the chip panel while a lookup is running', () => {
+      storeState.isRunning = true
+      render(<InputEditor onRun={vi.fn()} onStop={vi.fn()} />)
+      expect(screen.queryByText('Try one of these')).not.toBeInTheDocument()
+    })
+
+    it('clicking a chip populates the input and calls onRun with the example', () => {
+      const onRun = vi.fn()
+      render(<InputEditor onRun={onRun} onStop={vi.fn()} />)
+      fireEvent.click(screen.getByRole('button', { name: 'Pikachu | Jungle' }))
+      expect(mockSetInputText).toHaveBeenCalledWith('Pikachu | Jungle')
+      expect(onRun).toHaveBeenCalledWith('Pikachu | Jungle')
+    })
   })
 })

--- a/web/src/components/InputEditor.tsx
+++ b/web/src/components/InputEditor.tsx
@@ -127,6 +127,7 @@ export function InputEditor({ onRun, onStop }: Props) {
             <button
               onClick={() => onRun()}
               disabled={lineCount === 0}
+              data-tour="run"
               className="flex items-center gap-1.5 rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
             >
               <Play size={13} fill="currentColor" />

--- a/web/src/components/InputEditor.tsx
+++ b/web/src/components/InputEditor.tsx
@@ -25,7 +25,7 @@ const EXAMPLE_QUERIES = [
   'Mew ex',
   'Charizard [holo]',
   'top:5 Charizard cards',
-  'All Energy Removal cards | Base Set',
+  'All Charizard cards | Base Set',
   'Pikachu >=20 <=50',
 ]
 

--- a/web/src/components/InputEditor.tsx
+++ b/web/src/components/InputEditor.tsx
@@ -14,9 +14,20 @@ import { useAppStore } from '../store'
 import type { CardQuery } from '../types'
 
 interface Props {
-  onRun: () => void
+  onRun: (overrideText?: string) => void
   onStop: () => void
 }
+
+const EXAMPLE_QUERIES = [
+  'Charizard | Base Set | 4/102',
+  'Pikachu | Jungle',
+  'Squirtle | 7/102',
+  'Mew ex',
+  'Charizard [holo]',
+  'top:5 Charizard cards',
+  'All Energy Removal cards | Base Set',
+  'Pikachu >=20 <=50',
+]
 
 // Very simple parse-preview: call /api/v1/parse for the currently focused line.
 function useLineParse(line: string) {
@@ -74,6 +85,16 @@ export function InputEditor({ onRun, onStop }: Props) {
   }, [])
 
   const lineCount = inputText.split('\n').filter((l) => l.trim() && !l.trim().startsWith('#')).length
+  const isEmpty = inputText.trim() === ''
+
+  const handleChipClick = useCallback(
+    (example: string) => {
+      if (isRunning) return
+      setInputText(example)
+      onRun(example)
+    },
+    [isRunning, setInputText, onRun],
+  )
 
   return (
     <div className="flex flex-col gap-2">
@@ -104,7 +125,7 @@ export function InputEditor({ onRun, onStop }: Props) {
             </button>
           ) : (
             <button
-              onClick={onRun}
+              onClick={() => onRun()}
               disabled={lineCount === 0}
               className="flex items-center gap-1.5 rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
             >
@@ -129,6 +150,24 @@ export function InputEditor({ onRun, onStop }: Props) {
         placeholder={`One card per line, e.g.:\nCharizard | Base Set | 4/102\nPikachu | Jungle\ntop:5 Charizard cards\nMew ex | Scarlet & Violet`}
         className="w-full resize-y rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2.5 font-mono text-sm text-zinc-100 placeholder:text-zinc-600 focus:outline-none focus:ring-1 focus:ring-blue-500"
       />
+
+      {/* Example query chips — guided empty-state */}
+      {isEmpty && !isRunning && (
+        <div className="flex flex-col gap-2 rounded-md border border-zinc-700 bg-zinc-800/40 px-3 py-3">
+          <span className="text-xs text-zinc-500">Try one of these</span>
+          <div className="flex flex-wrap gap-1.5">
+            {EXAMPLE_QUERIES.map((example) => (
+              <button
+                key={example}
+                onClick={() => handleChipClick(example)}
+                className="rounded-full border border-zinc-700 bg-zinc-900 px-2.5 py-1 font-mono text-xs text-zinc-300 hover:border-blue-500 hover:bg-zinc-800 hover:text-zinc-100 transition-colors"
+              >
+                {example}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Parse preview for the active line */}
       {parsedPreview && (

--- a/web/src/components/Tour.test.tsx
+++ b/web/src/components/Tour.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { Tour } from './Tour'
+
+// jsdom doesn't implement scrollIntoView; the tour uses it on every step.
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = vi.fn()
+}
+
+const { mockSetInputText, mockClearRows, mockSetProcessingLines, mockSetProgress, mockSetIsRunning, storeState } =
+  vi.hoisted(() => ({
+    mockSetInputText: vi.fn(),
+    mockClearRows: vi.fn(),
+    mockSetProcessingLines: vi.fn(),
+    mockSetProgress: vi.fn(),
+    mockSetIsRunning: vi.fn(),
+    storeState: { inputText: '' },
+  }))
+
+vi.mock('../store', () => {
+  const useAppStore = ((selector?: (s: ReturnType<typeof getState>) => unknown) => {
+    const state = getState()
+    return selector ? selector(state) : state
+  }) as unknown as { (...args: unknown[]): unknown; getState: typeof getState }
+
+  function getState() {
+    return {
+      inputText: storeState.inputText,
+      setInputText: (v: string) => {
+        storeState.inputText = v
+        mockSetInputText(v)
+      },
+      clearRows: mockClearRows,
+      setProcessingLines: mockSetProcessingLines,
+      setProgress: mockSetProgress,
+      setIsRunning: mockSetIsRunning,
+    }
+  }
+  useAppStore.getState = getState
+  return { useAppStore }
+})
+
+function makeAnchors() {
+  // Each step's CSS selector needs a matching DOM element so the highlight
+  // effect can find a target. Tests run in jsdom — these are bare divs.
+  const ids = ['input', 'run', 'settings', 'results', 'exports']
+  return ids.map((id) => {
+    const el = document.createElement('div')
+    el.setAttribute('data-tour', id)
+    document.body.appendChild(el)
+    return el
+  })
+}
+
+describe('Tour', () => {
+  beforeEach(() => {
+    mockSetInputText.mockClear()
+    mockClearRows.mockClear()
+    mockSetProcessingLines.mockClear()
+    mockSetProgress.mockClear()
+    mockSetIsRunning.mockClear()
+    storeState.inputText = ''
+    document.body.innerHTML = ''
+  })
+
+  it('renders the first step with a Skip control', () => {
+    makeAnchors()
+    render(<Tour onClose={vi.fn()} onRun={vi.fn()} />)
+    expect(screen.getByText(/Step 1 of 5/)).toBeInTheDocument()
+    expect(screen.getByText('Card list')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Skip tour' })).toBeInTheDocument()
+  })
+
+  it('seeds the input on mount when empty and highlights step 1 target', () => {
+    const [inputEl] = makeAnchors()
+    render(<Tour onClose={vi.fn()} onRun={vi.fn()} />)
+    expect(mockSetInputText).toHaveBeenCalledWith('Pikachu | Jungle')
+    expect(inputEl.classList.contains('tour-highlight')).toBe(true)
+  })
+
+  it('does not seed the input when it already has user content', () => {
+    storeState.inputText = 'Charizard'
+    makeAnchors()
+    render(<Tour onClose={vi.fn()} onRun={vi.fn()} />)
+    expect(mockSetInputText).not.toHaveBeenCalled()
+  })
+
+  it('Next advances steps and fires onRun once when leaving the Look-up step', () => {
+    makeAnchors()
+    const onRun = vi.fn()
+    render(<Tour onClose={vi.fn()} onRun={onRun} />)
+    // Step 1 → Step 2 (no run yet)
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }))
+    expect(onRun).not.toHaveBeenCalled()
+    // Step 2 → Step 3 (run fires)
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }))
+    expect(onRun).toHaveBeenCalledWith('Pikachu | Jungle')
+    expect(onRun).toHaveBeenCalledTimes(1)
+    // Going Back + Next again does not re-trigger
+    fireEvent.click(screen.getByRole('button', { name: /Back/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }))
+    expect(onRun).toHaveBeenCalledTimes(1)
+  })
+
+  it('Done on the last step calls onClose', () => {
+    makeAnchors()
+    const onClose = vi.fn()
+    render(<Tour onClose={onClose} onRun={vi.fn()} />)
+    for (let i = 0; i < 4; i++) {
+      fireEvent.click(screen.getByRole('button', { name: /Next|Done/i }))
+    }
+    expect(screen.getByText(/Step 5 of 5/)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Done/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('Escape calls onClose; ArrowRight/ArrowLeft step navigation', () => {
+    makeAnchors()
+    const onClose = vi.fn()
+    render(<Tour onClose={onClose} onRun={vi.fn()} />)
+
+    fireEvent.keyDown(window, { key: 'ArrowRight' })
+    expect(screen.getByText(/Step 2 of 5/)).toBeInTheDocument()
+
+    fireEvent.keyDown(window, { key: 'ArrowLeft' })
+    expect(screen.getByText(/Step 1 of 5/)).toBeInTheDocument()
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('arrow keys do not navigate when focus is inside a textarea', () => {
+    makeAnchors()
+    render(<Tour onClose={vi.fn()} onRun={vi.fn()} />)
+    const ta = document.createElement('textarea')
+    document.body.appendChild(ta)
+    ta.focus()
+
+    fireEvent.keyDown(ta, { key: 'ArrowRight', bubbles: true })
+    expect(screen.getByText(/Step 1 of 5/)).toBeInTheDocument()
+  })
+
+  it('cleans up highlight class and (when run fired) the tour-owned state on unmount', () => {
+    const [inputEl] = makeAnchors()
+    const onRun = vi.fn()
+    const { unmount } = render(<Tour onClose={vi.fn()} onRun={onRun} />)
+    // Advance past the Look-up step so the run is recorded.
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }))
+    expect(onRun).toHaveBeenCalledOnce()
+
+    unmount()
+    // Highlight class removed from every anchor.
+    expect(inputEl.classList.contains('tour-highlight')).toBe(false)
+    // Tour-owned state wiped — only because hasRunRef was set.
+    expect(mockSetInputText).toHaveBeenLastCalledWith('')
+    expect(mockClearRows).toHaveBeenCalled()
+    expect(mockSetProcessingLines).toHaveBeenCalledWith([])
+    expect(mockSetProgress).toHaveBeenCalledWith(null)
+    expect(mockSetIsRunning).toHaveBeenCalledWith(false)
+  })
+
+  it('does not clear rows/processing/progress on unmount if the tour never ran', () => {
+    makeAnchors()
+    const { unmount } = render(<Tour onClose={vi.fn()} onRun={vi.fn()} />)
+    unmount()
+    expect(mockClearRows).not.toHaveBeenCalled()
+    expect(mockSetProcessingLines).not.toHaveBeenCalled()
+    expect(mockSetProgress).not.toHaveBeenCalled()
+    expect(mockSetIsRunning).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/components/Tour.test.tsx
+++ b/web/src/components/Tour.test.tsx
@@ -18,24 +18,26 @@ const { mockSetInputText, mockClearRows, mockSetProcessingLines, mockSetProgress
   }))
 
 vi.mock('../store', () => {
+  // Stable references across renders so useEffect deps don't thrash and
+  // re-run the seed/cleanup on every render.
+  const setInputText = (v: string) => {
+    storeState.inputText = v
+    mockSetInputText(v)
+  }
+  const api = {
+    setInputText,
+    clearRows: mockClearRows,
+    setProcessingLines: mockSetProcessingLines,
+    setProgress: mockSetProgress,
+    setIsRunning: mockSetIsRunning,
+  }
+  function getState() {
+    return { inputText: storeState.inputText, ...api }
+  }
   const useAppStore = ((selector?: (s: ReturnType<typeof getState>) => unknown) => {
     const state = getState()
     return selector ? selector(state) : state
   }) as unknown as { (...args: unknown[]): unknown; getState: typeof getState }
-
-  function getState() {
-    return {
-      inputText: storeState.inputText,
-      setInputText: (v: string) => {
-        storeState.inputText = v
-        mockSetInputText(v)
-      },
-      clearRows: mockClearRows,
-      setProcessingLines: mockSetProcessingLines,
-      setProgress: mockSetProgress,
-      setIsRunning: mockSetIsRunning,
-    }
-  }
   useAppStore.getState = getState
   return { useAppStore }
 })
@@ -65,7 +67,7 @@ describe('Tour', () => {
 
   it('renders the first step with a Skip control', () => {
     makeAnchors()
-    render(<Tour onClose={vi.fn()} onRun={vi.fn()} />)
+    render(<Tour onClose={vi.fn()} onRun={vi.fn()} onStop={vi.fn()} />)
     expect(screen.getByText(/Step 1 of 5/)).toBeInTheDocument()
     expect(screen.getByText('Card list')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Skip tour' })).toBeInTheDocument()
@@ -73,7 +75,7 @@ describe('Tour', () => {
 
   it('seeds the input on mount when empty and highlights step 1 target', () => {
     const [inputEl] = makeAnchors()
-    render(<Tour onClose={vi.fn()} onRun={vi.fn()} />)
+    render(<Tour onClose={vi.fn()} onRun={vi.fn()} onStop={vi.fn()} />)
     expect(mockSetInputText).toHaveBeenCalledWith('Pikachu | Jungle')
     expect(inputEl.classList.contains('tour-highlight')).toBe(true)
   })
@@ -81,22 +83,19 @@ describe('Tour', () => {
   it('does not seed the input when it already has user content', () => {
     storeState.inputText = 'Charizard'
     makeAnchors()
-    render(<Tour onClose={vi.fn()} onRun={vi.fn()} />)
+    render(<Tour onClose={vi.fn()} onRun={vi.fn()} onStop={vi.fn()} />)
     expect(mockSetInputText).not.toHaveBeenCalled()
   })
 
   it('Next advances steps and fires onRun once when leaving the Look-up step', () => {
     makeAnchors()
     const onRun = vi.fn()
-    render(<Tour onClose={vi.fn()} onRun={onRun} />)
-    // Step 1 → Step 2 (no run yet)
+    render(<Tour onClose={vi.fn()} onRun={onRun} onStop={vi.fn()} />)
     fireEvent.click(screen.getByRole('button', { name: /Next/i }))
     expect(onRun).not.toHaveBeenCalled()
-    // Step 2 → Step 3 (run fires)
     fireEvent.click(screen.getByRole('button', { name: /Next/i }))
     expect(onRun).toHaveBeenCalledWith('Pikachu | Jungle')
     expect(onRun).toHaveBeenCalledTimes(1)
-    // Going Back + Next again does not re-trigger
     fireEvent.click(screen.getByRole('button', { name: /Back/i }))
     fireEvent.click(screen.getByRole('button', { name: /Next/i }))
     expect(onRun).toHaveBeenCalledTimes(1)
@@ -105,7 +104,7 @@ describe('Tour', () => {
   it('Done on the last step calls onClose', () => {
     makeAnchors()
     const onClose = vi.fn()
-    render(<Tour onClose={onClose} onRun={vi.fn()} />)
+    render(<Tour onClose={onClose} onRun={vi.fn()} onStop={vi.fn()} />)
     for (let i = 0; i < 4; i++) {
       fireEvent.click(screen.getByRole('button', { name: /Next|Done/i }))
     }
@@ -117,7 +116,7 @@ describe('Tour', () => {
   it('Escape calls onClose; ArrowRight/ArrowLeft step navigation', () => {
     makeAnchors()
     const onClose = vi.fn()
-    render(<Tour onClose={onClose} onRun={vi.fn()} />)
+    render(<Tour onClose={onClose} onRun={vi.fn()} onStop={vi.fn()} />)
 
     fireEvent.keyDown(window, { key: 'ArrowRight' })
     expect(screen.getByText(/Step 2 of 5/)).toBeInTheDocument()
@@ -131,7 +130,7 @@ describe('Tour', () => {
 
   it('arrow keys do not navigate when focus is inside a textarea', () => {
     makeAnchors()
-    render(<Tour onClose={vi.fn()} onRun={vi.fn()} />)
+    render(<Tour onClose={vi.fn()} onRun={vi.fn()} onStop={vi.fn()} />)
     const ta = document.createElement('textarea')
     document.body.appendChild(ta)
     ta.focus()
@@ -140,30 +139,54 @@ describe('Tour', () => {
     expect(screen.getByText(/Step 1 of 5/)).toBeInTheDocument()
   })
 
-  it('cleans up highlight class and (when run fired) the tour-owned state on unmount', () => {
+  it('on unmount with seed intact and run fired: aborts request and wipes state', () => {
     const [inputEl] = makeAnchors()
     const onRun = vi.fn()
-    const { unmount } = render(<Tour onClose={vi.fn()} onRun={onRun} />)
-    // Advance past the Look-up step so the run is recorded.
+    const onStop = vi.fn()
+    const { unmount } = render(<Tour onClose={vi.fn()} onRun={onRun} onStop={onStop} />)
     fireEvent.click(screen.getByRole('button', { name: /Next/i }))
     fireEvent.click(screen.getByRole('button', { name: /Next/i }))
     expect(onRun).toHaveBeenCalledOnce()
 
     unmount()
-    // Highlight class removed from every anchor.
     expect(inputEl.classList.contains('tour-highlight')).toBe(false)
-    // Tour-owned state wiped — only because hasRunRef was set.
     expect(mockSetInputText).toHaveBeenLastCalledWith('')
+    expect(onStop).toHaveBeenCalledOnce()
     expect(mockClearRows).toHaveBeenCalled()
     expect(mockSetProcessingLines).toHaveBeenCalledWith([])
     expect(mockSetProgress).toHaveBeenCalledWith(null)
     expect(mockSetIsRunning).toHaveBeenCalledWith(false)
   })
 
+  it('does not wipe state or call onStop when the user typed over the seed', () => {
+    makeAnchors()
+    const onRun = vi.fn()
+    const onStop = vi.fn()
+    const { unmount } = render(<Tour onClose={vi.fn()} onRun={onRun} onStop={onStop} />)
+    // Advance past the run step so hasRunRef is set.
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Next/i }))
+    expect(onRun).toHaveBeenCalledOnce()
+    // Simulate the user editing the input mid-tour.
+    storeState.inputText = 'My own card'
+
+    unmount()
+    // Seed no longer matches — user's input is preserved AND their lookup
+    // (if any) is left alone. onStop must not fire either.
+    expect(onStop).not.toHaveBeenCalled()
+    expect(mockClearRows).not.toHaveBeenCalled()
+    expect(mockSetProcessingLines).not.toHaveBeenCalled()
+    expect(mockSetProgress).not.toHaveBeenCalled()
+    expect(mockSetIsRunning).not.toHaveBeenCalled()
+    expect(storeState.inputText).toBe('My own card')
+  })
+
   it('does not clear rows/processing/progress on unmount if the tour never ran', () => {
     makeAnchors()
-    const { unmount } = render(<Tour onClose={vi.fn()} onRun={vi.fn()} />)
+    const onStop = vi.fn()
+    const { unmount } = render(<Tour onClose={vi.fn()} onRun={vi.fn()} onStop={onStop} />)
     unmount()
+    expect(onStop).not.toHaveBeenCalled()
     expect(mockClearRows).not.toHaveBeenCalled()
     expect(mockSetProcessingLines).not.toHaveBeenCalled()
     expect(mockSetProgress).not.toHaveBeenCalled()

--- a/web/src/components/Tour.tsx
+++ b/web/src/components/Tour.tsx
@@ -52,12 +52,13 @@ const STEPS: Step[] = [
 interface Props {
   onClose: () => void
   onRun: (overrideText?: string) => void
+  onStop: () => void
 }
 
 // 0-indexed step that runs the lookup when the user advances past it.
 const RUN_STEP_INDEX = 1
 
-export function Tour({ onClose, onRun }: Props) {
+export function Tour({ onClose, onRun, onStop }: Props) {
   const [stepIndex, setStepIndex] = useState(0)
   const setInputText = useAppStore((s) => s.setInputText)
   const hasRunRef = useRef(false)
@@ -69,28 +70,31 @@ export function Tour({ onClose, onRun }: Props) {
 
   // Seed the textarea with a sample line on first mount so disabled-only
   // elements (Look up button) have a meaningful highlight at step 2.
-  // On unmount, undo everything the tour put in place — clear the seeded
-  // input (only if it's still untouched), and if the tour kicked off its
-  // own lookup, clear the rows / processing queue / progress state too so
-  // the user lands back on the same empty-state experience they started
-  // with. User-typed input and user-run results are never touched.
+  // On unmount, undo everything the tour put in place: clear the seeded
+  // input (only if it's still untouched), and — only if the seed is *still*
+  // the input text and the tour kicked off its own lookup — abort any
+  // in-flight tour request and clear the rows / processing queue / progress
+  // state too. The seed check is the key guard: if the user typed over the
+  // seed and ran their own query, their results stay put.
   useEffect(() => {
     const initial = useAppStore.getState().inputText
     if (initial.trim() !== '') return
     setInputText(TOUR_SEED)
     return () => {
       const store = useAppStore.getState()
-      if (store.inputText === TOUR_SEED) {
+      const seedIntact = store.inputText === TOUR_SEED
+      if (seedIntact) {
         store.setInputText('')
       }
-      if (hasRunRef.current) {
+      if (hasRunRef.current && seedIntact) {
+        onStop() // aborts the underlying request so streaming events stop
         store.clearRows()
         store.setProcessingLines([])
         store.setProgress(null)
         store.setIsRunning(false)
       }
     }
-  }, [setInputText])
+  }, [setInputText, onStop])
 
   // Scroll the target element into view and glow it while this step is active.
   useEffect(() => {

--- a/web/src/components/Tour.tsx
+++ b/web/src/components/Tour.tsx
@@ -11,6 +11,9 @@
  */
 import { useEffect, useState } from 'react'
 import { X, ChevronLeft, ChevronRight } from 'lucide-react'
+import { useAppStore } from '../store'
+
+const TOUR_SEED = 'Pikachu | Jungle'
 
 interface Step {
   selector: string
@@ -52,6 +55,22 @@ interface Props {
 
 export function Tour({ onClose }: Props) {
   const [stepIndex, setStepIndex] = useState(0)
+  const setInputText = useAppStore((s) => s.setInputText)
+
+  // Seed the textarea with a sample line on first mount so disabled-only
+  // elements (Look up button) have a meaningful highlight at step 2.
+  // Restore on unmount only if the seed is still there untouched — never
+  // clobber the user's own input.
+  useEffect(() => {
+    const initial = useAppStore.getState().inputText
+    if (initial.trim() !== '') return
+    setInputText(TOUR_SEED)
+    return () => {
+      if (useAppStore.getState().inputText === TOUR_SEED) {
+        setInputText('')
+      }
+    }
+  }, [setInputText])
 
   // Scroll the target element into view and glow it while this step is active.
   useEffect(() => {

--- a/web/src/components/Tour.tsx
+++ b/web/src/components/Tour.tsx
@@ -9,7 +9,7 @@
  * Mounted only while running — the parent renders <Tour /> when the
  * user starts the tour, so step state resets cleanly on each open.
  */
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { X, ChevronLeft, ChevronRight } from 'lucide-react'
 import { useAppStore } from '../store'
 
@@ -30,7 +30,7 @@ const STEPS: Step[] = [
   {
     selector: '[data-tour="run"]',
     title: 'Look up',
-    body: 'Run the lookup. Results stream in as each line resolves — ⌘ Enter is the keyboard shortcut.',
+    body: 'Run the lookup. Results stream in as each line resolves — Ctrl/Cmd + Enter is the keyboard shortcut.',
   },
   {
     selector: '[data-tour="settings"]',
@@ -51,11 +51,21 @@ const STEPS: Step[] = [
 
 interface Props {
   onClose: () => void
+  onRun: (overrideText?: string) => void
 }
 
-export function Tour({ onClose }: Props) {
+// 0-indexed step that runs the lookup when the user advances past it.
+const RUN_STEP_INDEX = 1
+
+export function Tour({ onClose, onRun }: Props) {
   const [stepIndex, setStepIndex] = useState(0)
   const setInputText = useAppStore((s) => s.setInputText)
+  const hasRunRef = useRef(false)
+  const stepIndexRef = useRef(0)
+
+  useEffect(() => {
+    stepIndexRef.current = stepIndex
+  }, [stepIndex])
 
   // Seed the textarea with a sample line on first mount so disabled-only
   // elements (Look up button) have a meaningful highlight at step 2.
@@ -81,29 +91,52 @@ export function Tour({ onClose }: Props) {
     return () => el.classList.remove('tour-highlight')
   }, [stepIndex])
 
-  // Esc closes; arrows step.
-  useEffect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') onClose()
-      else if (e.key === 'ArrowRight') setStepIndex((i) => Math.min(i + 1, STEPS.length - 1))
-      else if (e.key === 'ArrowLeft') setStepIndex((i) => Math.max(i - 1, 0))
-    }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [onClose])
-
   const step = STEPS[stepIndex]
   const isFirst = stepIndex === 0
   const isLast = stepIndex === STEPS.length - 1
 
-  function next() {
-    if (isLast) onClose()
-    else setStepIndex((i) => i + 1)
-  }
+  // Advance one step. The first time the user advances past the "Look up"
+  // step, kick off the lookup so the Results/Exports steps later in the tour
+  // have real streaming data to highlight.
+  const next = useCallback(() => {
+    if (stepIndexRef.current === STEPS.length - 1) {
+      onClose()
+      return
+    }
+    if (stepIndexRef.current === RUN_STEP_INDEX && !hasRunRef.current) {
+      hasRunRef.current = true
+      onRun(TOUR_SEED)
+    }
+    setStepIndex((i) => Math.min(i + 1, STEPS.length - 1))
+  }, [onClose, onRun])
 
-  function prev() {
+  const prev = useCallback(() => {
     setStepIndex((i) => Math.max(i - 1, 0))
-  }
+  }, [])
+
+  // Esc closes; arrows step — but only when the user is not typing in an
+  // input/textarea/contentEditable, so step 1 doesn't hijack cursor movement
+  // in the card-list textarea.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        onClose()
+        return
+      }
+      const target = e.target as HTMLElement | null
+      const tag = target?.tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return
+      if (e.key === 'ArrowRight') {
+        e.preventDefault()
+        next()
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault()
+        prev()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose, next, prev])
 
   return (
     <div

--- a/web/src/components/Tour.tsx
+++ b/web/src/components/Tour.tsx
@@ -69,15 +69,25 @@ export function Tour({ onClose, onRun }: Props) {
 
   // Seed the textarea with a sample line on first mount so disabled-only
   // elements (Look up button) have a meaningful highlight at step 2.
-  // Restore on unmount only if the seed is still there untouched — never
-  // clobber the user's own input.
+  // On unmount, undo everything the tour put in place — clear the seeded
+  // input (only if it's still untouched), and if the tour kicked off its
+  // own lookup, clear the rows / processing queue / progress state too so
+  // the user lands back on the same empty-state experience they started
+  // with. User-typed input and user-run results are never touched.
   useEffect(() => {
     const initial = useAppStore.getState().inputText
     if (initial.trim() !== '') return
     setInputText(TOUR_SEED)
     return () => {
-      if (useAppStore.getState().inputText === TOUR_SEED) {
-        setInputText('')
+      const store = useAppStore.getState()
+      if (store.inputText === TOUR_SEED) {
+        store.setInputText('')
+      }
+      if (hasRunRef.current) {
+        store.clearRows()
+        store.setProcessingLines([])
+        store.setProgress(null)
+        store.setIsRunning(false)
       }
     }
   }, [setInputText])

--- a/web/src/components/Tour.tsx
+++ b/web/src/components/Tour.tsx
@@ -1,0 +1,137 @@
+/**
+ * Tour — opt-in guided walkthrough of the main UI sections. Triggered
+ * from HelpModal. Each step scrolls a target element into view, draws
+ * a glowing ring around it, and shows a step card at the bottom of
+ * the viewport with Prev / Next / Skip controls.
+ *
+ * Target elements are matched by `data-tour="<id>"` attributes.
+ *
+ * Mounted only while running — the parent renders <Tour /> when the
+ * user starts the tour, so step state resets cleanly on each open.
+ */
+import { useEffect, useState } from 'react'
+import { X, ChevronLeft, ChevronRight } from 'lucide-react'
+
+interface Step {
+  selector: string
+  title: string
+  body: string
+}
+
+const STEPS: Step[] = [
+  {
+    selector: '[data-tour="input"]',
+    title: 'Card list',
+    body: 'Paste or type one card per line. Try a precise format like "Charizard | Base Set | 4/102", a bulk lookup like "top:5 Charizard cards", or a name on its own. Blank lines and # comments are skipped.',
+  },
+  {
+    selector: '[data-tour="run"]',
+    title: 'Look up',
+    body: 'Run the lookup. Results stream in as each line resolves — ⌘ Enter is the keyboard shortcut.',
+  },
+  {
+    selector: '[data-tour="settings"]',
+    title: 'Settings',
+    body: 'Drawer for the API key, source tag, sort order, price cap, dedupe, and image toggles. Settings apply to both the table and every export.',
+  },
+  {
+    selector: '[data-tour="results"]',
+    title: 'Results',
+    body: 'Matched cards appear here with prices and negotiation comps. Click any column header to sort; use Filter for per-column substring or price ranges.',
+  },
+  {
+    selector: '[data-tour="exports"]',
+    title: 'Exports',
+    body: 'Download .xlsx, PDF binder, condensed PDF, or per-tag checklist once you have matched rows. "Set ID cards" works without any input.',
+  },
+]
+
+interface Props {
+  onClose: () => void
+}
+
+export function Tour({ onClose }: Props) {
+  const [stepIndex, setStepIndex] = useState(0)
+
+  // Scroll the target element into view and glow it while this step is active.
+  useEffect(() => {
+    const el = document.querySelector<HTMLElement>(STEPS[stepIndex].selector)
+    if (!el) return
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    el.classList.add('tour-highlight')
+    return () => el.classList.remove('tour-highlight')
+  }, [stepIndex])
+
+  // Esc closes; arrows step.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+      else if (e.key === 'ArrowRight') setStepIndex((i) => Math.min(i + 1, STEPS.length - 1))
+      else if (e.key === 'ArrowLeft') setStepIndex((i) => Math.max(i - 1, 0))
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  const step = STEPS[stepIndex]
+  const isFirst = stepIndex === 0
+  const isLast = stepIndex === STEPS.length - 1
+
+  function next() {
+    if (isLast) onClose()
+    else setStepIndex((i) => i + 1)
+  }
+
+  function prev() {
+    setStepIndex((i) => Math.max(i - 1, 0))
+  }
+
+  return (
+    <div
+      className="fixed inset-x-0 bottom-4 z-50 mx-auto w-[min(560px,92vw)] rounded-lg border border-blue-500/60 bg-zinc-900 shadow-2xl"
+      role="dialog"
+      aria-label={`Tour: ${step.title}`}
+    >
+      <div className="flex items-center justify-between border-b border-zinc-700 px-4 py-2.5">
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold text-blue-400">
+            Step {stepIndex + 1} of {STEPS.length}
+          </span>
+          <span className="text-sm font-semibold text-zinc-100">{step.title}</span>
+        </div>
+        <button
+          onClick={onClose}
+          className="rounded p-1 text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700 transition-colors"
+          aria-label="Skip tour"
+          title="Skip tour"
+        >
+          <X size={16} />
+        </button>
+      </div>
+      <div className="px-4 py-3 text-sm text-zinc-300">{step.body}</div>
+      <div className="flex items-center justify-between border-t border-zinc-700 px-4 py-2.5">
+        <button
+          onClick={prev}
+          disabled={isFirst}
+          className="flex items-center gap-1 rounded px-2 py-1 text-xs text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+        >
+          <ChevronLeft size={14} />
+          Back
+        </button>
+        <button
+          onClick={onClose}
+          className="rounded px-2 py-1 text-xs text-zinc-500 hover:text-zinc-200 transition-colors"
+        >
+          Skip
+        </button>
+        <button
+          onClick={next}
+          className="flex items-center gap-1 rounded-md bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-500 transition-colors"
+        >
+          {isLast ? 'Done' : 'Next'}
+          {!isLast && <ChevronRight size={14} />}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -10,3 +10,10 @@
     transform: translateY(0);
   }
 }
+
+.tour-highlight {
+  position: relative;
+  box-shadow: 0 0 0 3px #3b82f6, 0 0 24px 6px rgba(59, 130, 246, 0.35);
+  border-radius: 6px;
+  transition: box-shadow 200ms ease-in-out;
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -13,7 +13,7 @@
 
 .tour-highlight {
   position: relative;
-  box-shadow: 0 0 0 3px #3b82f6, 0 0 24px 6px rgba(59, 130, 246, 0.35);
+  box-shadow: 0 0 0 3px #ef4444, 0 0 24px 6px rgba(239, 68, 68, 0.4);
   border-radius: 6px;
   transition: box-shadow 200ms ease-in-out;
 }


### PR DESCRIPTION
Closes #177

## What

Adds three layered onboarding surfaces to the SPA, from quickest to deepest:

1. **Example query chips** — when the card-list textarea is empty, a row of 8 clickable chips covers the parser's main formats. Clicking a chip drops the example into the textarea and runs the lookup immediately.
2. **Help modal** — new **Help** button in the header opens a Radix Dialog covering what the tool does, how to write queries (with copyable examples), each setting, each export format, and keyboard shortcuts. First-time visitors see a subtle pulse on the button, dismissed once the modal opens (localStorage-backed).
3. **Interactive tour** — opt-in "Take the tour" button inside the modal launches a five-step walkthrough (card list → look-up button → settings → results → exports). Each step scrolls its target into view and glows it with a blue ring via a `tour-highlight` utility class. Bottom-anchored step card with Back / Skip / Next; Esc closes, arrow keys navigate.

## Why

The pre-existing empty textarea had a placeholder with example formats but no actual way to *do* anything without already understanding the query grammar. Per discussion in this PR, chips alone solve "give me one working click" but don't explain the broader tool — the modal teaches the surface area; the tour walks new users through the flow.

## How to verify

`make dev-api` + `make dev-web`, open the SPA:

- [x] First load shows a blue pulse around the **Help** button in the header
- [x] Click Help → modal opens with sections for queries, settings, exports, shortcuts; pulse stops
- [x] Click **Take the tour** → modal closes, step 1 ("Card list") appears at the bottom with the card-list section glowing
- [x] Back / Next walk through the 5 steps; Skip / Esc / Done all close the tour and clear the highlight
- [x] Empty textarea shows the "Try one of these" chip strip; clicking a chip populates the input and runs the lookup
- [x] Mobile (375px): chips wrap cleanly, modal fills 92vw, tour step card fits the viewport

See live demo [here](https://jam.dev/c/b9e63367-26e2-401e-9b2f-5f025e267b52).