### PR TITLE
Bump version to 1.1.1 and rotate changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-05-25
+
+### Fixed
+
+- README: the project logo now renders on the
+  [PyPI description tab](https://pypi.org/project/mgz-pkmn/#description).
+  The prior `<img src="assets/logo.svg">` relative path 404'd on PyPI
+  (the README is rendered standalone, with no repo-relative context);
+  switched to an absolute `raw.githubusercontent.com` URL.
+
 ## [1.1.0] - 2026-05-25
 
 ### Added
@@ -278,7 +288,8 @@ UI, multi-source card lookup, all output formats, and release infrastructure.
 - Incomplete URL substring sanitization (CodeQL alerts).
 - Workflow permissions hardening (CodeQL alerts).
 
-[Unreleased]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.1.1...HEAD
+[1.1.1]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/mgzwarrior/mgz-pkmn/compare/v0.1.0...v1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mgz-pkmn"
-version = "1.1.0"
+version = "1.1.1"
 description = "CLI and web app to look up Pokemon cards across open data sources, fetch images and prices, and emit an .xlsx, PDF binder, set-completion checklist, and JSON report for card-show prep."
 readme = "README.md"
 license = "MIT"

--- a/src/mgz_pkmn/__init__.py
+++ b/src/mgz_pkmn/__init__.py
@@ -1,6 +1,6 @@
 """Pokemon card list -> spreadsheet for card shows."""
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 from mgz_pkmn.parser import CardQuery, parse_lines
 

--- a/uv.lock
+++ b/uv.lock
@@ -374,7 +374,7 @@ wheels = [
 
 [[package]]
 name = "mgz-pkmn"
-version = "1.1.0"
+version = "1.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Cuts **v1.1.1** — patch release whose sole job is to get the project
logo onto the PyPI description tab. Merging triggers
`release-on-version-bump.yml`, which tags \`v1.1.1\` and fires the
PyPI publish + GitHub Release workflows.

## What

- **CHANGELOG.md** — rotates \`[Unreleased]\` into
  \`[1.1.1] - 2026-05-25\`; adds a \`### Fixed\` entry pointing at the
  README logo path; refreshes the compare-link footer with \`v1.1.1\`.
- **Version bump** — \`pyproject.toml\`, \`src/mgz_pkmn/__init__.py\`,
  and \`uv.lock\` go from \`1.1.0\` to \`1.1.1\`.

## Why

PyPI's per-version README is immutable, so the v1.1.0 description
tab stays broken (relative \`assets/logo.svg\` path 404s on PyPI). The
README fix landed in [#280](https://github.com/mgzwarrior/mgz-pkmn/pull/280) —
this release is the smallest possible thing that lights the logo up
on https://pypi.org/project/mgz-pkmn/#description.

No roadmap or doc changes — a patch release isn't worth the
restructuring noise. The roadmap already lists v1.1 as shipped and
v1.2 as the next committed milestone; v1.1.1 just slots in as a
patch on the v1.1 line.

## How to verify

\`\`\`bash
# Local sanity
grep -E '^version' pyproject.toml       # version = "1.1.1"
grep __version__ src/mgz_pkmn/__init__.py
sed -n '8,18p' CHANGELOG.md             # [Unreleased] (empty) + [1.1.1] - 2026-05-25 + Fixed entry
tail -6 CHANGELOG.md                    # compare links include v1.1.1
\`\`\`

After merge:

1. \`release-on-version-bump.yml\` detects 1.1.1 in pyproject.toml on
   main, pushes the \`v1.1.1\` tag.
2. \`release.yml\` fires on the tag: builds sdist + wheel, publishes
   to https://pypi.org/project/mgz-pkmn/ via trusted-publisher OIDC,
   opens a GitHub Release with auto-notes.
3. Reload https://pypi.org/project/mgz-pkmn/#description — logo
   should render in the description header.