### PR TITLE
docs(site): refresh stale version copy in hero and roadmap

### DIFF
--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -21,7 +21,7 @@ const repoUrl = "https://github.com/mgzwarrior/mgz-pkmn";
       class="inline-flex items-center gap-2 rounded-full border border-zinc-800 bg-zinc-900/60 px-3 py-1 text-xs font-medium text-zinc-300"
     >
       <span class="h-1.5 w-1.5 rounded-full bg-brand-400"></span>
-      Now shipping 1.0
+      Now shipping 1.1.1
     </p>
 
     <h1

--- a/site/src/components/RoadmapTeaser.astro
+++ b/site/src/components/RoadmapTeaser.astro
@@ -1,16 +1,16 @@
 ---
 const milestones = [
   {
-    label: "1.0 — Shipped",
+    label: "1.1 — Shipped",
     state: "done",
-    body: "Multi-source lookup, full output suite, web UI, complete release engineering. The defensible 1.0 with no obvious gaps.",
-    href: "https://github.com/mgzwarrior/mgz-pkmn/milestone/1",
+    body: "Polish and on-ramp: starter-issue curation, CITATION.cff, docs troubleshooting, py.typed marker, Discussions visibility, cache subcommands. Open to first-time contributors.",
+    href: "https://github.com/mgzwarrior/mgz-pkmn/milestone/2",
   },
   {
-    label: "1.1 — In flight",
+    label: "1.2 — In flight",
     state: "active",
-    body: "Polish and on-ramp: starter-issue curation, CITATION.cff, docs troubleshooting, py.typed marker, Discussions visibility. Open to first-time contributors.",
-    href: "https://github.com/mgzwarrior/mgz-pkmn/milestone/2",
+    body: "Persistence foundation and web/site polish. Bridges v1.1's devex work and v2.0's deeper architectural changes.",
+    href: "https://github.com/mgzwarrior/mgz-pkmn/milestone/4",
   },
   {
     label: "2.0 — Next major",


### PR DESCRIPTION
Closes #285

## What

- Hero badge → "Now shipping 1.1.1" (was "Now shipping 1.0").
- Roadmap teaser → rolling window of three cards:
  - **1.1 — Shipped** (was "1.1 — In flight" linking to a closed milestone, which read "abandoned" to a stranger)
  - **1.2 — In flight** (new; body sourced from the v1.2 milestone description on GitHub)
  - **2.0 — Next major** (unchanged)
- Dropped the standalone "1.0 — Shipped" card to keep the layout at three cards. The roadmap now reads as a rolling window: most recent shipped → current → next major. v1.0 is implicit (covered by the 1.1 history).

## Why

A developer who lands on the marketing site checks for project health before contributing. The old copy advertised v1.0 in the hero and linked the roadmap to a closed milestone — both signals that the project had stalled, when in fact 1.1.0 and 1.1.1 had shipped and 1.2 was already accepting issues. First of five marketing-site iterations (#283–#287) aimed at lowering the friction between "developer arrives" and "developer opens a PR".

## How to verify

```bash
cd site && npm ci && npm run build  # build is green
cd site && npm run dev               # then open localhost:4321
```

- Hero pill reads "Now shipping 1.1.1".
- Roadmap shows three cards: 1.1 Shipped (emerald), 1.2 In flight (brand), 2.0 Planned (zinc).
- Each card's "View milestone →" link resolves to the matching GitHub milestone.

Verified locally with the dev server: hero text confirmed via accessibility snapshot, roadmap card content confirmed by DOM read (`badge`, `body`, `href` for all three cards). No console errors. `cd site && npm run build` ✓; `make check` ✓.

> Note: this is a UI-visible change but the screenshot artifact (per project convention) has to be drag-dropped via the GitHub UI — happy to add one as a follow-up comment if you want it on record.