### PR TITLE
feat(cli): add `pkmn cache clear` subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- CLI: `pkmn cache clear` subcommand wipes the API response cache
+  without forcing you to run a lookup. URL overrides and the
+  indefinite-TTL image cache are preserved (they take real effort to
+  populate); the on-disk wipe is the same one `pkmn lookup --clear-cache`
+  performs. Honoured even when `MGZ_PKMN_NO_CACHE=1` is set — explicit
+  wipe wins over implicit skip.
 - Web: **Set picker modal** for the Set ID cards export. Clicking
   **Set ID cards…** in the Export dropdown now opens a picker that
   groups every set by series **newest → oldest** (modern blocks like

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -70,6 +70,23 @@ writes during normal lookups, but inspecting real files should still
 show what's there. Combine with [`--clear-cache`](#behavior) on the next
 `pkmn lookup` if the API cache has grown stale relative to the code.
 
+`pkmn cache clear` wipes the API response cache without forcing you to
+run a lookup. URL overrides and the indefinite-TTL image cache are left
+in place — the same trade-off the in-line `--clear-cache` flag makes:
+
+```text
+▸ Clearing API response cache
+  ✓ 175 entries cleared · 8.8 MB freed (overrides + images preserved)
+```
+
+The command runs even when `MGZ_PKMN_NO_CACHE=1` is set — the explicit
+wipe wins over the implicit skip, same as
+[`--clear-cache`](#behavior). There's no confirmation prompt: the wipe
+is recoverable (the next lookup re-fetches) and a prompt would
+complicate scripted use. Wipe images explicitly with
+`rm -rf "$(pkmn cache path)/images"` when you want to evict warmed
+artwork too.
+
 Use `pkmn cache stats --json` for scripts and monitoring. It emits the
 same snapshot with snake_case keys:
 

--- a/src/mgz_pkmn/cli.py
+++ b/src/mgz_pkmn/cli.py
@@ -1018,6 +1018,36 @@ def cache_stats_command(as_json: bool) -> None:
     )
 
 
+@cache_group.command(name="clear", context_settings={"help_option_names": ["-h", "--help"]})
+def cache_clear_command() -> None:
+    """Wipe cached API responses; preserve URL overrides and images.
+
+    Standalone counterpart to `pkmn lookup --clear-cache` — same wipe, no
+    lookup required. Reclaims the regenerable API slice (`cache/api/*.json`)
+    while leaving the user-supplied `url_overrides.json` and the
+    indefinite-TTL image cache (`cache/images/`) untouched, since those
+    take real effort to populate.
+
+    Runs even when `MGZ_PKMN_NO_CACHE=1` is set: the user explicitly asked
+    for a wipe, and a no-op surprise would defeat the purpose. No
+    confirmation prompt — the action is recoverable (next run re-fetches)
+    and prompts complicate scripting; the `clear` name is intent enough."""
+    # Snapshot API-slice size before the wipe so the summary can report how
+    # much disk we freed. Reads the same `stats()` snapshot the stats command
+    # renders, but only the api_bytes field is surfaced — overrides and
+    # images aren't touched by this command.
+    before = disk_cache.stats()
+    count = disk_cache.clear_api_cache()
+
+    _print_section("Clearing API response cache")
+    click.secho("  ✓ ", fg="green", nl=False)
+    click.echo(
+        f"{count} entr{'y' if count == 1 else 'ies'} cleared · "
+        + click.style(f"{_format_bytes(before.api_bytes)} freed", bold=True)
+        + click.style(" (overrides + images preserved)", fg="bright_black")
+    )
+
+
 @cache_group.command(name="warm-sets", context_settings={"help_option_names": ["-h", "--help"]})
 @click.option(
     "--api-key",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -407,6 +407,58 @@ class CacheStatsCommandTests(unittest.TestCase):
         self.assertEqual(result.output, f"{expected}\n")
         self.assertNotRegex(result.output, r"\x1b\[")
 
+    def test_clear_command_on_empty_cache_reports_zero(self) -> None:
+        # Fresh cache: nothing to wipe, but the command should still exit
+        # cleanly and report a coherent summary rather than blowing up on
+        # the missing `api/` directory.
+        result = CliRunner().invoke(cli, ["cache", "clear"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Clearing API response cache", result.output)
+        self.assertIn("0 entries cleared", result.output)
+        self.assertIn("0 B freed", result.output)
+
+    def test_clear_command_wipes_api_entries_and_preserves_overrides(self) -> None:
+        cache.write_api("https://example.com/a", {"x": 1})
+        cache.write_api("https://example.com/b", {"y": 2})
+        cache.record_url_override("Mew", None, "https://pc/mew")
+        cache.write_image("sets/logo", "sv8", b"img-bytes")
+        api_bytes_before = cache.stats().api_bytes
+        self.assertGreater(api_bytes_before, 0)
+
+        result = CliRunner().invoke(cli, ["cache", "clear"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("2 entries cleared", result.output)
+        # Bytes-freed reflects the pre-wipe API slice — humanised via
+        # `_format_bytes`, so we just assert the unit suffix is present
+        # rather than pinning a precise byte count that changes with
+        # JSON formatting.
+        self.assertRegex(result.output, r"\d+ B freed|\d+\.\d+ KB freed")
+        # API slice is gone; overrides + images stay put.
+        after = cache.stats()
+        self.assertEqual(after.api_entry_count, 0)
+        self.assertEqual(after.api_bytes, 0)
+        self.assertEqual(after.override_count, 1)
+        self.assertEqual(after.image_entry_count, 1)
+        # Overrides remain usable after the wipe (not just on disk — the
+        # full read path still resolves).
+        self.assertEqual(cache.find_url_override("Mew", None), "https://pc/mew")
+
+    def test_clear_command_runs_even_when_no_cache_env_set(self) -> None:
+        # `--clear-cache` / `clear_api_cache()` are documented as honoured
+        # even under `MGZ_PKMN_NO_CACHE=1` — the user's explicit wipe wins
+        # over the implicit skip. The subcommand has to honour the same
+        # contract so scripts that set the env still get a working wipe.
+        cache.write_api("https://example.com/a", {"x": 1})
+        os.environ[cache._NO_CACHE_ENV] = "1"
+
+        result = CliRunner().invoke(cli, ["cache", "clear"])
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("1 entry cleared", result.output)
+        self.assertEqual(cache.stats().api_entry_count, 0)
+
 
 class WarnIfCacheLargeTests(unittest.TestCase):
     """The soft-warn helper invoked at `pkmn lookup` start. We drive it


### PR DESCRIPTION
Closes #206

## What

New `pkmn cache clear` subcommand wipes the API response cache without
forcing you to run a lookup first. URL overrides and the
indefinite-TTL image cache are preserved — same trade-off
`pkmn lookup --clear-cache` already makes.

```text
$ pkmn cache clear
▸ Clearing API response cache
  ✓ 175 entries cleared · 8.8 MB freed (overrides + images preserved)
```

Honoured even when `MGZ_PKMN_NO_CACHE=1` is set — explicit wipe wins
over implicit skip, matching the contract of `clear_api_cache()` and
the in-line `--clear-cache` flag. No confirmation prompt: the wipe is
recoverable (next lookup re-fetches), and prompts complicate scripting.

## Why

Today the only way to drop a stale API cache is `pkmn lookup --clear-cache`,
which forces you to run a lookup just to free space. `pkmn cache clear`
makes the wipe a first-class operation that pairs cleanly with
`pkmn cache stats` / `pkmn cache path` for inspection-then-action workflows.

## How to verify

```bash
./pkmn lookup input/example-cards.txt --no-images -o /tmp/a.xlsx   # populate cache
pkmn cache stats                                                   # see entries
pkmn cache clear                                                   # wipe
pkmn cache stats                                                   # entries == 0, overrides preserved
```

Test suite:

```bash
.venv/bin/python -m unittest tests.test_cli.CacheStatsCommandTests -v
```

Three new tests cover: empty cache (no error, zero summary), populated
cache (entries gone + overrides/images preserved), `MGZ_PKMN_NO_CACHE=1`
(wipe still runs).

301 tests pass locally (was 298, +3). `make check` is green.