### PR TITLE
Add JSON output for cache stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- CLI: `pkmn cache stats --json` now emits the cache health snapshot
+  with snake_case keys for scripts and monitoring.
 - Web: onboarding help surface. A new **Help** button in the header
   opens a modal covering what the tool does, how to write queries
   (with copyable examples), each setting, each export format, and

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -62,6 +62,20 @@ writes during normal lookups, but inspecting real files should still
 show what's there. Combine with [`--clear-cache`](#behavior) on the next
 `pkmn lookup` if the API cache has grown stale relative to the code.
 
+Use `pkmn cache stats --json` for scripts and monitoring. It emits the
+same snapshot with snake_case keys:
+
+```json
+{
+  "root": "/Users/you/.cache/mgz-pkmn",
+  "api_entry_count": 175,
+  "api_bytes": 9227468,
+  "api_oldest_mtime": 1789400000.0,
+  "override_count": 20,
+  "override_bytes": 2253
+}
+```
+
 ## Environment variables
 
 | Variable | Effect |

--- a/src/mgz_pkmn/cli.py
+++ b/src/mgz_pkmn/cli.py
@@ -8,6 +8,7 @@ import re
 import shlex
 import sys
 import time
+from dataclasses import asdict
 from pathlib import Path
 
 import click
@@ -936,13 +937,20 @@ def _format_age(mtime: float | None, *, now: float | None = None) -> str:
 
 
 @cache_group.command(name="stats", context_settings={"help_option_names": ["-h", "--help"]})
-def cache_stats_command() -> None:
+@click.option("--json", "as_json", is_flag=True, help="Emit JSON instead of the human summary.")
+def cache_stats_command(as_json: bool) -> None:
     """Show on-disk cache health: total size, oldest entry, override count.
 
     Reports stats even when MGZ_PKMN_NO_CACHE is set — the user is asking
     about real on-disk state, not the effective behaviour of the current
     run."""
     s = disk_cache.stats()
+    if as_json:
+        payload = asdict(s)
+        payload["root"] = str(s.root)
+        click.echo(json.dumps(payload, indent=2))
+        return
+
     total_bytes = s.api_bytes + s.override_bytes
 
     _print_section("Cache stats")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -175,6 +175,32 @@ class CacheStatsCommandTests(unittest.TestCase):
         self.assertIn("API responses: 0 entries", result.output)
         self.assertIn("oldest —", result.output)
 
+    def test_stats_command_can_emit_json(self) -> None:
+        cache.write_api("https://example.com/a", {"x": 1})
+        cache.record_url_override("Mew", None, "https://pc/mew")
+
+        result = CliRunner().invoke(cli, ["cache", "stats", "--json"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(
+            set(payload),
+            {
+                "api_bytes",
+                "api_entry_count",
+                "api_oldest_mtime",
+                "override_bytes",
+                "override_count",
+                "root",
+            },
+        )
+        self.assertEqual(payload["api_entry_count"], 1)
+        self.assertGreater(payload["api_bytes"], 0)
+        self.assertIsInstance(payload["api_oldest_mtime"], float)
+        self.assertEqual(payload["override_count"], 1)
+        self.assertGreater(payload["override_bytes"], 0)
+        self.assertEqual(payload["root"], str(Path(self._tmp.name) / "mgz-pkmn"))
+
 
 class WarnIfCacheLargeTests(unittest.TestCase):
     """The soft-warn helper invoked at `pkmn lookup` start. We drive it


### PR DESCRIPTION
Closes #207

## What

- Added `pkmn cache stats --json` for machine-readable cache statistics.
- Serialized the existing `CacheStats` fields with snake_case keys and converted `root` to a string for JSON output.
- Kept the default human-readable `pkmn cache stats` output unchanged.
- Added focused CLI coverage, cache docs, and a changelog entry.

## Why

This gives scripts and CI jobs a stable way to read cache counts, sizes, oldest mtimes, and the cache root without parsing the human summary.

## How to verify

- `uv run python -m unittest tests.test_cli.CacheStatsCommandTests` passed, 3 tests.
- `.venv/bin/ruff check src/ tests/ api/` passed.
- `.venv/bin/ruff format --check src/ tests/ api/` passed.
- `uv sync --extra api` completed so optional API test dependencies were available.
- `.venv/bin/python -m unittest discover -s tests` passed, 246 tests.
- `tmpdir=$(mktemp -d); XDG_CACHE_HOME="$tmpdir" .venv/bin/pkmn cache stats --json; rm -rf "$tmpdir"` emitted valid zero-count JSON.
- `git diff --check HEAD~1 HEAD` passed.
- `git diff HEAD~1 HEAD | gitleaks stdin --no-banner --redact` passed with no leaks found.

## Notes

I used OpenAI Codex to inspect the issue, make this focused change, and run the checks above. I reviewed the diff before submission.
