### PR TITLE
feat(cache): unified indefinite-TTL image cache + pkmn cache warm-sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- CLI: new `pkmn cache warm-sets` subcommand walks every Pokémon TCG set
+  and pre-downloads each set's logo + symbol into the unified disk image
+  cache. Cold warm is a single up-front cost (~30 s on a fresh install,
+  173 sets / 346 images / ~19 MB); subsequent `pkmn set-cards` runs and
+  every `/api/v1/set-cards.pdf` request serve images from cache instead of
+  the network. Second warm pass is 0.2 s — already-cached entries
+  short-circuit.
+- Cache: new indefinite-TTL image slice under `cache/images/<category>/`
+  (today: `sets/logo`, `sets/symbol`; tomorrow: card art). Survives
+  `clear_api_cache()` so wiping stale API payloads no longer re-downloads
+  tens of megabytes of stable artwork. `pkmn cache stats` surfaces the
+  slice on its own line so the on-disk cost is always visible.
 - API: new `GET /version` endpoint returns
   `{"version": "<current __version__>"}` for deploy verification,
   monitoring, and SPA footer version display.
@@ -44,6 +56,17 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Outputs: `pkmn set-cards` and `/api/v1/set-cards.pdf` now resolve set
+  logo images through the unified disk image cache instead of a bespoke
+  per-output `logos_dir`. The CLI's `--logos-dir` flag still works as a
+  sidecar mirror for users who want a writable directory alongside the
+  PDF, but the cache itself (under `cache/images/sets/`) is now the
+  source of truth. The API route's hard-coded `~/.cache/mgz-pkmn/set-logos`
+  path is gone — both surfaces share the same cache.
+- Outputs: `fetch_all_sets()` now routes the pokemontcg.io set catalog
+  through the existing API disk cache, so repeated `pkmn set-cards`
+  invocations within a week reuse the cached catalog (~61 KB) instead of
+  re-fetching the full list.
 - CI: the `api` job now runs tests under `coverage` (via `pytest`,
   which discovers the existing `unittest.TestCase` suites unchanged)
   and uploads both `coverage.xml` and `junit.xml` to

--- a/api/routes/set_cards.py
+++ b/api/routes/set_cards.py
@@ -20,12 +20,6 @@ from mgz_pkmn.sources import TCGClient
 
 router = APIRouter()
 
-# Logos are cached on disk across requests so we don't re-download the entire
-# set catalog every time someone hits this endpoint. Shared with the CLI's
-# default `--logos-dir` only when the API runs as the same user — otherwise
-# each gets its own cache, which is fine.
-_LOGOS_CACHE_DIR = Path("~/.cache/mgz-pkmn/set-logos").expanduser()
-
 
 @router.get("/set-cards.pdf")
 async def get_set_cards_pdf(
@@ -54,9 +48,12 @@ def _render(api_key: str | None, no_images: bool) -> bytes:
         raise HTTPException(status_code=502, detail=f"upstream fetch failed: {exc}") from exc
     if not sets:
         raise HTTPException(status_code=502, detail="pokemontcg.io returned no sets")
-    logos_dir = None if no_images else _LOGOS_CACHE_DIR
+    # Logo storage now flows entirely through the unified disk image cache
+    # under `cache/images/sets/`, shared with the CLI. We pass `session` so
+    # the writer can fetch on a miss; no `logos_dir` is needed (the cache
+    # path is fixed and resolved internally).
     session = None if no_images else client.session
     with tempfile.TemporaryDirectory() as tmpdir:
         out_path = Path(tmpdir) / "set-cards.pdf"
-        write_set_cards_pdf(sets, out_path, logos_dir=logos_dir, session=session)
+        write_set_cards_pdf(sets, out_path, session=session)
         return out_path.read_bytes()

--- a/src/mgz_pkmn/cache.py
+++ b/src/mgz_pkmn/cache.py
@@ -1,6 +1,6 @@
 """Disk-backed caches for mgz-pkmn.
 
-Two stores live under `$XDG_CACHE_HOME/mgz-pkmn` (or `~/.cache/mgz-pkmn`):
+Three stores live under `$XDG_CACHE_HOME/mgz-pkmn` (or `~/.cache/mgz-pkmn`):
 
 - **api/<sha1>.json** — one file per upstream API request URL. TTL is enforced
   via mtime; reads older than `DEFAULT_API_TTL_SECONDS` miss and force a
@@ -13,9 +13,17 @@ Two stores live under `$XDG_CACHE_HOME/mgz-pkmn` (or `~/.cache/mgz-pkmn`):
   up the previously-recorded one automatically. Lets the user paste a URL
   once and forget it.
 
+- **images/<category>/<key>.<ext>** — binary image blobs (set logos, set
+  symbols, card art). **No TTL.** Set images don't change once a set ships,
+  so the cost of an occasional stale image is far below the cost of
+  re-downloading the catalog every show. Cleared explicitly via
+  `clear_image_cache()`; survives `clear_api_cache()` so a "wipe stale API
+  payloads" never re-downloads tens of megabytes of stable artwork.
+
 Disk persistence is opt-out via `MGZ_PKMN_NO_CACHE=1` (the CLI's `--no-cache`
-flag sets this) so a clean run skips both stores entirely. There is no LRU
-eviction — the cache is small (KB per query) and clearing is a manual
+flag sets this) so a clean run skips every store entirely. There is no LRU
+eviction — the cache is small (KB per query for API; a few MB per warmed
+set catalog for images) and clearing is a manual
 `rm -rf ~/.cache/mgz-pkmn` away."""
 
 from __future__ import annotations
@@ -24,10 +32,15 @@ import contextlib
 import hashlib
 import json
 import os
+import re
+import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import requests
 
 DEFAULT_API_TTL_SECONDS = 7 * 24 * 60 * 60  # one week
 DEFAULT_CACHE_WARN_BYTES = 50 * 1024 * 1024  # 50 MB
@@ -35,6 +48,11 @@ _NO_CACHE_ENV = "MGZ_PKMN_NO_CACHE"
 _WARN_BYTES_ENV = "MGZ_PKMN_CACHE_WARN_BYTES"
 _OVERRIDES_FILE = "url_overrides.json"
 OVERRIDES_SCHEMA_VERSION = 1
+_IMAGES_SUBDIR = "images"
+# Allowed image extensions for read-side discovery; write-side derives the
+# extension from the source URL but normalises it through this list so an
+# unexpected suffix doesn't end up on disk.
+_IMAGE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".webp", ".svg")
 
 # Per-run counters for the API response cache: hits = served from disk,
 # fetches = written after a successful network call. Reset at the start of
