### PR TITLE
feat(site): add 'Built in the open' contributor section to homepage

### DIFF
--- a/site/src/components/BuiltInTheOpen.astro
+++ b/site/src/components/BuiltInTheOpen.astro
@@ -1,0 +1,57 @@
+---
+const cards = [
+  {
+    title: "Good first issues",
+    body: "A curated list of small, well-scoped tasks for first-time contributors. Labels for the area you want to touch — lookup, outputs, cache, web, site.",
+    cta: "Browse starter issues",
+    href: "https://github.com/mgzwarrior/mgz-pkmn/labels/good%20first%20issue",
+  },
+  {
+    title: "Discussions",
+    body: "Open questions, design proposals, and announcements live here. The right place to float an idea before it's an issue — or just say hi.",
+    cta: "Open Discussions",
+    href: "https://github.com/mgzwarrior/mgz-pkmn/discussions",
+  },
+  {
+    title: "Contributing guide",
+    body: "The full workflow from issue to merged PR: branch naming, sign-off, the local gate, PR conventions. Everything you need to land your first change.",
+    cta: "Read the guide",
+    href: "https://github.com/mgzwarrior/mgz-pkmn/blob/main/docs/contributing.md",
+  },
+];
+---
+
+<section id="contribute" class="border-b border-zinc-900/80 px-6 py-20 sm:py-24">
+  <div class="mx-auto max-w-6xl">
+    <div class="max-w-2xl">
+      <h2 class="text-3xl sm:text-4xl font-bold tracking-tight text-white">
+        Built in the open.
+      </h2>
+      <p class="mt-4 text-lg text-zinc-400">
+        MIT-licensed, public roadmap, first-time contributors welcome. The same
+        tool you're trying — shaped by anyone who wants to help.
+      </p>
+    </div>
+
+    <ul class="mt-12 grid gap-6 md:grid-cols-3">
+      {
+        cards.map((card) => (
+          <li>
+            <a
+              href={card.href}
+              class="flex h-full flex-col rounded-xl border border-zinc-800 bg-zinc-900/40 p-6 hover:border-zinc-700 transition"
+            >
+              <h3 class="text-lg font-semibold text-white">{card.title}</h3>
+              <p class="mt-3 text-sm leading-relaxed text-zinc-400 flex-1">
+                {card.body}
+              </p>
+              <span class="mt-5 inline-flex items-center gap-1 text-sm font-semibold text-brand-400">
+                {card.cta} →
+              </span>
+            </a>
+          </li>
+        ))
+      }
+    </ul>
+  </div>
+</section>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -4,6 +4,7 @@ import Header from "../components/Header.astro";
 import Hero from "../components/Hero.astro";
 import FeaturesGrid from "../components/FeaturesGrid.astro";
 import HowItWorks from "../components/HowItWorks.astro";
+import BuiltInTheOpen from "../components/BuiltInTheOpen.astro";
 import RoadmapTeaser from "../components/RoadmapTeaser.astro";
 import Footer from "../components/Footer.astro";
 ---
@@ -14,6 +15,7 @@ import Footer from "../components/Footer.astro";
     <Hero />
     <FeaturesGrid />
     <HowItWorks />
+    <BuiltInTheOpen />
     <RoadmapTeaser />
   </main>
   <Footer />


### PR DESCRIPTION
Closes #284

## What

Adds a new `BuiltInTheOpen.astro` section to the marketing-site homepage, slotted between `HowItWorks` and `RoadmapTeaser`. Three cards that fork on intent:

- **Good first issues** → curated label page
- **Discussions** → GitHub Discussions board
- **Contributing guide** → `docs/contributing.md`

Each card is a single large click target (`<a>` wraps the whole card body) so the visual hover affordance and the actionable target line up.

The section's anchor id is `#contribute` so the header link added in #283 can point at it without needing a separate page (the dedicated `/contribute` page is still tracked separately in #286).

## Why

Per the audit upstream, the single most contributor-friendly line on the site lived as a body fragment inside a roadmap card ("Open to first-time contributors"). A developer who lands from a search result or social link saw zero contributor-aimed copy above the fold and had to navigate to the footer's "Community" column to find any path in. This section pulls the recruiting message forward and forks on intent at the same place a visitor is already deciding whether to engage.

Out of scope here (tracked separately): live data fed from the GitHub API (#287), and the dedicated `/contribute` page (#286).

## How to verify

```bash
cd site && npm run dev
```

- Open `localhost:4321`.
- Scroll past How it works — new "Built in the open." section renders before Roadmap.
- Heading: "Built in the open."
- Sub: "MIT-licensed, public roadmap, first-time contributors welcome. The same tool you're trying — shaped by anyone who wants to help."
- Three cards in a `md:grid-cols-3` layout (stacks on mobile), each entire card clickable, each linking to the right GitHub destination.
- No console errors.
- `npm run build` succeeds.

Verified locally with the dev server: accessibility snapshot confirms the section is positioned between `how-it-works` and `roadmap`; DOM read confirms all three card titles, bodies, CTAs, and hrefs. `make check` ✓; `cd site && npm run build` ✓.

> Visible UI change but screenshot artifacts have to be drag-dropped via the GitHub UI — happy to add one as a follow-up comment if you want it on record.