### PR TITLE
devex: `make dev` to build + run the Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- New `make dev` target rebuilds the single-image Docker artifact
+  (API + built SPA) and runs it on `:8000`. One terminal, one
+  Ctrl+C, no two-window juggling — at the cost of no hot reload,
+  so it's intended for smoke runs and demos rather than the inner
+  edit/reload loop. `make dev-api` and `make dev-web` continue to
+  cover active development.
+
 ## [1.0.1] - 2026-05-16
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,10 @@ install-hooks:  ## Install pre-commit as a uv tool and register the git hooks (p
 
 ## Dev servers
 
+.PHONY: dev
+dev: docker-build  ## Rebuild the Docker image and run it on :8000 (API + built SPA in one container). No hot reload — use `dev-api` + `dev-web` for the inner edit/reload loop.
+	docker run --rm -e POKEMONTCG_IO_API_KEY -p $(PORT_API):8000 mgz-pkmn
+
 .PHONY: dev-api
 dev-api:  ## Start the FastAPI dev server with reload on :8000 (override: PORT_API=).
 	uv run uvicorn api.main:app --reload --port $(PORT_API)

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ install-hooks:  ## Install pre-commit as a uv tool and register the git hooks (p
 
 .PHONY: dev
 dev: docker-build  ## Rebuild the Docker image and run it on :8000 (API + built SPA in one container). No hot reload — use `dev-api` + `dev-web` for the inner edit/reload loop.
-	docker run --rm -e POKEMONTCG_IO_API_KEY -p $(PORT_API):8000 mgz-pkmn
+	@$(MAKE) -s docker-run
 
 .PHONY: dev-api
 dev-api:  ## Start the FastAPI dev server with reload on :8000 (override: PORT_API=).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -205,6 +205,21 @@ make check              # CI-equivalent: lint + format-check + tests + web lint
 make precommit          # run all pre-commit hooks against every file
 ```
 
+For running the app locally:
+
+```bash
+make dev-api            # FastAPI on :8000 with reload (active dev, terminal 1)
+make dev-web            # Vite on :5173 proxying /api → :8000 (active dev, terminal 2)
+make dev                # build + run the Docker image on :8000 (single terminal,
+                        # no hot reload — for quick smoke runs and demos)
+```
+
+Use `dev-api` + `dev-web` for the edit-save-reload loop. `make dev` rebuilds
+the production Docker image and serves the API plus the prebuilt SPA from a
+single container — handy for previewing the production bundle or showing
+someone the app without running two terminals, but every code change requires
+a full rebuild.
+
 Direct invocations still work if you'd rather skip Make:
 
 ```bash


### PR DESCRIPTION
Closes #201

## What

Adds a \`make dev\` target that depends on \`docker-build\` and then runs the resulting image on \`:8000\`:

\`\`\`makefile
.PHONY: dev
dev: docker-build  ## ...
	docker run --rm -e POKEMONTCG_IO_API_KEY -p \$(PORT_API):8000 mgz-pkmn
\`\`\`

The image already bundles FastAPI + the built SPA on one port, so this gives you the whole app in a single terminal with a single Ctrl+C to stop.

## Why

Two terminals (\`make dev-api\` + \`make dev-web\`) plus remembering to Ctrl+C each one is friction for quick smoke runs and demos. I tried wiring uvicorn + vite together from one Makefile recipe first, but shell-based concurrent processes with reliable Ctrl+C cleanup are surprisingly fragile in Make — recursive shells and grandchildren in their own process groups leak orphans. The container is a single process from Make's perspective and Ctrl+C forwards cleanly.

**Trade-off, called out in the help line + docs:** no hot reload. Every code change requires a full rebuild. Use \`dev-api\` + \`dev-web\` for the inner edit/reload loop; reach for \`make dev\` when you want to preview the production bundle or hand someone the app without juggling two windows.

## How to verify

Requires Docker Desktop running (the Docker daemon wasn't available in my dev env, so this hasn't been smoke-tested end-to-end — verify locally):

- [x] \`make dev\` builds the image then starts the container; \`http://localhost:8000\` serves the SPA
- [x] \`http://localhost:8000/api/v1/health\` (or any \`/api\` route) reaches the FastAPI server
- [x] Single Ctrl+C stops the container cleanly (\`docker ps\` shows nothing)
- [x] \`make help\` line for \`dev\` explains the no-hot-reload trade-off
- [x] \`make dev-api\` and \`make dev-web\` still work standalone