@@ -48,7 +66,12 @@ class CacheStats:
     """Snapshot of disk-cache usage. Returned by `stats()` for the CLI to render.
 
     `api_oldest_mtime` is None when the API cache holds no entries — callers
-    should treat that as "no oldest" rather than an unfilled field."""
+    should treat that as "no oldest" rather than an unfilled field.
+
+    `image_entry_count` / `image_bytes` cover the indefinite-TTL image slice
+    (set logos, set symbols, card art). They live in their own bucket because
+    they survive `clear_api_cache()` and tend to dominate the total once a
+    set catalog has been warmed."""
 
     root: Path
     api_entry_count: int
@@ -56,6 +79,8 @@ class CacheStats:
     api_oldest_mtime: float | None
     override_count: int
     override_bytes: int
+    image_entry_count: int
+    image_bytes: int
 
 
 def _disabled() -> bool:
@@ -102,7 +127,7 @@ def cache_warn_threshold() -> int:
 
 
 def cache_size_bytes() -> int:
-    """Total on-disk cache size in bytes (API responses + URL overrides file).
+    """Total on-disk cache size in bytes (API + URL overrides + images).
 
     Stat-only — no payload reads, no JSON parsing, and no side effects: the
     cache directory is not created if it doesn't exist yet. Safe to call at
@@ -126,6 +151,18 @@ def cache_size_bytes() -> int:
     overrides = root / _OVERRIDES_FILE
     with contextlib.suppress(OSError):
         total += overrides.stat().st_size
+    images_dir = root / _IMAGES_SUBDIR
+    if images_dir.exists():
+        # Image cache is one level deeper than `api/`: `images/<category>/...`.
+        # `rglob("*")` is fine here because the dir tree is shallow (categories
+        # + leaf files) and the stat-only walk costs O(entries).
+        try:
+            entries = [p for p in images_dir.rglob("*") if p.is_file()]
+        except OSError:
+            entries = []
+        for entry in entries:
+            with contextlib.suppress(OSError):
+                total += entry.stat().st_size
     return total
 
 
@@ -334,6 +371,184 @@ def list_url_overrides() -> dict[str, str]:
 
 
 # ---------------------------------------------------------------------------
+# Image cache (indefinite TTL — set logos, set symbols, card art).
+# ---------------------------------------------------------------------------
+
+
+def _safe_image_key(key: str) -> str:
+    """Sanitise an arbitrary key (e.g. a set id like `sv8`) into a filename.
+
+    Set ids from the upstream sources are already mostly safe, but a handful
+    use slashes or punctuation; we collapse anything outside `[A-Za-z0-9_-]`
+    to a single underscore so the filesystem layout stays predictable."""
+    safe = re.sub(r"[^a-zA-Z0-9_-]+", "_", key.strip())
+    return safe or "image"
+
+
+def _normalise_image_extension(url_or_ext: str) -> str:
+    """Return an allowed extension (`.png` by default) for a URL or raw ext.
+
+    The cache only stores formats we can serve back as-is to the writers
+    (PIL + reportlab). Anything outside `_IMAGE_EXTENSIONS` falls back to
+    `.png` — the writers handle PNG universally and the original bytes
+    survive intact, so a wrong extension just hurts content-type guessing,
+    not correctness."""
+    candidate = url_or_ext.strip().lower()
+    if "?" in candidate:
+        candidate = candidate.split("?", 1)[0]
+    if "/" in candidate:
+        candidate = Path(candidate).suffix
+    if not candidate.startswith("."):
+        candidate = f".{candidate}" if candidate else ".png"
+    return candidate if candidate in _IMAGE_EXTENSIONS else ".png"
+
+
+def _image_dir(category: str) -> Path:
+    """Return the directory holding cached images for `category`, creating it.
+
+    `category` is a slash-free string like `"sets/logo"` or `"sets/symbol"`.
+    Nested categories are allowed; the slash drives the on-disk layout."""
+    parts = [p for p in category.split("/") if p]
+    target = cache_root().joinpath(_IMAGES_SUBDIR, *parts)
+    target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def read_image(category: str, key: str) -> Path | None:
+    """Return the path of a cached image for `(category, key)` if present.
+
+    No TTL check: presence on disk is sufficient. Discovers any allowed
+    extension so callers don't have to know whether the original was PNG
+    vs. JPG — the first match wins. Returns None when the cache is disabled
+    via `MGZ_PKMN_NO_CACHE`, when the directory doesn't exist yet, or when
+    no file matches."""
+    if _disabled():
+        return None
+    parts = [p for p in category.split("/") if p]
+    target_dir = _cache_root_path().joinpath(_IMAGES_SUBDIR, *parts)
+    if not target_dir.exists():
+        return None
+    safe = _safe_image_key(key)
+    for ext in _IMAGE_EXTENSIONS:
+        candidate = target_dir / f"{safe}{ext}"
+        if candidate.exists() and candidate.stat().st_size > 0:
+            return candidate
+    return None
+
+
+def write_image(category: str, key: str, content: bytes, *, ext: str = ".png") -> Path | None:
+    """Persist `content` bytes for `(category, key)` and return the written path.
+
+    Atomic write: bytes go to a sibling `.tmp` file and rename into place,
+    so a partial download never produces a half-written cache entry. A
+    failing write is silently dropped (returns None) — the caller treats
+    the cache as best-effort.
+
+    `ext` is the file extension; pass the original URL extension when
+    available so the on-disk layout mirrors the source format. Unknown
+    extensions are normalised to `.png` (see `_normalise_image_extension`).
+    """
+    if _disabled() or not content:
+        return None
+    safe = _safe_image_key(key)
+    safe_ext = _normalise_image_extension(ext)
+    target = _image_dir(category) / f"{safe}{safe_ext}"
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    try:
+        tmp.write_bytes(content)
+        tmp.replace(target)
+    except OSError:
+        with contextlib.suppress(OSError):
+            tmp.unlink()
+        return None
+    return target
+
+
+def download_and_cache_image(
+    category: str,
+    key: str,
+    url: str,
+    session: requests.Session,
+    *,
+    timeout: float = 30.0,
+) -> Path | None:
+    """Return a cached image path, downloading via `session` on a miss.
+
+    Cache-aside: a hit returns immediately without touching the network;
+    a miss fetches the URL, persists the bytes through `write_image`, and
+    returns the new path. A network failure logs to stderr (consistent
+    with `images.download_image`) and returns None, leaving the cache
+    untouched. The extension is derived from the URL so PNGs stay PNGs."""
+    cached = read_image(category, key)
+    if cached is not None:
+        return cached
+    if _disabled():
+        return None
+    # Local import to keep `requests` out of the cache module's import-time
+    # surface — callers already depend on it, and tests can mock it out.
+    import requests as _requests
+
+    try:
+        resp = session.get(url, timeout=timeout)
+        resp.raise_for_status()
+    except _requests.RequestException as exc:
+        print(f"  ! image download failed for {url}: {exc}", file=sys.stderr)
+        return None
+    return write_image(category, key, resp.content, ext=url)
+
+
+def clear_image_cache() -> int:
+    """Remove every cached image. Returns the number of files deleted.
+
+    Honoured even when `MGZ_PKMN_NO_CACHE=1` is set — same rationale as
+    `clear_api_cache`: the user explicitly asked for a wipe.
+
+    Distinct from `clear_api_cache` on purpose. Image entries are indefinite
+    and tend to dominate disk usage once a catalog has been warmed; the user
+    should opt into evicting them rather than losing them every time stale
+    API payloads need clearing."""
+    images_dir = _cache_root_path() / _IMAGES_SUBDIR
+    if not images_dir.exists():
+        return 0
+    count = 0
+    for entry in images_dir.rglob("*"):
+        if not entry.is_file():
+            continue
+        try:
+            entry.unlink()
+            count += 1
+        except OSError:
+            continue
+    # Best-effort prune of now-empty category directories so subsequent
+    # `stats()` doesn't show ghost entries.
+    for sub in sorted(images_dir.rglob("*"), reverse=True):
+        if sub.is_dir():
+            with contextlib.suppress(OSError):
+                sub.rmdir()
+    return count
+
+
+def image_cache_size() -> tuple[int, int]:
+    """Return `(entry_count, total_bytes)` for the image cache.
+
+    Stat-only walk, mirrors `cache_size_bytes` for the API slice. Used by
+    `stats()` to populate the dataclass and by `cache warm-sets` to report
+    how much the warm pass cost on disk."""
+    images_dir = _cache_root_path() / _IMAGES_SUBDIR
+    if not images_dir.exists():
+        return 0, 0
+    count = 0
+    total = 0
+    for entry in images_dir.rglob("*"):
+        if not entry.is_file():
+            continue
+        with contextlib.suppress(OSError):
+            total += entry.stat().st_size
+            count += 1
+    return count, total
+
+
+# ---------------------------------------------------------------------------
 # Stats — health snapshot for `pkmn cache stats`.
 # ---------------------------------------------------------------------------
 
@@ -378,6 +593,8 @@ def stats() -> CacheStats:
             # Malformed file — report bytes (if we got them) but no entries.
             pass
 
+    image_count, image_bytes = image_cache_size()
+
     return CacheStats(
         root=root,
         api_entry_count=api_count,
@@ -385,4 +602,6 @@ def stats() -> CacheStats:
         api_oldest_mtime=api_oldest,
         override_count=override_count,
         override_bytes=override_bytes,
+        image_entry_count=image_count,
+        image_bytes=image_bytes,
     )

--- a/src/mgz_pkmn/cache.py
+++ b/src/mgz_pkmn/cache.py
@@ -406,8 +406,12 @@ def _normalise_image_extension(url_or_ext: str) -> str:
 def _image_dir(category: str) -> Path:
     """Return the directory holding cached images for `category`, creating it.
 
-    `category` is a slash-free string like `"sets/logo"` or `"sets/symbol"`.
-    Nested categories are allowed; the slash drives the on-disk layout."""
+    `category` is a slash-delimited category path: each `/`-separated
+    segment becomes a subdirectory under `cache/images/`. So `"sets/logo"`
+    maps onto `cache/images/sets/logo/` and `"sets/symbol"` onto
+    `cache/images/sets/symbol/`. Empty segments (leading/trailing/double
+    slashes) are dropped, and a single-segment category like `"avatars"`
+    is just as valid as a nested one."""
     parts = [p for p in category.split("/") if p]
     target = cache_root().joinpath(_IMAGES_SUBDIR, *parts)
     target.mkdir(parents=True, exist_ok=True)
@@ -421,7 +425,12 @@ def read_image(category: str, key: str) -> Path | None:
     extension so callers don't have to know whether the original was PNG
     vs. JPG — the first match wins. Returns None when the cache is disabled
     via `MGZ_PKMN_NO_CACHE`, when the directory doesn't exist yet, or when
-    no file matches."""
+    no file matches.
+
+    TOCTOU-safe: the file may be deleted between the existence check and
+    the size check (concurrent `clear_image_cache`, external cleanup,
+    network filesystem hiccup), so we swallow `OSError` from the stat and
+    treat a vanished file the same as a missing one."""
     if _disabled():
         return None
     parts = [p for p in category.split("/") if p]
@@ -431,8 +440,13 @@ def read_image(category: str, key: str) -> Path | None:
     safe = _safe_image_key(key)
     for ext in _IMAGE_EXTENSIONS:
         candidate = target_dir / f"{safe}{ext}"
-        if candidate.exists() and candidate.stat().st_size > 0:
-            return candidate
+        try:
+            if candidate.is_file() and candidate.stat().st_size > 0:
+                return candidate
+        except OSError:
+            # File vanished between the check and the stat (or stat itself
+            # failed transiently). Treat as miss and try the next extension.
+            continue
     return None
 
 

--- a/src/mgz_pkmn/cli.py
+++ b/src/mgz_pkmn/cli.py
@@ -23,7 +23,7 @@ from .lookup import find_card, find_top_cards
 from .parser import CardQuery, read_input
 from .pricing import Pricing, extract_pricing
 from .report import build_json_report
