### PR TITLE
docs: add "Environment variables" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,19 @@ echo 'export POKEMONTCG_IO_API_KEY=your-key-here' >> ~/.zshrc   # persistent
 
 Prefer the env var over `--api-key` — flags get saved to shell history.
 
+## Environment variables
+
+Every variable the tool reads, in one place:
+
+| Variable | Purpose |
+|---|---|
+| `POKEMONTCG_IO_API_KEY` | Raises pokemontcg.io rate limits from 1k/day to 20k/day. Free key at <https://dev.pokemontcg.io>. |
+| `MGZ_PKMN_NO_CACHE` | Disables the disk cache for the current process. The CLI's `--no-cache` flag sets this internally. |
+| `MGZ_PKMN_CACHE_WARN_BYTES` | Threshold for the cache-size soft-warn at startup (default 50 MB, `0` disables). |
+| `XDG_CACHE_HOME` | Overrides the cache root (`$XDG_CACHE_HOME/mgz-pkmn`). Standard XDG semantics. |
+
+See [docs/cache.md → Environment variables](docs/cache.md#environment-variables) for the full behavior of the cache-related vars.
+
 ## Web UI
 
 ```bash


### PR DESCRIPTION
Closes #210

## What

Adds an `## Environment variables` section to the README that lists every environment variable the tool reads, with a one-line explanation per var. Cache-related rows link out to [`docs/cache.md` → Environment variables](docs/cache.md#environment-variables) instead of duplicating the deeper table.

Vars covered:
- `POKEMONTCG_IO_API_KEY`
- `MGZ_PKMN_NO_CACHE`
- `MGZ_PKMN_CACHE_WARN_BYTES`
- `XDG_CACHE_HOME`

Placed right after the existing "API key (optional but recommended)" subsection — that's where a reader who's just set their API key naturally encounters the broader env-var picture.

## Why

Environment variables were scattered: `MGZ_PKMN_NO_CACHE` and `MGZ_PKMN_CACHE_WARN_BYTES` lived only in `docs/cache.md`; `POKEMONTCG_IO_API_KEY` was mentioned inline in the README install section; `XDG_CACHE_HOME` was in `docs/cache.md`. Anyone deploying or scripting around the tool had to hunt. Now they're all listed in one place a reader is likely to land on.

## How to verify

```bash
grep -n -E "POKEMONTCG_IO_API_KEY|XDG_CACHE|MGZ_PKMN_" README.md
```

Should show the new table rows plus the existing API-key mention in the API-key subsection. Open `README.md` in a Markdown viewer — the link to `docs/cache.md#environment-variables` should resolve to the existing source-of-truth table.

Acceptance criteria from #210:

- [x] README has a single discoverable place that names every env var the tool reads
- [x] Cache-var entries link to `docs/cache.md` for full detail (no duplication)
- [x] No CHANGELOG entry needed (docs-only)