### PR TITLE
Add API version endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- API: `GET /version` returns the running package version
+  (`{"version": "..."}`) for build/deploy probes, alongside
+  `/health`.
 - CLI: `pkmn cache stats --json` now emits the cache health snapshot
   with snake_case keys for scripts and monitoring.
 - Web: onboarding help surface. A new **Help** button in the header

--- a/api/README.md
+++ b/api/README.md
@@ -63,6 +63,7 @@ without CORS gymnastics. CORS is also pre-allowed for `localhost:5173` and
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET`  | `/health` | Liveness probe — returns `{"status": "ok"}` |
+| `GET`  | `/version` | Build version probe — returns `{"version": "..."}` |
 | `POST` | `/api/v1/parse` | Parse one card-list line → `CardQuery` |
 | `POST` | `/api/v1/lookup` | Resolve one card line → array of rows |
 | `POST` | `/api/v1/bulk` | Resolve many lines, streaming each row as SSE |

--- a/api/main.py
+++ b/api/main.py
@@ -18,6 +18,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from starlette.responses import Response
 
+from mgz_pkmn import __version__
+
 from .routes import export, lookup, overrides, parse, set_cards, sets
 
 
@@ -75,6 +77,11 @@ app.include_router(overrides.router, prefix="/api/v1", tags=["overrides"])
 @app.get("/health")
 def health() -> dict:
     return {"status": "ok"}
+
+
+@app.get("/version")
+def version() -> dict[str, str]:
+    return {"version": __version__}
 
 
 # Serve the built SPA when present (single-unit production deploy). The mount

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -19,9 +19,22 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from fastapi.testclient import TestClient
 
 from api.main import app
-from mgz_pkmn import cache
+from mgz_pkmn import __version__, cache
 
 client = TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# /version
+# ---------------------------------------------------------------------------
+
+
+class VersionRouteTests(unittest.TestCase):
+    def test_version_returns_package_version(self) -> None:
+        resp = client.get("/version")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {"version": __version__})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# PR Draft: mgzwarrior/mgz-pkmn#211

## Title

Add API version endpoint

## Summary

Adds a lightweight `GET /version` endpoint that returns the package version exported by `mgz_pkmn.__version__`.

This gives deploy verification, monitoring, and UI consumers a stable way to check which build is running without scraping docs or OpenAPI metadata.

## Changes

- Import `__version__` from `mgz_pkmn`.
- Add `GET /version` returning `{"version": __version__}`.
- Add a route test using the existing `TestClient` pattern.
- Document the endpoint in `api/README.md`.
- Add an `[Unreleased]` changelog entry.

## Tests

```bash
uv sync --extra api --group dev
make check
```

Results:

- Ruff check: passed.
- Ruff format check: passed.
- Python unittest suite: `247` tests passed.
- Web lint: passed after installing web dependencies with `npm install`.

Closes #211.