### PR TITLE
docs: explain the over-cap row fill in xlsx output

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -41,7 +41,7 @@ boundary.
 | `--images-dir PATH` | `output/images/` | Where to save downloaded card images. |
 | `--api-key TEXT` | `$POKEMONTCG_IO_API_KEY` | pokemontcg.io API key (raises rate limits). |
 | `--no-images` | off | Skip image downloads + embedding. |
-| `--max-price FLOAT` | (none) | Per-card budget cap. **Bulk** `top:N` / `All …` lookups respect it strictly — candidates above the cap are excluded *before* the top-N cut, so an "affordable top 10" still returns 10. **Single-card** lookups always appear in every artifact even when above the cap, but get a visual flag (amber-fill on the Market cell in xlsx — see [over-cap highlighting](outputs.md#over-cap-highlighting), red `! MP $X` line in the PDF, `over_max_price: true` in JSON). See the currency-blindness warning below. |
+| `--max-price FLOAT` | (none) | Per-card budget cap. **Bulk** `top:N` / `All …` lookups respect it strictly — candidates above the cap are excluded *before* the top-N cut, so an "affordable top 10" still returns 10. **Single-card** lookups always appear in every artifact even when above the cap, but get a visual flag (amber-fill on the Market + comp cells in xlsx — see [over-cap highlighting](outputs.md#over-cap-highlighting), red `! MP $X` line in the PDF, `over_max_price: true` in JSON). See the currency-blindness warning below. |
 | `--dedupe` | off | Remove duplicate matched cards across all queries (keyed by card id), keeping the first occurrence in xlsx / PDF / JSON. |
 | `--report-json PATH` | (none) | Also dump a structured JSON report. See [Outputs](outputs.md#json-report). |
 | `--pdf PATH` | (none) | Also write a 3×3 binder-style PDF (9 cards/page) — image-forward, sized to print and slip into 9-pocket pages as physical placeholders. See [PDF binder](binder-pdf.md). |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -41,7 +41,7 @@ boundary.
 | `--images-dir PATH` | `output/images/` | Where to save downloaded card images. |
 | `--api-key TEXT` | `$POKEMONTCG_IO_API_KEY` | pokemontcg.io API key (raises rate limits). |
 | `--no-images` | off | Skip image downloads + embedding. |
-| `--max-price FLOAT` | (none) | Per-card budget cap. **Bulk** `top:N` / `All …` lookups respect it strictly — candidates above the cap are excluded *before* the top-N cut, so an "affordable top 10" still returns 10. **Single-card** lookups always appear in every artifact even when above the cap, but get a visual flag (amber-fill on the Market cell in xlsx, red `! MP $X` line in the PDF, `over_max_price: true` in JSON). See the currency-blindness warning below. |
+| `--max-price FLOAT` | (none) | Per-card budget cap. **Bulk** `top:N` / `All …` lookups respect it strictly — candidates above the cap are excluded *before* the top-N cut, so an "affordable top 10" still returns 10. **Single-card** lookups always appear in every artifact even when above the cap, but get a visual flag (amber-fill on the Market cell in xlsx — see [over-cap highlighting](outputs.md#over-cap-highlighting), red `! MP $X` line in the PDF, `over_max_price: true` in JSON). See the currency-blindness warning below. |
 | `--dedupe` | off | Remove duplicate matched cards across all queries (keyed by card id), keeping the first occurrence in xlsx / PDF / JSON. |
 | `--report-json PATH` | (none) | Also dump a structured JSON report. See [Outputs](outputs.md#json-report). |
 | `--pdf PATH` | (none) | Also write a 3×3 binder-style PDF (9 cards/page) — image-forward, sized to print and slip into 9-pocket pages as physical placeholders. See [PDF binder](binder-pdf.md). |

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -30,11 +30,13 @@ the matched card id).
 ### Over-cap highlighting
 
 When [`--max-price`](cli.md#pkmn-lookup-options) is set, rows whose
-**Market** price exceeds the cap get the **Market** cell (and its
-matching comps + listing URL) tinted soft amber (`#FFE9A8`). The row
-is still included in the output — single-card lookups always appear
-even when above the cap — and the fill is a visual flag so you can
-decide what to do with it at the table.
+**Market** price exceeds the cap get the **Market** cell and the
+**80% / 85% / 90% / 95%** comp cells tinted soft amber (`#FFE9A8`);
+the Market cell additionally renders in bold amber type. The Listing
+URL keeps its standard blue underline. The row is still included in
+the output — single-card lookups always appear even when above the
+cap — and the fill is a visual flag so you can decide what to do
+with it at the table.
 
 Bulk lookups (`top:N` / `All …`) cull above-cap candidates before the
 top-N cut instead of flagging them, so the highlight only fires for

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -27,6 +27,19 @@ a number looks off.
 Full-resolution PNGs land in `output/images/` by default (named after
 the matched card id).
 
+### Over-cap highlighting
+
+When [`--max-price`](cli.md#pkmn-lookup-options) is set, rows whose
+**Market** price exceeds the cap get the **Market** cell (and its
+matching comps + listing URL) tinted soft amber (`#FFE9A8`). The row
+is still included in the output — single-card lookups always appear
+even when above the cap — and the fill is a visual flag so you can
+decide what to do with it at the table.
+
+Bulk lookups (`top:N` / `All …`) cull above-cap candidates before the
+top-N cut instead of flagging them, so the highlight only fires for
+explicit single-card lines.
+
 ## JSON report (`--report-json`)
 
 Pass `--report-json output/summary.json` to get a structured digest


### PR DESCRIPTION
Closes #213

## What

`docs/outputs.md` now has a short **Over-cap highlighting** subsection
under **Spreadsheet** explaining what the soft-amber fill on the
**Market** cell means when `--max-price` is set. `docs/cli.md` gets a
cross-link from the `--max-price` flag description to the new anchor.

## Why

The amber tint at `src/mgz_pkmn/spreadsheet.py:65` is the only visual
cue in the xlsx that isn't self-explanatory. A reader who opens the
file fresh — without the CLI flag context — had no way to decode it.

## How to verify

- `docs/outputs.md` § Spreadsheet now contains an `### Over-cap
  highlighting` subsection.
- `docs/cli.md` `--max-price` row links to `outputs.md#over-cap-highlighting`.
- `make check` is green (docs-only; no test or code changes).

No CHANGELOG entry — per `CLAUDE.md` the changelog skips docs-only
updates.