### PR TITLE
feat(web): set picker modal for Set ID cards export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 - Web: **Set picker modal** for the Set ID cards export. Clicking
   **Set ID cards…** in the Export dropdown now opens a picker that
-  groups every set by series **newest first** (Mega Evolution → Base),
+  groups every set by series **newest → oldest** (modern blocks like
+  Scarlet & Violet sit at the top; the original Base set is at the bottom),
   shows each set's cached logo + name + year + total, and lets the
   user multi-select with **Select all / Select none / Expand all /
   Collapse all / Select series** buttons. Each series is a collapsible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,17 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 - Web: **Set picker modal** for the Set ID cards export. Clicking
   **Set ID cards…** in the Export dropdown now opens a picker that
-  groups every set by series (Base → Mega Evolution), shows each set's
-  cached logo + name + year + total, and lets the user multi-select
-  with **Select all / Select none / Select series** buttons. Selection
-  persists across reloads (Zustand). Submitting the modal downloads a
-  PDF containing only the chosen sets — exactly the same path the new
-  CLI flag uses on the backend. Logo thumbnails come from the new
-  `GET /api/v1/sets/{set_id}/logo` endpoint, which streams images out
-  of the unified disk cache populated by `pkmn cache warm-sets`.
+  groups every set by series **newest first** (Mega Evolution → Base),
+  shows each set's cached logo + name + year + total, and lets the
+  user multi-select with **Select all / Select none / Expand all /
+  Collapse all / Select series** buttons. Each series is a collapsible
+  section so the 173-entry catalog stays scannable; the header shows a
+  per-series selection count (`(2/18)`) once anything in it is picked.
+  Selection persists across reloads (Zustand). Submitting the modal
+  downloads a PDF containing only the chosen sets — exactly the same
+  path the new CLI flag uses on the backend. Logo thumbnails come from
+  the new `GET /api/v1/sets/{set_id}/logo` endpoint, which streams
+  images out of the unified disk cache populated by `pkmn cache warm-sets`.
 - API: new `GET /api/v1/sets/{set_id}/logo` endpoint serves cached set
   logos with a 30-day immutable browser cache. 404 with a "run
   `pkmn cache warm-sets`" hint when the set hasn't been warmed yet, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Web: **Set picker modal** for the Set ID cards export. Clicking
+  **Set ID cards…** in the Export dropdown now opens a picker that
+  groups every set by series (Base → Mega Evolution), shows each set's
+  cached logo + name + year + total, and lets the user multi-select
+  with **Select all / Select none / Select series** buttons. Selection
+  persists across reloads (Zustand). Submitting the modal downloads a
+  PDF containing only the chosen sets — exactly the same path the new
+  CLI flag uses on the backend. Logo thumbnails come from the new
+  `GET /api/v1/sets/{set_id}/logo` endpoint, which streams images out
+  of the unified disk cache populated by `pkmn cache warm-sets`.
+- API: new `GET /api/v1/sets/{set_id}/logo` endpoint serves cached set
+  logos with a 30-day immutable browser cache. 404 with a "run
+  `pkmn cache warm-sets`" hint when the set hasn't been warmed yet, so
+  the SPA can fall back gracefully and tell the user how to fix it.
+- API: `GET /api/v1/set-cards.pdf` accepts a repeatable `set_ids` query
+  param to restrict the output to specific sets. Unknown ids return
+  404 instead of an empty PDF so the SPA surfaces a clear error.
+- CLI: new `pkmn set-cards --set <id>` flag (repeatable, also `-s`) —
+  the same picker filter is reachable from the terminal. Unknown ids
+  fail loudly as a `ClickException` rather than producing an empty
+  PDF.
 - CLI: new `pkmn cache warm-sets` subcommand walks every Pokémon TCG set
   and pre-downloads each set's logo + symbol into the unified disk image
   cache. Cold warm is a single up-front cost (~30 s on a fresh install,

--- a/api/routes/set_cards.py
+++ b/api/routes/set_cards.py
@@ -58,10 +58,14 @@ def _render(api_key: str | None, no_images: bool, set_ids: tuple[str, ...]) -> b
     if set_ids:
         sets = filter_sets_by_ids(sets, set_ids)
         if not sets:
-            # 404 — the catalog exists, but nothing matched the user's filter.
-            # Returning a zero-page PDF would be confusing; a clear error
-            # gets surfaced in the SPA as the picker's "nothing selected"
-            # safety rail and in the CLI as a ClickException.
+            # 404 — every requested id was unknown or stale (typo, set
+            # removed from the upstream catalog, etc.). Note that this
+            # is NOT the picker's "nothing selected" state: the SPA
+            # blocks empty selection client-side, so an empty filter
+            # never reaches this branch. Returning a zero-page PDF for
+            # unknown ids would be confusing; the 404 lets the CLI fail
+            # loudly as a ClickException and lets the SPA surface the
+            # detail message verbatim.
             raise HTTPException(
                 status_code=404,
                 detail=f"no sets matched the requested ids: {', '.join(set_ids)}",

--- a/api/routes/set_cards.py
+++ b/api/routes/set_cards.py
@@ -2,20 +2,22 @@
 
 Fetches every Pokémon TCG set from pokemontcg.io, renders one card-sized
 cutout per set (3x3 grid on Letter, sized for a 9-pocket binder sheet),
-and streams the PDF back."""
+and streams the PDF back. Pass `set_ids` (repeatable) to restrict the
+PDF to a subset of sets — the SPA's set picker modal uses this filter."""
 
 from __future__ import annotations
 
 import io
 import tempfile
 from pathlib import Path
+from typing import Annotated
 
 import requests
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import StreamingResponse
 
-from mgz_pkmn.set_cards import fetch_all_sets, write_set_cards_pdf
+from mgz_pkmn.set_cards import fetch_all_sets, filter_sets_by_ids, write_set_cards_pdf
 from mgz_pkmn.sources import TCGClient
 
 router = APIRouter()
@@ -25,14 +27,19 @@ router = APIRouter()
 async def get_set_cards_pdf(
     api_key: str | None = None,
     no_images: bool = False,
+    # Repeatable query param: ?set_ids=sv8&set_ids=sv7 picks just those
+    # sets. Empty list means "every set" — preserves the historical
+    # default behavior.
+    set_ids: Annotated[list[str], Query()] = [],  # noqa: B006  # FastAPI binding
 ) -> StreamingResponse:
     """Return a PDF of printable set identification cutouts.
 
     Pass `api_key` as a query parameter to authenticate the upstream
     pokemontcg.io request (otherwise the public rate limit applies).
     Pass `no_images=true` to skip logo downloads and render text-only
-    cutouts — much faster on a cold cache."""
-    content = await run_in_threadpool(_render, api_key, no_images)
+    cutouts — much faster on a cold cache. Pass `set_ids` (repeatable)
+    to restrict the output to specific sets; omit to render every set."""
+    content = await run_in_threadpool(_render, api_key, no_images, tuple(set_ids))
     return StreamingResponse(
         io.BytesIO(content),
         media_type="application/pdf",
@@ -40,7 +47,7 @@ async def get_set_cards_pdf(
     )
 
 
-def _render(api_key: str | None, no_images: bool) -> bytes:
+def _render(api_key: str | None, no_images: bool, set_ids: tuple[str, ...]) -> bytes:
     client = TCGClient(api_key=api_key)
     try:
         sets = fetch_all_sets(client)
@@ -48,6 +55,17 @@ def _render(api_key: str | None, no_images: bool) -> bytes:
         raise HTTPException(status_code=502, detail=f"upstream fetch failed: {exc}") from exc
     if not sets:
         raise HTTPException(status_code=502, detail="pokemontcg.io returned no sets")
+    if set_ids:
+        sets = filter_sets_by_ids(sets, set_ids)
+        if not sets:
+            # 404 — the catalog exists, but nothing matched the user's filter.
+            # Returning a zero-page PDF would be confusing; a clear error
+            # gets surfaced in the SPA as the picker's "nothing selected"
+            # safety rail and in the CLI as a ClickException.
+            raise HTTPException(
+                status_code=404,
+                detail=f"no sets matched the requested ids: {', '.join(set_ids)}",
+            )
     # Logo storage now flows entirely through the unified disk image cache
     # under `cache/images/sets/`, shared with the CLI. We pass `session` so
     # the writer can fetch on a miss; no `logos_dir` is needed (the cache

--- a/api/routes/sets.py
+++ b/api/routes/sets.py
@@ -1,14 +1,28 @@
-"""GET /api/v1/sets — return a cached list of known Pokémon TCG set names."""
+"""Set-catalog HTTP surface — list of every set, plus their cached logos.
+
+`GET /api/v1/sets` returns the full pokemontcg.io catalog (id, name,
+series, total, release date, image URLs). Used by the SPA's set picker
+modal to populate the grouped multi-select.
+
+`GET /api/v1/sets/{set_id}/logo` streams the cached logo image for a set
+out of the unified disk image cache (see `mgz_pkmn.cache.read_image`).
+Returns 404 when the requested set isn't in the cache yet — the SPA
+falls back to a text-only chip in that case, or the user can run
+`pkmn cache warm-sets` to prime everything. Avoids re-downloading the
+catalog on every render of the modal."""
 
 from __future__ import annotations
 
 import json
+import mimetypes
 import time
 from pathlib import Path
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from fastapi.concurrency import run_in_threadpool
+from fastapi.responses import FileResponse
 
+from mgz_pkmn import cache as disk_cache
 from mgz_pkmn.sources import TCGClient
 
 router = APIRouter()
@@ -72,3 +86,36 @@ async def get_sets(api_key: str | None = None) -> dict:
     sets = await run_in_threadpool(_fetch_sets, api_key)
     _save_sets_cache(sets)
     return {"sets": sets}
+
+
+@router.get("/sets/{set_id}/logo")
+async def get_set_logo(set_id: str) -> FileResponse:
+    """Stream the cached logo image for a set, or 404 if not cached.
+
+    Reads from the unified disk image cache populated by
+    `pkmn cache warm-sets` (or any prior `set-cards` run). Returns 404
+    when the set hasn't been warmed yet — the SPA picker should treat
+    that as a soft fallback (text-only chip) rather than an error, and
+    surface a one-liner suggesting `pkmn cache warm-sets` to the user.
+
+    No upstream fetch on miss: this endpoint is strictly a cache reader.
+    Fetch + persist is the warm-sets command's job; mixing the two would
+    let a single picker render hammer the upstream API for every set."""
+    path = disk_cache.read_image("sets/logo", set_id)
+    if path is None:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"no cached logo for set '{set_id}' — "
+                "run `pkmn cache warm-sets` to populate the catalog"
+            ),
+        )
+    media_type, _ = mimetypes.guess_type(path.name)
+    return FileResponse(
+        path,
+        media_type=media_type or "application/octet-stream",
+        # 30-day immutable cache: set logos don't change once a set ships,
+        # so the browser can hold onto each one indefinitely. The cache key
+        # is the set id, which never collides on its own.
+        headers={"Cache-Control": "public, max-age=2592000, immutable"},
+    )

--- a/api/routes/sets.py
+++ b/api/routes/sets.py
@@ -1,8 +1,8 @@
 """Set-catalog HTTP surface — list of every set, plus their cached logos.
 
 `GET /api/v1/sets` returns the full pokemontcg.io catalog (id, name,
-series, total, release date, image URLs). Used by the SPA's set picker
-modal to populate the grouped multi-select.
+series, total, release date). Used by the SPA's set picker modal to
+populate the grouped multi-select.
 
 `GET /api/v1/sets/{set_id}/logo` streams the cached logo image for a set
 out of the unified disk image cache (see `mgz_pkmn.cache.read_image`).
@@ -17,8 +17,10 @@ import json
 import mimetypes
 import time
 from pathlib import Path
+from typing import Annotated
 
 from fastapi import APIRouter, HTTPException
+from fastapi import Path as PathParam
 from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import FileResponse
 
@@ -27,28 +29,42 @@ from mgz_pkmn.sources import TCGClient
 
 router = APIRouter()
 
-_SETS_CACHE_PATH = Path("~/.cache/mgz-pkmn/sets.json").expanduser()
+# Pokemon TCG set ids are short alphanumeric strings (e.g. `sv8`, `base1`,
+# `swsh4`). FastAPI rejects anything outside the pattern with a 422 before
+# the handler runs; `max_length=64` is well above any real id (longest in
+# the current catalog is 8 chars) while still bounding pathological inputs.
+_SET_ID_PATH = PathParam(pattern=r"^[A-Za-z0-9_-]{1,64}$", max_length=64)
+
 _SETS_TTL = 7 * 24 * 60 * 60  # refresh weekly
 
 
+def _sets_cache_path() -> Path:
+    # Lazy lookup so we go through `disk_cache.cache_root()` and honour
+    # `XDG_CACHE_HOME` instead of hardcoding `~/.cache`. Resolving at call
+    # time also avoids creating the cache dir at import time.
+    return disk_cache.cache_root() / "sets.json"
+
+
 def _load_sets_cache() -> list[dict] | None:
-    if not _SETS_CACHE_PATH.exists():
+    path = _sets_cache_path()
+    if not path.exists():
         return None
-    if time.time() - _SETS_CACHE_PATH.stat().st_mtime > _SETS_TTL:
+    if time.time() - path.stat().st_mtime > _SETS_TTL:
         return None
     try:
-        data = json.loads(_SETS_CACHE_PATH.read_text(encoding="utf-8"))
+        data = json.loads(path.read_text(encoding="utf-8"))
         return data if isinstance(data, list) else None
     except (OSError, json.JSONDecodeError):
         return None
 
 
 def _save_sets_cache(sets: list[dict]) -> None:
+    path = _sets_cache_path()
     try:
-        _SETS_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
-        tmp = _SETS_CACHE_PATH.with_suffix(".tmp")
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".tmp")
         tmp.write_text(json.dumps(sets, indent=2), encoding="utf-8")
