### PR TITLE
build: add `make uninstall` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,9 +57,9 @@ install-hooks:  ## Install pre-commit as a uv tool and register the git hooks (p
 	uv tool run pre-commit install --hook-type commit-msg
 
 .PHONY: uninstall
-uninstall:  ## Remove the local venv and uninstall the pre-commit git hooks (inverse of `make install`). Leaves the user cache (~/.cache/mgz-pkmn) untouched.
-	-uv tool run pre-commit uninstall --hook-type commit-msg 2>/dev/null
-	-uv tool run pre-commit uninstall 2>/dev/null
+uninstall:  ## Remove the local Python venv and uninstall the pre-commit git hooks. Use `make clean` for the broader nuke (also removes web/node_modules, site/node_modules, build artifacts). Leaves the user cache ($XDG_CACHE_HOME/mgz-pkmn, default ~/.cache/mgz-pkmn) alone — wipe that with `pkmn cache clear`.
+	uv tool run pre-commit uninstall --hook-type commit-msg >/dev/null 2>&1 || true
+	uv tool run pre-commit uninstall >/dev/null 2>&1 || true
 	rm -rf .venv
 	@echo "✓ removed .venv and uninstalled pre-commit git hooks"
 

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,13 @@ install-hooks:  ## Install pre-commit as a uv tool and register the git hooks (p
 	uv tool run pre-commit install
 	uv tool run pre-commit install --hook-type commit-msg
 
+.PHONY: uninstall
+uninstall:  ## Remove the local venv and uninstall the pre-commit git hooks (inverse of `make install`). Leaves the user cache (~/.cache/mgz-pkmn) untouched.
+	-uv tool run pre-commit uninstall --hook-type commit-msg 2>/dev/null
+	-uv tool run pre-commit uninstall 2>/dev/null
+	rm -rf .venv
+	@echo "✓ removed .venv and uninstalled pre-commit git hooks"
+
 ## Dev servers
 
 .PHONY: dev

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -197,6 +197,7 @@ The Makefile at the repo root wraps the common dev commands. Run
 
 ```bash
 make install            # one-shot: deps + pre-commit hook
+make uninstall          # inverse of install: remove .venv + pre-commit hooks (leaves user cache alone)
 make test               # python tests
 make coverage           # python tests under coverage; emits htmlcov/ + coverage.xml + junit.xml
 make lint               # ruff + eslint

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -197,7 +197,7 @@ The Makefile at the repo root wraps the common dev commands. Run
 
 ```bash
 make install            # one-shot: deps + pre-commit hook
-make uninstall          # inverse of install: remove .venv + pre-commit hooks (leaves user cache alone)
+make uninstall          # remove .venv + pre-commit hooks (use `make clean` for the broader nuke incl. node_modules)
 make test               # python tests
 make coverage           # python tests under coverage; emits htmlcov/ + coverage.xml + junit.xml
 make lint               # ruff + eslint


### PR DESCRIPTION
Closes #214

## What

Adds a new `make uninstall` target — the symmetric inverse of `make install`. It removes the local `.venv` and uninstalls the pre-commit git hooks (both the `pre-commit` and `commit-msg` stages registered by `make install-hooks`). The user cache at `~/.cache/mgz-pkmn` is intentionally left alone — that's user data, managed via `pkmn cache clear`.

Also adds a one-line mention in `docs/contributing.md` next to the existing `make install` line in the dev commands cheatsheet.

## Why

Contributors who want to nuke their dev workspace (or test a fresh install) currently reach for ad-hoc `rm -rf .venv` and have to remember the pre-commit hook removal separately. A single `make uninstall` makes the teardown discoverable from `make help` and keeps it scoped to what `make install` actually created.

## How to verify

```bash
make install
test -d .venv             # exists
make uninstall
test ! -d .venv           # gone
git status                # tree clean (apart from the changes in this PR)
```

`make help` also lists the new target under the **Setup** section, right after `install-hooks`.

Acceptance criteria from #214:

- [x] `make uninstall` target exists with a `##` help comment so it shows in `make help`
- [x] Removes the venv created by `make install`
- [x] Uninstalls the pre-commit hook (silently ignores if not installed)
- [x] Does NOT touch `~/.cache/mgz-pkmn` or any user data
- [x] `docs/contributing.md` mentions it next to the install target
- [x] No CHANGELOG entry needed (devex-only, not user-facing)