### PR TITLE
fix(web): always render export controls as a dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,14 @@ Versions follow [Semantic Versioning](https://semver.org/).
   scrollable body keyboard-focusable so users can scroll without
   first tabbing through every dialog control.
 
+### Fixed
+
+- Web: the export controls now always render as a single "Export"
+  dropdown, with the matched-row count shown at the bottom of the
+  menu. Previously the row count appeared beneath a row of buttons
+  after a successful run, which pushed the Export controls out of
+  alignment with the other header buttons.
+
 ## [1.0.1] - 2026-05-16
 
 ### Added

--- a/web/src/components/ExportBar.test.tsx
+++ b/web/src/components/ExportBar.test.tsx
@@ -1,15 +1,102 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { ExportBar } from './ExportBar'
+import { useAppStore } from '../store'
+import type { Row } from '../types'
 
 vi.mock('../api/client', () => ({
   exportFile: vi.fn(),
   downloadSetCardsPdf: vi.fn(),
 }))
 
+/**
+ * Radix DropdownMenu opens on `pointerdown`, not on `click`, so the plain
+ * `fireEvent.click` shorthand doesn't reveal the menu in jsdom. Fire the
+ * full sequence keyboard users follow: focus the trigger and press Enter.
+ */
+function openDropdown() {
+  const trigger = screen.getByRole('button', { name: 'Export' })
+  trigger.focus()
+  fireEvent.keyDown(trigger, { key: 'Enter', code: 'Enter' })
+}
+
+function makeRow(matched: boolean): Row {
+  return {
+    query: {
+      raw: 'Pikachu | Jungle',
+      name: 'Pikachu',
+      set_hint: 'Jungle',
+      number: null,
+      variant_hint: null,
+      url_hint: null,
+      bulk_top: null,
+      bulk_all: false,
+      price_min: null,
+      price_max: null,
+    },
+    card: matched ? { id: 'jungle-60', name: 'Pikachu' } : null,
+    pricing: { market: null, variant: null, source: null, url: null, currency: 'USD' },
+    tag: '',
+    matched,
+    reason: matched ? 'matched' : 'no match',
+  }
+}
+
 describe('ExportBar', () => {
+  beforeEach(() => {
+    // Each test starts with the default empty store.
+    useAppStore.setState({ rows: [] })
+  })
+
   it('renders an Export trigger', () => {
     render(<ExportBar />)
     expect(screen.getByRole('button', { name: 'Export' })).toBeInTheDocument()
+  })
+
+  it('lists every export format when the dropdown opens', () => {
+    render(<ExportBar />)
+    openDropdown()
+    expect(screen.getByText('Download .xlsx')).toBeInTheDocument()
+    expect(screen.getByText('PDF binder')).toBeInTheDocument()
+    expect(screen.getByText('Condensed PDF')).toBeInTheDocument()
+    expect(screen.getByText('Checklist')).toBeInTheDocument()
+    expect(screen.getByText('Set ID cards')).toBeInTheDocument()
+  })
+
+  it('disables row-dependent items when no rows are matched, but keeps Set ID cards enabled', () => {
+    render(<ExportBar />)
+    openDropdown()
+
+    for (const label of ['Download .xlsx', 'PDF binder', 'Condensed PDF', 'Checklist']) {
+      const item = screen.getByText(label).closest('[role="menuitem"]')!
+      expect(item).toHaveAttribute('data-disabled')
+    }
+    const setCards = screen.getByText('Set ID cards').closest('[role="menuitem"]')!
+    expect(setCards).not.toHaveAttribute('data-disabled')
+
+    // Row count label is only shown when there are matched rows.
+    expect(screen.queryByText(/^\d+ rows?$/)).not.toBeInTheDocument()
+  })
+
+  it('enables row-dependent items and shows the row count when matches exist', () => {
+    useAppStore.setState({ rows: [makeRow(true), makeRow(true), makeRow(false)] })
+
+    render(<ExportBar />)
+    openDropdown()
+
+    for (const label of ['Download .xlsx', 'PDF binder', 'Condensed PDF', 'Checklist']) {
+      const item = screen.getByText(label).closest('[role="menuitem"]')!
+      expect(item).not.toHaveAttribute('data-disabled')
+    }
+    expect(screen.getByText('2 rows')).toBeInTheDocument()
+  })
+
+  it('uses singular "row" when exactly one match exists', () => {
+    useAppStore.setState({ rows: [makeRow(true)] })
+
+    render(<ExportBar />)
+    openDropdown()
+
+    expect(screen.getByText('1 row')).toBeInTheDocument()
   })
 })

--- a/web/src/components/ExportBar.test.tsx
+++ b/web/src/components/ExportBar.test.tsx
@@ -8,12 +8,8 @@ vi.mock('../api/client', () => ({
 }))
 
 describe('ExportBar', () => {
-  it('renders all export buttons', () => {
+  it('renders an Export trigger', () => {
     render(<ExportBar />)
-    expect(screen.getByText('Download .xlsx')).toBeInTheDocument()
-    expect(screen.getByText('PDF binder')).toBeInTheDocument()
-    expect(screen.getByText('Condensed PDF')).toBeInTheDocument()
-    expect(screen.getByText('Checklist')).toBeInTheDocument()
-    expect(screen.getByText('Set ID cards')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Export' })).toBeInTheDocument()
   })
 })

--- a/web/src/components/ExportBar.test.tsx
+++ b/web/src/components/ExportBar.test.tsx
@@ -1,13 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { ExportBar } from './ExportBar'
 import { useAppStore } from '../store'
 import type { Row } from '../types'
+import { exportFile, downloadSetCardsPdf } from '../api/client'
 
 vi.mock('../api/client', () => ({
   exportFile: vi.fn(),
   downloadSetCardsPdf: vi.fn(),
 }))
+
+const mockExportFile = vi.mocked(exportFile)
+const mockDownloadSetCardsPdf = vi.mocked(downloadSetCardsPdf)
 
 /**
  * Radix DropdownMenu opens on `pointerdown`, not on `click`, so the plain
@@ -44,8 +48,25 @@ function makeRow(matched: boolean): Row {
 
 describe('ExportBar', () => {
   beforeEach(() => {
-    // Each test starts with the default empty store.
-    useAppStore.setState({ rows: [] })
+    // Each test starts with the default empty store and fresh mocks.
+    // Zustand's persist middleware keeps prior `settings` around across
+    // tests via the in-memory localStorage stub, so we reset both slices
+    // explicitly to default values rather than relying on the initial state.
+    useAppStore.setState({
+      rows: [],
+      settings: {
+        apiKey: '',
+        maxPrice: null,
+        noImages: true,
+        tag: '',
+        dedupe: false,
+        sort: 'number',
+      },
+    })
+    mockExportFile.mockReset()
+    mockDownloadSetCardsPdf.mockReset()
+    mockExportFile.mockResolvedValue(undefined)
+    mockDownloadSetCardsPdf.mockResolvedValue(undefined)
   })
 
   it('renders an Export trigger', () => {
@@ -98,5 +119,121 @@ describe('ExportBar', () => {
     openDropdown()
 
     expect(screen.getByText('1 row')).toBeInTheDocument()
+  })
+
+  it('calls exportFile with the current rows + settings when a format is picked', async () => {
+    const rows = [makeRow(true), makeRow(true)]
+    useAppStore.setState({
+      rows,
+      settings: {
+        apiKey: 'k',
+        maxPrice: 25,
+        noImages: false,
+        tag: 'binder',
+        dedupe: true,
+        sort: 'alpha',
+      },
+    })
+
+    render(<ExportBar />)
+    openDropdown()
+    fireEvent.click(screen.getByText('Download .xlsx'))
+
+    await waitFor(() => expect(mockExportFile).toHaveBeenCalledTimes(1))
+    expect(mockExportFile).toHaveBeenCalledWith(rows, 'xlsx', {
+      maxPrice: 25,
+      title: 'binder',
+      sort: 'alpha',
+      noImages: false,
+      dedupe: true,
+    })
+  })
+
+  it('falls back to "cards" as the export title when no tag is set', async () => {
+    useAppStore.setState({ rows: [makeRow(true)] })
+
+    render(<ExportBar />)
+    openDropdown()
+    fireEvent.click(screen.getByText('PDF binder'))
+
+    await waitFor(() => expect(mockExportFile).toHaveBeenCalledTimes(1))
+    expect(mockExportFile.mock.calls[0][2]).toMatchObject({ title: 'cards' })
+  })
+
+  it('does not fire exportFile when the dropdown is opened with no matched rows', async () => {
+    render(<ExportBar />)
+    openDropdown()
+    // Item is disabled but the menuitem element still exists; clicking it
+    // should be a no-op because Radix forwards data-disabled to onSelect.
+    fireEvent.click(screen.getByText('Download .xlsx'))
+
+    // Give any stray microtasks a tick to settle.
+    await new Promise((r) => setTimeout(r, 0))
+    expect(mockExportFile).not.toHaveBeenCalled()
+  })
+
+  it('calls downloadSetCardsPdf when Set ID cards is picked, even without matched rows', async () => {
+    useAppStore.setState({
+      rows: [],
+      settings: {
+        apiKey: 'secret-key',
+        maxPrice: null,
+        noImages: true,
+        tag: '',
+        dedupe: false,
+        sort: 'number',
+      },
+    })
+
+    render(<ExportBar />)
+    openDropdown()
+    fireEvent.click(screen.getByText('Set ID cards'))
+
+    await waitFor(() => expect(mockDownloadSetCardsPdf).toHaveBeenCalledTimes(1))
+    expect(mockDownloadSetCardsPdf).toHaveBeenCalledWith('secret-key')
+  })
+
+  it('passes undefined to downloadSetCardsPdf when no API key is configured', async () => {
+    useAppStore.setState({ rows: [] })
+
+    render(<ExportBar />)
+    openDropdown()
+    fireEvent.click(screen.getByText('Set ID cards'))
+
+    await waitFor(() => expect(mockDownloadSetCardsPdf).toHaveBeenCalledTimes(1))
+    expect(mockDownloadSetCardsPdf).toHaveBeenCalledWith(undefined)
+  })
+
+  it('surfaces export errors in the bar', async () => {
+    mockExportFile.mockRejectedValueOnce(new Error('boom'))
+    useAppStore.setState({ rows: [makeRow(true)] })
+
+    render(<ExportBar />)
+    openDropdown()
+    fireEvent.click(screen.getByText('Checklist'))
+
+    expect(await screen.findByText('boom')).toBeInTheDocument()
+  })
+
+  it('stringifies non-Error rejections from the export client', async () => {
+    mockExportFile.mockRejectedValueOnce('rate-limited')
+    useAppStore.setState({ rows: [makeRow(true)] })
+
+    render(<ExportBar />)
+    openDropdown()
+    fireEvent.click(screen.getByText('Condensed PDF'))
+
+    expect(await screen.findByText('rate-limited')).toBeInTheDocument()
+  })
+
+  it('surfaces Set ID cards errors in the bar', async () => {
+    mockDownloadSetCardsPdf.mockRejectedValueOnce(new Error('catalog down'))
+    useAppStore.setState({ rows: [] })
+
+    render(<ExportBar />)
+    openDropdown()
+    fireEvent.click(screen.getByText('Set ID cards'))
+
+    expect(await screen.findByText('catalog down')).toBeInTheDocument()
   })
 })

--- a/web/src/components/ExportBar.tsx
+++ b/web/src/components/ExportBar.tsx
@@ -1,19 +1,18 @@
 /**
- * ExportBar — download buttons for xlsx, standard PDF binder, condensed PDF
- * binder, the per-tag checklist PDF, and the set identification cards PDF.
+ * ExportBar — a single "Export" dropdown that lists xlsx, standard PDF
+ * binder, condensed PDF binder, the per-tag checklist PDF, and the set
+ * identification cards PDF.
  *
- * Row-dependent buttons (xlsx/pdf/condensed-pdf/checklist) are disabled
- * until at least one matched row is available. The Set ID cards button
- * is always enabled — it fetches the full set catalog server-side and
+ * Row-dependent items (xlsx/pdf/condensed-pdf/checklist) are disabled
+ * until at least one matched row is available. The Set ID cards item is
+ * always enabled — it fetches the full set catalog server-side and
  * doesn't require any input rows.
  *
- * On screens below `sm` (640px) the row collapses into a single
- * "Export" dropdown to keep the header compact. Only one tree (desktop
- * or mobile) is mounted at a time, driven by a matchMedia subscription,
- * so tests and the dropdown Portal don't have to fight CSS visibility
- * rules to know which copy of a label is "real".
+ * The matched-row count lives at the bottom of the dropdown list so the
+ * trigger stays the same size whether or not a run has produced rows;
+ * that keeps it aligned with the other header controls.
  */
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import type { ReactNode } from 'react'
 import {
   FileSpreadsheet,
@@ -37,28 +36,10 @@ const BUTTONS: { format: ExportFormat; label: string; icon: ReactNode }[] = [
   { format: 'checklist', label: 'Checklist', icon: <ListChecks size={14} /> },
 ]
 
-// Matches Tailwind's `sm` breakpoint (640px). Anything below is mobile.
-const MOBILE_QUERY = '(max-width: 639px)'
-
-function useIsMobile(): boolean {
-  const [isMobile, setIsMobile] = useState(() => {
-    if (typeof window === 'undefined') return false
-    return window.matchMedia(MOBILE_QUERY).matches
-  })
-  useEffect(() => {
-    const mq = window.matchMedia(MOBILE_QUERY)
-    const onChange = (e: MediaQueryListEvent) => setIsMobile(e.matches)
-    mq.addEventListener('change', onChange)
-    return () => mq.removeEventListener('change', onChange)
-  }, [])
-  return isMobile
-}
-
 export function ExportBar() {
   const { rows, settings } = useAppStore()
   const [loading, setLoading] = useState<ExportFormat | 'set-cards' | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const isMobile = useIsMobile()
 
   const matchedRows = rows.filter((r) => r.matched)
   const disabled = matchedRows.length === 0
@@ -95,111 +76,59 @@ export function ExportBar() {
     }
   }
 
-  if (isMobile) {
-    return (
-      <div className="flex flex-col items-end gap-1">
-        <DropdownMenu.Root>
-          <DropdownMenu.Trigger asChild>
-            <button
-              className="flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-200 hover:bg-zinc-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-              disabled={anyLoading}
-              aria-label="Export"
-            >
-              {anyLoading ? <Loader2 size={14} className="animate-spin" /> : <Download size={14} />}
-              Export
-              <ChevronDown size={13} className="opacity-70" />
-            </button>
-          </DropdownMenu.Trigger>
-          <DropdownMenu.Portal>
-            <DropdownMenu.Content
-              align="end"
-              sideOffset={6}
-              className="z-50 min-w-[200px] rounded-md border border-zinc-700 bg-zinc-900 p-1 shadow-xl"
-            >
-              {BUTTONS.map((b) => (
-                <DropdownMenu.Item
-                  key={b.format}
-                  disabled={disabled}
-                  onSelect={() => handleExport(b.format)}
-                  className="flex items-center gap-2 rounded px-2.5 py-2 text-sm text-zinc-200 outline-none data-[highlighted]:bg-zinc-800 data-[disabled]:opacity-40 data-[disabled]:cursor-not-allowed"
-                >
-                  {b.icon}
-                  {b.label}
-                </DropdownMenu.Item>
-              ))}
-              <DropdownMenu.Separator className="my-1 h-px bg-zinc-800" />
+  return (
+    <div className="flex flex-col items-end gap-1">
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger asChild>
+          <button
+            className="flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-200 hover:bg-zinc-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            disabled={anyLoading}
+            aria-label="Export"
+          >
+            {anyLoading ? <Loader2 size={14} className="animate-spin" /> : <Download size={14} />}
+            Export
+            <ChevronDown size={13} className="opacity-70" />
+          </button>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content
+            align="end"
+            sideOffset={6}
+            className="z-50 min-w-[200px] rounded-md border border-zinc-700 bg-zinc-900 p-1 shadow-xl"
+          >
+            {BUTTONS.map((b) => (
               <DropdownMenu.Item
-                onSelect={handleSetCards}
-                className="flex items-center gap-2 rounded px-2.5 py-2 text-sm text-zinc-200 outline-none data-[highlighted]:bg-zinc-800"
+                key={b.format}
+                disabled={disabled}
+                onSelect={() => handleExport(b.format)}
+                className="flex items-center gap-2 rounded px-2.5 py-2 text-sm text-zinc-200 outline-none data-[highlighted]:bg-zinc-800 data-[disabled]:opacity-40 data-[disabled]:cursor-not-allowed"
               >
-                <Tags size={14} />
-                Set ID cards
+                {b.icon}
+                {b.label}
               </DropdownMenu.Item>
-            </DropdownMenu.Content>
-          </DropdownMenu.Portal>
-        </DropdownMenu.Root>
-        {/* Status / error lives outside the dropdown menu so it stays
-            visible after the user picks a format and the menu closes. */}
-        {matchedRows.length > 0 && !disabled && !error && (
-          <span className="text-xs text-zinc-400">
-            {matchedRows.length} row{matchedRows.length !== 1 ? 's' : ''}
-          </span>
-        )}
-        {error && <span className="text-xs text-red-400">{error}</span>}
-      </div>
-    )
-  }
-
-  return (
-    <div className="flex items-center gap-2 flex-wrap">
-      {BUTTONS.map((b) => (
-        <ExportButton
-          key={b.format}
-          label={b.label}
-          icon={b.icon}
-          loading={loading === b.format}
-          disabled={disabled || anyLoading}
-          onClick={() => handleExport(b.format)}
-        />
-      ))}
-      <ExportButton
-        label="Set ID cards"
-        icon={<Tags size={14} />}
-        loading={loading === 'set-cards'}
-        disabled={anyLoading}
-        onClick={handleSetCards}
-      />
-      {matchedRows.length > 0 && !disabled && (
-        <span className="text-xs text-zinc-400 ml-1">
-          {matchedRows.length} row{matchedRows.length !== 1 ? 's' : ''}
-        </span>
-      )}
-      {error && <span className="text-xs text-red-400 ml-1">{error}</span>}
+            ))}
+            <DropdownMenu.Separator className="my-1 h-px bg-zinc-800" />
+            <DropdownMenu.Item
+              onSelect={handleSetCards}
+              className="flex items-center gap-2 rounded px-2.5 py-2 text-sm text-zinc-200 outline-none data-[highlighted]:bg-zinc-800"
+            >
+              <Tags size={14} />
+              Set ID cards
+            </DropdownMenu.Item>
+            {matchedRows.length > 0 && (
+              <>
+                <DropdownMenu.Separator className="my-1 h-px bg-zinc-800" />
+                <DropdownMenu.Label className="px-2.5 py-1.5 text-xs text-zinc-400">
+                  {matchedRows.length} row{matchedRows.length !== 1 ? 's' : ''}
+                </DropdownMenu.Label>
+              </>
+            )}
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
+      {/* Errors live outside the dropdown so they stay visible after the
+          user picks a format and the menu closes. */}
+      {error && <span className="text-xs text-red-400">{error}</span>}
     </div>
-  )
-}
-
-function ExportButton({
-  label,
-  icon,
-  loading,
-  disabled,
-  onClick,
-}: {
-  label: string
-  icon: ReactNode
-  loading: boolean
-  disabled: boolean
-  onClick: () => void
-}) {
-  return (
-    <button
-      onClick={onClick}
-      disabled={disabled || loading}
-      className="flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-200 hover:bg-zinc-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-    >
-      {loading ? <Loader2 size={14} className="animate-spin" /> : icon}
-      {label}
-    </button>
   )
 }


### PR DESCRIPTION
Closes #251

## What

The ExportBar in the header always renders as a single "Export" dropdown
now, regardless of viewport width. The matched-row count moved from a
line beneath the button row into a small label at the bottom of the
dropdown menu.

## Why

On desktop the ExportBar used to render a row of buttons and append the
row count (`12 rows`) underneath them after a successful run. That extra
line pushed the whole control out of vertical alignment with the help
and settings buttons in the header.

Collapsing to the existing mobile dropdown (and parking the row count
inside it) keeps the trigger the same height before and after a run,
so the header stays aligned. The dropdown was already the mobile
layout, so this is mostly a deletion — the `useIsMobile` / matchMedia
switch and the inline button row are gone.

## How to verify

1. `cd web && npm run dev` and open the app.
2. Confirm the header shows a single **Export** button aligned with
   the help and settings buttons.
3. Click **Export** with no rows — every item except "Set ID cards" is
   disabled, no row count is shown.
4. Run a lookup that produces matched rows, then open **Export** again
   — the items are enabled and a `N rows` label appears at the bottom
   of the menu. The trigger button has not moved.