### PR TITLE
web: a11y audit — zero axe violations, keyboard nav verified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@ Versions follow [Semantic Versioning](https://semver.org/).
   settings drawer takes the full viewport width on mobile so the
   sort-order select and helper text no longer truncate. Desktop
   layout is unchanged.
+- Web: accessibility pass against axe-core. Closes the a11y half of
+  #62 — zero critical or serious violations across the idle page,
+  open Help modal, open Settings drawer, populated results table,
+  and expanded filter row. Bumped muted text from `text-zinc-500` /
+  `text-zinc-600` to `text-zinc-400` so helper copy, section
+  headings, and the footer meet WCAG AA contrast. Added an `<h1>`
+  inside the header so the page has a top-level heading. Gave the
+  Settings drawer close button an `aria-label`, the empty
+  results-table header cells `sr-only` labels, and the card-list
+  textarea an `aria-label`. Made the Help modal's scrollable body
+  keyboard-focusable so users can scroll without first tabbing
+  through every dialog control.
 
 ## [1.0.1] - 2026-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ Versions follow [Semantic Versioning](https://semver.org/).
   so it's intended for smoke runs and demos rather than the inner
   edit/reload loop. `make dev-api` and `make dev-web` continue to
   cover active development.
+- [`docs/accessibility.md`](docs/accessibility.md) — single home for
+  what the project commits to (no critical/serious axe violations,
+  WCAG AA contrast, full keyboard reach), how it's enforced
+  (vitest-axe in CI + a live-browser scan snippet), the keyboard
+  shortcut table, and how to add new UI without regressing.
 
 ### Changed
 
@@ -45,11 +50,12 @@ Versions follow [Semantic Versioning](https://semver.org/).
   `text-zinc-600` to `text-zinc-400` so helper copy, section
   headings, and the footer meet WCAG AA contrast. Added an `<h1>`
   inside the header so the page has a top-level heading. Gave the
-  Settings drawer close button an `aria-label`, the empty
-  results-table header cells `sr-only` labels, and the card-list
-  textarea an `aria-label`. Made the Help modal's scrollable body
-  keyboard-focusable so users can scroll without first tabbing
-  through every dialog control.
+  Settings drawer close button an `aria-label`, every empty
+  results-table header cell `sr-only` labels (column header row +
+  filter row, including the four comp-tier columns), and the
+  card-list textarea an `aria-label`. Made the Help modal's
+  scrollable body keyboard-focusable so users can scroll without
+  first tabbing through every dialog control.
 
 ## [1.0.1] - 2026-05-16
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ point — start there, then drill into a topic below.
 | [PDF binder](binder-pdf.md) | Standard 3×3 (placeholder cards) and condensed 6×4 (visual scan) layouts. |
 | [Checklist PDF](checklist.md) | Front-of-binder checklist output and how `--sort` shapes its order. |
 | [Cache](cache.md) | Disk cache layout, TTLs, URL overrides, and when to use `--no-cache` / `--clear-cache`. |
+| [Accessibility](accessibility.md) | What we commit to, how we enforce it (axe-core in CI + live-browser scan), keyboard reference, and how to add new UI without regressing. |
 | [Deployment](deployment.md) | Production recipes: Render, Docker, env vars, reverse-proxy config. |
 
 ## Sub-project docs (co-located with code)

--- a/docs/_Sidebar.md
+++ b/docs/_Sidebar.md
@@ -12,6 +12,7 @@
 - [PDF binder](binder-pdf)
 - [Checklist PDF](checklist)
 - [Cache](cache)
+- [Accessibility](accessibility)
 - [Deployment](deployment)
 
 ### Project direction

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,0 +1,99 @@
+# Accessibility
+
+The mgz-pkmn web UI ([api/](../api/) + [web/](../web/)) is built to be
+usable with a keyboard, a screen reader, or low-vision settings. This
+page describes what we commit to, how the commitment is enforced, and
+where to file a regression.
+
+The CLI is a separate surface — color output is opt-out via standard
+terminal conventions (`NO_COLOR=1` honored by [Click][click-no-color]).
+The rest of this page is web-UI only.
+
+[click-no-color]: https://click.palletsprojects.com/en/stable/api/#click.echo
+
+## What we commit to
+
+- **No critical or serious axe-core violations** on the rendered UI.
+  This is enforced in CI — see [How we enforce it](#how-we-enforce-it).
+- **WCAG 2.1 AA color contrast** on every piece of text the user is
+  expected to read. Helper copy, section headings, the footer, and the
+  empty-state messages all clear 4.5:1 against their background.
+- **Full keyboard reach.** Every interactive control is reachable via
+  Tab in a sensible order. No keyboard traps. Modal dialogs close on
+  `Esc` and return focus to the trigger that opened them.
+- **Accessible names on every interactive.** Icon-only buttons (Help,
+  Settings, close buttons, the empty results-table action column) all
+  carry an `aria-label` or an `sr-only` label so a screen reader
+  announces what they do.
+- **Landmark structure.** The page has exactly one `<h1>` (visually
+  hidden but present in the accessibility tree) inside the `<header>`
+  landmark, plus `<main>` and `<footer>` landmarks.
+- **Visible focus indicators.** Every focusable element shows a focus
+  ring when reached via keyboard.
+
+## How we enforce it
+
+Two layers.
+
+**1. Per-component axe-core assertions** in
+[`web/src/components/a11y.test.tsx`](../web/src/components/a11y.test.tsx).
+The test mounts each top-level component in its common states (closed
+and open for modals, empty and populated for the results table) and
+asserts no axe violations. The matcher fails on **any** violation, not
+just critical — so the regression bar is stricter than the policy
+statement above. Runs as part of `npm test` and CI's `web` job.
+
+**2. Live-browser scan.** During the original audit ([#62][issue-62] /
+[PR #220][pr-220]), axe-core 4.10 was injected into the running dev
+server and re-run against every UI state — including states JSDOM
+can't fully model (modal portals, real color contrast computation,
+scrollable region detection). Use this when adding new UI surfaces:
+
+```bash
+make dev-api & make dev-web
+# open http://localhost:5173, then in the browser console:
+const s = document.createElement('script')
+s.src = 'https://cdnjs.cloudflare.com/ajax/libs/axe-core/4.10.2/axe.min.js'
+s.onload = async () => console.table((await axe.run(document)).violations)
+document.head.appendChild(s)
+```
+
+[issue-62]: https://github.com/mgzwarrior/mgz-pkmn/issues/62
+[pr-220]: https://github.com/mgzwarrior/mgz-pkmn/pull/220
+
+## Keyboard reference
+
+| Where | Key | Effect |
+|---|---|---|
+| Anywhere | `Tab` / `Shift+Tab` | Move focus to the next / previous interactive |
+| Card-list textarea | `Cmd/Ctrl + Enter` | Run the lookup (same as the **Look up** button) |
+| Help / Settings modal | `Esc` | Close the modal; focus returns to the trigger button |
+| Help modal body | `↑` / `↓` / `PageUp` / `PageDown` | Scroll the modal body (it's a focusable region) |
+| Results table column header | `Enter` / `Space` | Cycle sort: asc → desc → off |
+| Filter toggle | `Enter` / `Space` | Show / hide the per-column filter row |
+
+The `Cmd+Enter` shortcut is the only application-specific binding; the
+rest are standard browser / Radix UI defaults.
+
+## Adding new UI
+
+When you add a new component or interactive surface:
+
+1. Add an `expectNoViolations` assertion for the new component to
+   `a11y.test.tsx`. If the component has meaningfully different states
+   (closed vs. open, empty vs. populated), cover each. The
+   `ResultsTable` block is the most complete example.
+2. Run the live-browser scan above against the new surface — JSDOM
+   doesn't compute color, so contrast regressions don't show up in CI.
+3. If the new component is rendered into a portal (Radix Dialog,
+   Tooltip, DropdownMenu) and the test mounts a closed trigger, scan
+   `document.body` rather than the mount `container` so the portal
+   content is included.
+
+## Filing a regression
+
+Open a bug report with the
+[bug template](https://github.com/mgzwarrior/mgz-pkmn/issues/new?template=bug.md)
+and tag it `area:web`. If the issue is reproducible with
+keyboard-only navigation or a specific assistive technology, please
+note which — that makes the fix much faster.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -41,7 +41,8 @@
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.59.3",
         "vite": "^8.0.13",
-        "vitest": "^4.1.6"
+        "vitest": "^4.1.6",
+        "vitest-axe": "^0.1.0"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -2959,6 +2960,16 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/axe-core": {
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -3068,6 +3079,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/clsx": {
@@ -3206,8 +3230,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.352",
@@ -4158,6 +4181,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -5182,6 +5212,24 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/vitest-axe": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/vitest-axe/-/vitest-axe-0.1.0.tgz",
+      "integrity": "sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.0.0",
+        "axe-core": "^4.4.2",
+        "chalk": "^5.0.1",
+        "dom-accessibility-api": "^0.5.14",
+        "lodash-es": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "peerDependencies": {
+        "vitest": ">=0.16.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/web/package.json
+++ b/web/package.json
@@ -47,6 +47,7 @@
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.59.3",
     "vite": "^8.0.13",
-    "vitest": "^4.1.6"
+    "vitest": "^4.1.6",
+    "vitest-axe": "^0.1.0"
   }
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -140,6 +140,7 @@ function App() {
     <div className="min-h-screen bg-zinc-950 text-zinc-100">
       {/* Header */}
       <header className="sticky top-0 z-30 border-b border-zinc-800 bg-zinc-950/90 backdrop-blur">
+        <h1 className="sr-only">mgz-pkmn — Pokemon card lookup</h1>
         <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3">
           <button
             type="button"
@@ -165,14 +166,14 @@ function App() {
       {/* Main content */}
       <main className="mx-auto max-w-7xl px-4 py-6 space-y-6">
         <section data-tour="input">
-          <h2 className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-500">
+          <h2 className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-400">
             Card list
           </h2>
           <InputEditor onRun={handleRun} onStop={handleStop} />
         </section>
 
         <section data-tour="results">
-          <h2 className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-500">
+          <h2 className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-400">
             Results
           </h2>
           <div className="flex flex-col gap-3">
@@ -238,13 +239,13 @@ function App() {
         </div>
       )}
 
-      <footer className="border-t border-zinc-800 py-4 text-center text-xs text-zinc-700">
+      <footer className="border-t border-zinc-800 py-4 text-center text-xs text-zinc-400">
         mgz-pkmn · a personal card-show prep tool ·{' '}
         <a
           href="https://github.com/mgzwarrior/mgz-pkmn"
           target="_blank"
           rel="noopener noreferrer"
-          className="hover:text-zinc-500"
+          className="hover:text-zinc-200"
         >
           GitHub
         </a>

--- a/web/src/components/ExportBar.tsx
+++ b/web/src/components/ExportBar.tsx
@@ -141,7 +141,7 @@ export function ExportBar() {
         {/* Status / error lives outside the dropdown menu so it stays
             visible after the user picks a format and the menu closes. */}
         {matchedRows.length > 0 && !disabled && !error && (
-          <span className="text-xs text-zinc-500">
+          <span className="text-xs text-zinc-400">
             {matchedRows.length} row{matchedRows.length !== 1 ? 's' : ''}
           </span>
         )}
@@ -170,7 +170,7 @@ export function ExportBar() {
         onClick={handleSetCards}
       />
       {matchedRows.length > 0 && !disabled && (
-        <span className="text-xs text-zinc-500 ml-1">
+        <span className="text-xs text-zinc-400 ml-1">
           {matchedRows.length} row{matchedRows.length !== 1 ? 's' : ''}
         </span>
       )}

--- a/web/src/components/HelpModal.tsx
+++ b/web/src/components/HelpModal.tsx
@@ -68,7 +68,10 @@ export function HelpModal({ onStartTour }: Props) {
 
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm" />
-        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 flex max-h-[90vh] w-[min(640px,92vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-zinc-700 bg-zinc-900 shadow-2xl">
+        <Dialog.Content
+          aria-describedby={undefined}
+          className="fixed left-1/2 top-1/2 z-50 flex max-h-[90vh] w-[min(640px,92vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-zinc-700 bg-zinc-900 shadow-2xl"
+        >
           {/* Header */}
           <div className="flex items-center justify-between border-b border-zinc-700 px-5 py-4">
             <Dialog.Title className="text-base font-semibold text-zinc-100">
@@ -85,7 +88,10 @@ export function HelpModal({ onStartTour }: Props) {
           </div>
 
           {/* Body */}
-          <div className="flex-1 overflow-y-auto px-5 py-4 space-y-6 text-sm text-zinc-300">
+          <div
+            tabIndex={0}
+            className="flex-1 overflow-y-auto px-5 py-4 space-y-6 text-sm text-zinc-300 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          >
             <Section title="What this does">
               <p>
                 Paste a list of Pokémon cards (one per line), click{' '}
@@ -151,7 +157,7 @@ export function HelpModal({ onStartTour }: Props) {
 
           {/* Footer */}
           <div className="flex items-center justify-between border-t border-zinc-700 px-5 py-4">
-            <span className="text-xs text-zinc-500">
+            <span className="text-xs text-zinc-400">
               New here? Take the interactive tour.
             </span>
             <button
@@ -170,7 +176,7 @@ export function HelpModal({ onStartTour }: Props) {
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <section>
-      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-500">
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-400">
         {title}
       </h3>
       {children}
@@ -194,7 +200,7 @@ function Examples({ rows }: { rows: [string, string][] }) {
           <code className="rounded bg-zinc-800 px-2 py-0.5 font-mono text-xs text-zinc-100">
             {query}
           </code>
-          <span className="text-xs text-zinc-500">{desc}</span>
+          <span className="text-xs text-zinc-400">{desc}</span>
         </li>
       ))}
     </ul>

--- a/web/src/components/InputEditor.tsx
+++ b/web/src/components/InputEditor.tsx
@@ -100,7 +100,7 @@ export function InputEditor({ onRun, onStop }: Props) {
     <div className="flex flex-col gap-2">
       {/* Toolbar */}
       <div className="flex items-center justify-between">
-        <span className="text-xs text-zinc-500">
+        <span className="text-xs text-zinc-400">
           {lineCount > 0 ? `${lineCount} card line${lineCount !== 1 ? 's' : ''}` : 'Enter card lines below'}
         </span>
         <div className="flex items-center gap-2">
@@ -132,7 +132,7 @@ export function InputEditor({ onRun, onStop }: Props) {
             >
               <Play size={13} fill="currentColor" />
               Look up&nbsp;
-              <span className="opacity-70 text-xs">(⌘↵)</span>
+              <span className="text-xs text-white">(⌘↵)</span>
             </button>
           )}
         </div>
@@ -141,6 +141,7 @@ export function InputEditor({ onRun, onStop }: Props) {
       {/* Textarea */}
       <textarea
         ref={textareaRef}
+        aria-label="Card list — one card per line"
         value={inputText}
         onChange={(e) => setInputText(e.target.value)}
         onKeyDown={handleKeyDown}
@@ -155,7 +156,7 @@ export function InputEditor({ onRun, onStop }: Props) {
       {/* Example query chips — guided empty-state */}
       {isEmpty && !isRunning && (
         <div className="flex flex-col gap-2 rounded-md border border-zinc-700 bg-zinc-800/40 px-3 py-3">
-          <span className="text-xs text-zinc-500">Try one of these</span>
+          <span className="text-xs text-zinc-400">Try one of these</span>
           <div className="flex flex-wrap gap-1.5">
             {EXAMPLE_QUERIES.map((example) => (
               <button

--- a/web/src/components/ProcessingQueue.tsx
+++ b/web/src/components/ProcessingQueue.tsx
@@ -27,7 +27,7 @@ export function ProcessingQueue() {
         <span className="text-xs font-medium text-zinc-400">
           Looking up cards…
         </span>
-        <span className="text-xs tabular-nums text-zinc-500">
+        <span className="text-xs tabular-nums text-zinc-400">
           {done} of {total} done
         </span>
       </div>

--- a/web/src/components/ResultsTable.tsx
+++ b/web/src/components/ResultsTable.tsx
@@ -66,7 +66,7 @@ export function ResultsTable({ onRerunLine }: Props) {
 
   if (rows.length === 0 && !isRunning) {
     return (
-      <div className="flex items-center justify-center rounded-md border border-zinc-700 bg-zinc-900 py-16 text-zinc-500 text-sm">
+      <div className="flex items-center justify-center rounded-md border border-zinc-700 bg-zinc-900 py-16 text-zinc-400 text-sm">
         Results will appear here after you run a lookup.
       </div>
     )
@@ -86,7 +86,7 @@ export function ResultsTable({ onRerunLine }: Props) {
             />
           </div>
           {progress && (
-            <span className="text-xs text-zinc-500 tabular-nums whitespace-nowrap">
+            <span className="text-xs text-zinc-400 tabular-nums whitespace-nowrap">
               {progress.done} / {progress.total}
             </span>
           )}
@@ -116,7 +116,7 @@ export function ResultsTable({ onRerunLine }: Props) {
               setSortDir(null)
               setFilters(EMPTY_FILTERS)
             }}
-            className="text-xs text-zinc-500 hover:text-zinc-300"
+            className="text-xs text-zinc-400 hover:text-zinc-300"
           >
             Clear sort &amp; filters
           </button>
@@ -174,11 +174,17 @@ export function ResultsTable({ onRerunLine }: Props) {
                 onClick={cycleSort}
                 className="hidden sm:table-cell"
               />
-              <th className="px-3 py-2 text-xs font-medium text-zinc-400 w-8" />
+              <th className="px-3 py-2 text-xs font-medium text-zinc-400 w-8">
+                <span className="sr-only">Actions</span>
+              </th>
             </tr>
             {showFilters && (
               <tr className="border-b border-zinc-700 bg-zinc-900">
-                {!settings.noImages && <th />}
+                {!settings.noImages && (
+                  <th>
+                    <span className="sr-only">Image (no filter)</span>
+                  </th>
+                )}
                 <FilterCell>
                   <FilterInput
                     aria-label="Filter by name"
@@ -233,7 +239,9 @@ export function ResultsTable({ onRerunLine }: Props) {
                     onChange={(v) => setFilters((f) => ({ ...f, source: v }))}
                   />
                 </FilterCell>
-                <th />
+                <th>
+                  <span className="sr-only">Actions (no filter)</span>
+                </th>
               </tr>
             )}
           </thead>
@@ -257,12 +265,12 @@ export function ResultsTable({ onRerunLine }: Props) {
         </table>
       </div>
 
-      <p className="text-xs text-zinc-600 text-right">
+      <p className="text-xs text-zinc-400 text-right">
         {displayedRows.filter((r) => r.matched).length} matched ·{' '}
         {displayedRows.filter((r) => !r.matched).length} unmatched ·{' '}
         {displayedRows.length} shown
         {displayedRows.length !== rows.length && (
-          <span className="text-zinc-500"> (of {rows.length})</span>
+          <span className="text-zinc-400"> (of {rows.length})</span>
         )}
       </p>
     </div>
@@ -415,7 +423,7 @@ function ResultRow({
               />
             ) : (
               <div className="w-10 h-14 rounded bg-zinc-800 flex items-center justify-center">
-                <span className="text-zinc-600 text-xs">?</span>
+                <span className="text-zinc-400 text-xs">?</span>
               </div>
             )}
           </td>
@@ -426,7 +434,7 @@ function ResultRow({
           {row.matched ? (
             <div>
               <div className="font-medium text-zinc-100 truncate">{card?.name as string}</div>
-              <div className="text-xs text-zinc-500 truncate">{row.query.raw}</div>
+              <div className="text-xs text-zinc-400 truncate">{row.query.raw}</div>
             </div>
           ) : (
             <div>
@@ -448,19 +456,19 @@ function ResultRow({
         <td className="px-3 py-2 text-zinc-400 text-xs hidden md:table-cell max-w-[160px]">
           <div className="truncate">{setName ?? '—'}</div>
           {card?.number && (
-            <div className="text-zinc-600">#{card.number as string}</div>
+            <div className="text-zinc-400">#{card.number as string}</div>
           )}
         </td>
 
         {/* Rarity */}
-        <td className="px-3 py-2 text-xs text-zinc-500 hidden lg:table-cell max-w-[120px] truncate">
+        <td className="px-3 py-2 text-xs text-zinc-400 hidden lg:table-cell max-w-[120px] truncate">
           {(card?.rarity as string | undefined) ?? '—'}
         </td>
 
         {/* Market */}
         <td
           className={`px-3 py-2 text-right font-mono tabular-nums ${
-            isOverCap ? 'text-amber-400 font-bold' : p.market ? 'text-green-400' : 'text-zinc-600'
+            isOverCap ? 'text-amber-400 font-bold' : p.market ? 'text-green-400' : 'text-zinc-400'
           }`}
         >
           {fmt(p.market, p.currency)}
@@ -481,7 +489,7 @@ function ResultRow({
         </td>
 
         {/* Price source */}
-        <td className="px-3 py-2 text-xs text-zinc-500 hidden sm:table-cell">
+        <td className="px-3 py-2 text-xs text-zinc-400 hidden sm:table-cell">
           {p.source ?? '—'}
         </td>
 
@@ -492,7 +500,7 @@ function ResultRow({
               href={p.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-zinc-500 hover:text-blue-400 transition-colors"
+              className="text-zinc-400 hover:text-blue-400 transition-colors"
               title="Open listing"
             >
               <ExternalLink size={13} />
@@ -523,7 +531,7 @@ function ResultRow({
               </button>
               <button
                 onClick={() => setShowOverrideForm(false)}
-                className="text-zinc-500 hover:text-zinc-300 text-xs"
+                className="text-zinc-400 hover:text-zinc-300 text-xs"
               >
                 Cancel
               </button>

--- a/web/src/components/ResultsTable.tsx
+++ b/web/src/components/ResultsTable.tsx
@@ -227,10 +227,20 @@ export function ResultsTable({ onRerunLine }: Props) {
                     />
                   </div>
                 </FilterCell>
-                <th className="hidden xl:table-cell" />
-                <th className="hidden xl:table-cell" />
-                <th className="hidden xl:table-cell" />
-                <th className="hidden xl:table-cell" />
+                {/* Comp-tier columns have no filter — sr-only labels keep axe
+                    happy without adding visible noise. */}
+                <th className="hidden xl:table-cell">
+                  <span className="sr-only">80% (no filter)</span>
+                </th>
+                <th className="hidden xl:table-cell">
+                  <span className="sr-only">85% (no filter)</span>
+                </th>
+                <th className="hidden xl:table-cell">
+                  <span className="sr-only">90% (no filter)</span>
+                </th>
+                <th className="hidden xl:table-cell">
+                  <span className="sr-only">95% (no filter)</span>
+                </th>
                 <FilterCell className="hidden sm:table-cell">
                   <FilterInput
                     aria-label="Filter by source"

--- a/web/src/components/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer.tsx
@@ -35,14 +35,20 @@ export function SettingsDrawer() {
 
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm" />
-        <Dialog.Content className="fixed right-0 top-0 z-50 h-full w-full sm:w-80 bg-zinc-900 border-l border-zinc-700 shadow-2xl flex flex-col">
+        <Dialog.Content
+          aria-describedby={undefined}
+          className="fixed right-0 top-0 z-50 h-full w-full sm:w-80 bg-zinc-900 border-l border-zinc-700 shadow-2xl flex flex-col"
+        >
           {/* Header */}
           <div className="flex items-center justify-between border-b border-zinc-700 px-5 py-4">
             <Dialog.Title className="text-base font-semibold text-zinc-100">
               Settings
             </Dialog.Title>
             <Dialog.Close asChild>
-              <button className="rounded p-1 text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700 transition-colors">
+              <button
+                aria-label="Close settings"
+                className="rounded p-1 text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700 transition-colors"
+              >
                 <X size={16} />
               </button>
             </Dialog.Close>
@@ -88,7 +94,7 @@ export function SettingsDrawer() {
                   </option>
                 ))}
               </select>
-              <p className="mt-1 text-xs text-zinc-500">
+              <p className="mt-1 text-xs text-zinc-400">
                 Applied to every export (xlsx, PDF binder, condensed PDF, checklist). Tag stays the
                 outermost group; this only changes order within each tag.
               </p>
@@ -110,7 +116,7 @@ export function SettingsDrawer() {
                 placeholder="No cap"
                 className="w-full rounded-md border border-zinc-600 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 placeholder:text-zinc-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
               />
-              <p className="mt-1 text-xs text-zinc-500">
+              <p className="mt-1 text-xs text-zinc-400">
                 Bulk top-N results above this price are excluded. Single-card lookups are always
                 shown (flagged amber in the export).
               </p>
@@ -205,7 +211,7 @@ function Toggle({
       </div>
       <div>
         <p className="text-sm text-zinc-200 group-hover:text-zinc-100">{label}</p>
-        <p className="text-xs text-zinc-500">{description}</p>
+        <p className="text-xs text-zinc-400">{description}</p>
       </div>
     </label>
   )

--- a/web/src/components/a11y.test.tsx
+++ b/web/src/components/a11y.test.tsx
@@ -23,6 +23,7 @@ import { InputEditor } from './InputEditor'
 import { ProcessingQueue } from './ProcessingQueue'
 import { ResultsTable } from './ResultsTable'
 import { SettingsDrawer } from './SettingsDrawer'
+import type { Row } from '../types'
 
 vi.mock('../api/client', () => ({
   exportFile: vi.fn(),
@@ -33,7 +34,7 @@ vi.mock('../api/client', () => ({
 
 const { storeState, storeApi } = vi.hoisted(() => {
   const state = {
-    rows: [] as unknown[],
+    rows: [] as Row[],
     inputText: '',
     isRunning: false,
     progress: null as { done: number; total: number } | null,
@@ -145,6 +146,36 @@ describe('a11y: ProcessingQueue (mid-run)', () => {
 describe('a11y: ResultsTable (empty state)', () => {
   it('empty-state has no violations', async () => {
     await expectNoViolations(<ResultsTable />)
+  })
+})
+
+// Populated-state coverage — empty-state never mounts the actual <table>,
+// so the sr-only labels on empty <th /> header cells, the SortableHeader
+// buttons, and the filter-row inputs all go unexercised unless we seed
+// rows and expand the filter row. Without this, axe regressions in the
+// real table markup would slip past the empty-state coverage above.
+describe('a11y: ResultsTable (populated + filters expanded)', () => {
+  it('table with rows and visible filter row has no violations', async () => {
+    storeState.rows = [
+      {
+        query: { raw: 'Pikachu | Jungle', name: 'Pikachu' },
+        card: {
+          id: 'jungle-60',
+          name: 'Pikachu',
+          number: '60',
+          rarity: 'Common',
+          set: { id: 'jungle', name: 'Jungle', series: 'Original' },
+        },
+        pricing: { market: 5.12, currency: 'USD', variant: 'normal', source: 'TCGPlayer', url: null },
+        tag: 'demo',
+        matched: true,
+        reason: '',
+      } as Row,
+    ]
+    const { container } = render(<ResultsTable />)
+    fireEvent.click(screen.getByRole('button', { name: /^filter$/i }))
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
   })
 })
 

--- a/web/src/components/a11y.test.tsx
+++ b/web/src/components/a11y.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * a11y.test — runs axe-core against every top-level component to enforce
+ * the "no critical violations" half of #62.
+ *
+ * Strategy: one `describe` per component, each mounting it with whatever
+ * store / props are needed to render the most common visible state. The
+ * matcher fails on any axe violation, so this is stricter than the issue
+ * requires — the bar is "no critical", but the test guards against
+ * regressions of any severity. If a non-critical finding turns out to be
+ * a wontfix (e.g. a third-party library quirk), narrow the rule via
+ * axe's `rules` config in the relevant test rather than weakening the
+ * matcher globally.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent, screen } from '@testing-library/react'
+import { axe } from 'vitest-axe'
+import type { ReactElement } from 'react'
+
+import { ErrorBoundary } from './ErrorBoundary'
+import { ExportBar } from './ExportBar'
+import { HelpModal } from './HelpModal'
+import { InputEditor } from './InputEditor'
+import { ProcessingQueue } from './ProcessingQueue'
+import { ResultsTable } from './ResultsTable'
+import { SettingsDrawer } from './SettingsDrawer'
+
+vi.mock('../api/client', () => ({
+  exportFile: vi.fn(),
+  downloadSetCardsPdf: vi.fn(),
+  parseLine: vi.fn(),
+  addOverride: vi.fn(),
+}))
+
+const { storeState, storeApi } = vi.hoisted(() => {
+  const state = {
+    rows: [] as unknown[],
+    inputText: '',
+    isRunning: false,
+    progress: null as { done: number; total: number } | null,
+    processingLines: [] as { line: string; status: 'pending' | 'resolved' | 'error' }[],
+    settings: {
+      apiKey: '',
+      maxPrice: null as number | null,
+      noImages: true,
+      tag: '',
+      dedupe: false,
+      sort: 'number' as const,
+    },
+  }
+  const api = {
+    setInputText: vi.fn((v: string) => {
+      state.inputText = v
+    }),
+    clearRows: vi.fn(() => {
+      state.rows = []
+    }),
+    setProcessingLines: vi.fn(),
+    setProgress: vi.fn(),
+    setIsRunning: vi.fn(),
+    updateSettings: vi.fn(),
+    resetSettings: vi.fn(),
+  }
+  return { storeState: state, storeApi: api }
+})
+
+vi.mock('../store', () => {
+  function getState() {
+    return { ...storeState, ...storeApi }
+  }
+  const useAppStore = ((selector?: (s: ReturnType<typeof getState>) => unknown) => {
+    const s = getState()
+    return selector ? selector(s) : s
+  }) as unknown as {
+    (...args: unknown[]): unknown
+    getState: typeof getState
+    setState: (patch: Partial<typeof storeState>) => void
+  }
+  useAppStore.getState = getState
+  useAppStore.setState = (patch) => {
+    Object.assign(storeState, patch)
+  }
+  return { useAppStore }
+})
+
+async function expectNoViolations(ui: ReactElement) {
+  const { container } = render(ui)
+  const results = await axe(container)
+  expect(results).toHaveNoViolations()
+}
+
+beforeEach(() => {
+  storeState.rows = []
+  storeState.inputText = ''
+  storeState.isRunning = false
+  storeState.progress = null
+  storeState.processingLines = []
+})
+
+describe('a11y: ErrorBoundary (error state)', () => {
+  it('rendered fallback has no violations', async () => {
+    // Suppress React's expected "caught error" stderr noise.
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    function Boom(): ReactElement {
+      throw new Error('boom')
+    }
+    await expectNoViolations(
+      <ErrorBoundary>
+        <Boom />
+      </ErrorBoundary>,
+    )
+    spy.mockRestore()
+  })
+})
+
+describe('a11y: ExportBar (no matched rows)', () => {
+  it('disabled-state buttons have no violations', async () => {
+    await expectNoViolations(<ExportBar />)
+  })
+})
+
+describe('a11y: HelpModal (trigger closed)', () => {
+  it('icon-only trigger has no violations', async () => {
+    await expectNoViolations(<HelpModal onStartTour={vi.fn()} />)
+  })
+})
+
+describe('a11y: InputEditor (empty)', () => {
+  it('textarea + run button have no violations', async () => {
+    await expectNoViolations(<InputEditor onRun={vi.fn()} onStop={vi.fn()} />)
+  })
+})
+
+describe('a11y: ProcessingQueue (mid-run)', () => {
+  it('queue list has no violations', async () => {
+    storeState.processingLines = [
+      { line: 'Charizard | Base Set | 4', status: 'resolved' },
+      { line: 'Pikachu | Jungle', status: 'error' },
+      { line: 'top:5 Mew ex', status: 'pending' },
+    ]
+    storeState.isRunning = true
+    await expectNoViolations(<ProcessingQueue />)
+  })
+})
+
+describe('a11y: ResultsTable (empty state)', () => {
+  it('empty-state has no violations', async () => {
+    await expectNoViolations(<ResultsTable />)
+  })
+})
+
+describe('a11y: SettingsDrawer (trigger closed)', () => {
+  it('icon-only trigger has no violations', async () => {
+    await expectNoViolations(<SettingsDrawer />)
+  })
+})
+
+// Open-modal coverage — Radix portals render to document.body, so we point
+// axe at the body to include the dialog content rather than just the mount
+// container.
+describe('a11y: HelpModal (opened)', () => {
+  it('open dialog content has no violations', async () => {
+    render(<HelpModal onStartTour={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: /help/i }))
+    const results = await axe(document.body)
+    expect(results).toHaveNoViolations()
+  })
+})
+
+describe('a11y: SettingsDrawer (opened)', () => {
+  it('open drawer content has no violations', async () => {
+    render(<SettingsDrawer />)
+    fireEvent.click(screen.getByRole('button', { name: /settings/i }))
+    const results = await axe(document.body)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/web/src/components/a11y.test.tsx
+++ b/web/src/components/a11y.test.tsx
@@ -99,17 +99,23 @@ beforeEach(() => {
 
 describe('a11y: ErrorBoundary (error state)', () => {
   it('rendered fallback has no violations', async () => {
-    // Suppress React's expected "caught error" stderr noise.
+    // Suppress React's expected "caught error" stderr noise. try/finally
+    // so a regression in the assertion doesn't leave the spy installed —
+    // a leaked stub would swallow legitimate console.error output in
+    // every subsequent test in the run.
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
     function Boom(): ReactElement {
       throw new Error('boom')
     }
-    await expectNoViolations(
-      <ErrorBoundary>
-        <Boom />
-      </ErrorBoundary>,
-    )
-    spy.mockRestore()
+    try {
+      await expectNoViolations(
+        <ErrorBoundary>
+          <Boom />
+        </ErrorBoundary>,
+      )
+    } finally {
+      spy.mockRestore()
+    }
   })
 })
 

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,6 +1,11 @@
 import '@testing-library/jest-dom/vitest'
-import { afterEach, vi } from 'vitest'
+import { afterEach, expect, vi } from 'vitest'
 import { cleanup } from '@testing-library/react'
+import * as axeMatchers from 'vitest-axe/matchers'
+
+// vitest-axe's `extend-expect` entry is empty in the published dist; register
+// the matcher ourselves so `expect(results).toHaveNoViolations()` works.
+expect.extend(axeMatchers)
 
 // Zustand's persist middleware reaches for `localStorage` on every state
 // change. jsdom in Node 22 exposes an experimental `localStorage` global

--- a/web/src/test/vitest-axe.d.ts
+++ b/web/src/test/vitest-axe.d.ts
@@ -1,0 +1,27 @@
+/**
+ * Type augmentation for vitest-axe's `toHaveNoViolations` matcher.
+ *
+ * vitest-axe ships its own augmentation, but it targets the legacy `Vi`
+ * namespace that Vitest 4 no longer uses. Re-augment against the modern
+ * `vitest` module so the matcher type-checks. Runtime registration of
+ * the matcher itself lives in `./setup.ts`.
+ *
+ * The `_phantom?: T` field is unused at runtime — TypeScript module
+ * augmentation requires the generic parameter signature to match
+ * `@vitest/expect`'s `Assertion<T = any>` declaration, and using `T` once
+ * in the interface body keeps the type parameter live.
+ */
+import type { AxeMatchers } from 'vitest-axe/matchers'
+
+declare module 'vitest' {
+  // `any` mirrors @vitest/expect's `Assertion<T = any>` signature — module
+  // augmentation requires identical parameter defaults to merge.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  interface Assertion<T = any> extends AxeMatchers {
+    _phantom?: T
+  }
+  // Empty extension is the standard pattern for module augmentation —
+  // it's how @testing-library/jest-dom augments AsymmetricMatchersContaining.
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  interface AsymmetricMatchersContaining extends AxeMatchers {}
+}


### PR DESCRIPTION
Closes #62

## What

Closes out the accessibility + keyboard-navigation half of #62 (the mobile-responsive half landed in #200).

- **axe-core: zero violations** across every state — idle page, open Help modal, open Settings drawer, **populated results table with the filter row expanded**, and every interactive in between. Verified both in JSDOM (`vitest-axe` harness, runs in CI) and against the live dev server (axe-core 4.10 injected at runtime).
- **Color contrast**: bumped muted text from `text-zinc-500` / `text-zinc-600` to `text-zinc-400` so helper copy, section headings, the row-count footer, and the page footer all clear WCAG AA. The footer was 1.9:1 before.
- **Heading structure**: added a screen-reader-only `<h1>` inside `<header>` so the page has a top-level heading inside a landmark region (was failing `page-has-heading-one` + `region`).
- **Accessible names**: gave the Settings drawer close button an `aria-label`, the card-list textarea an `aria-label`, and every empty `<th />` cell in the results table (header row + filter row, including the four comp-tier columns) `sr-only` labels.
- **Keyboard reach**: Help modal's scroll body is now `tabindex=0` with a focus ring so keyboard users can scroll without first tabbing through every dialog control.
- **Esc behavior**: verified live — Esc closes either modal and focus returns to its trigger button (Radix handles this; I just confirmed it).

## Test harness

`src/components/a11y.test.tsx` runs axe against every top-level component in both closed and open states **and** against the populated results table with the filter row expanded — 10 assertions, all green. The populated-table test was the lone Copilot finding on the first push, and it immediately surfaced four more empty `<th />` cells in the comp-tier columns that the original browser scan missed (test viewport was narrower than the `xl:` breakpoint that reveals those columns).

Two infrastructure files alongside it:

- `src/test/setup.ts` — registers the `toHaveNoViolations` matcher manually (vitest-axe's `extend-expect` entry ships as an empty file in the published dist).
- `src/test/vitest-axe.d.ts` — re-augments the modern `vitest` module so the matcher type-checks; vitest-axe's bundled types target the legacy `Vi` namespace Vitest 4 dropped.

## Documentation

New [`docs/accessibility.md`](docs/accessibility.md) — single home for the a11y commitment, the enforcement story (vitest-axe in CI + a copy-paste live-browser scan snippet), the keyboard reference, and the "adding new UI" checklist. Indexed in `docs/README.md` and the GitHub wiki sidebar.

## Why this scope

The issue's bar was "no critical violations". The real picture from a live axe run was 7 `serious` contrast findings (one with 1.9:1 on the footer) plus a `moderate` heading-structure miss. Fixing them all was cheaper than filing follow-ups and they share a single PR with the tooling that prevents regressions.

## How to verify

```bash
cd web && npm test -- --run src/components/a11y.test.tsx
```

Or manually in the dev server:

- `make dev-api` + `make dev-web`
- Open `http://localhost:5173`
- Tab through the page — every interactive reachable, focus rings visible
- Open Help, hit Esc, focus returns to the Help trigger; same for Settings
- Run an axe scan in browser devtools (or paste the snippet from `docs/accessibility.md`) — zero violations expected on every state

## CHANGELOG

Entry under `[Unreleased] → Changed` covers the audit fixes; `[Unreleased] → Added` covers `docs/accessibility.md`.