### PR TITLE
Add cache path command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- CLI: `pkmn cache path` prints the cache root as a bare path for shell
+  composition.
 - CLI: `pkmn cache stats --json` now emits the cache health snapshot
   with snake_case keys for scripts and monitoring.
 - Web: onboarding help surface. A new **Help** button in the header

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -44,6 +44,14 @@ list don't keep re-spending API quota. Two stores live there:
 
 ## Inspecting the cache
 
+`pkmn cache path` prints the cache root as a single bare line for shell
+composition:
+
+```bash
+cd "$(pkmn cache path)"
+du -sh "$(pkmn cache path)"
+```
+
 `pkmn cache stats` prints a one-screen summary of on-disk usage —
 useful for spotting a runaway cache or a stale `url_overrides.json`
 without `du`-ing the directory by hand.

--- a/src/mgz_pkmn/cli.py
+++ b/src/mgz_pkmn/cli.py
@@ -936,6 +936,12 @@ def _format_age(mtime: float | None, *, now: float | None = None) -> str:
     return f"{int(delta // 86400)}d ago"
 
 
+@cache_group.command(name="path", context_settings={"help_option_names": ["-h", "--help"]})
+def cache_path_command() -> None:
+    """Print the cache root path for shell composition."""
+    click.echo(str(disk_cache.cache_root()))
+
+
 @cache_group.command(name="stats", context_settings={"help_option_names": ["-h", "--help"]})
 @click.option("--json", "as_json", is_flag=True, help="Emit JSON instead of the human summary.")
 def cache_stats_command(as_json: bool) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -201,6 +201,15 @@ class CacheStatsCommandTests(unittest.TestCase):
         self.assertGreater(payload["override_bytes"], 0)
         self.assertEqual(payload["root"], str(Path(self._tmp.name) / "mgz-pkmn"))
 
+    def test_path_command_prints_bare_cache_root(self) -> None:
+        expected = Path(self._tmp.name) / "mgz-pkmn"
+
+        result = CliRunner().invoke(cli, ["cache", "path"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(result.output, f"{expected}\n")
+        self.assertNotRegex(result.output, r"\x1b\[")
+
 
 class WarnIfCacheLargeTests(unittest.TestCase):
     """The soft-warn helper invoked at `pkmn lookup` start. We drive it


### PR DESCRIPTION
Closes #205

## What

- Added `pkmn cache path` to print the cache root as a single bare line.
- Added CLI coverage for exact output, trailing newline, and no ANSI escape sequence.
- Documented shell-composition examples and recorded the change in the changelog.

## Why

This lets users compose cache inspection and cleanup commands with shell tools without parsing the human `pkmn cache stats` summary.

## How to verify

- `uv run python -m unittest tests.test_cli.CacheStatsCommandTests` passed, 4 tests.
- `.venv/bin/ruff check src/ tests/ api/` passed.
- `.venv/bin/ruff format --check src/ tests/ api/` passed, 43 files already formatted.
- `git diff --check` passed.
- `.venv/bin/python -m unittest discover -s tests` passed, 247 tests.
- `.venv/bin/pkmn cache --help` showed the `path` and `stats` subcommands.
- `XDG_CACHE_HOME="$tmpdir" .venv/bin/pkmn cache path | .venv/bin/python -c 'import pathlib, sys; data=sys.stdin.read(); assert data.endswith("\n"); assert "\x1b[" not in data; p=pathlib.Path(data.strip()); assert p.name == "mgz-pkmn"; assert p.is_dir(); print("cache path smoke ok", p)'` passed.
- `git diff --check HEAD~1 HEAD` passed.
- `git diff HEAD~1 HEAD | gitleaks stdin --no-banner --redact` passed with no leaks found.

## Notes

The command uses the existing `disk_cache.cache_root()` behavior, so it resolves and creates the cache root the same way the rest of the cache CLI does.

I used OpenAI Codex to inspect the issue, make this focused change, and run the checks above. I reviewed the diff before submission.
