### PR TITLE
docs: require screenshots or Jam videos as PR verification artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,28 @@ make check
 
 ---
 
+## PR verification artifacts
+
+Every PR that is observable in the browser preview, or that fixes a
+user-reported bug (even a backend one), must include a screenshot or
+[Jam](https://jam.dev) recording in the PR body so reviewers can see
+the change without reproducing it locally.
+
+- **UI change** — drop a screenshot (or a before/after pair for
+  positional or layout fixes) under **How to verify**, or under a
+  dedicated **Proof** subsection. Upload via the GitHub PR-body image
+  picker so the asset lives on `user-images.githubusercontent.com`.
+- **Multi-step interaction** (dropdown, drawer, tour, streaming
+  results) — record a short Jam clip and paste the link.
+- **Backend bug fix** that closes a user-reported issue — paste a
+  `curl` or log artifact showing the fixed response, or a screenshot
+  of the corrected surface in the SPA.
+
+Exempt: dependency bumps, internal refactors with no behavior change,
+test-only or docs-only PRs.
+
+---
+
 ## Doc cross-link conventions
 
 When adding or changing a public-facing behaviour:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,9 +97,11 @@ make check
 ## PR verification artifacts
 
 Every PR that is observable in the browser preview, or that fixes a
-user-reported bug (even a backend one), must include a screenshot or
-[Jam](https://jam.dev) recording in the PR body so reviewers can see
-the change without reproducing it locally.
+user-reported bug (even a backend one), must include a **verification
+artifact** in the PR body — a screenshot, a [Jam](https://jam.dev)
+recording, or a `curl` / log snippet — so reviewers can see the
+change without reproducing it locally. Pick the form that matches the
+change:
 
 - **UI change** — drop a screenshot (or a before/after pair for
   positional or layout fixes) under **How to verify**, or under a
@@ -113,6 +115,11 @@ the change without reproducing it locally.
 
 Exempt: dependency bumps, internal refactors with no behavior change,
 test-only or docs-only PRs.
+
+**Required for merge.** All [CI checks](docs/contributing.md#ci) must
+be green before a PR is merged. The verification artifact requirement
+is enforced by reviewers, not by CI — a reviewer should withhold
+approval (and re-request changes) on any in-scope PR that lacks one.
 
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -191,10 +191,12 @@ and for auto-closing the issue on merge.
 ### Verification artifacts
 
 PRs that are observable in the browser preview, or that fix a
-user-reported bug (even a backend one), need a screenshot or
-[Jam](https://jam.dev) recording in the body so reviewers can see the
+user-reported bug (even a backend one), need a **verification
+artifact** in the body — a screenshot, a [Jam](https://jam.dev)
+recording, or a `curl` / log snippet — so reviewers can see the
 change without reproducing it locally. Drop it under **How to verify**
-or in a dedicated **Proof** subsection:
+or in a dedicated **Proof** subsection. Pick the form that matches the
+change:
 
 - **UI change** — paste a screenshot, or a before/after pair for
   positional and layout fixes. Use the GitHub PR-body image picker so
@@ -207,6 +209,16 @@ or in a dedicated **Proof** subsection:
 
 Exempt: dependency bumps, internal refactors with no behavior change,
 test-only or docs-only PRs.
+
+**Required for merge.** Both checks below have to clear before a PR
+can be merged:
+
+1. All [CI checks](#ci) (`api`, `web`, `site`, `DCO`, CodeQL) are
+   green.
+2. For any in-scope PR (see above), a verification artifact is in the
+   PR body. This is reviewer-enforced, not gated by CI — reviewers
+   should withhold approval and re-request changes on any in-scope PR
+   that lacks one.
 
 If you have a question before you open the PR, use [GitHub Discussions](https://github.com/mgzwarrior/mgz-pkmn/discussions) for that first-pass conversation — it keeps exploratory design talk out of the issue tracker until there is a concrete change to make.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -188,6 +188,26 @@ The PR body must still include a closing keyword (`Fixes #N`, `Closes
 #N`, `Resolves #N`) — that's what GitHub uses for the issue/PR link
 and for auto-closing the issue on merge.
 
+### Verification artifacts
+
+PRs that are observable in the browser preview, or that fix a
+user-reported bug (even a backend one), need a screenshot or
+[Jam](https://jam.dev) recording in the body so reviewers can see the
+change without reproducing it locally. Drop it under **How to verify**
+or in a dedicated **Proof** subsection:
+
+- **UI change** — paste a screenshot, or a before/after pair for
+  positional and layout fixes. Use the GitHub PR-body image picker so
+  the asset lives on `user-images.githubusercontent.com`.
+- **Multi-step interaction** (dropdown, drawer, tour, streaming
+  results) — record a short Jam clip and paste the link.
+- **Backend bug fix** that closes a user-reported issue — paste a
+  `curl` or log snippet showing the fixed response, or a screenshot
+  of the corrected surface in the SPA.
+
+Exempt: dependency bumps, internal refactors with no behavior change,
+test-only or docs-only PRs.
+
 If you have a question before you open the PR, use [GitHub Discussions](https://github.com/mgzwarrior/mgz-pkmn/discussions) for that first-pass conversation — it keeps exploratory design talk out of the issue tracker until there is a concrete change to make.
 
 ## Development


### PR DESCRIPTION
Closes #253

## What

Adds a **Verification artifacts** section to `AGENTS.md` and to
`docs/contributing.md` (under **Opening a PR**) requiring a screenshot
or [Jam](https://jam.dev) recording for any PR observable in the
browser preview or fixing a user-reported bug.

## Why

PR bodies already have a **How to verify** section, but reviewers
still have to read the steps and mentally simulate the result. A
visible artifact catches positional/layout regressions and stale-fix
regressions that the test suite can miss. Cheap for the author,
high-leverage for the reviewer.

Exemptions are listed inline: dependency bumps, internal refactors
with no behavior change, test-only or docs-only PRs.

## How to verify

1. Skim the new **PR verification artifacts** section in
   [`AGENTS.md`](AGENTS.md).
2. Skim the new **Verification artifacts** subsection inside
   **Opening a PR** in [`docs/contributing.md`](docs/contributing.md).
3. Confirm both call out the same three cases (UI, multi-step
   interaction, backend bug fix) and the same exemptions.