### PR TITLE
docs: refresh curated starter issues table

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -79,9 +79,9 @@ relevant, CHANGELOG decision).
 | Issue | What you'll do | Why it's a good starter |
 |---|---|---|
 | [#214](https://github.com/mgzwarrior/mgz-pkmn/issues/214) | Add a `make uninstall` target | One Makefile target, symmetric to `make install`. No production code touched. |
-| [#208](https://github.com/mgzwarrior/mgz-pkmn/issues/208) | Tests for `_format_bytes` / `_format_age` in `cli.py` | Pure helpers, deterministic boundaries, no fixtures or HTTP. Test-only PR. |
 | [#210](https://github.com/mgzwarrior/mgz-pkmn/issues/210) | README "Environment variables" section | Pure docs. One section, links out to `docs/cache.md` instead of duplicating content. |
-| [#211](https://github.com/mgzwarrior/mgz-pkmn/issues/211) | API `GET /version` endpoint | Two-line route mirroring the existing `/health`, one route test. Teaches the API + test pattern. |
+| [#230](https://github.com/mgzwarrior/mgz-pkmn/issues/230) | Test coverage: lookup sources (pokemontcg + TCGdex + base) | Mocked-HTTP tests against well-defined inputs/outputs. `pricecharting.py` (78% covered) is the model. Test-only PR. |
+| [#234](https://github.com/mgzwarrior/mgz-pkmn/issues/234) | Test coverage: interactive web components | Each component is a focused surface with a clear public API. `Tour.test.tsx` (98% covered) is the model for the React Testing Library + user-event pattern. Test-only PR. |
 
 Pick one, drop a comment on the issue saying you're picking it up, and
 follow the [branch naming](#branch-naming) / [opening a PR](#opening-a-pr)


### PR DESCRIPTION
Closes #236

## What

Refreshes [\`docs/contributing.md\` → Curated starter issues](https://github.com/mgzwarrior/mgz-pkmn/blob/main/docs/contributing.md#curated-starter-issues):

- **Removed:** #208 (shipped in #218 by @nvphungdev), #211 (shipped in #224 by @nitinryali).
- **Added:** #230 (lookup sources coverage), #234 (interactive web components coverage) — both newly filed test-coverage starters from the Codecov baseline analysis. Both have clear in-tree models contributors can copy (\`pricecharting.py\` at 78% for sources; \`Tour.test.tsx\` at 98% for components).

Kept #214 and #210 — still open, still on-brand.

## Why

The starter table is the public front door for first-time contributors. Listing already-shipped issues sends people on dead-end clicks; the recent coverage work surfaced two natural replacements that are test-only and pattern-matched to existing code.