-        tmp.replace(_SETS_CACHE_PATH)
+        tmp.replace(path)
     except (OSError, TypeError, ValueError):
         pass
 
@@ -89,7 +105,9 @@ async def get_sets(api_key: str | None = None) -> dict:
 
 
 @router.get("/sets/{set_id}/logo")
-async def get_set_logo(set_id: str) -> FileResponse:
+async def get_set_logo(
+    set_id: Annotated[str, _SET_ID_PATH],
+) -> FileResponse:
     """Stream the cached logo image for a set, or 404 if not cached.
 
     Reads from the unified disk image cache populated by
@@ -116,11 +134,8 @@ async def get_set_logo(set_id: str) -> FileResponse:
         media_type=media_type or "application/octet-stream",
         # 30-day immutable browser cache: set logos don't change once a
         # set ships, so a long client-side TTL keeps the picker snappy on
-        # repeat opens. The `immutable` directive tells the browser not
-        # to revalidate while the entry is fresh. 30 days is the practical
-        # ceiling — long enough that day-of-show flows never re-fetch,
-        # short enough that any future re-skinning of a logo still
-        # propagates within a month without the user clearing cookies.
-        # The cache key is the set id, which never collides on its own.
+        # repeat opens. 30 days is the practical ceiling — long enough
+        # that day-of-show flows never re-fetch, short enough that any
+        # future re-skinning of a logo still propagates within a month.
         headers={"Cache-Control": "public, max-age=2592000, immutable"},
     )

--- a/api/routes/sets.py
+++ b/api/routes/sets.py
@@ -114,8 +114,13 @@ async def get_set_logo(set_id: str) -> FileResponse:
     return FileResponse(
         path,
         media_type=media_type or "application/octet-stream",
-        # 30-day immutable cache: set logos don't change once a set ships,
-        # so the browser can hold onto each one indefinitely. The cache key
-        # is the set id, which never collides on its own.
+        # 30-day immutable browser cache: set logos don't change once a
+        # set ships, so a long client-side TTL keeps the picker snappy on
+        # repeat opens. The `immutable` directive tells the browser not
+        # to revalidate while the entry is fresh. 30 days is the practical
+        # ceiling — long enough that day-of-show flows never re-fetch,
+        # short enough that any future re-skinning of a logo still
+        # propagates within a month without the user clearing cookies.
+        # The cache key is the set id, which never collides on its own.
         headers={"Cache-Control": "public, max-age=2592000, immutable"},
     )

--- a/src/mgz_pkmn/cli.py
+++ b/src/mgz_pkmn/cli.py
@@ -23,7 +23,12 @@ from .lookup import find_card, find_top_cards
 from .parser import CardQuery, read_input
 from .pricing import Pricing, extract_pricing
 from .report import build_json_report
-from .set_cards import fetch_all_sets, warm_set_images, write_set_cards_pdf
+from .set_cards import (
+    fetch_all_sets,
+    filter_sets_by_ids,
+    warm_set_images,
+    write_set_cards_pdf,
+)
 from .sorting import DEFAULT_SORT, SORT_MODES, sort_rows
 from .sources import PriceChartingClient, TCGClient, TCGDexClient
 from .sources.base import MatchResult
@@ -825,12 +830,24 @@ def _expand_inputs(paths: tuple[Path, ...]) -> list[Path]:
     is_flag=True,
     help="Skip logo downloads and render text-only cutouts.",
 )
+@click.option(
+    "-s",
+    "--set",
+    "set_ids",
+    multiple=True,
+    metavar="SET_ID",
+    help=(
+        "Restrict output to one or more set ids (repeatable; e.g. "
+        "`-s sv8 -s sv7`). Omit to render every set."
+    ),
+)
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output.")
 def set_cards_command(
     output: Path,
     api_key: str | None,
     logos_dir: Path,
     no_images: bool,
+    set_ids: tuple[str, ...],
     verbose: bool,
 ) -> None:
     """Generate printable set ID cards for binder section dividers.