-from .set_cards import fetch_all_sets, write_set_cards_pdf
+from .set_cards import fetch_all_sets, warm_set_images, write_set_cards_pdf
 from .sorting import DEFAULT_SORT, SORT_MODES, sort_rows
 from .sources import PriceChartingClient, TCGClient, TCGDexClient
 from .sources.base import MatchResult
@@ -957,7 +957,7 @@ def cache_stats_command(as_json: bool) -> None:
         click.echo(json.dumps(payload, indent=2))
         return
 
-    total_bytes = s.api_bytes + s.override_bytes
+    total_bytes = s.api_bytes + s.override_bytes + s.image_bytes
 
     _print_section("Cache stats")
     click.echo("  " + click.style("Location:      ", fg="bright_black") + str(s.root))
@@ -977,6 +977,73 @@ def cache_stats_command(as_json: bool) -> None:
         + click.style("URL overrides: ", fg="bright_black")
         + f"{s.override_count} entries · {_format_bytes(s.override_bytes)}"
     )
+    # Indefinite-TTL slice (set logos, set symbols, future card art). Lives
+    # in its own line so it's visible even when zero — when it's non-zero
+    # it tends to dominate the total and the user should see why.
+    click.echo(
+        "  "
+        + click.style("Images:        ", fg="bright_black")
+        + f"{s.image_entry_count} entries · {_format_bytes(s.image_bytes)} · indefinite TTL"
+    )
+
+
+@cache_group.command(name="warm-sets", context_settings={"help_option_names": ["-h", "--help"]})
+@click.option(
+    "--api-key",
+    envvar="POKEMONTCG_IO_API_KEY",
+    default=None,
+    help="pokemontcg.io API key (or set POKEMONTCG_IO_API_KEY).",
+)
+@click.option("-v", "--verbose", is_flag=True, help="Print each set as it warms.")
+def cache_warm_sets_command(api_key: str | None, verbose: bool) -> None:
+    """Pre-download every set's logo + symbol into the unified image cache.
+
+    Walks the pokemontcg.io set catalog (~200+ sets) and persists each
+    logo + symbol into `cache/images/sets/` with no TTL — so the first
+    `pkmn set-cards` (or web Set ID cards) run after a fresh install
+    serves every image from disk instead of the network. Re-running is
+    cheap: already-cached entries short-circuit on hit.
+
+    Pairs with `pkmn cache stats`, which surfaces the indefinite-TTL
+    image slice on its own line."""
+    _print_banner(__version__)
+
+    _print_section("Warming set image cache")
+    client = TCGClient(api_key=api_key, verbose=verbose)
+
+    def _progress(index: int, total: int, set_id: str) -> None:
+        if not verbose:
+            return
+        click.echo(
+            click.style(f"  [{index}/{total}] ", fg="bright_black") + set_id,
+            err=False,
+        )
+
+    try:
+        result = warm_set_images(client, on_progress=_progress)
+    except requests.RequestException as exc:
+        raise click.ClickException(f"set fetch failed: {exc}") from exc
+
+    if result.sets == 0:
+        raise click.ClickException("pokemontcg.io returned no sets")
+
+    click.secho("  ✓ ", fg="green", nl=False)
+    click.echo(
+        f"{result.sets} sets · "
+        + click.style(f"{result.logos_cached} logos", fg="cyan")
+        + " · "
+        + click.style(f"{result.symbols_cached} symbols", fg="cyan")
+        + (click.style(f" · {result.failures} failures", fg="yellow") if result.failures else "")
+    )
+
+    # Render the post-warm stats inline so the user can see the on-disk cost
+    # immediately without running `pkmn cache stats` separately.
+    count, total_bytes = disk_cache.image_cache_size()
+    click.secho("  ✓ ", fg="green", nl=False)
+    click.echo(f"image cache now {count} entries · {_format_bytes(total_bytes)}")
+
+    click.echo()
+    click.secho("Done!", fg="green", bold=True)
 
 
 if __name__ == "__main__":

--- a/src/mgz_pkmn/set_cards.py
+++ b/src/mgz_pkmn/set_cards.py
@@ -8,13 +8,22 @@ binder is self-labelling.
 The CLI subcommand `pkmn set-cards` fetches the full set catalog from
 pokemontcg.io and emits a cutout for every one of them. The API route
 `GET /api/v1/set-cards.pdf` uses the same code path.
+
+Set images (logos + symbols) flow through the unified disk image cache
+(`mgz_pkmn.cache.download_and_cache_image`) under category `sets/logo` /
+`sets/symbol`. They have no TTL — set art doesn't change once a set ships
+and re-downloading 200+ logos every time someone hits this endpoint is the
+single most painful path in the tool. `pkmn cache warm-sets` primes the
+cache in one pass so the first export request after install is fast.
 """
 
 from __future__ import annotations
 
 import datetime as _dt
 import re
+import shutil
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -24,8 +33,16 @@ from reportlab.lib.units import inch
 from reportlab.lib.utils import ImageReader
 from reportlab.pdfgen import canvas
 
+from . import cache as disk_cache
 from .images import download_image
 from .sources import TCGClient
+
+# Unified cache categories for set art. Two slots per set — the logo is the
+# big wordmark used in cutouts and the picker UI; the symbol is the tiny
+# corner glyph reserved for future surfaces (e.g. the per-row set chip in
+# the results table).
+_LOGO_CATEGORY = "sets/logo"
+_SYMBOL_CATEGORY = "sets/symbol"
 
 PAGE_W, PAGE_H = letter  # 612 x 792 pt
 CARD_W = 2.5 * inch
@@ -43,15 +60,39 @@ LOGO_BOX_RATIO = 0.50  # share of cell height reserved for logo art
 TEXT_BLOCK_GAP = 8
 
 
+@dataclass(frozen=True)
+class WarmResult:
+    """Outcome of a `warm_set_images` run.
+
+    `sets` is the number of sets walked; `logos_cached` / `symbols_cached`
+    are the per-kind success counts (already-cached entries count as
+    successes — they did not need a new fetch); `failures` is the number
+    of image URLs the warm pass could not download (logged to stderr by
+    `download_and_cache_image`). Returned by the CLI's `pkmn cache warm-sets`
+    for the summary line."""
+
+    sets: int
+    logos_cached: int
+    symbols_cached: int
+    failures: int
+
+
 def fetch_all_sets(client: TCGClient) -> list[dict[str, Any]]:
     """Return every Pokémon TCG set on pokemontcg.io, sorted oldest → newest.
 
     Each dict has at minimum: id, name. Optionally: series, total,
-    printedTotal, releaseDate, images.{logo,symbol}."""
+    printedTotal, releaseDate, images.{logo,symbol}.
+
+    The raw response is routed through the API disk cache (same path the
+    per-card lookup uses), so repeated `pkmn set-cards` invocations within
+    a week reuse the cached catalog instead of re-fetching the full list."""
     url = "https://api.pokemontcg.io/v2/sets?orderBy=releaseDate&pageSize=250"
