### PR TITLE
docs(README): absolute logo URL so PyPI renders it

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1>
-  <img src="assets/logo.svg" alt="mgz-pkmn" height="64">
+  <img src="https://raw.githubusercontent.com/mgzwarrior/mgz-pkmn/main/assets/logo.svg" alt="mgz-pkmn" height="64">
 </h1>
 
 [![CI](https://github.com/mgzwarrior/mgz-pkmn/actions/workflows/ci.yml/badge.svg)](https://github.com/mgzwarrior/mgz-pkmn/actions/workflows/ci.yml)


### PR DESCRIPTION
Closes #279

## What

Swap the relative \`<img src="assets/logo.svg">\` at the top of \`README.md\`
for an absolute \`raw.githubusercontent.com\` URL.

## Why

PyPI renders the README standalone, so \`assets/logo.svg\` resolves to
\`https://pypi.org/.../assets/logo.svg\` and 404s — the logo never appears
on the project's [PyPI description tab](https://pypi.org/project/mgz-pkmn/#description).
Absolute raw-GitHub URLs survive PyPI's bleach allowlist (\`<img>\` keeps
\`src\`/\`alt\`/\`height\`) and \`raw.githubusercontent.com\` serves SVG with
\`Content-Type: image/svg+xml\`, which all browsers render. Same form
the project already uses for the inline logo in GitHub Discussion posts.

## Timing

The per-version README is **immutable** on PyPI, so this won't retro-fix
v1.1.0's description tab. It lands ahead of the next version publish
(v1.1.1 if cut soon; otherwise it'll ride v1.2) and the logo lights up
there.

## How to verify

\`\`\`bash
grep -n "logo.svg" README.md
# 2:  <img src="https://raw.githubusercontent.com/mgzwarrior/mgz-pkmn/main/assets/logo.svg" alt="mgz-pkmn" height="64">
\`\`\`

After the next release publishes, refresh
<https://pypi.org/project/mgz-pkmn/#description> — the logo should render
in the description tab header.

## Out of scope

Every other relative link in the README (\`docs/cli.md\`, \`[api/](api/)\`,
\`[web/](web/)\`, \`[input/](input/)\`, the entire docs cross-link table) is
**also broken on PyPI** for the same reason. Fixing those is a structural
decision (absolute-rewrite vs. ship a separate PyPI-only README via
\`pyproject.toml\` \`readme = {file, content-type}\`); tracked separately.

No CHANGELOG entry per CLAUDE.md (docs-only).