### PR TITLE
devex: add make dev target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ help:  ## Print this help. Default when `make` is run with no target.
 
 .PHONY: install
 install: install-api install-web install-hooks  ## Full dev setup: API + web + pre-commit hook.
-	@echo "✓ install complete — try \`make dev-api\` and \`make dev-web\` next."
+	@echo "✓ install complete — try \`make dev\` next."
 
 .PHONY: install-cli
 install-cli:  ## CLI dependencies only (no API, no web). Fastest install.
@@ -57,6 +57,20 @@ install-hooks:  ## Install pre-commit as a uv tool and register the git hooks (p
 	uv tool run pre-commit install --hook-type commit-msg
 
 ## Dev servers
+
+.PHONY: dev
+dev:  ## Start the API and web dev servers together. Ctrl+C stops both.
+	@api_pid=; web_pid=; \
+	cleanup() { \
+		trap - INT TERM EXIT; \
+		[ -z "$$api_pid" ] || kill "$$api_pid" 2>/dev/null || true; \
+		[ -z "$$web_pid" ] || kill "$$web_pid" 2>/dev/null || true; \
+		wait 2>/dev/null || true; \
+	}; \
+	trap cleanup INT TERM EXIT; \
+	$(MAKE) -s dev-api & api_pid=$$!; \
+	$(MAKE) -s dev-web & web_pid=$$!; \
+	wait
 
 .PHONY: dev-api
 dev-api:  ## Start the FastAPI dev server with reload on :8000 (override: PORT_API=).

--- a/README.md
+++ b/README.md
@@ -90,12 +90,15 @@ Prefer the env var over `--api-key` — flags get saved to shell history.
 
 ```bash
 make install         # one-time setup
-make dev-api         # Terminal 1 — API on :8000
-make dev-web         # Terminal 2 — Vite dev server on :5173
+make dev             # API on :8000 + Vite dev server on :5173
 ```
 
-Open <http://localhost:5173>. The Vite dev server proxies `/api/*` to
-the FastAPI server. Swagger UI lives at <http://localhost:8000/docs>.
+Open <http://localhost:5173>. Press `Ctrl+C` once to stop both dev
+servers. The Vite dev server proxies `/api/*` to the FastAPI server.
+Swagger UI lives at <http://localhost:8000/docs>.
+
+If you only need one half of the stack, `make dev-api` and
+`make dev-web` still run the FastAPI and Vite dev servers separately.
 
 Prefer not to install anything? The same UI is hosted at
 <https://mgz-pkmn.onrender.com>.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -197,6 +197,9 @@ The Makefile at the repo root wraps the common dev commands. Run
 
 ```bash
 make install            # one-shot: deps + pre-commit hook
+make dev                # API + web dev servers; Ctrl+C stops both
+make dev-api            # API dev server only
+make dev-web            # Vite dev server only
 make test               # python tests
 make lint               # ruff + eslint
 make format             # ruff format in-place


### PR DESCRIPTION
## Summary
- add `make dev` to start the API and web dev servers together
- clean up both child server processes from one Ctrl+C
- document the new combined target while keeping `make dev-api` and `make dev-web` available

Closes #201

## Validation
- `make help`
- `make -n dev`
- `git diff --check`

## Notes
- `make check` could not run in this local environment because `uv` is not installed (`make: uv: No such file or directory`).