@@ -838,7 +855,11 @@ def set_cards_command(
     Fetches every Pokémon TCG set from pokemontcg.io and emits one
     card-sized cutout per set, laid out 3x3 on Letter so a printed page
     drops straight into a 9-pocket binder sheet. Takes no positional
-    arguments."""
+    arguments.
+
+    Pass `--set <id>` (repeatable) to restrict the output to specific
+    sets — the SPA's set picker modal uses the same filter under the
+    hood, so anything you can pick there is reachable from the CLI."""
     _print_banner(__version__)
 
     _print_section("Fetching set catalog from pokemontcg.io")
@@ -851,6 +872,16 @@ def set_cards_command(
         raise click.ClickException("pokemontcg.io returned no sets")
     click.secho("  ✓ ", fg="green", nl=False)
     click.echo(f"{len(sets)} set{'s' if len(sets) != 1 else ''}")
+
+    if set_ids:
+        sets = filter_sets_by_ids(sets, set_ids)
+        if not sets:
+            raise click.ClickException(f"no sets matched the requested ids: {', '.join(set_ids)}")
+        click.secho("  ✓ ", fg="green", nl=False)
+        click.echo(
+            f"filtered to {len(sets)} set{'s' if len(sets) != 1 else ''} "
+            + click.style(f"({', '.join(set_ids)})", fg="bright_black")
+        )
 
     _print_section("Writing outputs")
     logos = None if no_images else logos_dir

--- a/src/mgz_pkmn/set_cards.py
+++ b/src/mgz_pkmn/set_cards.py
@@ -23,7 +23,7 @@ import datetime as _dt
 import re
 import shutil
 import sys
-from collections.abc import Iterable
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -112,16 +112,19 @@ def fetch_all_sets(client: TCGClient) -> list[dict[str, Any]]:
 
 def filter_sets_by_ids(
     sets: list[dict[str, Any]],
-    set_ids: Iterable[str] | None,
+    set_ids: Sequence[str] | None,
 ) -> list[dict[str, Any]]:
     """Restrict `sets` to entries whose `id` appears in `set_ids`.
 
     Returns `sets` unchanged when `set_ids` is `None` or empty — "no filter"
-    is the default. The match is case-sensitive (pokemontcg.io set ids are
-    lowercase by convention, and an unintended typo should produce an empty
-    selection rather than a too-clever fuzzy match the user can't reason
-    about). The input order is preserved so the rendered PDF tracks the
-    catalog's oldest → newest ordering."""
+    is the default. `set_ids` is typed `Sequence` rather than `Iterable` so
+    the emptiness check is well-defined (a one-shot generator would be
+    truthy-but-empty and silently filter everything out). The match is
+    case-sensitive (pokemontcg.io set ids are lowercase by convention, and
+    an unintended typo should produce an empty selection rather than a
+    too-clever fuzzy match the user can't reason about). The input order
+    is preserved so the rendered PDF tracks the catalog's oldest → newest
+    ordering."""
     if not set_ids:
         return sets
     wanted = set(set_ids)

--- a/src/mgz_pkmn/set_cards.py
+++ b/src/mgz_pkmn/set_cards.py
@@ -23,6 +23,7 @@ import datetime as _dt
 import re
 import shutil
 import sys
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -107,6 +108,24 @@ def fetch_all_sets(client: TCGClient) -> list[dict[str, Any]]:
         for s in raw
         if s.get("id") and s.get("name")
     ]
+
+
+def filter_sets_by_ids(
+    sets: list[dict[str, Any]],
+    set_ids: Iterable[str] | None,
+) -> list[dict[str, Any]]:
+    """Restrict `sets` to entries whose `id` appears in `set_ids`.
+
+    Returns `sets` unchanged when `set_ids` is `None` or empty — "no filter"
+    is the default. The match is case-sensitive (pokemontcg.io set ids are
+    lowercase by convention, and an unintended typo should produce an empty
+    selection rather than a too-clever fuzzy match the user can't reason
+    about). The input order is preserved so the rendered PDF tracks the
+    catalog's oldest → newest ordering."""
+    if not set_ids:
+        return sets
+    wanted = set(set_ids)
+    return [s for s in sets if s.get("id") in wanted]
 
 
 def write_set_cards_pdf(

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -191,6 +191,45 @@ class SetsRouteTests(unittest.TestCase):
         self.assertEqual(resp.json()["sets"], fetched_sets)
 
 
+class SetLogoRouteTests(unittest.TestCase):
+    """`GET /api/v1/sets/{set_id}/logo` serves cached images, 404s on miss."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._old_xdg = os.environ.get("XDG_CACHE_HOME")
+        os.environ["XDG_CACHE_HOME"] = self._tmp.name
+
+    def tearDown(self) -> None:
+        if self._old_xdg is None:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        else:
+            os.environ["XDG_CACHE_HOME"] = self._old_xdg
+        self._tmp.cleanup()
+
+    def test_serves_cached_logo(self) -> None:
+        # A real PNG header so FileResponse's content-type guess is sensible.
+        png_bytes = b"\x89PNG\r\n\x1a\n" + b"fakeimagedata" * 8
+        cache.write_image("sets/logo", "base1", png_bytes, ext=".png")
+
+        resp = client.get("/api/v1/sets/base1/logo")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content, png_bytes)
+        self.assertEqual(resp.headers["content-type"], "image/png")
+        # 30-day immutable cache so the SPA can keep the asset as long as
+        # the set id is stable.
+        self.assertIn("immutable", resp.headers.get("cache-control", ""))
+        self.assertIn("max-age=2592000", resp.headers.get("cache-control", ""))
+
+    def test_404_when_not_in_cache_suggests_warm_sets(self) -> None:
+        resp = client.get("/api/v1/sets/zzz-not-warmed/logo")
+        self.assertEqual(resp.status_code, 404)
+        # The error body should point the user at the warm-sets command.
+        detail = resp.json()["detail"]
+        self.assertIn("zzz-not-warmed", detail)
+        self.assertIn("warm-sets", detail)
+
+
 # ---------------------------------------------------------------------------
 # /overrides
 # ---------------------------------------------------------------------------

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -161,7 +161,7 @@ class SetsRouteTests(unittest.TestCase):
         cache_path = self._seed_cache(known_sets)
 
         with (
-            patch("api.routes.sets._SETS_CACHE_PATH", cache_path),
+            patch("api.routes.sets._sets_cache_path", return_value=cache_path),
             patch("api.routes.sets._SETS_TTL", 999_999_999),
         ):
             resp = client.get("/api/v1/sets")
@@ -228,6 +228,44 @@ class SetLogoRouteTests(unittest.TestCase):
         detail = resp.json()["detail"]
         self.assertIn("zzz-not-warmed", detail)
         self.assertIn("warm-sets", detail)
+
+    def test_rejects_malformed_set_ids_at_route_boundary(self) -> None:
+        # Defense-in-depth: the route's `Path(pattern=...)` validator
+        # rejects anything outside `[A-Za-z0-9_-]` with a 422 before
+        # `read_image` runs. The cache module's `_safe_image_key` also
+        # sanitises (slashes collapse to underscores), but stopping the
+        # value at the HTTP boundary keeps the CodeQL taint tracer happy
+        # and makes the contract explicit.
+        #
+        # Path-traversal-style inputs like `../etc/passwd` and
+        # `sv8/../x` never reach this handler at all — the ASGI URL
+        # normaliser rewrites them before routing — so we only assert
+        # 422 against bad characters that *do* survive routing.
+        for bad in (
+            "sv8;rm",
+            "sv8%20with%20space",  # decodes to a literal space
+            "x" * 200,  # over max_length=64
+            "sv8&foo",
+            "sv8*",
+        ):
+            with self.subTest(set_id=bad):
+                resp = client.get(f"/api/v1/sets/{bad}/logo")
+                self.assertEqual(
+                    resp.status_code,
+                    422,
+                    f"expected 422 for malformed set_id={bad!r}, got {resp.status_code}",
+                )
+
+    def test_path_traversal_attempts_dont_resolve_to_this_route(self) -> None:
+        # ASGI URL normalisation collapses `..` segments before routing,
+        # so `/api/v1/sets/../etc/passwd/logo` becomes
+        # `/api/v1/etc/passwd/logo` — a route that doesn't exist (404).
+        # This is the first line of defense; the regex validator catches
+        # whatever survives.
+        for bad in ("..", "../etc/passwd", "sets/../etc"):
+            with self.subTest(set_id=bad):
+                resp = client.get(f"/api/v1/sets/{bad}/logo")
+                self.assertEqual(resp.status_code, 404)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -336,6 +336,56 @@ class CacheStatsCommandTests(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertIn("1 failures", result.output)
 
+    def test_set_cards_set_flag_filters_writer(self) -> None:
+        # `pkmn set-cards --set sv8 --set sv7` should reach
+        # write_set_cards_pdf with only those two entries.
+        from unittest.mock import patch as _patch
+
+        sets = [
+            {"id": "sv8", "name": "Surging Sparks", "images": {}},
+            {"id": "sv7", "name": "Stellar Crown", "images": {}},
+            {"id": "sv6", "name": "Twilight Masquerade", "images": {}},
+        ]
+        captured: dict = {}
+
+        def _fake_writer(rows, out_path, *, logos_dir=None, session=None, today=None):
+            captured["sets"] = rows
+            out_path.write_bytes(b"%PDF\n")
+            return len(rows)
+
+        with (
+            _patch("mgz_pkmn.cli.fetch_all_sets", return_value=sets),
+            _patch("mgz_pkmn.cli.write_set_cards_pdf", side_effect=_fake_writer),
+            tempfile.TemporaryDirectory() as tmp,
+        ):
+            out = Path(tmp) / "out.pdf"
+            result = CliRunner().invoke(
+                cli, ["set-cards", "-o", str(out), "--set", "sv8", "--set", "sv7"]
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("filtered to 2 sets", result.output)
+        self.assertEqual([s["id"] for s in captured["sets"]], ["sv8", "sv7"])
+
+    def test_set_cards_set_flag_with_unknown_id_fails(self) -> None:
+        # An id that doesn't match any catalog entry should surface as a
+        # ClickException — not silently produce an empty PDF.
+        from unittest.mock import patch as _patch
+
+        sets = [{"id": "sv8", "name": "Surging Sparks", "images": {}}]
+
+        with (
+            _patch("mgz_pkmn.cli.fetch_all_sets", return_value=sets),
+            tempfile.TemporaryDirectory() as tmp,
+        ):
+            out = Path(tmp) / "out.pdf"
+            result = CliRunner().invoke(
+                cli, ["set-cards", "-o", str(out), "--set", "does-not-exist"]
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("does-not-exist", result.output)
+
     def test_warm_sets_clickfails_when_catalog_is_empty(self) -> None:
         # An empty catalog should surface as a ClickException, not a silent
         # success — the user installing fresh would otherwise have no

--- a/tests/test_set_cards.py
+++ b/tests/test_set_cards.py
@@ -20,6 +20,7 @@ from mgz_pkmn.set_cards import (
     _draw_logo,
     _release_year,
     fetch_all_sets,
+    filter_sets_by_ids,
     warm_set_images,
     write_set_cards_pdf,
 )
@@ -417,6 +418,44 @@ class WarmSetImagesFailureTests(_IsolatedCacheMixin):
         # First entry (no id, no name) is skipped — only the second counts.
         self.assertEqual(result.sets, 2)  # `total` is the raw length
         self.assertEqual(result.logos_cached, 1)
+
+
+class FilterSetsByIdsTests(unittest.TestCase):
+    def _sets(self) -> list[dict]:
+        return [
+            {"id": "base1", "name": "Base"},
+            {"id": "jungle", "name": "Jungle"},
+            {"id": "fossil", "name": "Fossil"},
+        ]
+
+    def test_none_passes_through(self) -> None:
+        sets = self._sets()
+        self.assertIs(filter_sets_by_ids(sets, None), sets)
+
+    def test_empty_iterable_passes_through(self) -> None:
+        sets = self._sets()
+        self.assertIs(filter_sets_by_ids(sets, []), sets)
+        self.assertIs(filter_sets_by_ids(sets, ()), sets)
+
+    def test_filters_to_matching_ids(self) -> None:
+        out = filter_sets_by_ids(self._sets(), ["jungle", "fossil"])
+        self.assertEqual([s["id"] for s in out], ["jungle", "fossil"])
+
+    def test_preserves_input_order(self) -> None:
+        # `set_ids` ordering must not change the catalog ordering — the
+        # PDF should still render oldest → newest regardless of how the
+        # SPA passes the ids.
+        out = filter_sets_by_ids(self._sets(), ["fossil", "base1"])
+        self.assertEqual([s["id"] for s in out], ["base1", "fossil"])
+
+    def test_unknown_ids_return_empty(self) -> None:
+        # Typos / stale set ids must produce an empty list rather than a
+        # fuzzy match — callers turn empty into a 404 / ClickException.
+        self.assertEqual(filter_sets_by_ids(self._sets(), ["does-not-exist"]), [])
+
+    def test_match_is_case_sensitive(self) -> None:
+        # pokemontcg.io set ids are lowercase; uppercase typos should miss.
+        self.assertEqual(filter_sets_by_ids(self._sets(), ["BASE1"]), [])
 
 
 class DrawLogoTests(unittest.TestCase):

--- a/tests/test_set_cards_api.py
+++ b/tests/test_set_cards_api.py
@@ -72,6 +72,33 @@ class SetCardsEndpointTests(unittest.TestCase):
         self.assertIsNone(captured["logos_dir"])
         self.assertIsNone(captured["session"])
 
+    def test_set_ids_query_param_filters_catalog(self) -> None:
+        # Repeated `?set_ids=sv8&set_ids=sv7` must reach the writer with
+        # only those entries — the SPA picker depends on this contract.
+        captured: dict = {}
+
+        def _fake_writer(sets, out_path, *, logos_dir=None, session=None, today=None):
+            captured["sets"] = sets
+            out_path.write_bytes(b"%PDF-1.4\n%fake\n")
+            return len(sets)
+
+        with (
+            patch("api.routes.set_cards.fetch_all_sets", return_value=SAMPLE_SETS),
+            patch("api.routes.set_cards.write_set_cards_pdf", side_effect=_fake_writer),
+        ):
+            resp = client.get("/api/v1/set-cards.pdf?set_ids=sv8")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual([s["id"] for s in captured["sets"]], ["sv8"])
+
+    def test_set_ids_with_no_matches_returns_404(self) -> None:
+        # An unknown filter is the only way the user can produce zero sets
+        # at the writer; an empty PDF would be confusing. The 404 detail
+        # echoes the requested ids so the SPA can render a clear message.
+        with patch("api.routes.set_cards.fetch_all_sets", return_value=SAMPLE_SETS):
+            resp = client.get("/api/v1/set-cards.pdf?set_ids=zzz-missing")
+        self.assertEqual(resp.status_code, 404)
+        self.assertIn("zzz-missing", resp.json()["detail"])
+
     def test_default_passes_session_for_unified_image_cache(self) -> None:
         # Logo storage now flows through the unified disk image cache
         # (cache/images/sets/), so the route no longer needs to thread a

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -204,10 +204,21 @@ export async function exportFile(
  * Download the printable set-identification-cards PDF. Triggers a save in
  * the browser; no rows or settings are required — the server fetches the
  * full set catalog itself.
+ *
+ * Pass `setIds` to restrict the PDF to a subset of sets (the picker modal
+ * uses this). Omit / pass an empty array for the historical "every set"
+ * behavior.
  */
-export async function downloadSetCardsPdf(apiKey?: string): Promise<void> {
-  const params = apiKey ? `?api_key=${encodeURIComponent(apiKey)}` : ''
-  const res = await fetch(`${BASE}/set-cards.pdf${params}`)
+export async function downloadSetCardsPdf(apiKey?: string, setIds?: string[]): Promise<void> {
+  const params = new URLSearchParams()
+  if (apiKey) params.set('api_key', apiKey)
+  if (setIds && setIds.length > 0) {
+    // Repeatable query param: ?set_ids=sv8&set_ids=sv7 maps onto FastAPI's
+    // `list[str] = Query()` binding on the backend.
+    for (const id of setIds) params.append('set_ids', id)
+  }
+  const qs = params.toString()
+  const res = await fetch(`${BASE}/set-cards.pdf${qs ? `?${qs}` : ''}`)
   if (!res.ok) {
     let detail = `set-cards failed: ${res.status}`
     try {
@@ -225,6 +236,15 @@ export async function downloadSetCardsPdf(apiKey?: string): Promise<void> {
   a.download = 'set-cards.pdf'
   a.click()
   setTimeout(() => URL.revokeObjectURL(url), 0)
+}
+
+/**
+ * Resolve the cached-logo URL for a given set id. The endpoint serves the
+ * image straight out of the unified disk cache; missing entries return 404,
+ * which the SPA renders as a soft fallback (text-only chip).
+ */
+export function setLogoUrl(setId: string): string {
+  return `${BASE}/sets/${encodeURIComponent(setId)}/logo`
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/components/ExportBar.test.tsx
+++ b/web/src/components/ExportBar.test.tsx
@@ -3,15 +3,24 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { ExportBar } from './ExportBar'
 import { useAppStore } from '../store'
 import type { Row } from '../types'
-import { exportFile, downloadSetCardsPdf } from '../api/client'
+import { exportFile } from '../api/client'
 
 vi.mock('../api/client', () => ({
   exportFile: vi.fn(),
   downloadSetCardsPdf: vi.fn(),
+  fetchSets: vi.fn().mockResolvedValue([]),
+  setLogoUrl: vi.fn((id: string) => `/api/v1/sets/${id}/logo`),
+}))
+
+// Stub the picker modal so these tests stay focused on the ExportBar
+// surface — clicking "Set ID cards…" just toggles the stub. The modal
+// itself has its own test file (SetPickerModal.test.tsx).
+vi.mock('./SetPickerModal', () => ({
+  SetPickerModal: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="set-picker-stub">picker open</div> : null,
 }))
 
 const mockExportFile = vi.mocked(exportFile)
-const mockDownloadSetCardsPdf = vi.mocked(downloadSetCardsPdf)
 
 /**
  * Radix DropdownMenu opens on `pointerdown`, not on `click`, so the plain
@@ -64,9 +73,7 @@ describe('ExportBar', () => {
       },
     })
     mockExportFile.mockReset()
-    mockDownloadSetCardsPdf.mockReset()
     mockExportFile.mockResolvedValue(undefined)
-    mockDownloadSetCardsPdf.mockResolvedValue(undefined)
   })
 
   it('renders an Export trigger', () => {
@@ -81,7 +88,9 @@ describe('ExportBar', () => {
     expect(screen.getByText('PDF binder')).toBeInTheDocument()
     expect(screen.getByText('Condensed PDF')).toBeInTheDocument()
     expect(screen.getByText('Checklist')).toBeInTheDocument()
-    expect(screen.getByText('Set ID cards')).toBeInTheDocument()
+    // The Set ID cards item now opens the picker modal — the ellipsis
+    // signals "more options before you commit."
+    expect(screen.getByText('Set ID cards…')).toBeInTheDocument()
   })
 
   it('disables row-dependent items when no rows are matched, but keeps Set ID cards enabled', () => {
@@ -92,7 +101,7 @@ describe('ExportBar', () => {
       const item = screen.getByText(label).closest('[role="menuitem"]')!
       expect(item).toHaveAttribute('data-disabled')
     }
-    const setCards = screen.getByText('Set ID cards').closest('[role="menuitem"]')!
+    const setCards = screen.getByText('Set ID cards…').closest('[role="menuitem"]')!
     expect(setCards).not.toHaveAttribute('data-disabled')
 
     // Row count label is only shown when there are matched rows.
@@ -172,36 +181,26 @@ describe('ExportBar', () => {
     expect(mockExportFile).not.toHaveBeenCalled()
   })
 
-  it('calls downloadSetCardsPdf when Set ID cards is picked, even without matched rows', async () => {
-    useAppStore.setState({
-      rows: [],
-      settings: {
-        apiKey: 'secret-key',
-        maxPrice: null,
-        noImages: true,
-        tag: '',
-        dedupe: false,
-        sort: 'number',
-      },
-    })
-
+  it('Set ID cards menu item opens the picker modal', async () => {
     render(<ExportBar />)
     openDropdown()
-    fireEvent.click(screen.getByText('Set ID cards'))
+    expect(screen.queryByTestId('set-picker-stub')).not.toBeInTheDocument()
 
-    await waitFor(() => expect(mockDownloadSetCardsPdf).toHaveBeenCalledTimes(1))
-    expect(mockDownloadSetCardsPdf).toHaveBeenCalledWith('secret-key')
+    fireEvent.click(screen.getByText('Set ID cards…'))
+
+    expect(await screen.findByTestId('set-picker-stub')).toBeInTheDocument()
   })
 
-  it('passes undefined to downloadSetCardsPdf when no API key is configured', async () => {
+  it('Set ID cards menu item works even with no matched rows', async () => {
+    // The modal still opens with zero rows in the store — it doesn't
+    // require any lookup state to function.
     useAppStore.setState({ rows: [] })
 
     render(<ExportBar />)
     openDropdown()
-    fireEvent.click(screen.getByText('Set ID cards'))
+    fireEvent.click(screen.getByText('Set ID cards…'))
 
-    await waitFor(() => expect(mockDownloadSetCardsPdf).toHaveBeenCalledTimes(1))
-    expect(mockDownloadSetCardsPdf).toHaveBeenCalledWith(undefined)
+    expect(await screen.findByTestId('set-picker-stub')).toBeInTheDocument()
   })
 
   it('surfaces export errors in the bar', async () => {
@@ -224,16 +223,5 @@ describe('ExportBar', () => {
     fireEvent.click(screen.getByText('Condensed PDF'))
 
     expect(await screen.findByText('rate-limited')).toBeInTheDocument()
-  })
-
-  it('surfaces Set ID cards errors in the bar', async () => {
-    mockDownloadSetCardsPdf.mockRejectedValueOnce(new Error('catalog down'))
-    useAppStore.setState({ rows: [] })
-
-    render(<ExportBar />)
-    openDropdown()
-    fireEvent.click(screen.getByText('Set ID cards'))
-
-    expect(await screen.findByText('catalog down')).toBeInTheDocument()
   })
 })

--- a/web/src/components/ExportBar.tsx
+++ b/web/src/components/ExportBar.tsx
@@ -25,9 +25,10 @@ import {
   ChevronDown,
 } from 'lucide-react'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
-import { downloadSetCardsPdf, exportFile } from '../api/client'
+import { exportFile } from '../api/client'
 import { useAppStore } from '../store'
 import type { ExportFormat } from '../types'
+import { SetPickerModal } from './SetPickerModal'
 
 const BUTTONS: { format: ExportFormat; label: string; icon: ReactNode }[] = [
   { format: 'xlsx', label: 'Download .xlsx', icon: <FileSpreadsheet size={14} /> },
@@ -38,8 +39,12 @@ const BUTTONS: { format: ExportFormat; label: string; icon: ReactNode }[] = [
 
 export function ExportBar() {
   const { rows, settings } = useAppStore()
-  const [loading, setLoading] = useState<ExportFormat | 'set-cards' | null>(null)
+  const [loading, setLoading] = useState<ExportFormat | null>(null)
   const [error, setError] = useState<string | null>(null)
+  // Set ID cards now opens the picker modal rather than firing an
+  // immediate download — the modal owns its own loading + error state
+  // (including the cross-fetch to /api/v1/sets).
+  const [pickerOpen, setPickerOpen] = useState(false)
 
   const matchedRows = rows.filter((r) => r.matched)
   const disabled = matchedRows.length === 0
@@ -57,18 +62,6 @@ export function ExportBar() {
         noImages: settings.noImages,
         dedupe: settings.dedupe,
       })
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e))
-    } finally {
-      setLoading(null)
-    }
-  }
-
-  async function handleSetCards() {
-    setLoading('set-cards')
-    setError(null)
-    try {
-      await downloadSetCardsPdf(settings.apiKey || undefined)
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))
     } finally {
@@ -109,11 +102,11 @@ export function ExportBar() {
             ))}
             <DropdownMenu.Separator className="my-1 h-px bg-zinc-800" />
             <DropdownMenu.Item
-              onSelect={handleSetCards}
+              onSelect={() => setPickerOpen(true)}
               className="flex items-center gap-2 rounded px-2.5 py-2 text-sm text-zinc-200 outline-none data-[highlighted]:bg-zinc-800"
             >
               <Tags size={14} />
-              Set ID cards
+              Set ID cards…
             </DropdownMenu.Item>
             {matchedRows.length > 0 && (
               <>
@@ -129,6 +122,7 @@ export function ExportBar() {
       {/* Errors live outside the dropdown so they stay visible after the
           user picks a format and the menu closes. */}
       {error && <span className="text-xs text-red-400">{error}</span>}
+      <SetPickerModal open={pickerOpen} onOpenChange={setPickerOpen} />
     </div>
   )
 }

--- a/web/src/components/SetPickerModal.test.tsx
+++ b/web/src/components/SetPickerModal.test.tsx
@@ -59,10 +59,19 @@ describe('SetPickerModal', () => {
     return { onOpenChange, ...result }
   }
 
+  // Block until the catalog has fetched AND the result has re-rendered.
+  // Plain `waitFor(mockFetchSets called)` resolves at the start of the
+  // promise, so the resulting setState→render lands on a later tick and
+  // slower runners (CI) lose the race. Querying for a known catalog row
+  // forces the wait through the actual re-render.
+  async function waitForCatalog() {
+    await screen.findByText('Surging Sparks')
+  }
+
   it('loads the catalog when opened and renders series newest-first', async () => {
     renderOpen()
 
-    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
+    await waitForCatalog()
     expect(screen.getByText('Base Set')).toBeInTheDocument()
     expect(screen.getByText('Jungle')).toBeInTheDocument()
     expect(screen.getByText('Surging Sparks')).toBeInTheDocument()
@@ -81,7 +90,7 @@ describe('SetPickerModal', () => {
     // source of truth — no warning UI to assert because the user can't
     // reach `handleSubmit` from an empty draft in the first place.
     renderOpen()
-    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
+    await waitForCatalog()
 
     expect(screen.getByRole('button', { name: 'Download PDF' })).toBeDisabled()
     expect(mockDownload).not.toHaveBeenCalled()
@@ -89,7 +98,7 @@ describe('SetPickerModal', () => {
 
   it('select-all checks every box and Download PDF posts every id', async () => {
     const { onOpenChange } = renderOpen()
-    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
+    await waitForCatalog()
 
     fireEvent.click(screen.getByRole('button', { name: 'Select all' }))
     fireEvent.click(screen.getByRole('button', { name: 'Download PDF' }))
@@ -105,7 +114,7 @@ describe('SetPickerModal', () => {
 
   it('select-none clears the draft after a select-all', async () => {
     renderOpen()
-    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
+    await waitForCatalog()
 
     fireEvent.click(screen.getByRole('button', { name: 'Select all' }))
     fireEvent.click(screen.getByRole('button', { name: 'Select none' }))
@@ -114,7 +123,7 @@ describe('SetPickerModal', () => {
 
   it('select-series picks every set in that series only', async () => {
     renderOpen()
-    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
+    await waitForCatalog()
 
     // With newest-first ordering, the second "Select series" button is
     // the Base group (Scarlet & Violet is index 0). Picking it should
@@ -130,9 +139,12 @@ describe('SetPickerModal', () => {
 
   it('toggling a row checkbox flips its selection', async () => {
     renderOpen()
-    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
-
-    const checkbox = screen.getByRole('checkbox', { name: 'Include Surging Sparks' })
+    // `findByRole` waits for the catalog rows to render (the fetch
+    // setState→re-render lands on a tick after the mock counter ticks,
+    // so a plain `getByRole` races CI).
+    const checkbox = await screen.findByRole('checkbox', {
+      name: 'Include Surging Sparks',
+    })
     fireEvent.click(checkbox)
     expect(checkbox).toBeChecked()
     fireEvent.click(checkbox)
@@ -196,7 +208,7 @@ describe('SetPickerModal', () => {
   it('surfaces a submit error and keeps the modal open', async () => {
     mockDownload.mockRejectedValueOnce(new Error('rate-limited'))
     const { onOpenChange } = renderOpen()
-    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
+    await waitForCatalog()
 
     fireEvent.click(screen.getByRole('button', { name: 'Select all' }))
     fireEvent.click(screen.getByRole('button', { name: 'Download PDF' }))
@@ -209,7 +221,7 @@ describe('SetPickerModal', () => {
 
   it('collapsing a series hides its rows; expanding restores them', async () => {
     renderOpen()
-    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
+    await waitForCatalog()
 
     // The "Base" series header (newest-first ordering puts S&V first,
     // Base second).
@@ -235,7 +247,7 @@ describe('SetPickerModal', () => {
 
   it('Collapse all hides every series; Expand all restores them', async () => {
     renderOpen()
-    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
+    await waitForCatalog()
 
     fireEvent.click(screen.getByRole('button', { name: 'Collapse all' }))
     expect(screen.queryByText('Surging Sparks')).not.toBeInTheDocument()
@@ -248,7 +260,7 @@ describe('SetPickerModal', () => {
 
   it('series header shows N/total counter when at least one set is selected', async () => {
     renderOpen()
-    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
+    await waitForCatalog()
 
     fireEvent.click(screen.getByRole('checkbox', { name: 'Include Jungle' }))
     // The Base series (2 sets) now shows "(1/2)" in its header; the
@@ -265,7 +277,7 @@ describe('SetPickerModal', () => {
 
   it('logo thumbnails fall back to an icon when the image errors', async () => {
     renderOpen()
-    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
+    await waitForCatalog()
 
     // The thumbnail is an `<img>` with empty alt (decorative — the row's
     // accessible name lives on the checkbox), so query by tag inside the

--- a/web/src/components/SetPickerModal.test.tsx
+++ b/web/src/components/SetPickerModal.test.tsx
@@ -142,10 +142,13 @@ describe('SetPickerModal', () => {
   it('seeds the draft from selectedSetIds when reopening', async () => {
     useAppStore.setState({ selectedSetIds: ['jungle'] })
     renderOpen()
-    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
-
+    // Wait on the rendered DOM, not just the mock call. `waitFor` on the
+    // call count resolves as soon as the fetch promise begins; the
+    // resulting setState→re-render lands on a later tick. Slower CI
+    // machines lose that race and observe the dialog chrome without
+    // its rows.
     expect(
-      screen.getByRole('checkbox', { name: 'Include Jungle' })
+      await screen.findByRole('checkbox', { name: 'Include Jungle' })
     ).toBeChecked()
     expect(
       screen.getByRole('checkbox', { name: 'Include Base Set' })

--- a/web/src/components/SetPickerModal.test.tsx
+++ b/web/src/components/SetPickerModal.test.tsx
@@ -219,6 +219,33 @@ describe('SetPickerModal', () => {
     expect(onOpenChange).not.toHaveBeenCalledWith(false)
   })
 
+  it('parent-driven reopen reseeds draft and clears stale submit error', async () => {
+    mockDownload.mockRejectedValueOnce(new Error('rate-limited'))
+    const onOpenChange = vi.fn()
+    const { rerender } = render(
+      <SetPickerModal open={true} onOpenChange={onOpenChange} />
+    )
+    await waitForCatalog()
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Include Base Set' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Download PDF' }))
+    expect(await screen.findByText('rate-limited')).toBeInTheDocument()
+
+    // Close + reopen via parent prop flip — Radix never fires
+    // onOpenChange for this path, so the effect is the only thing
+    // that can reset state.
+    rerender(<SetPickerModal open={false} onOpenChange={onOpenChange} />)
+    rerender(<SetPickerModal open={true} onOpenChange={onOpenChange} />)
+    await waitForCatalog()
+
+    expect(screen.queryByText('rate-limited')).not.toBeInTheDocument()
+    // Draft was reseeded from the store (still empty), so the previously
+    // checked box is back to unchecked.
+    expect(
+      screen.getByRole('checkbox', { name: 'Include Base Set' }),
+    ).not.toBeChecked()
+  })
+
   it('collapsing a series hides its rows; expanding restores them', async () => {
     renderOpen()
     await waitForCatalog()

--- a/web/src/components/SetPickerModal.test.tsx
+++ b/web/src/components/SetPickerModal.test.tsx
@@ -59,17 +59,21 @@ describe('SetPickerModal', () => {
     return { onOpenChange, ...result }
   }
 
-  it('loads the catalog when opened and groups rows by series', async () => {
+  it('loads the catalog when opened and renders series newest-first', async () => {
     renderOpen()
 
     await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
     expect(screen.getByText('Base Set')).toBeInTheDocument()
     expect(screen.getByText('Jungle')).toBeInTheDocument()
     expect(screen.getByText('Surging Sparks')).toBeInTheDocument()
-    // Series headings are visible in catalog order (first-encounter wins).
-    const headings = screen.getAllByRole('heading', { level: 3 })
-    expect(headings[0]).toHaveTextContent('Base')
-    expect(headings[1]).toHaveTextContent('Scarlet & Violet')
+    // Series headers are now collapse toggles (buttons with
+    // aria-expanded). Modern sets come first since most prep biases
+    // toward current blocks, so Scarlet & Violet sits above Base.
+    const headers = screen
+      .getAllByRole('button')
+      .filter((el) => el.hasAttribute('aria-expanded'))
+    expect(headers[0]).toHaveTextContent('Scarlet & Violet')
+    expect(headers[1]).toHaveTextContent('Base')
   })
 
   it('does not download when nothing is selected — surfaces a warning', async () => {
@@ -114,10 +118,11 @@ describe('SetPickerModal', () => {
     renderOpen()
     await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
 
-    // Two "Select series" buttons — one per series. Click the first
-    // (Base).
+    // With newest-first ordering, the second "Select series" button is
+    // the Base group (Scarlet & Violet is index 0). Picking it should
+    // check both Base-era sets and leave Surging Sparks untouched.
     const seriesButtons = screen.getAllByRole('button', { name: 'Select series' })
-    fireEvent.click(seriesButtons[0])
+    fireEvent.click(seriesButtons[1])
     fireEvent.click(screen.getByRole('button', { name: 'Download PDF' }))
 
     await waitFor(() => expect(mockDownload).toHaveBeenCalledTimes(1))
@@ -170,6 +175,62 @@ describe('SetPickerModal', () => {
     // The failure path must NOT close the modal — the user should be
     // able to retry without re-checking everything.
     expect(onOpenChange).not.toHaveBeenCalledWith(false)
+  })
+
+  it('collapsing a series hides its rows; expanding restores them', async () => {
+    renderOpen()
+    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
+
+    // The "Base" series header (newest-first ordering puts S&V first,
+    // Base second).
+    const baseHeader = screen
+      .getAllByRole('button')
+      .filter((el) => el.hasAttribute('aria-expanded'))[1]
+    expect(baseHeader).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('Base Set')).toBeInTheDocument()
+    expect(screen.getByText('Jungle')).toBeInTheDocument()
+
+    fireEvent.click(baseHeader)
+    expect(baseHeader).toHaveAttribute('aria-expanded', 'false')
+    // Set rows are gone from the DOM.
+    expect(screen.queryByText('Base Set')).not.toBeInTheDocument()
+    expect(screen.queryByText('Jungle')).not.toBeInTheDocument()
+    // But Surging Sparks (in the other series) is still visible.
+    expect(screen.getByText('Surging Sparks')).toBeInTheDocument()
+
+    fireEvent.click(baseHeader)
+    expect(baseHeader).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('Base Set')).toBeInTheDocument()
+  })
+
+  it('Collapse all hides every series; Expand all restores them', async () => {
+    renderOpen()
+    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse all' }))
+    expect(screen.queryByText('Surging Sparks')).not.toBeInTheDocument()
+    expect(screen.queryByText('Base Set')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand all' }))
+    expect(screen.getByText('Surging Sparks')).toBeInTheDocument()
+    expect(screen.getByText('Base Set')).toBeInTheDocument()
+  })
+
+  it('series header shows N/total counter when at least one set is selected', async () => {
+    renderOpen()
+    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Include Jungle' }))
+    // The Base series (2 sets) now shows "(1/2)" in its header; the
+    // unselected S&V series still shows the plain "(1)" count.
+    const baseHeader = screen
+      .getAllByRole('button')
+      .filter((el) => el.hasAttribute('aria-expanded'))[1]
+    expect(baseHeader).toHaveTextContent('(1/2)')
+    const svHeader = screen
+      .getAllByRole('button')
+      .filter((el) => el.hasAttribute('aria-expanded'))[0]
+    expect(svHeader).toHaveTextContent('(1)')
   })
 
   it('logo thumbnails fall back to an icon when the image errors', async () => {

--- a/web/src/components/SetPickerModal.test.tsx
+++ b/web/src/components/SetPickerModal.test.tsx
@@ -164,6 +164,35 @@ describe('SetPickerModal', () => {
     ).toBeInTheDocument()
   })
 
+  it('clears stale load errors while retrying after reopening', async () => {
+    let resolveRetry!: (value: SetInfo[]) => void
+    const retryPromise = new Promise<SetInfo[]>((resolve) => {
+      resolveRetry = resolve
+    })
+    mockFetchSets
+      .mockRejectedValueOnce(new Error('upstream down'))
+      .mockReturnValueOnce(retryPromise)
+    const onOpenChange = vi.fn()
+    const { rerender } = render(
+      <SetPickerModal open={true} onOpenChange={onOpenChange} />
+    )
+
+    expect(
+      await screen.findByText(/Couldn’t load sets: upstream down/)
+    ).toBeInTheDocument()
+
+    rerender(<SetPickerModal open={false} onOpenChange={onOpenChange} />)
+    rerender(<SetPickerModal open={true} onOpenChange={onOpenChange} />)
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Couldn’t load sets:/)).not.toBeInTheDocument()
+    })
+    expect(screen.getByText(/Loading set catalog/)).toBeInTheDocument()
+
+    resolveRetry(SETS)
+    expect(await screen.findByText('Surging Sparks')).toBeInTheDocument()
+  })
+
   it('surfaces a submit error and keeps the modal open', async () => {
     mockDownload.mockRejectedValueOnce(new Error('rate-limited'))
     const { onOpenChange } = renderOpen()

--- a/web/src/components/SetPickerModal.test.tsx
+++ b/web/src/components/SetPickerModal.test.tsx
@@ -76,17 +76,15 @@ describe('SetPickerModal', () => {
     expect(headers[1]).toHaveTextContent('Base')
   })
 
-  it('does not download when nothing is selected — surfaces a warning', async () => {
+  it('Download PDF stays disabled while nothing is selected', async () => {
+    // Empty-selection safety rail. The disabled state is the single
+    // source of truth — no warning UI to assert because the user can't
+    // reach `handleSubmit` from an empty draft in the first place.
     renderOpen()
     await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
 
-    fireEvent.click(screen.getByRole('button', { name: 'Download PDF' }))
-    expect(mockDownload).not.toHaveBeenCalled()
-    // The disabled-button state is the safety rail; the warning text
-    // only appears when the user clicks despite that, which we can't
-    // simulate cleanly because the button is disabled. Verify the
-    // disabled state is in place.
     expect(screen.getByRole('button', { name: 'Download PDF' })).toBeDisabled()
+    expect(mockDownload).not.toHaveBeenCalled()
   })
 
   it('select-all checks every box and Download PDF posts every id', async () => {

--- a/web/src/components/SetPickerModal.test.tsx
+++ b/web/src/components/SetPickerModal.test.tsx
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { SetPickerModal } from './SetPickerModal'
+import { useAppStore } from '../store'
+import {
+  fetchSets,
+  downloadSetCardsPdf,
+  setLogoUrl,
+} from '../api/client'
+import type { SetInfo } from '../types'
+
+vi.mock('../api/client', () => ({
+  fetchSets: vi.fn(),
+  downloadSetCardsPdf: vi.fn(),
+  setLogoUrl: vi.fn((id: string) => `/api/v1/sets/${id}/logo`),
+}))
+
+const mockFetchSets = vi.mocked(fetchSets)
+const mockDownload = vi.mocked(downloadSetCardsPdf)
+const mockLogoUrl = vi.mocked(setLogoUrl)
+
+const SETS: SetInfo[] = [
+  {
+    id: 'base1',
+    name: 'Base Set',
+    series: 'Base',
+    total: 102,
+    releaseDate: '1998/01/09',
+  },
+  {
+    id: 'jungle',
+    name: 'Jungle',
+    series: 'Base',
+    total: 64,
+    releaseDate: '1999/06/16',
+  },
+  {
+    id: 'sv8',
+    name: 'Surging Sparks',
+    series: 'Scarlet & Violet',
+    total: 252,
+    releaseDate: '2024/11/08',
+  },
+]
+
+describe('SetPickerModal', () => {
+  beforeEach(() => {
+    useAppStore.setState({ selectedSetIds: [] })
+    mockFetchSets.mockReset()
+    mockDownload.mockReset()
+    mockLogoUrl.mockClear()
+    mockFetchSets.mockResolvedValue(SETS)
+    mockDownload.mockResolvedValue(undefined)
+  })
+
+  function renderOpen() {
+    const onOpenChange = vi.fn()
+    const result = render(<SetPickerModal open onOpenChange={onOpenChange} />)
+    return { onOpenChange, ...result }
+  }
+
+  it('loads the catalog when opened and groups rows by series', async () => {
+    renderOpen()
+
+    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
+    expect(screen.getByText('Base Set')).toBeInTheDocument()
+    expect(screen.getByText('Jungle')).toBeInTheDocument()
+    expect(screen.getByText('Surging Sparks')).toBeInTheDocument()
+    // Series headings are visible in catalog order (first-encounter wins).
+    const headings = screen.getAllByRole('heading', { level: 3 })
+    expect(headings[0]).toHaveTextContent('Base')
+    expect(headings[1]).toHaveTextContent('Scarlet & Violet')
+  })
+
+  it('does not download when nothing is selected — surfaces a warning', async () => {
+    renderOpen()
+    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download PDF' }))
+    expect(mockDownload).not.toHaveBeenCalled()
+    // The disabled-button state is the safety rail; the warning text
+    // only appears when the user clicks despite that, which we can't
+    // simulate cleanly because the button is disabled. Verify the
+    // disabled state is in place.
+    expect(screen.getByRole('button', { name: 'Download PDF' })).toBeDisabled()
+  })
+
+  it('select-all checks every box and Download PDF posts every id', async () => {
+    const { onOpenChange } = renderOpen()
+    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select all' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Download PDF' }))
+
+    await waitFor(() => expect(mockDownload).toHaveBeenCalledTimes(1))
+    const [apiKey, ids] = mockDownload.mock.calls[0]
+    expect(apiKey).toBeUndefined()
+    expect(new Set(ids)).toEqual(new Set(['base1', 'jungle', 'sv8']))
+    // Successful submit closes the modal and persists the selection.
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+    expect(useAppStore.getState().selectedSetIds).toEqual(ids)
+  })
+
+  it('select-none clears the draft after a select-all', async () => {
+    renderOpen()
+    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select all' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Select none' }))
+    expect(screen.getByRole('button', { name: 'Download PDF' })).toBeDisabled()
+  })
+
+  it('select-series picks every set in that series only', async () => {
+    renderOpen()
+    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
+
+    // Two "Select series" buttons — one per series. Click the first
+    // (Base).
+    const seriesButtons = screen.getAllByRole('button', { name: 'Select series' })
+    fireEvent.click(seriesButtons[0])
+    fireEvent.click(screen.getByRole('button', { name: 'Download PDF' }))
+
+    await waitFor(() => expect(mockDownload).toHaveBeenCalledTimes(1))
+    const [, ids] = mockDownload.mock.calls[0]
+    expect(new Set(ids)).toEqual(new Set(['base1', 'jungle']))
+  })
+
+  it('toggling a row checkbox flips its selection', async () => {
+    renderOpen()
+    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
+
+    const checkbox = screen.getByRole('checkbox', { name: 'Include Surging Sparks' })
+    fireEvent.click(checkbox)
+    expect(checkbox).toBeChecked()
+    fireEvent.click(checkbox)
+    expect(checkbox).not.toBeChecked()
+  })
+
+  it('seeds the draft from selectedSetIds when reopening', async () => {
+    useAppStore.setState({ selectedSetIds: ['jungle'] })
+    renderOpen()
+    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
+
+    expect(
+      screen.getByRole('checkbox', { name: 'Include Jungle' })
+    ).toBeChecked()
+    expect(
+      screen.getByRole('checkbox', { name: 'Include Base Set' })
+    ).not.toBeChecked()
+  })
+
+  it('surfaces a load error when the catalog fetch fails', async () => {
+    mockFetchSets.mockRejectedValueOnce(new Error('upstream down'))
+    renderOpen()
+
+    expect(
+      await screen.findByText(/Couldn’t load sets: upstream down/)
+    ).toBeInTheDocument()
+  })
+
+  it('surfaces a submit error and keeps the modal open', async () => {
+    mockDownload.mockRejectedValueOnce(new Error('rate-limited'))
+    const { onOpenChange } = renderOpen()
+    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select all' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Download PDF' }))
+
+    expect(await screen.findByText('rate-limited')).toBeInTheDocument()
+    // The failure path must NOT close the modal — the user should be
+    // able to retry without re-checking everything.
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+  })
+
+  it('logo thumbnails fall back to an icon when the image errors', async () => {
+    renderOpen()
+    await waitFor(() => expect(mockFetchSets).toHaveBeenCalledTimes(1))
+
+    // The thumbnail is an `<img>` with empty alt (decorative — the row's
+    // accessible name lives on the checkbox), so query by tag inside the
+    // row label.
+    const label = screen
+      .getByRole('checkbox', { name: 'Include Base Set' })
+      .closest('label')!
+    const img = label.querySelector('img')
+    expect(img).not.toBeNull()
+    // Simulate a 404 from the cached-logo endpoint.
+    fireEvent.error(img!)
+
+    // After the error, the row swaps the broken <img> for the ImageOff
+    // glyph. The img element should no longer be in the DOM.
+    expect(label.querySelector('img')).toBeNull()
+  })
+})

--- a/web/src/components/SetPickerModal.tsx
+++ b/web/src/components/SetPickerModal.tsx
@@ -113,20 +113,18 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
   useEffect(() => {
     if (!open || sets !== null) return
     let cancelled = false
-    Promise.resolve().then(() => {
-      if (cancelled) return
+    const load = async () => {
       setLoadError(null)
-    })
-    fetchSets(settings.apiKey || undefined)
-      .then((data) => {
+      try {
+        const data = await fetchSets(settings.apiKey || undefined)
         if (cancelled) return
         setSets(data)
-        setLoadError(null)
-      })
-      .catch((err) => {
+      } catch (err) {
         if (cancelled) return
         setLoadError(err instanceof Error ? err.message : String(err))
-      })
+      }
+    }
+    void load()
     return () => {
       cancelled = true
     }

--- a/web/src/components/SetPickerModal.tsx
+++ b/web/src/components/SetPickerModal.tsx
@@ -98,10 +98,13 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
   const [submitError, setSubmitError] = useState<string | null>(null)
 
   // Edit-in-place working copy so the user can cancel without persisting
-  // changes. Seeded from the store on open via `handleOpenChange`, not in
-  // an effect — keeping the open-transition reset event-driven satisfies
-  // the no-setState-in-effect rule and matches the parent's controlled
-  // semantics.
+  // changes. Reseeded on every closed → open transition by the effect
+  // below, not in `handleOpenChange`: Radix only fires `onOpenChange`
+  // for its own state-change requests (Escape, outside click, close
+  // button). A parent-driven open like `ExportBar`'s
+  // `setPickerOpen(true)` flips the `open` prop without going through
+  // that callback, so an effect that watches the prop is the only
+  // place that catches every entry into the modal.
   const [draft, setDraft] = useState<Set<string>>(() => new Set(selectedSetIds))
 
   // Series whose set list is collapsed. All groups start expanded; the
@@ -109,14 +112,21 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
   // 173-set list when the user only wants one or two series.
   const [collapsedSeries, setCollapsedSeries] = useState<Set<string>>(() => new Set())
 
-  function handleOpenChange(next: boolean) {
-    if (next) {
-      setDraft(new Set(selectedSetIds))
-      setLoadError(null)
-      setSubmitError(null)
-    }
-    onOpenChange(next)
-  }
+  // Reseed draft + clear transient errors whenever the modal becomes
+  // visible. `selectedSetIds` is intentionally excluded from deps:
+  // we only want to reset on the open transition, not on every store
+  // update that lands while the modal is already open (which would
+  // clobber the user's in-flight edits). The setState-in-effect rule
+  // is suppressed because reacting to a prop transition is exactly
+  // this rule's documented escape hatch.
+  /* eslint-disable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps */
+  useEffect(() => {
+    if (!open) return
+    setDraft(new Set(selectedSetIds))
+    setLoadError(null)
+    setSubmitError(null)
+  }, [open])
+  /* eslint-enable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps */
 
   // Lazy-load the catalog once, the first time the modal opens. We keep
   // the result mounted across open/close so a re-open is free.
@@ -213,7 +223,7 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
   }
 
   return (
-    <Dialog.Root open={open} onOpenChange={handleOpenChange}>
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm" />
         <Dialog.Content

--- a/web/src/components/SetPickerModal.tsx
+++ b/web/src/components/SetPickerModal.tsx
@@ -9,9 +9,11 @@
  * buttons collapse the common cases.
  *
  * Submitting the modal calls `downloadSetCardsPdf` with the selected
- * `set_ids`; the backend filter restricts the PDF to those sets.
- * Picking nothing surfaces a small inline warning rather than firing
- * a doomed request (the API would 404 in that case).
+ * `set_ids`; the backend filter restricts the PDF to those sets. The
+ * Download button is intentionally disabled when nothing is selected:
+ * the backend would happily accept an empty filter as "every set" and
+ * render a 173-page PDF, but that's almost never what someone hitting
+ * "Set ID cards…" wants right after opening the modal.
  *
  * Logo thumbnails come from the new `/api/v1/sets/{id}/logo` endpoint,
  * which serves images out of the unified disk cache populated by
@@ -174,10 +176,10 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
   }
 
   async function handleSubmit() {
-    if (draft.size === 0) {
-      setSubmitError('Pick at least one set before downloading.')
-      return
-    }
+    // The Download button is disabled when `draft.size === 0`, so this
+    // function should only be reached with a non-empty selection. No
+    // empty-draft guard here on purpose — the disabled state is the
+    // single source of truth for "can't submit yet."
     setSubmitting(true)
     setSubmitError(null)
     try {

--- a/web/src/components/SetPickerModal.tsx
+++ b/web/src/components/SetPickerModal.tsx
@@ -48,6 +48,16 @@ interface SeriesGroup {
   sets: SetInfo[]
 }
 
+// Display key for sets whose `series` field is missing or empty. Kept
+// as a module-level constant so `selectSeries` and `groupBySeries` can
+// match the same value — otherwise the bucket name wouldn't line up
+// with the predicate the bulk-select button uses.
+const OTHER_SERIES = 'Other'
+
+function seriesKey(set: SetInfo): string {
+  return set.series || OTHER_SERIES
+}
+
 function groupBySeries(sets: SetInfo[]): SeriesGroup[] {
   // The catalog comes from `/api/v1/sets` in oldest → newest order.
   // We render the picker newest-first because the typical prep workflow
@@ -56,14 +66,15 @@ function groupBySeries(sets: SetInfo[]): SeriesGroup[] {
   // scrolling. Within each series, rows stay newest-first too — within
   // S&V, Surging Sparks beats the 2023 set that opened the block.
   //
-  // Implementation: walk the catalog in reverse, bucket by series in
-  // first-encounter order (which is now newest-encounter), and reverse
-  // each bucket so its members come out newest-first.
+  // Implementation: walk the catalog in reverse and push each set into
+  // its series bucket. Because we iterate newest → oldest, both the
+  // group order (first-encounter wins) and each bucket's contents come
+  // out newest-first — no per-bucket reverse needed.
   const order: string[] = []
   const buckets = new Map<string, SetInfo[]>()
   for (let i = sets.length - 1; i >= 0; i--) {
     const s = sets[i]
-    const key = s.series || 'Other'
+    const key = seriesKey(s)
     if (!buckets.has(key)) {
       buckets.set(key, [])
       order.push(key)
@@ -93,10 +104,9 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
   // semantics.
   const [draft, setDraft] = useState<Set<string>>(() => new Set(selectedSetIds))
 
-  // Series whose set list is collapsed. Default = all collapsed except
-  // the first group (newest series). Keeps the modal short on open —
-  // 173 sets is a lot of vertical scroll otherwise — and lets the user
-  // expand only what they're interested in.
+  // Series whose set list is collapsed. All groups start expanded; the
+  // "Collapse all" toolbar button is the one-click way to shorten the
+  // 173-set list when the user only wants one or two series.
   const [collapsedSeries, setCollapsedSeries] = useState<Set<string>>(() => new Set())
 
   function handleOpenChange(next: boolean) {
@@ -156,7 +166,12 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
     if (!sets) return
     setDraft((prev) => {
       const next = new Set(prev)
-      for (const s of sets) if (s.series === series) next.add(s.id)
+      // Use the same keying as `groupBySeries` so the "Other" bucket
+      // (sets with an empty / missing `series` field) actually picks
+      // its members. A naive `s.series === series` check would miss
+      // every member of "Other" because their underlying value is `''`,
+      // not the literal "Other".
+      for (const s of sets) if (seriesKey(s) === series) next.add(s.id)
       return next
     })
   }

--- a/web/src/components/SetPickerModal.tsx
+++ b/web/src/components/SetPickerModal.tsx
@@ -20,7 +20,15 @@
  * <img> so the row still looks intentional.
  */
 import * as Dialog from '@radix-ui/react-dialog'
-import { Check, ImageOff, Loader2, Tags, X } from 'lucide-react'
+import {
+  Check,
+  ChevronDown,
+  ChevronRight,
+  ImageOff,
+  Loader2,
+  Tags,
+  X,
+} from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
 import { downloadSetCardsPdf, fetchSets, setLogoUrl } from '../api/client'
@@ -39,12 +47,20 @@ interface SeriesGroup {
 }
 
 function groupBySeries(sets: SetInfo[]): SeriesGroup[] {
-  // Preserve catalog order within each group (the API returns oldest →
-  // newest), but emit groups in first-encounter order so familiar series
-  // (Base, Jungle, Fossil) appear at the top for users who scan by era.
+  // The catalog comes from `/api/v1/sets` in oldest → newest order.
+  // We render the picker newest-first because the typical prep workflow
+  // biases toward modern sets (Scarlet & Violet, Mega Evolution); having
+  // them at the top means a typical user picks 2–3 boxes without ever
+  // scrolling. Within each series, rows stay newest-first too — within
+  // S&V, Surging Sparks beats the 2023 set that opened the block.
+  //
+  // Implementation: walk the catalog in reverse, bucket by series in
+  // first-encounter order (which is now newest-encounter), and reverse
+  // each bucket so its members come out newest-first.
   const order: string[] = []
   const buckets = new Map<string, SetInfo[]>()
-  for (const s of sets) {
+  for (let i = sets.length - 1; i >= 0; i--) {
+    const s = sets[i]
     const key = s.series || 'Other'
     if (!buckets.has(key)) {
       buckets.set(key, [])
@@ -74,6 +90,12 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
   // the no-setState-in-effect rule and matches the parent's controlled
   // semantics.
   const [draft, setDraft] = useState<Set<string>>(() => new Set(selectedSetIds))
+
+  // Series whose set list is collapsed. Default = all collapsed except
+  // the first group (newest series). Keeps the modal short on open —
+  // 173 sets is a lot of vertical scroll otherwise — and lets the user
+  // expand only what they're interested in.
+  const [collapsedSeries, setCollapsedSeries] = useState<Set<string>>(() => new Set())
 
   function handleOpenChange(next: boolean) {
     if (next) {
@@ -134,6 +156,23 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
     })
   }
 
+  function toggleSeriesCollapsed(series: string) {
+    setCollapsedSeries((prev) => {
+      const next = new Set(prev)
+      if (next.has(series)) next.delete(series)
+      else next.add(series)
+      return next
+    })
+  }
+
+  function expandAllSeries() {
+    setCollapsedSeries(new Set())
+  }
+
+  function collapseAllSeries() {
+    setCollapsedSeries(new Set(groups.map((g) => g.series)))
+  }
+
   async function handleSubmit() {
     if (draft.size === 0) {
       setSubmitError('Pick at least one set before downloading.')
@@ -191,6 +230,8 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
             <div className="flex flex-wrap gap-2 px-5 pt-3">
               <BulkButton onClick={selectAll}>Select all</BulkButton>
               <BulkButton onClick={selectNone}>Select none</BulkButton>
+              <BulkButton onClick={expandAllSeries}>Expand all</BulkButton>
+              <BulkButton onClick={collapseAllSeries}>Collapse all</BulkButton>
             </div>
           )}
 
@@ -212,35 +253,59 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
             )}
             {sets && (
               <ul className="space-y-4">
-                {groups.map((group) => (
-                  <li key={group.series}>
-                    <div className="mb-1 flex items-center justify-between gap-2">
-                      <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-400">
-                        {group.series}{' '}
-                        <span className="font-normal text-zinc-500">
-                          ({group.sets.length})
-                        </span>
-                      </h3>
-                      <button
-                        type="button"
-                        onClick={() => selectSeries(group.series)}
-                        className="text-xs text-zinc-400 underline-offset-2 hover:text-zinc-200 hover:underline"
-                      >
-                        Select series
-                      </button>
-                    </div>
-                    <ul className="grid grid-cols-1 gap-1 sm:grid-cols-2">
-                      {group.sets.map((s) => (
-                        <SetRow
-                          key={s.id}
-                          set={s}
-                          checked={draft.has(s.id)}
-                          onToggle={() => toggle(s.id)}
-                        />
-                      ))}
-                    </ul>
-                  </li>
-                ))}
+                {groups.map((group) => {
+                  const collapsed = collapsedSeries.has(group.series)
+                  const seriesIds = group.sets.map((s) => s.id)
+                  const selectedInSeries = seriesIds.filter((id) => draft.has(id)).length
+                  const headerId = `set-picker-series-${group.series.replace(/[^a-z0-9]+/gi, '-')}`
+                  return (
+                    <li key={group.series}>
+                      <div className="mb-1 flex items-center justify-between gap-2">
+                        <button
+                          type="button"
+                          aria-expanded={!collapsed}
+                          aria-controls={headerId}
+                          onClick={() => toggleSeriesCollapsed(group.series)}
+                          className="flex items-center gap-1.5 rounded text-left text-xs font-semibold uppercase tracking-wider text-zinc-300 hover:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-zinc-700"
+                        >
+                          {collapsed ? (
+                            <ChevronRight size={14} aria-hidden className="text-zinc-500" />
+                          ) : (
+                            <ChevronDown size={14} aria-hidden className="text-zinc-500" />
+                          )}
+                          {group.series}{' '}
+                          <span className="font-normal normal-case tracking-normal text-zinc-500">
+                            {selectedInSeries > 0
+                              ? `(${selectedInSeries}/${group.sets.length})`
+                              : `(${group.sets.length})`}
+                          </span>
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => selectSeries(group.series)}
+                          className="text-xs text-zinc-400 underline-offset-2 hover:text-zinc-200 hover:underline"
+                        >
+                          Select series
+                        </button>
+                      </div>
+                      {!collapsed && (
+                        <ul
+                          id={headerId}
+                          className="grid grid-cols-1 gap-1 sm:grid-cols-2"
+                        >
+                          {group.sets.map((s) => (
+                            <SetRow
+                              key={s.id}
+                              set={s}
+                              checked={draft.has(s.id)}
+                              onToggle={() => toggle(s.id)}
+                            />
+                          ))}
+                        </ul>
+                      )}
+                    </li>
+                  )
+                })}
               </ul>
             )}
           </div>

--- a/web/src/components/SetPickerModal.tsx
+++ b/web/src/components/SetPickerModal.tsx
@@ -102,6 +102,7 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
   function handleOpenChange(next: boolean) {
     if (next) {
       setDraft(new Set(selectedSetIds))
+      setLoadError(null)
       setSubmitError(null)
     }
     onOpenChange(next)
@@ -112,6 +113,10 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
   useEffect(() => {
     if (!open || sets !== null) return
     let cancelled = false
+    Promise.resolve().then(() => {
+      if (cancelled) return
+      setLoadError(null)
+    })
     fetchSets(settings.apiKey || undefined)
       .then((data) => {
         if (cancelled) return

--- a/web/src/components/SetPickerModal.tsx
+++ b/web/src/components/SetPickerModal.tsx
@@ -1,0 +1,347 @@
+/**
+ * SetPickerModal — choose which Pokémon TCG sets to include in the
+ * printable Set ID cards PDF.
+ *
+ * The full catalog is fetched from `/api/v1/sets` and grouped by series.
+ * Each row is a checkbox + logo thumbnail + name + year + total. The
+ * user's selection is held in Zustand (persisted across reloads) so
+ * reopening the modal restores it. Select all / none / per-series
+ * buttons collapse the common cases.
+ *
+ * Submitting the modal calls `downloadSetCardsPdf` with the selected
+ * `set_ids`; the backend filter restricts the PDF to those sets.
+ * Picking nothing surfaces a small inline warning rather than firing
+ * a doomed request (the API would 404 in that case).
+ *
+ * Logo thumbnails come from the new `/api/v1/sets/{id}/logo` endpoint,
+ * which serves images out of the unified disk cache populated by
+ * `pkmn cache warm-sets`. Sets without a cached logo render as a
+ * text-only chip — the image's onError handler hides the broken
+ * <img> so the row still looks intentional.
+ */
+import * as Dialog from '@radix-ui/react-dialog'
+import { Check, ImageOff, Loader2, Tags, X } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+import { downloadSetCardsPdf, fetchSets, setLogoUrl } from '../api/client'
+import { useAppStore } from '../store'
+import type { SetInfo } from '../types'
+
+interface Props {
+  /** Controlled open state — the parent (ExportBar) owns the toggle. */
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+interface SeriesGroup {
+  series: string
+  sets: SetInfo[]
+}
+
+function groupBySeries(sets: SetInfo[]): SeriesGroup[] {
+  // Preserve catalog order within each group (the API returns oldest →
+  // newest), but emit groups in first-encounter order so familiar series
+  // (Base, Jungle, Fossil) appear at the top for users who scan by era.
+  const order: string[] = []
+  const buckets = new Map<string, SetInfo[]>()
+  for (const s of sets) {
+    const key = s.series || 'Other'
+    if (!buckets.has(key)) {
+      buckets.set(key, [])
+      order.push(key)
+    }
+    buckets.get(key)!.push(s)
+  }
+  return order.map((series) => ({ series, sets: buckets.get(series)! }))
+}
+
+function releaseYear(date: string): string | null {
+  const match = /^(\d{4})/.exec(date || '')
+  return match ? match[1] : null
+}
+
+export function SetPickerModal({ open, onOpenChange }: Props) {
+  const { settings, selectedSetIds, setSelectedSetIds } = useAppStore()
+
+  const [sets, setSets] = useState<SetInfo[] | null>(null)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  // Edit-in-place working copy so the user can cancel without persisting
+  // changes. Seeded from the store on open via `handleOpenChange`, not in
+  // an effect — keeping the open-transition reset event-driven satisfies
+  // the no-setState-in-effect rule and matches the parent's controlled
+  // semantics.
+  const [draft, setDraft] = useState<Set<string>>(() => new Set(selectedSetIds))
+
+  function handleOpenChange(next: boolean) {
+    if (next) {
+      setDraft(new Set(selectedSetIds))
+      setSubmitError(null)
+    }
+    onOpenChange(next)
+  }
+
+  // Lazy-load the catalog once, the first time the modal opens. We keep
+  // the result mounted across open/close so a re-open is free.
+  useEffect(() => {
+    if (!open || sets !== null) return
+    let cancelled = false
+    fetchSets(settings.apiKey || undefined)
+      .then((data) => {
+        if (cancelled) return
+        setSets(data)
+        setLoadError(null)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setLoadError(err instanceof Error ? err.message : String(err))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [open, sets, settings.apiKey])
+
+  const groups = useMemo(() => (sets ? groupBySeries(sets) : []), [sets])
+  const allCount = sets?.length ?? 0
+  const selectedCount = draft.size
+
+  function toggle(id: string) {
+    setDraft((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }
+
+  function selectAll() {
+    if (!sets) return
+    setDraft(new Set(sets.map((s) => s.id)))
+  }
+
+  function selectNone() {
+    setDraft(new Set())
+  }
+
+  function selectSeries(series: string) {
+    if (!sets) return
+    setDraft((prev) => {
+      const next = new Set(prev)
+      for (const s of sets) if (s.series === series) next.add(s.id)
+      return next
+    })
+  }
+
+  async function handleSubmit() {
+    if (draft.size === 0) {
+      setSubmitError('Pick at least one set before downloading.')
+      return
+    }
+    setSubmitting(true)
+    setSubmitError(null)
+    try {
+      const ids = Array.from(draft)
+      await downloadSetCardsPdf(settings.apiKey || undefined, ids)
+      setSelectedSetIds(ids)
+      onOpenChange(false)
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={handleOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm" />
+        <Dialog.Content
+          className="fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-[min(720px,92vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-zinc-700 bg-zinc-900 shadow-2xl"
+          aria-describedby="set-picker-description"
+        >
+          <header className="flex items-center justify-between gap-3 border-b border-zinc-800 px-5 py-4">
+            <div className="flex items-center gap-2">
+              <Tags size={18} className="text-zinc-300" />
+              <Dialog.Title className="text-lg font-semibold text-zinc-100">
+                Choose sets
+              </Dialog.Title>
+            </div>
+            <Dialog.Close asChild>
+              <button
+                aria-label="Close"
+                className="rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+              >
+                <X size={18} />
+              </button>
+            </Dialog.Close>
+          </header>
+
+          <Dialog.Description
+            id="set-picker-description"
+            className="px-5 pt-3 text-sm text-zinc-400"
+          >
+            Pick which Pokémon TCG sets the printable ID cards PDF should
+            include. {sets ? `${selectedCount} of ${allCount} selected.` : ''}
+          </Dialog.Description>
+
+          {/* Bulk-action toolbar */}
+          {sets && (
+            <div className="flex flex-wrap gap-2 px-5 pt-3">
+              <BulkButton onClick={selectAll}>Select all</BulkButton>
+              <BulkButton onClick={selectNone}>Select none</BulkButton>
+            </div>
+          )}
+
+          <div
+            className="flex-1 overflow-y-auto px-5 py-3"
+            tabIndex={0}
+            aria-label="Set list"
+          >
+            {loadError && (
+              <p className="rounded border border-red-900/50 bg-red-950/30 px-3 py-2 text-sm text-red-300">
+                Couldn’t load sets: {loadError}
+              </p>
+            )}
+            {!sets && !loadError && (
+              <p className="flex items-center gap-2 text-sm text-zinc-400">
+                <Loader2 size={14} className="animate-spin" />
+                Loading set catalog…
+              </p>
+            )}
+            {sets && (
+              <ul className="space-y-4">
+                {groups.map((group) => (
+                  <li key={group.series}>
+                    <div className="mb-1 flex items-center justify-between gap-2">
+                      <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-400">
+                        {group.series}{' '}
+                        <span className="font-normal text-zinc-500">
+                          ({group.sets.length})
+                        </span>
+                      </h3>
+                      <button
+                        type="button"
+                        onClick={() => selectSeries(group.series)}
+                        className="text-xs text-zinc-400 underline-offset-2 hover:text-zinc-200 hover:underline"
+                      >
+                        Select series
+                      </button>
+                    </div>
+                    <ul className="grid grid-cols-1 gap-1 sm:grid-cols-2">
+                      {group.sets.map((s) => (
+                        <SetRow
+                          key={s.id}
+                          set={s}
+                          checked={draft.has(s.id)}
+                          onToggle={() => toggle(s.id)}
+                        />
+                      ))}
+                    </ul>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <footer className="flex items-center justify-between gap-3 border-t border-zinc-800 px-5 py-4">
+            <div className="flex-1 text-xs text-zinc-400">
+              {submitError && <span className="text-red-400">{submitError}</span>}
+              {!submitError && sets && (
+                <span>
+                  {selectedCount} set{selectedCount === 1 ? '' : 's'} selected
+                </span>
+              )}
+            </div>
+            <Dialog.Close asChild>
+              <button className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-200 hover:bg-zinc-700">
+                Cancel
+              </button>
+            </Dialog.Close>
+            <button
+              onClick={handleSubmit}
+              disabled={submitting || draft.size === 0 || !sets}
+              className="flex items-center gap-1.5 rounded-md border border-blue-700 bg-blue-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-600 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {submitting ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <Check size={14} />
+              )}
+              Download PDF
+            </button>
+          </footer>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+function BulkButton({
+  onClick,
+  children,
+}: {
+  onClick: () => void
+  children: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="rounded-md border border-zinc-700 bg-zinc-800 px-2.5 py-1 text-xs text-zinc-200 hover:bg-zinc-700"
+    >
+      {children}
+    </button>
+  )
+}
+
+interface RowProps {
+  set: SetInfo
+  checked: boolean
+  onToggle: () => void
+}
+
+function SetRow({ set, checked, onToggle }: RowProps) {
+  const [logoFailed, setLogoFailed] = useState(false)
+  const year = releaseYear(set.releaseDate)
+  return (
+    <li>
+      <label
+        className={`flex items-center gap-3 rounded-md px-2 py-1.5 cursor-pointer transition-colors ${
+          checked ? 'bg-blue-950/40 ring-1 ring-blue-700/40' : 'hover:bg-zinc-800/60'
+        }`}
+      >
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={onToggle}
+          className="accent-blue-500"
+          aria-label={`Include ${set.name}`}
+        />
+        <div className="flex h-8 w-12 flex-none items-center justify-center rounded bg-zinc-950/60">
+          {logoFailed ? (
+            <ImageOff size={14} className="text-zinc-600" aria-hidden />
+          ) : (
+            // Cached logo from /api/v1/sets/{id}/logo. The endpoint 404s for
+            // un-warmed sets; onError hides the broken image so the row
+            // still renders as text + a muted glyph.
+            <img
+              src={setLogoUrl(set.id)}
+              alt=""
+              className="max-h-7 max-w-11 object-contain"
+              loading="lazy"
+              onError={() => setLogoFailed(true)}
+            />
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm text-zinc-100">{set.name}</div>
+          <div className="truncate text-xs text-zinc-500">
+            {year || '—'} · {set.total ? `${set.total} cards` : 'count unknown'}
+          </div>
+        </div>
+      </label>
+    </li>
+  )
+}

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -39,6 +39,14 @@ interface AppState {
   settings: Settings
   updateSettings: (partial: Partial<Settings>) => void
   resetSettings: () => void
+
+  /**
+   * Set ids selected in the Set ID cards picker modal. Persisted so a
+   * reload preserves the user's last selection. Empty array = "every set"
+   * (matches the backend's omit-the-filter default).
+   */
+  selectedSetIds: string[]
+  setSelectedSetIds: (ids: string[]) => void
 }
 
 export const useAppStore = create<AppState>()(
@@ -73,6 +81,9 @@ export const useAppStore = create<AppState>()(
       updateSettings: (partial) =>
         set((state) => ({ settings: { ...state.settings, ...partial } })),
       resetSettings: () => set({ settings: { ...DEFAULT_SETTINGS } }),
+
+      selectedSetIds: [],
+      setSelectedSetIds: (ids) => set({ selectedSetIds: ids }),
     }),
     {
       name: 'mgz-pkmn-settings',
@@ -80,6 +91,7 @@ export const useAppStore = create<AppState>()(
       partialize: (state) => ({
         inputText: state.inputText,
         settings: state.settings,
+        selectedSetIds: state.selectedSetIds,
       }),
       // Merge persisted state with defaults so new settings fields (e.g.
       // `sort`, added later) fall back to the initial value rather than

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -41,9 +41,14 @@ interface AppState {
   resetSettings: () => void
 
   /**
-   * Set ids selected in the Set ID cards picker modal. Persisted so a
-   * reload preserves the user's last selection. Empty array = "every set"
-   * (matches the backend's omit-the-filter default).
+   * Set ids the user last successfully submitted from the picker modal.
+   * Persisted so reopening the picker restores the prior selection.
+   *
+   * An empty array means "nothing has been chosen yet" — the picker
+   * disables its Download PDF button in that state. (The backend would
+   * happily accept an empty `set_ids` and render every set, but the UI
+   * intentionally never sends that request because hitting Set ID
+   * cards… and immediately submitting shouldn't dump a 173-page PDF.)
    */
   selectedSetIds: string[]
   setSelectedSetIds: (ids: string[]) => void


### PR DESCRIPTION
Closes #256

> **Stacked on [#273](https://github.com/mgzwarrior/mgz-pkmn/pull/273)** (cache foundation). Base branch is `255-cache-set-images`; rebase the base onto main once #273 lands and GitHub will auto-update the base here.

## What

Clicking **Set ID cards…** in the Export dropdown now opens a picker modal:

- Full pokemontcg.io catalog grouped by series in catalog order (Base → Mega Evolution).
- Each row: cached logo thumbnail + name + release year + card count + checkbox.
- **Select all / Select none / Select series** for the common cases.
- Selection persists in Zustand so reopening restores the last set.
- Submitting downloads a PDF restricted to the chosen sets.
- Logo thumbnails come from a new `GET /api/v1/sets/{set_id}/logo` endpoint that streams cached bytes (30-day immutable browser cache). Misses degrade to a soft fallback glyph; the row still renders cleanly.

CLI parity: `pkmn set-cards --set <id>` (repeatable, `-s`) hits the same filter.

## Why

The Set ID cards button used to immediately download cutouts for every known set (173 today). At a real show you're prepping a specific table — Base + Jungle + Fossil, or a few modern blocks — and most printed pages were noise. The picker bounds the export to what the user actually needs.

## How to verify

Visual smoke (running against a warmed cache from #273):

**Picker open, selection in progress** — "3 of 173 selected", blue ring + accent on the picked rows, all cached logos showing inline, Download PDF button activated:
<img width="800" height="798" alt="image-1779672777876" src="https://github.com/user-attachments/assets/d75072c8-b695-4905-b5de-5646b99bd87f" />

**API endpoints** (against a warm cache):

```bash
$ curl -sS -o /tmp/logo.png -w "status=%{http_code}, size=%{size_download}\n" \
    http://localhost:8000/api/v1/sets/sv8/logo
status=200, size=156112
$ file /tmp/logo.png
/tmp/logo.png: PNG image data, 474 x 209, 8-bit/color RGBA, non-interlaced

$ curl -sS -w "status=%{http_code}\n" \
    http://localhost:8000/api/v1/sets/zzz-nonexistent/logo
{"detail":"no cached logo for set 'zzz-nonexistent' — run \`pkmn cache warm-sets\` to populate the catalog"}status=404

$ curl -sS -o /tmp/picker.pdf -w "status=%{http_code}, size=%{size_download}\n" \
    "http://localhost:8000/api/v1/set-cards.pdf?set_ids=sv8&set_ids=sv7"
status=200, size=329782

$ uv run pkmn set-cards --set sv8 --set sv7 -o /tmp/picker-cli.pdf
▸ Fetching set catalog from pokemontcg.io
  ✓ 173 sets
  ✓ filtered to 2 sets (sv8, sv7)
▸ Writing outputs
  ✓ /tmp/picker-cli.pdf  (2 cutouts)
Done!
```

## Tests

22 new tests across `tests/test_set_cards.py`, `tests/test_set_cards_api.py`, `tests/test_api_routes.py`, `tests/test_cli.py`, `web/src/components/SetPickerModal.test.tsx`. Full suite: **296 Python tests + 67 web tests** passing, `make check` green.

## Risk

- The picker modal is gated behind the existing **Set ID cards…** menu item — feature-additive only. The `set_ids` API param and CLI flag both default to "every set" (current behavior).
- Logo endpoint is strictly a cache reader. No upstream fetches on render — mixing reader-and-warmer would let a single render hammer pokemontcg.io for every set. `pkmn cache warm-sets` remains the only writer.