### PR TITLE
feat(site): add Contribute link to header nav

### DIFF
--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -34,6 +34,13 @@ const repoUrl = "https://github.com/mgzwarrior/mgz-pkmn";
       </li>
       <li>
         <a
+          href="#contribute"
+          class="px-3 py-2 rounded-md text-brand-400 hover:text-brand-300 hover:bg-zinc-900 transition"
+          >Contribute</a
+        >
+      </li>
+      <li>
+        <a
           href={repoUrl}
           class="px-3 py-2 rounded-md text-zinc-300 hover:text-white hover:bg-zinc-900 transition"
           >GitHub</a


### PR DESCRIPTION
Closes #283

## What

Adds a "Contribute" link to the marketing-site header nav, pointing at the homepage `#contribute` anchor (the section landed in #284). Sits between Roadmap and GitHub.

Two intentional styling decisions:

- **Brand color** (`text-brand-400`) rather than the default zinc — the contributor path should be visually distinct from the user-aimed nav items.
- **Visible on mobile** (no `hidden sm:list-item` class) — How it works and Roadmap collapse below the `sm` breakpoint to keep the bar tight; Contribute stays visible because that's the whole point of the issue.

## Why

The header was the most-visible navigation surface and offered zero path for a developer-visitor: Features → How it works → Roadmap → GitHub. The footer's Community column was the only way to find contributor links, and it sat below ~3000px of scroll on the homepage.

When the dedicated `/contribute` page lands (#286), this link can switch from anchor to page href in a one-line change — no further nav restructuring needed.

## How to verify

```bash
cd site && npm run dev
```

- `Contribute` appears in the header between Roadmap and GitHub.
- Rendered in brand color (blue-400), distinct from the zinc nav items.
- Clicking it scrolls to the `Built in the open.` section on the homepage.
- Mobile width (< 640px): Features, Contribute, GitHub remain visible; How it works and Roadmap collapse.
- `npm run build` ✓.

Verified locally with the dev server: DOM read confirms link href, hover-visibility, and color; anchor target resolves to the `#contribute` section. No console errors.

> Visible UI change but screenshot artifacts must be drag-dropped via the GitHub UI — happy to drop one as a follow-up comment.