### PR TITLE
ci: add codecov.yml — rich PR comments + components, no blocking thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,14 @@ Versions follow [Semantic Versioning](https://semver.org/).
   uploads `coverage/lcov.info` + `junit.xml` to Codecov under the
   `web` flag, mirroring the `api` job. The dashboard now tracks both
   suites separately.
+- CI: Codecov config landed at [`codecov.yml`](codecov.yml). PRs now
+  get a richer comment (project + patch coverage, flag and component
+  breakdowns) and `codecov/project` + `codecov/patch` status checks,
+  all set to `informational: true` — they post coverage deltas on
+  every PR but never block merging. Six components are tracked
+  individually (lookup, outputs, CLI, cache, API routes, web SPA) so
+  the dashboard surfaces where coverage shifts are happening. Hard
+  thresholds intentionally deferred until baseline stabilizes.
 - Web: header is now mobile-friendly. On screens below `sm` (640 px)
   the five export buttons collapse into a single **Export** dropdown,
   and the **Help** / **Settings** buttons render as icon-only. The

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,79 @@
+codecov:
+  require_ci_to_pass: true
+  notify:
+    wait_for_ci: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "60...90"
+
+  status:
+    project:
+      default:
+        target: auto
+        informational: true
+    patch:
+      default:
+        target: auto
+        informational: true
+
+comment:
+  layout: "header, diff, flags, components, files"
+  behavior: default
+  require_changes: false
+  show_carryforward_flags: true
+
+flags:
+  api:
+    paths:
+      - src/mgz_pkmn/
+      - api/
+    carryforward: true
+  web:
+    paths:
+      - web/src/
+    carryforward: true
+
+component_management:
+  individual_components:
+    - component_id: lookup
+      name: Lookup pipeline
+      paths:
+        - src/mgz_pkmn/lookup.py
+        - src/mgz_pkmn/sources/**
+        - src/mgz_pkmn/parser.py
+        - src/mgz_pkmn/pricing.py
+    - component_id: outputs
+      name: Outputs (xlsx / PDF / JSON)
+      paths:
+        - src/mgz_pkmn/binder.py
+        - src/mgz_pkmn/checklist.py
+        - src/mgz_pkmn/spreadsheet.py
+        - src/mgz_pkmn/set_cards.py
+        - src/mgz_pkmn/report.py
+    - component_id: cli
+      name: CLI
+      paths:
+        - src/mgz_pkmn/cli.py
+    - component_id: cache
+      name: Disk cache
+      paths:
+        - src/mgz_pkmn/cache.py
+    - component_id: api-routes
+      name: API routes
+      paths:
+        - api/**
+    - component_id: web-app
+      name: Web SPA
+      paths:
+        - web/src/**
+
+ignore:
+  - "tests/**"
+  - "web/src/test/**"
+  - "web/src/**/*.test.{ts,tsx}"
+  - "web/src/main.tsx"
+  - "web/src/vite-env.d.ts"
+  - "src/mgz_pkmn/__main__.py"
+  - "site/**"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -198,6 +198,7 @@ The Makefile at the repo root wraps the common dev commands. Run
 ```bash
 make install            # one-shot: deps + pre-commit hook
 make test               # python tests
+make coverage           # python tests under coverage; emits htmlcov/ + coverage.xml + junit.xml
 make lint               # ruff + eslint
 make format             # ruff format in-place
 make fix                # ruff --fix + ruff format
@@ -336,10 +337,17 @@ to `main`, plus a DCO check on PRs:
 
 | Job | What it checks |
 |---|---|
-| `api` | ruff lint + format check + full test suite (`src/` and `api/`), across Python 3.11 / 3.12 / 3.13 |
-| `web` | ESLint + Vitest + TypeScript build (`tsc -b && vite build`) for `web/` |
+| `api` | ruff lint + format check + full test suite (`src/` and `api/`), across Python 3.11 / 3.12 / 3.13. Uploads coverage + junit to [Codecov](https://codecov.io/gh/mgzwarrior/mgz-pkmn) on the 3.13 entry. |
+| `web` | ESLint + Vitest (with v8 coverage) + TypeScript build (`tsc -b && vite build`) for `web/`. Uploads coverage + junit to Codecov. |
 | `site` | Astro build for the marketing site (`site/`) |
 | `DCO` | Every non-merge PR commit carries a well-formed `Signed-off-by:` trailer (PRs only; advisory until added to branch protection's required-checks list) |
+
+Codecov is configured via [`codecov.yml`](../codecov.yml). Both project
+and patch status checks run as `informational: true` — they post the
+delta on every PR but never fail the build. The PR comment shows
+project + patch coverage, the per-flag breakdown (`api`, `web`), and
+per-component numbers (lookup, outputs, CLI, cache, API routes, web
+SPA). Thresholds will be revisited once we have a stable baseline.
 
 ## Changelog
 


### PR DESCRIPTION
Closes #227

## What

Adds [\`codecov.yml\`](codecov.yml) at the repo root to turn on the Codecov features that came with the uploads in #226 / #229 but weren't yet enabled. No thresholds are set — both status checks are \`informational: true\` so PRs get the delta on every commit without merge being gated on an arbitrary number.

- **Status checks** (`codecov/project`, `codecov/patch`): both `informational: true`. They post the coverage delta but always pass.
- **PR comment**: layout customized to `\"header, diff, flags, components, files\"` — shows project + patch coverage, the per-flag breakdown (`api` / `web`), and per-component numbers.
- **Flags**: \`api\` and \`web\` scoped to their owning paths with \`carryforward: true\` so a single-suite CI run doesn't drop the other flag's coverage.
- **Components** (under \`component_management\`): six logical groupings so the dashboard surfaces where coverage shifts are happening — \`lookup\`, \`outputs\`, \`cli\`, \`cache\`, \`api-routes\`, \`web-app\`.
- **Ignore list**: tests, vitest setup, \`main.tsx\`, the trivial \`__main__.py\` shim, the marketing site.

## Documentation

- [\`docs/contributing.md\`](docs/contributing.md): \`make coverage\` added to the make targets table; the CI table now explains that Codecov status checks are informational and lists what the components are.

## Why

#226 / #229 wired up the uploads but Codecov was running with defaults — basic PR comment, no component breakdown, and (importantly) status checks with default thresholds that could block PRs on noise. The right move for this stage is rich reporting **without** enforcement: developers see the signal, but the number doesn't gate merging until we have enough baseline data to set a meaningful threshold.

## How to verify

- Schema validation: \`curl --data-binary @codecov.yml https://codecov.io/validate\` returns **Valid!** (run during prep).
- Once merged and a couple of PRs land, the Codecov PR comment should show the new layout (flags + components) and the two status checks should appear as informational.

## Follow-ups

- A future issue can revisit \`informational: true\` once we have a stable baseline — convert to a hard floor or no-regression-vs-base. Not filed yet; can be opened from the dashboard observations.
- Coverage-improvement issues filed for the gaps surfaced by this work: #230 (sources), #231 (lookup orchestration), #232 (CLI), #233 (web SPA + client), #234 (interactive web components).