-    resp = client.session.get(url, timeout=30)
-    resp.raise_for_status()
-    raw = resp.json().get("data", [])
+    raw = disk_cache.read_api(url)
+    if raw is None:
+        resp = client.session.get(url, timeout=30)
+        resp.raise_for_status()
+        raw = resp.json().get("data", [])
+        disk_cache.write_api(url, raw)
     return [
         {
             "id": s.get("id"),
@@ -86,7 +127,12 @@ def write_set_cards_pdf(
     today = today or _dt.date.today()
     cutouts = [_normalize(s, today) for s in sets]
 
-    if logos_dir is not None and session is not None:
+    # `session is not None` is the canonical "fetch images" switch — the
+    # unified disk cache covers the storage half, so a caller can drop
+    # `logos_dir` entirely and still get cache-hit images. `logos_dir` is
+    # kept as an optional sidecar mirror for users who want a writable
+    # directory of logos alongside the PDF.
+    if session is not None:
         for co in cutouts:
             co["logo_path"] = _fetch_logo(co["logo_url"], co["set_id"], logos_dir, session)
 
@@ -132,16 +178,97 @@ def _release_year(release_date: str | None) -> str | None:
 
 
 def _fetch_logo(
-    url: str | None, set_id: str, logos_dir: Path, session: requests.Session
+    url: str | None,
+    set_id: str,
+    logos_dir: Path | None,
+    session: requests.Session,
 ) -> Path | None:
+    """Resolve a usable on-disk path for the set's logo image.
+
+    Cache-aside: the canonical store is the unified image cache
+    (`cache/images/sets/logo/<set_id>.<ext>`). On a hit we return the
+    cached path; on a miss we download once and persist there.
+
+    `logos_dir` is kept for back-compat with the CLI's `--logos-dir`
+    option (and a few existing tests that expect a writable sidecar
+    directory): when callers pass one, we copy the cached file into it
+    after the cache resolves. That keeps `output/images/set-logos/` a
+    usable artifact for archival without making it the source of truth."""
     if not url:
         return None
-    safe = re.sub(r"[^a-zA-Z0-9_-]+", "_", set_id) or "set"
-    ext = Path(url).suffix or ".png"
-    dest = logos_dir / f"{safe}{ext}"
-    if download_image(url, dest, session):
-        return dest
-    return None
+    cached = disk_cache.download_and_cache_image(_LOGO_CATEGORY, set_id, url, session)
+    if cached is None:
+        # Cache is disabled (MGZ_PKMN_NO_CACHE=1) or the download itself
+        # failed. Fall back to the legacy per-output `logos_dir` path so
+        # `--no-cache` runs still produce art when they can.
+        if logos_dir is None:
+            return None
+        safe = re.sub(r"[^a-zA-Z0-9_-]+", "_", set_id) or "set"
+        ext = Path(url).suffix or ".png"
+        dest = logos_dir / f"{safe}{ext}"
+        return dest if download_image(url, dest, session) else None
+    if logos_dir is not None:
+        try:
+            logos_dir.mkdir(parents=True, exist_ok=True)
+            sidecar = logos_dir / cached.name
+            if not sidecar.exists() or sidecar.stat().st_size == 0:
+                shutil.copyfile(cached, sidecar)
+        except OSError as exc:
+            print(f"  ! logos_dir mirror failed for {set_id}: {exc}", file=sys.stderr)
+    return cached
+
+
+def warm_set_images(
+    client: TCGClient,
+    *,
+    sets: list[dict[str, Any]] | None = None,
+    on_progress: Any | None = None,
+) -> WarmResult:
+    """Pre-download every set's logo + symbol into the unified image cache.
+
+    Walks `pokemontcg.io`'s set catalog (or the supplied `sets` list, useful
+    for tests) and fetches every available image into the cache under
+    `sets/logo` and `sets/symbol`. Already-cached entries are short-circuited
+    by `download_and_cache_image` so a second warm pass is effectively free.
+
+    `on_progress`, when provided, is invoked once per set with
+    `(index, total, set_id)` for callers that want to render a progress
+    bar. The function is otherwise quiet (the underlying download helper
+    logs failures to stderr)."""
+    sets_list = sets if sets is not None else fetch_all_sets(client)
+    total = len(sets_list)
+    logos_cached = 0
+    symbols_cached = 0
+    failures = 0
+    for index, s in enumerate(sets_list, start=1):
+        set_id = s.get("id") or s.get("name") or ""
+        if not set_id:
+            continue
+        if on_progress is not None:
+            on_progress(index, total, set_id)
+        images = s.get("images") or {}
+        logo_url = images.get("logo")
+        symbol_url = images.get("symbol")
+        if logo_url:
+            if disk_cache.download_and_cache_image(
+                _LOGO_CATEGORY, set_id, logo_url, client.session
+            ):
+                logos_cached += 1
+            else:
+                failures += 1
+        if symbol_url:
+            if disk_cache.download_and_cache_image(
+                _SYMBOL_CATEGORY, set_id, symbol_url, client.session
+            ):
+                symbols_cached += 1
+            else:
+                failures += 1
+    return WarmResult(
+        sets=total,
+        logos_cached=logos_cached,
+        symbols_cached=symbols_cached,
+        failures=failures,
+    )
 
 
 def _draw_cutout(c: canvas.Canvas, x: float, y: float, co: dict[str, Any]) -> None:

--- a/src/mgz_pkmn/set_cards.py
+++ b/src/mgz_pkmn/set_cards.py
@@ -26,6 +26,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 import requests
 from reportlab.lib.pagesizes import letter
@@ -118,9 +119,20 @@ def write_set_cards_pdf(
 ) -> int:
     """Render one cutout per set to a PDF. Returns the count written.
 
-    `logos_dir` + `session` enable set-logo downloading & caching to disk.
-    Pass both as None to render the cutouts text-only (used in tests, and
-    by the CLI's `--no-images` mode)."""
+    `session` is the canonical "fetch images" switch. When provided, the
+    writer resolves each set's logo through the unified disk image cache
+    (`cache/images/sets/logo/<id>.<ext>`) — already-cached logos are
+    served from disk; misses fetch via `session` and persist there.
+
+    `logos_dir` is optional. When passed alongside `session`, the cached
+    logo is mirrored into that directory as a writable sidecar (legacy
+    back-compat with the CLI's `--logos-dir` flag). When omitted, the
+    cache is the only on-disk store, which is what the FastAPI route
+    wants.
+
+    Passing `session=None` renders the cutouts text-only (no logo
+    fetches, no cache writes) — used by tests and by the CLI's
+    `--no-images` mode."""
     if not sets:
         return 0
 
@@ -204,7 +216,10 @@ def _fetch_logo(
         if logos_dir is None:
             return None
         safe = re.sub(r"[^a-zA-Z0-9_-]+", "_", set_id) or "set"
-        ext = Path(url).suffix or ".png"
+        # Strip the query string before deriving the extension — a URL
+        # like `…/logo.png?x=1` otherwise yields a `.png?x=1` suffix and
+        # an unusable filename in `logos_dir`.
+        ext = Path(urlsplit(url).path).suffix or ".png"
         dest = logos_dir / f"{safe}{ext}"
         return dest if download_image(url, dest, session) else None
     if logos_dir is not None:
@@ -247,8 +262,13 @@ def warm_set_images(
         if on_progress is not None:
             on_progress(index, total, set_id)
         images = s.get("images") or {}
-        logo_url = images.get("logo")
         symbol_url = images.get("symbol")
+        # Mirror `_normalize`'s logo→symbol fallback so the writer's
+        # `_fetch_logo` lookup against `sets/logo` lands a cache hit for
+        # sets that only ship a symbol image. Without this fallback, a
+        # warmed cache could still trigger a re-download in
+        # `write_set_cards_pdf` for those sets.
+        logo_url = images.get("logo") or symbol_url
         if logo_url:
             if disk_cache.download_and_cache_image(
                 _LOGO_CATEGORY, set_id, logo_url, client.session

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -477,6 +477,62 @@ class DownloadAndCacheImageTests(_IsolatedCacheDirMixin):
         self.assertIsNone(cache.read_image("sets/logo", "sv8"))
 
 
+class ImageCacheEdgeCaseTests(_IsolatedCacheDirMixin):
+    def test_safe_image_key_empty_falls_back_to_default(self) -> None:
+        # An empty (or whitespace-only) key collapses to "image" rather than
+        # producing a hidden dot-prefixed file like `.png`. Non-empty but
+        # all-punctuation keys collapse to `_` via the regex sub.
+        path_blank = cache.write_image("sets/logo", "   ", b"data")
+        self.assertIsNotNone(path_blank)
+        self.assertTrue(path_blank.name.startswith("image"))  # type: ignore[union-attr]
+        path_punct = cache.write_image("sets/logo", "!!!", b"other")
+        self.assertIsNotNone(path_punct)
+        self.assertEqual(path_punct.name, "_.png")  # type: ignore[union-attr]
+
+    def test_read_image_returns_none_when_dir_missing(self) -> None:
+        # Cache root exists (touched by setUp via overrides path) but the
+        # `images/` subdir was never created — read should short-circuit.
+        self.assertIsNone(cache.read_image("sets/logo", "anything"))
+
+    def test_zero_byte_file_is_treated_as_missing(self) -> None:
+        # An interrupted write that left a zero-byte file shouldn't poison
+        # the cache — the next read must fall through to a fresh fetch.
+        target = cache._image_dir("sets/logo") / "ghost.png"
+        target.write_bytes(b"")
+        self.assertIsNone(cache.read_image("sets/logo", "ghost"))
+
+    def test_write_returns_none_when_filesystem_errors(self) -> None:
+        # Simulate a transient OS write error during the rename step. The
+        # function should swallow it and return None rather than crash the
+        # caller, and no half-written temp should be left behind.
+        from unittest.mock import patch as _patch
+
+        with _patch("pathlib.Path.replace", side_effect=OSError("disk full")):
+            self.assertIsNone(cache.write_image("sets/logo", "x", b"bytes"))
+        # And the temp file is cleaned up so the next attempt sees an empty
+        # category dir.
+        leftovers = list((cache.cache_root() / "images").rglob("*"))
+        self.assertEqual([p.name for p in leftovers if p.is_file()], [])
+
+
+class ClearImageCacheEdgeCaseTests(_IsolatedCacheDirMixin):
+    def test_clear_returns_zero_when_no_image_dir(self) -> None:
+        # Fresh cache with no `images/` subdir — clear is a no-op, not an
+        # error.
+        self.assertEqual(cache.clear_image_cache(), 0)
+
+    def test_clear_removes_nested_category_dirs(self) -> None:
+        # After clear, the category subdirectories should be pruned so
+        # subsequent `stats()` doesn't show ghost entries.
+        cache.write_image("sets/logo", "a", b"x")
+        cache.write_image("sets/symbol", "b", b"y")
+        cache.clear_image_cache()
+        images_dir = cache.cache_root() / "images"
+        # The leaf categories should be gone.
+        self.assertFalse((images_dir / "sets" / "logo").exists())
+        self.assertFalse((images_dir / "sets" / "symbol").exists())
+
+
 class ImageCacheStatsAndClearTests(_IsolatedCacheDirMixin):
     def test_size_and_count_reflect_writes(self) -> None:
         cache.write_image("sets/logo", "a", b"abcdef")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -367,5 +367,158 @@ class UrlOverrideSchemaTests(_IsolatedCacheDirMixin):
         self.assertEqual(cache.stats().override_count, 2)
 
 
+# ---------------------------------------------------------------------------
+# Image cache (indefinite TTL) — set logos, set symbols, future card art.
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Stand-in for `requests.Response` with just the bits the cache needs."""
+
+    def __init__(self, content: bytes, status: int = 200) -> None:
+        self.content = content
+        self.status_code = status
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            import requests as _r
+
+            raise _r.HTTPError(f"HTTP {self.status_code}")
+
+
+class _FakeSession:
+    """Minimal session stub. `responses` is a URL → bytes (or exception) map."""
+
+    def __init__(self, responses: dict[str, bytes | Exception]) -> None:
+        self.responses = responses
+        self.calls: list[str] = []
+
+    def get(self, url: str, timeout: float | None = None) -> _FakeResponse:
+        self.calls.append(url)
+        result = self.responses.get(url)
+        if isinstance(result, Exception):
+            raise result
+        if result is None:
+            return _FakeResponse(b"", status=404)
+        return _FakeResponse(result, status=200)
+
+
+class ImageCacheRoundTripTests(_IsolatedCacheDirMixin):
+    def test_write_then_read_returns_path(self) -> None:
+        path = cache.write_image("sets/logo", "sv8", b"PNGDATA", ext=".png")
+        self.assertIsNotNone(path)
+        self.assertTrue(path.exists())  # type: ignore[union-attr]
+        self.assertEqual(path.read_bytes(), b"PNGDATA")  # type: ignore[union-attr]
+
+        found = cache.read_image("sets/logo", "sv8")
+        self.assertEqual(found, path)
+
+    def test_read_returns_none_when_missing(self) -> None:
+        self.assertIsNone(cache.read_image("sets/logo", "nope"))
+
+    def test_read_finds_any_allowed_extension(self) -> None:
+        cache.write_image("sets/symbol", "base1", b"data", ext=".jpg")
+        found = cache.read_image("sets/symbol", "base1")
+        self.assertIsNotNone(found)
+        self.assertEqual(found.suffix, ".jpg")  # type: ignore[union-attr]
+
+    def test_unknown_extension_falls_back_to_png(self) -> None:
+        path = cache.write_image("sets/logo", "x", b"bytes", ext=".bogus")
+        self.assertIsNotNone(path)
+        self.assertEqual(path.suffix, ".png")  # type: ignore[union-attr]
+
+    def test_safe_image_key_strips_unsafe_chars(self) -> None:
+        # Keys with slashes / spaces / punctuation must collapse to safe names
+        # so no surprise subdirs sneak in via category-tunneling.
+        path = cache.write_image("sets/logo", "weird id / with spaces!", b"x")
+        self.assertIsNotNone(path)
+        self.assertNotIn("/", path.name)  # type: ignore[union-attr]
+        self.assertNotIn(" ", path.name)  # type: ignore[union-attr]
+
+    def test_write_is_noop_when_cache_disabled(self) -> None:
+        os.environ[cache._NO_CACHE_ENV] = "1"
+        self.assertIsNone(cache.write_image("sets/logo", "x", b"bytes"))
+
+    def test_read_returns_none_when_cache_disabled(self) -> None:
+        cache.write_image("sets/logo", "x", b"bytes")
+        os.environ[cache._NO_CACHE_ENV] = "1"
+        self.assertIsNone(cache.read_image("sets/logo", "x"))
+
+
+class DownloadAndCacheImageTests(_IsolatedCacheDirMixin):
+    def test_miss_downloads_and_persists(self) -> None:
+        session = _FakeSession({"https://example/logo.png": b"PNGBYTES"})
+        path = cache.download_and_cache_image(
+            "sets/logo", "sv8", "https://example/logo.png", session
+        )
+        self.assertIsNotNone(path)
+        self.assertEqual(path.read_bytes(), b"PNGBYTES")  # type: ignore[union-attr]
+        self.assertEqual(session.calls, ["https://example/logo.png"])
+
+    def test_hit_skips_network(self) -> None:
+        cache.write_image("sets/logo", "sv8", b"CACHED", ext=".png")
+        session = _FakeSession({"https://example/logo.png": b"FRESH"})
+        path = cache.download_and_cache_image(
+            "sets/logo", "sv8", "https://example/logo.png", session
+        )
+        self.assertIsNotNone(path)
+        self.assertEqual(path.read_bytes(), b"CACHED")  # type: ignore[union-attr]
+        self.assertEqual(session.calls, [], "cache hit must not touch the network")
+
+    def test_network_failure_returns_none_and_does_not_write(self) -> None:
+        import requests
+
+        session = _FakeSession({"https://example/logo.png": requests.ConnectionError("down")})
+        path = cache.download_and_cache_image(
+            "sets/logo", "sv8", "https://example/logo.png", session
+        )
+        self.assertIsNone(path)
+        # Nothing on disk for that key.
+        self.assertIsNone(cache.read_image("sets/logo", "sv8"))
+
+
+class ImageCacheStatsAndClearTests(_IsolatedCacheDirMixin):
+    def test_size_and_count_reflect_writes(self) -> None:
+        cache.write_image("sets/logo", "a", b"abcdef")
+        cache.write_image("sets/symbol", "a", b"01234")
+        count, total = cache.image_cache_size()
+        self.assertEqual(count, 2)
+        self.assertEqual(total, len(b"abcdef") + len(b"01234"))
+
+    def test_stats_surfaces_image_slice(self) -> None:
+        cache.write_image("sets/logo", "a", b"1234")
+        s = cache.stats()
+        self.assertEqual(s.image_entry_count, 1)
+        self.assertEqual(s.image_bytes, 4)
+
+    def test_cache_size_bytes_includes_images(self) -> None:
+        cache.write_api("k", {"x": 1})
+        cache.write_image("sets/logo", "a", b"123456")
+        # API write + image write must both appear in the total.
+        total = cache.cache_size_bytes()
+        api_size = sum(p.stat().st_size for p in (cache.cache_root() / "api").glob("*.json"))
+        self.assertEqual(total, api_size + 6)
+
+    def test_clear_image_cache_removes_only_images(self) -> None:
+        cache.write_api("k", {"x": 1})
+        cache.write_image("sets/logo", "a", b"img")
+        removed = cache.clear_image_cache()
+        self.assertEqual(removed, 1)
+        # API cache survived.
+        api_dir = cache.cache_root() / "api"
+        self.assertGreater(len(list(api_dir.glob("*.json"))), 0)
+        # Image cache is empty.
+        self.assertEqual(cache.image_cache_size(), (0, 0))
+
+    def test_clear_api_cache_does_not_touch_images(self) -> None:
+        # The defining property of the indefinite slice: it survives an API
+        # wipe. A user clearing stale API payloads should not lose a 30 MB
+        # warmed set catalog.
+        cache.write_image("sets/logo", "a", b"img-bytes")
+        cache.write_api("k", {"x": 1})
+        cache.clear_api_cache()
+        self.assertEqual(cache.image_cache_size(), (1, len(b"img-bytes")))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -255,6 +255,87 @@ class CacheStatsCommandTests(unittest.TestCase):
         self.assertIsNotNone(cache.read_image("sets/symbol", "sv8"))
         self.assertIsNone(cache.read_image("sets/symbol", "sv7"))
 
+    def test_warm_sets_verbose_prints_per_set_progress(self) -> None:
+        # `-v` should fire the on_progress callback so each set's id lands
+        # in the output. Covers the verbose branch of cache_warm_sets_command.
+        from unittest.mock import patch as _patch
+
+        sets = [
+            {"id": "sv8", "name": "Surging Sparks", "images": {"logo": "u"}},
+            {"id": "sv7", "name": "Stellar Crown", "images": {"logo": "u"}},
+        ]
+
+        def _fake_download(category, key, url, session, *, timeout=30):
+            return cache.write_image(category, key, b"warm", ext=url)
+
+        with (
+            _patch("mgz_pkmn.set_cards.fetch_all_sets", return_value=sets),
+            _patch(
+                "mgz_pkmn.set_cards.disk_cache.download_and_cache_image",
+                side_effect=_fake_download,
+            ),
+        ):
+            result = CliRunner().invoke(cli, ["cache", "warm-sets", "-v"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        # Both set ids appear with [n/total] prefixes.
+        self.assertIn("[1/2]", result.output)
+        self.assertIn("sv8", result.output)
+        self.assertIn("[2/2]", result.output)
+        self.assertIn("sv7", result.output)
+
+    def test_warm_sets_surfaces_upstream_request_failures(self) -> None:
+        # A network failure during `fetch_all_sets` should surface as a
+        # ClickException with the underlying error message — not a bare
+        # traceback.
+        from unittest.mock import patch as _patch
+
+        import requests as _requests
+
+        with _patch(
+            "mgz_pkmn.set_cards.fetch_all_sets",
+            side_effect=_requests.ConnectionError("network down"),
+        ):
+            result = CliRunner().invoke(cli, ["cache", "warm-sets"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("set fetch failed", result.output)
+        self.assertIn("network down", result.output)
+
+    def test_warm_sets_reports_failures_in_summary(self) -> None:
+        # When some images fail to download, the summary line should
+        # surface the failure count in yellow rather than hiding it.
+        from unittest.mock import patch as _patch
+
+        sets = [
+            {
+                "id": "sv8",
+                "name": "Surging Sparks",
+                "images": {
+                    "logo": "https://example/sv8-logo.png",
+                    "symbol": "https://example/sv8-symbol.png",
+                },
+            },
+        ]
+
+        def _half_failing(category, key, url, session, *, timeout=30):
+            # Logo succeeds, symbol fails.
+            if "logo" in category:
+                return cache.write_image(category, key, b"warm", ext=url)
+            return None
+
+        with (
+            _patch("mgz_pkmn.set_cards.fetch_all_sets", return_value=sets),
+            _patch(
+                "mgz_pkmn.set_cards.disk_cache.download_and_cache_image",
+                side_effect=_half_failing,
+            ),
+        ):
+            result = CliRunner().invoke(cli, ["cache", "warm-sets"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("1 failures", result.output)
+
     def test_warm_sets_clickfails_when_catalog_is_empty(self) -> None:
         # An empty catalog should surface as a ClickException, not a silent
         # success — the user installing fresh would otherwise have no

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -161,12 +161,15 @@ class CacheStatsCommandTests(unittest.TestCase):
         cache.write_api("https://example.com/a", {"x": 1})
         cache.write_api("https://example.com/b", {"y": 2})
         cache.record_url_override("Mew", None, "https://pc/mew")
+        cache.write_image("sets/logo", "sv8", b"img-bytes")
 
         result = CliRunner().invoke(cli, ["cache", "stats"])
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn("Cache stats", result.output)
         self.assertIn("API responses: 2 entries", result.output)
         self.assertIn("URL overrides: 1 entries", result.output)
+        self.assertIn("Images:        1 entries", result.output)
+        self.assertIn("indefinite TTL", result.output)
         self.assertIn(self._tmp.name, result.output)
 
     def test_stats_command_on_empty_cache(self) -> None:
@@ -191,6 +194,8 @@ class CacheStatsCommandTests(unittest.TestCase):
                 "api_oldest_mtime",
                 "override_bytes",
                 "override_count",
+                "image_bytes",
+                "image_entry_count",
                 "root",
             },
         )
@@ -199,7 +204,68 @@ class CacheStatsCommandTests(unittest.TestCase):
         self.assertIsInstance(payload["api_oldest_mtime"], float)
         self.assertEqual(payload["override_count"], 1)
         self.assertGreater(payload["override_bytes"], 0)
+        # New indefinite-TTL image slice. Defaults to zero on a fresh cache;
+        # exercised end-to-end by the warm-sets test.
+        self.assertEqual(payload["image_entry_count"], 0)
+        self.assertEqual(payload["image_bytes"], 0)
         self.assertEqual(payload["root"], str(Path(self._tmp.name) / "mgz-pkmn"))
+
+    def test_warm_sets_primes_cache_and_summarises(self) -> None:
+        # The CLI subcommand should walk the catalog (mocked here) and
+        # populate `cache/images/sets/{logo,symbol}` with one entry per set,
+        # then print a summary line that reflects the per-kind counts.
+        from unittest.mock import patch as _patch
+
+        sets = [
+            {
+                "id": "sv8",
+                "name": "Surging Sparks",
+                "images": {
+                    "logo": "https://ex/sv8-logo.png",
+                    "symbol": "https://ex/sv8-symbol.png",
+                },
+            },
+            {
+                "id": "sv7",
+                "name": "Stellar Crown",
+                "images": {"logo": "https://ex/sv7-logo.png"},
+            },
+        ]
+
+        def _fake_download(category, key, url, session, *, timeout=30):
+            # Persist a sentinel byte so image_cache_size reports >0.
+            return cache.write_image(category, key, b"warm", ext=url)
+
+        with (
+            _patch("mgz_pkmn.set_cards.fetch_all_sets", return_value=sets),
+            _patch(
+                "mgz_pkmn.set_cards.disk_cache.download_and_cache_image",
+                side_effect=_fake_download,
+            ),
+        ):
+            result = CliRunner().invoke(cli, ["cache", "warm-sets"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("2 sets", result.output)
+        self.assertIn("2 logos", result.output)
+        self.assertIn("1 symbols", result.output)
+        # On-disk: a logo for each set, plus the one symbol.
+        self.assertIsNotNone(cache.read_image("sets/logo", "sv8"))
+        self.assertIsNotNone(cache.read_image("sets/logo", "sv7"))
+        self.assertIsNotNone(cache.read_image("sets/symbol", "sv8"))
+        self.assertIsNone(cache.read_image("sets/symbol", "sv7"))
+
+    def test_warm_sets_clickfails_when_catalog_is_empty(self) -> None:
+        # An empty catalog should surface as a ClickException, not a silent
+        # success — the user installing fresh would otherwise have no
+        # signal that the warm pass did nothing.
+        from unittest.mock import patch as _patch
+
+        with _patch("mgz_pkmn.set_cards.fetch_all_sets", return_value=[]):
+            result = CliRunner().invoke(cli, ["cache", "warm-sets"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("no sets", result.output.lower())
 
     def test_path_command_prints_bare_cache_root(self) -> None:
         expected = Path(self._tmp.name) / "mgz-pkmn"

--- a/tests/test_set_cards.py
+++ b/tests/test_set_cards.py
@@ -134,12 +134,18 @@ class WritePdfTests(unittest.TestCase):
 
 
 class _IsolatedCacheMixin(unittest.TestCase):
-    """Point cache_root() at a tempdir so the image cache stays test-local."""
+    """Point cache_root() at a tempdir so the image cache stays test-local.
+
+    Saves and restores both `XDG_CACHE_HOME` and `MGZ_PKMN_NO_CACHE` so
+    a test that toggles `MGZ_PKMN_NO_CACHE=1` mid-run can't leak state
+    into the next test (matches the contract on `_IsolatedCacheDirMixin`
+    in `tests/test_cache.py`)."""
 
     def setUp(self) -> None:
         super().setUp()
         self._tmp = tempfile.TemporaryDirectory()
         self._old_xdg = os.environ.get("XDG_CACHE_HOME")
+        self._old_no_cache = os.environ.get(disk_cache._NO_CACHE_ENV)
         os.environ["XDG_CACHE_HOME"] = self._tmp.name
         os.environ.pop(disk_cache._NO_CACHE_ENV, None)
 
@@ -148,6 +154,10 @@ class _IsolatedCacheMixin(unittest.TestCase):
             os.environ.pop("XDG_CACHE_HOME", None)
         else:
             os.environ["XDG_CACHE_HOME"] = self._old_xdg
+        if self._old_no_cache is None:
+            os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+        else:
+            os.environ[disk_cache._NO_CACHE_ENV] = self._old_no_cache
         self._tmp.cleanup()
         super().tearDown()
 

--- a/tests/test_set_cards.py
+++ b/tests/test_set_cards.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime as _dt
 import io
+import os
 import sys
 import tempfile
 import unittest
@@ -14,10 +15,12 @@ from reportlab.pdfgen import canvas
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
+from mgz_pkmn import cache as disk_cache
 from mgz_pkmn.set_cards import (
     _draw_logo,
     _release_year,
     fetch_all_sets,
+    warm_set_images,
     write_set_cards_pdf,
 )
 
@@ -128,6 +131,138 @@ class WritePdfTests(unittest.TestCase):
             out = Path(tmp) / "set-cards.pdf"
             written = write_set_cards_pdf(sets, out, today=_dt.date(2026, 5, 10))
             self.assertEqual(written, 1)
+
+
+class _IsolatedCacheMixin(unittest.TestCase):
+    """Point cache_root() at a tempdir so the image cache stays test-local."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._tmp = tempfile.TemporaryDirectory()
+        self._old_xdg = os.environ.get("XDG_CACHE_HOME")
+        os.environ["XDG_CACHE_HOME"] = self._tmp.name
+        os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+
+    def tearDown(self) -> None:
+        if self._old_xdg is None:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        else:
+            os.environ["XDG_CACHE_HOME"] = self._old_xdg
+        self._tmp.cleanup()
+        super().tearDown()
+
+
+def _client_with_responses(responses: dict[str, bytes]) -> MagicMock:
+    """Build a TCGClient stand-in whose session returns the mapped bytes."""
+    client = MagicMock()
+
+    def _get(url: str, timeout: float | None = None) -> MagicMock:
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.content = responses.get(url, b"")
+        resp.raise_for_status.return_value = None
+        return resp
+
+    client.session.get.side_effect = _get
+    return client
+
+
+class WarmSetImagesTests(_IsolatedCacheMixin):
+    def test_warms_logo_and_symbol_for_every_set(self) -> None:
+        sets = [
+            {
+                "id": "sv8",
+                "name": "Surging Sparks",
+                "images": {
+                    "logo": "https://example/sv8-logo.png",
+                    "symbol": "https://example/sv8-symbol.png",
+                },
+            },
+            {
+                "id": "sv7",
+                "name": "Stellar Crown",
+                "images": {
+                    "logo": "https://example/sv7-logo.png",
+                    "symbol": "https://example/sv7-symbol.png",
+                },
+            },
+        ]
+        client = _client_with_responses(
+            {
+                "https://example/sv8-logo.png": b"sv8-logo",
+                "https://example/sv8-symbol.png": b"sv8-symbol",
+                "https://example/sv7-logo.png": b"sv7-logo",
+                "https://example/sv7-symbol.png": b"sv7-symbol",
+            }
+        )
+
+        result = warm_set_images(client, sets=sets)
+
+        self.assertEqual(result.sets, 2)
+        self.assertEqual(result.logos_cached, 2)
+        self.assertEqual(result.symbols_cached, 2)
+        self.assertEqual(result.failures, 0)
+        # Verify each artifact landed in the right cache slot.
+        for sid in ("sv8", "sv7"):
+            self.assertIsNotNone(disk_cache.read_image("sets/logo", sid))
+            self.assertIsNotNone(disk_cache.read_image("sets/symbol", sid))
+
+    def test_second_warm_pass_is_cache_only(self) -> None:
+        sets = [
+            {
+                "id": "sv8",
+                "name": "Surging Sparks",
+                "images": {"logo": "https://example/sv8-logo.png"},
+            }
+        ]
+        client = _client_with_responses({"https://example/sv8-logo.png": b"sv8-logo"})
+
+        warm_set_images(client, sets=sets)
+        first_calls = client.session.get.call_count
+        warm_set_images(client, sets=sets)
+
+        # First pass downloaded; second pass should not have touched the network.
+        self.assertEqual(client.session.get.call_count, first_calls)
+
+    def test_skips_sets_without_images(self) -> None:
+        sets = [
+            {"id": "old1", "name": "No Images"},
+            {
+                "id": "old2",
+                "name": "Only Logo",
+                "images": {"logo": "https://example/old2-logo.png"},
+            },
+        ]
+        client = _client_with_responses({"https://example/old2-logo.png": b"old2-logo"})
+
+        result = warm_set_images(client, sets=sets)
+
+        self.assertEqual(result.sets, 2)
+        self.assertEqual(result.logos_cached, 1)
+        self.assertEqual(result.symbols_cached, 0)
+        self.assertEqual(result.failures, 0)
+
+
+class WritePdfUsesImageCacheTests(_IsolatedCacheMixin):
+    def test_uses_cached_logo_when_present(self) -> None:
+        # Pre-seed the cache and confirm write_set_cards_pdf reads from it
+        # instead of calling the session.
+        disk_cache.write_image("sets/logo", "sv8", b"\x89PNG\r\n\x1a\n" + b"fake")
+        sets = [
+            {
+                "id": "sv8",
+                "name": "Surging Sparks",
+                "images": {"logo": "https://example/sv8-logo.png"},
+            }
+        ]
+        session = MagicMock()  # Should never be invoked.
+
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "set-cards.pdf"
+            written = write_set_cards_pdf(sets, out, session=session)
+            self.assertEqual(written, 1)
+            self.assertTrue(out.exists())
+        session.get.assert_not_called()
 
 
 class DrawLogoTests(unittest.TestCase):

--- a/tests/test_set_cards.py
+++ b/tests/test_set_cards.py
@@ -60,7 +60,55 @@ class ReleaseYearTests(unittest.TestCase):
         self.assertIsNone(_release_year(""))
 
 
-class FetchAllSetsTests(unittest.TestCase):
+class _IsolatedCacheMixin(unittest.TestCase):
+    """Point cache_root() at a tempdir so the image cache stays test-local.
+
+    Saves and restores both `XDG_CACHE_HOME` and `MGZ_PKMN_NO_CACHE` so
+    a test that toggles `MGZ_PKMN_NO_CACHE=1` mid-run can't leak state
+    into the next test (matches the contract on `_IsolatedCacheDirMixin`
+    in `tests/test_cache.py`)."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._tmp = tempfile.TemporaryDirectory()
+        self._old_xdg = os.environ.get("XDG_CACHE_HOME")
+        self._old_no_cache = os.environ.get(disk_cache._NO_CACHE_ENV)
+        os.environ["XDG_CACHE_HOME"] = self._tmp.name
+        os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+
+    def tearDown(self) -> None:
+        if self._old_xdg is None:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        else:
+            os.environ["XDG_CACHE_HOME"] = self._old_xdg
+        if self._old_no_cache is None:
+            os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+        else:
+            os.environ[disk_cache._NO_CACHE_ENV] = self._old_no_cache
+        self._tmp.cleanup()
+        super().tearDown()
+
+
+def _client_with_responses(responses: dict[str, bytes]) -> MagicMock:
+    """Build a TCGClient stand-in whose session returns the mapped bytes."""
+    client = MagicMock()
+
+    def _get(url: str, timeout: float | None = None) -> MagicMock:
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.content = responses.get(url, b"")
+        resp.raise_for_status.return_value = None
+        return resp
+
+    client.session.get.side_effect = _get
+    return client
+
+
+class FetchAllSetsTests(_IsolatedCacheMixin):
+    # `fetch_all_sets` now routes the catalog response through the API
+    # disk cache. Inheriting the isolation mixin keeps the test from
+    # reading a real cached payload out of $HOME/.cache/mgz-pkmn (which
+    # would otherwise mask the mocked session response).
     def test_normalizes_pokemontcg_payload(self) -> None:
         client = MagicMock()
         response = MagicMock()
@@ -131,50 +179,6 @@ class WritePdfTests(unittest.TestCase):
             out = Path(tmp) / "set-cards.pdf"
             written = write_set_cards_pdf(sets, out, today=_dt.date(2026, 5, 10))
             self.assertEqual(written, 1)
-
-
-class _IsolatedCacheMixin(unittest.TestCase):
-    """Point cache_root() at a tempdir so the image cache stays test-local.
-
-    Saves and restores both `XDG_CACHE_HOME` and `MGZ_PKMN_NO_CACHE` so
-    a test that toggles `MGZ_PKMN_NO_CACHE=1` mid-run can't leak state
-    into the next test (matches the contract on `_IsolatedCacheDirMixin`
-    in `tests/test_cache.py`)."""
-
-    def setUp(self) -> None:
-        super().setUp()
-        self._tmp = tempfile.TemporaryDirectory()
-        self._old_xdg = os.environ.get("XDG_CACHE_HOME")
-        self._old_no_cache = os.environ.get(disk_cache._NO_CACHE_ENV)
-        os.environ["XDG_CACHE_HOME"] = self._tmp.name
-        os.environ.pop(disk_cache._NO_CACHE_ENV, None)
-
-    def tearDown(self) -> None:
-        if self._old_xdg is None:
-            os.environ.pop("XDG_CACHE_HOME", None)
-        else:
-            os.environ["XDG_CACHE_HOME"] = self._old_xdg
-        if self._old_no_cache is None:
-            os.environ.pop(disk_cache._NO_CACHE_ENV, None)
-        else:
-            os.environ[disk_cache._NO_CACHE_ENV] = self._old_no_cache
-        self._tmp.cleanup()
-        super().tearDown()
-
-
-def _client_with_responses(responses: dict[str, bytes]) -> MagicMock:
-    """Build a TCGClient stand-in whose session returns the mapped bytes."""
-    client = MagicMock()
-
-    def _get(url: str, timeout: float | None = None) -> MagicMock:
-        resp = MagicMock()
-        resp.status_code = 200
-        resp.content = responses.get(url, b"")
-        resp.raise_for_status.return_value = None
-        return resp
-
-    client.session.get.side_effect = _get
-    return client
 
 
 class WarmSetImagesTests(_IsolatedCacheMixin):
@@ -398,8 +402,10 @@ class WarmSetImagesFailureTests(_IsolatedCacheMixin):
         self.assertEqual(result.symbols_cached, 0)
         self.assertEqual(result.failures, 2)
 
-    def test_skips_sets_with_no_id(self) -> None:
-        # A bogus set with no id and no name must not crash the walk.
+    def test_skips_sets_with_no_id_and_no_name(self) -> None:
+        # `warm_set_images` falls back to `s.get("name")` when `id` is
+        # missing, so the only entries it actually skips are ones where
+        # BOTH are empty. A bogus set like that must not crash the walk.
         sets = [{"name": ""}, {"id": "sv8", "images": {"logo": "u"}}]
         client = MagicMock()
         resp = MagicMock()

--- a/tests/test_set_cards.py
+++ b/tests/test_set_cards.py
@@ -264,6 +264,144 @@ class WritePdfUsesImageCacheTests(_IsolatedCacheMixin):
             self.assertTrue(out.exists())
         session.get.assert_not_called()
 
+    def test_logos_dir_sidecar_mirrors_cached_file(self) -> None:
+        # When `logos_dir` is provided alongside an active cache, the cached
+        # file should be copied into the sidecar directory for archival.
+        # This is the legacy back-compat path for the CLI's --logos-dir flag.
+        disk_cache.write_image("sets/logo", "sv8", b"PNGCACHE", ext=".png")
+        sets = [
+            {
+                "id": "sv8",
+                "name": "Surging Sparks",
+                "images": {"logo": "https://example/sv8-logo.png"},
+            }
+        ]
+        session = MagicMock()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            sidecar_dir = Path(tmp) / "set-logos"
+            out = Path(tmp) / "set-cards.pdf"
+            write_set_cards_pdf(sets, out, logos_dir=sidecar_dir, session=session)
+            # The cache file was copied into the sidecar dir.
+            self.assertTrue(sidecar_dir.exists())
+            sidecar_files = list(sidecar_dir.iterdir())
+            self.assertEqual(len(sidecar_files), 1)
+            self.assertEqual(sidecar_files[0].read_bytes(), b"PNGCACHE")
+        # Cache short-circuited the session, sidecar mirror copied the bytes.
+        session.get.assert_not_called()
+
+    def test_no_cache_and_no_logos_dir_returns_none(self) -> None:
+        # With both the cache disabled AND no logos_dir, there's nowhere to
+        # put the image — `_fetch_logo` should bail to None cleanly rather
+        # than trying to write somewhere it shouldn't.
+        os.environ[disk_cache._NO_CACHE_ENV] = "1"
+        try:
+            from mgz_pkmn.set_cards import _fetch_logo
+
+            session = MagicMock()
+            self.assertIsNone(_fetch_logo("https://example/logo.png", "sv8", None, session))
+            # We never even reached the download path.
+            session.get.assert_not_called()
+        finally:
+            os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+
+    def test_no_cache_falls_back_to_legacy_logos_dir_path(self) -> None:
+        # With MGZ_PKMN_NO_CACHE=1, the cache is bypassed entirely and
+        # `_fetch_logo` falls back to writing into `logos_dir` directly via
+        # `download_image`. The session must still be called.
+        os.environ[disk_cache._NO_CACHE_ENV] = "1"
+        try:
+            sets = [
+                {
+                    "id": "sv8",
+                    "name": "Surging Sparks",
+                    "images": {"logo": "https://example/sv8-logo.png"},
+                }
+            ]
+            session = MagicMock()
+            resp = MagicMock()
+            resp.content = b"FALLBACK"
+            resp.raise_for_status.return_value = None
+            session.get.return_value = resp
+
+            with tempfile.TemporaryDirectory() as tmp:
+                sidecar_dir = Path(tmp) / "logos"
+                out = Path(tmp) / "set-cards.pdf"
+                write_set_cards_pdf(sets, out, logos_dir=sidecar_dir, session=session)
+                # The fallback path wrote directly to sidecar_dir.
+                files = list(sidecar_dir.iterdir())
+                self.assertEqual(len(files), 1)
+                self.assertEqual(files[0].read_bytes(), b"FALLBACK")
+            session.get.assert_called_once()
+        finally:
+            os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+
+
+class FetchAllSetsCacheTests(_IsolatedCacheMixin):
+    def test_cold_fetch_writes_to_api_cache(self) -> None:
+        # First call goes over the wire and writes the response into the
+        # API disk cache.
+        payload = {
+            "data": [
+                {"id": "sv8", "name": "Surging Sparks", "images": {"logo": "x"}},
+            ]
+        }
+        client = MagicMock()
+        resp = MagicMock()
+        resp.json.return_value = payload
+        resp.raise_for_status.return_value = None
+        client.session.get.return_value = resp
+
+        sets = fetch_all_sets(client)
+        self.assertEqual(len(sets), 1)
+        client.session.get.assert_called_once()
+        # Second call should hit the cache and skip the session entirely.
+        client.session.get.reset_mock()
+        sets2 = fetch_all_sets(client)
+        self.assertEqual(sets2, sets)
+        client.session.get.assert_not_called()
+
+
+class WarmSetImagesFailureTests(_IsolatedCacheMixin):
+    def test_counts_failures_when_download_returns_none(self) -> None:
+        # A session whose get() raises for both URLs forces
+        # download_and_cache_image to return None for each — failures
+        # should tick up rather than being silently absorbed.
+        import requests
+
+        sets = [
+            {
+                "id": "sv8",
+                "name": "Surging Sparks",
+                "images": {
+                    "logo": "https://example/sv8-logo.png",
+                    "symbol": "https://example/sv8-symbol.png",
+                },
+            }
+        ]
+        client = MagicMock()
+        client.session.get.side_effect = requests.ConnectionError("down")
+
+        result = warm_set_images(client, sets=sets)
+        self.assertEqual(result.sets, 1)
+        self.assertEqual(result.logos_cached, 0)
+        self.assertEqual(result.symbols_cached, 0)
+        self.assertEqual(result.failures, 2)
+
+    def test_skips_sets_with_no_id(self) -> None:
+        # A bogus set with no id and no name must not crash the walk.
+        sets = [{"name": ""}, {"id": "sv8", "images": {"logo": "u"}}]
+        client = MagicMock()
+        resp = MagicMock()
+        resp.content = b"img"
+        resp.raise_for_status.return_value = None
+        client.session.get.return_value = resp
+
+        result = warm_set_images(client, sets=sets)
+        # First entry (no id, no name) is skipped — only the second counts.
+        self.assertEqual(result.sets, 2)  # `total` is the raw length
+        self.assertEqual(result.logos_cached, 1)
+
 
 class DrawLogoTests(unittest.TestCase):
     def test_corrupt_file_logs_and_draws_placeholder(self) -> None:

--- a/tests/test_set_cards_api.py
+++ b/tests/test_set_cards_api.py
@@ -72,13 +72,17 @@ class SetCardsEndpointTests(unittest.TestCase):
         self.assertIsNone(captured["logos_dir"])
         self.assertIsNone(captured["session"])
 
-    def test_default_uses_persistent_logo_cache(self) -> None:
-        # Default request must pass a persistent on-disk cache dir (not a
-        # per-request TemporaryDirectory) so logos survive across calls.
+    def test_default_passes_session_for_unified_image_cache(self) -> None:
+        # Logo storage now flows through the unified disk image cache
+        # (cache/images/sets/), so the route no longer needs to thread a
+        # custom `logos_dir`. It just passes `session` and lets the cache
+        # resolve the on-disk path internally — this is the contract that
+        # makes the cache survive across requests without a sidecar dir.
         captured: dict = {}
 
         def _fake_writer(sets, out_path, *, logos_dir=None, session=None, today=None):
             captured["logos_dir"] = logos_dir
+            captured["session"] = session
             out_path.write_bytes(b"%PDF-1.4\n%fake\n")
             return len(sets)
 
@@ -88,8 +92,8 @@ class SetCardsEndpointTests(unittest.TestCase):
         ):
             resp = client.get("/api/v1/set-cards.pdf")
         self.assertEqual(resp.status_code, 200)
-        self.assertIsNotNone(captured["logos_dir"])
-        self.assertIn(".cache/mgz-pkmn", str(captured["logos_dir"]))
+        self.assertIsNone(captured["logos_dir"])
+        self.assertIsNotNone(captured["session"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #255

## What

A unified indefinite-TTL image cache for set art (logos + symbols today; card art tomorrow), plus a `pkmn cache warm-sets` subcommand to prime it in one pass.

- New `cache/images/<category>/<key>.<ext>` slice on the existing disk cache. No TTL — set art doesn't change once a set ships.
- `pkmn set-cards` (CLI) and `/api/v1/set-cards.pdf` (API) both resolve logos through the cache instead of two separate ad-hoc directories.
- `fetch_all_sets()` now routes the pokemontcg.io catalog JSON through the existing API disk cache, so the JSON layer is warm across runs too.
- `pkmn cache warm-sets` walks the catalog and primes both logo + symbol for every set; re-runs are cache-only and effectively free.
- `pkmn cache stats` gains a dedicated "Images" line so the indefinite slice is always visible — when it grows, the user can see why.
- `clear_image_cache()` is distinct from `clear_api_cache()` so a "wipe stale API payloads" never re-downloads tens of MB of stable artwork.

## Why

Before this PR, set logos lived in two parallel directories — the CLI's `--logos-dir` (default `output/images/set-logos/`) and a hard-coded `~/.cache/mgz-pkmn/set-logos/` on the API side. They drifted, neither showed up in `pkmn cache stats`, and every fresh install re-downloaded the full set catalog on the first `set-cards` run.

This collapses them onto one cache, gives the user a single warm command, and makes the on-disk cost visible.

## How to verify

Run the smoke from a fresh cache:

```bash
$ XDG_CACHE_HOME=/tmp/mgz-test uv run pkmn cache stats
▸ Cache stats
  Location:      /tmp/mgz-test/mgz-pkmn
  Total size:    0 B
  API responses: 0 entries · 0 B · oldest —
  URL overrides: 0 entries · 0 B
  Images:        0 entries · 0 B · indefinite TTL

$ XDG_CACHE_HOME=/tmp/mgz-test uv run pkmn cache warm-sets
┌───────────────────────┐
│  mgz-pkmn · 1.0.2rc1  │
└───────────────────────┘

▸ Warming set image cache
  ✓ 173 sets · 173 logos · 173 symbols
  ✓ image cache now 346 entries · 19.4 MB

Done!

$ XDG_CACHE_HOME=/tmp/mgz-test uv run pkmn cache stats
▸ Cache stats
  Location:      /tmp/mgz-test/mgz-pkmn
  Total size:    19.4 MB
  API responses: 1 entries · 61.3 KB · oldest just now
  URL overrides: 0 entries · 0 B
  Images:        346 entries · 19.4 MB · indefinite TTL

$ /usr/bin/time -p sh -c 'XDG_CACHE_HOME=/tmp/mgz-test uv run pkmn cache warm-sets > /dev/null'
real 0.22   # cache-only second pass

$ /usr/bin/time -p sh -c 'XDG_CACHE_HOME=/tmp/mgz-test uv run pkmn set-cards -o /tmp/sc.pdf > /dev/null'
real 4.04   # full 17 MB PDF on warm cache
```

That's the user-visible contract:
- The new **Images** line appears in `pkmn cache stats` even on an empty cache.
- `pkmn cache warm-sets` is a single-shot warm; re-runs are 0.2 s.
- `pkmn set-cards` on a warm cache is now ~4 s for the full 173-cutout PDF.
- `pkmn cache clear` (API cache) leaves the image slice untouched — verified by the new `test_clear_api_cache_does_not_touch_images` test.

## Tests

21 new tests across `tests/test_cache.py`, `tests/test_set_cards.py`, `tests/test_cli.py`, `tests/test_set_cards_api.py`. Full suite: 269 Python tests passing, `make check` green, `make fix` clean.

## Out of scope (next PR)

The picker modal in #256 — this PR is the cache foundation it needs. With the image cache shipping, the modal can fetch every set's thumbnail without an extra network round-trip per render.