### PR TITLE
feat(site): add dedicated /contribute page

### DIFF
--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -13,21 +13,21 @@ const repoUrl = "https://github.com/mgzwarrior/mgz-pkmn";
     <ul class="flex items-center gap-1 sm:gap-2 text-sm">
       <li>
         <a
-          href="#features"
+          href="/#features"
           class="px-3 py-2 rounded-md text-zinc-300 hover:text-white hover:bg-zinc-900 transition"
           >Features</a
         >
       </li>
       <li class="hidden sm:list-item">
         <a
-          href="#how-it-works"
+          href="/#how-it-works"
           class="px-3 py-2 rounded-md text-zinc-300 hover:text-white hover:bg-zinc-900 transition"
           >How it works</a
         >
       </li>
       <li class="hidden sm:list-item">
         <a
-          href="#roadmap"
+          href="/#roadmap"
           class="px-3 py-2 rounded-md text-zinc-300 hover:text-white hover:bg-zinc-900 transition"
           >Roadmap</a
         >

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -34,7 +34,7 @@ const repoUrl = "https://github.com/mgzwarrior/mgz-pkmn";
       </li>
       <li>
         <a
-          href="#contribute"
+          href="/contribute"
           class="px-3 py-2 rounded-md text-brand-400 hover:text-brand-300 hover:bg-zinc-900 transition"
           >Contribute</a
         >

--- a/site/src/pages/contribute.astro
+++ b/site/src/pages/contribute.astro
@@ -1,0 +1,242 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import Header from "../components/Header.astro";
+import Footer from "../components/Footer.astro";
+
+const repoUrl = "https://github.com/mgzwarrior/mgz-pkmn";
+
+const shapes = [
+  {
+    title: "Bugs",
+    body: "Hit something weird? File an issue with a reproducible example. Bug fixes ship faster than features and get prioritized accordingly.",
+  },
+  {
+    title: "Features",
+    body: "Got an idea? Float it in Discussions first — saves design churn. Then an issue, then a PR. Small, well-scoped wins.",
+  },
+  {
+    title: "Docs",
+    body: "README, the contributing guide, ADRs, code comments, error messages. Writing matters as much as the code; if something tripped you up, it'll trip the next person too.",
+  },
+  {
+    title: "Lookup sources",
+    body: "Adapters for new data sources — eBay sold listings, Cardmarket variants, regional indexes. The lookup pipeline is built around source interfaces; adding one is a self-contained PR.",
+  },
+  {
+    title: "Web & SPA",
+    body: "FastAPI + React + Tailwind. The web client mirrors the CLI; UI work and accessibility polish are always welcome.",
+  },
+  {
+    title: "Tests",
+    body: "Edge cases, parser fixtures, integration coverage. The test suite is the safety net everyone else relies on — every contribution here punches above its weight.",
+  },
+];
+
+const steps = [
+  {
+    n: "01",
+    title: "Pick (or open) an issue",
+    body: "Every change is traceable to an issue. Browse the curated good-first-issue list, or open one yourself and tag the area. Comment to claim it before you start.",
+  },
+  {
+    n: "02",
+    title: "Branch and implement",
+    body: "Branch name format: <issueNumber>-<short-description>. Match existing patterns. Run make fix before committing — pre-commit hooks handle the rest.",
+  },
+  {
+    n: "03",
+    title: "Open the PR",
+    body: "Sign off with -s. Mirror the issue's labels and milestone on the PR. The local gate (make check) and CI must be green; first-time contributors get a celebration on the contributors thread when their PR merges.",
+  },
+];
+
+const ctas = [
+  {
+    title: "Browse starter issues",
+    body: "Curated, well-scoped, ready to claim.",
+    href: `${repoUrl}/labels/good%20first%20issue`,
+  },
+  {
+    title: "Open a Discussion",
+    body: "Float an idea, ask a question, say hi.",
+    href: `${repoUrl}/discussions`,
+  },
+  {
+    title: "Read the full guide",
+    body: "Branch conventions, sign-off, CI, the works.",
+    href: `${repoUrl}/blob/main/docs/contributing.md`,
+  },
+];
+---
+
+<BaseLayout
+  title="Contribute to mgz-pkmn — open-source Pokemon TCG prep tool"
+  description="How to contribute to mgz-pkmn: pick an issue, open a PR, get your first change merged. Bugs, features, docs, data sources, web, tests — all welcome."
+>
+  <Header />
+  <main>
+    <!-- Hero -->
+    <section class="relative overflow-hidden border-b border-zinc-900/80 px-6 py-20 sm:py-24">
+      <div
+        aria-hidden="true"
+        class="pointer-events-none absolute inset-0 -z-10 [mask-image:radial-gradient(ellipse_at_center,black_30%,transparent_70%)]"
+      >
+        <div
+          class="absolute inset-x-0 top-0 mx-auto h-[30rem] w-[30rem] -translate-y-1/3 rounded-full bg-brand-600/15 blur-3xl"
+        >
+        </div>
+      </div>
+
+      <div class="mx-auto max-w-3xl text-center">
+        <p
+          class="inline-flex items-center gap-2 rounded-full border border-zinc-800 bg-zinc-900/60 px-3 py-1 text-xs font-medium text-zinc-300"
+        >
+          <span class="h-1.5 w-1.5 rounded-full bg-brand-400"></span>
+          First-time contributors welcome
+        </p>
+
+        <h1
+          class="mt-6 text-4xl sm:text-5xl font-bold tracking-tight text-white text-balance"
+        >
+          Help build the prep tool we all wish existed.
+        </h1>
+
+        <p class="mt-6 text-lg text-zinc-300 text-balance max-w-2xl mx-auto">
+          Open-source, MIT-licensed, public roadmap. Whether you're fixing a typo, adding a
+          data source, or designing a new export — there's a way in.
+        </p>
+      </div>
+    </section>
+
+    <!-- Ways to contribute -->
+    <section class="border-b border-zinc-900/80 px-6 py-20 sm:py-24">
+      <div class="mx-auto max-w-6xl">
+        <div class="max-w-2xl">
+          <h2 class="text-3xl sm:text-4xl font-bold tracking-tight text-white">
+            Ways in.
+          </h2>
+          <p class="mt-4 text-lg text-zinc-400">
+            Six shapes of contribution. Pick the one that matches what you'd rather spend
+            an afternoon on.
+          </p>
+        </div>
+
+        <ul class="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {
+            shapes.map((s) => (
+              <li class="rounded-xl border border-zinc-800 bg-zinc-900/40 p-6 hover:border-zinc-700 transition">
+                <h3 class="text-lg font-semibold text-white">{s.title}</h3>
+                <p class="mt-3 text-sm leading-relaxed text-zinc-400">{s.body}</p>
+              </li>
+            ))
+          }
+        </ul>
+      </div>
+    </section>
+
+    <!-- How it works -->
+    <section class="border-b border-zinc-900/80 px-6 py-20 sm:py-24">
+      <div class="mx-auto max-w-6xl">
+        <div class="max-w-2xl">
+          <h2 class="text-3xl sm:text-4xl font-bold tracking-tight text-white">
+            How it works.
+          </h2>
+          <p class="mt-4 text-lg text-zinc-400">
+            Three steps from "I'd like to help" to a merged PR. The full reference lives
+            in <a
+              href={`${repoUrl}/blob/main/docs/contributing.md`}
+              class="text-brand-400 hover:text-brand-300 underline-offset-4 hover:underline"
+              >docs/contributing.md</a
+            >.
+          </p>
+        </div>
+
+        <ol class="mt-12 grid gap-8 md:grid-cols-3">
+          {
+            steps.map((step) => (
+              <li class="relative rounded-xl border border-zinc-800 bg-zinc-900/40 p-6">
+                <span class="absolute -top-3 -left-3 inline-flex h-10 w-10 items-center justify-center rounded-md bg-brand-500 text-sm font-bold text-white shadow-lg shadow-brand-500/30">
+                  {step.n}
+                </span>
+                <h3 class="mt-2 text-lg font-semibold text-white">{step.title}</h3>
+                <p class="mt-3 text-sm leading-relaxed text-zinc-400">{step.body}</p>
+              </li>
+            ))
+          }
+        </ol>
+      </div>
+    </section>
+
+    <!-- Recognition -->
+    <section class="border-b border-zinc-900/80 px-6 py-20 sm:py-24">
+      <div class="mx-auto max-w-6xl">
+        <div class="max-w-2xl">
+          <h2 class="text-3xl sm:text-4xl font-bold tracking-tight text-white">
+            Recognition.
+          </h2>
+          <p class="mt-4 text-lg text-zinc-400">
+            What you get for showing up.
+          </p>
+        </div>
+
+        <div class="mt-12 grid gap-6 md:grid-cols-2">
+          <div class="rounded-xl border border-zinc-800 bg-zinc-900/40 p-6">
+            <h3 class="text-lg font-semibold text-white">First PR celebration</h3>
+            <p class="mt-3 text-sm leading-relaxed text-zinc-400">
+              When your first PR merges, we post a welcome on the <a
+                href={`${repoUrl}/discussions/141`}
+                class="text-brand-400 hover:text-brand-300 underline-offset-4 hover:underline"
+                >contributors thread</a
+              >. Small thing; matters anyway.
+            </p>
+          </div>
+
+          <div class="rounded-xl border border-zinc-800 bg-zinc-900/40 p-6">
+            <h3 class="text-lg font-semibold text-white">Citable</h3>
+            <p class="mt-3 text-sm leading-relaxed text-zinc-400">
+              Writing a blog post, paper, or talk that uses mgz-pkmn? The repo ships a <a
+                href={`${repoUrl}/blob/main/CITATION.cff`}
+                class="text-brand-400 hover:text-brand-300 underline-offset-4 hover:underline"
+                >CITATION.cff</a
+              > so a one-click citation is always available.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Get started -->
+    <section class="border-b border-zinc-900/80 px-6 py-20 sm:py-24">
+      <div class="mx-auto max-w-6xl">
+        <div class="max-w-2xl">
+          <h2 class="text-3xl sm:text-4xl font-bold tracking-tight text-white">
+            Get started.
+          </h2>
+          <p class="mt-4 text-lg text-zinc-400">
+            Three doors — pick whichever you'd rather walk through first.
+          </p>
+        </div>
+
+        <ul class="mt-12 grid gap-6 md:grid-cols-3">
+          {
+            ctas.map((cta) => (
+              <li>
+                <a
+                  href={cta.href}
+                  class="flex h-full flex-col rounded-xl border border-brand-500/40 bg-brand-500/5 p-6 hover:border-brand-500/70 hover:bg-brand-500/10 transition"
+                >
+                  <h3 class="text-lg font-semibold text-white">{cta.title}</h3>
+                  <p class="mt-3 text-sm leading-relaxed text-zinc-300 flex-1">{cta.body}</p>
+                  <span class="mt-5 inline-flex items-center gap-1 text-sm font-semibold text-brand-400">
+                    Go →
+                  </span>
+                </a>
+              </li>
+            ))
+          }
+        </ul>
+      </div>
+    </section>
+  </main>
+  <Footer />
+</BaseLayout>


### PR DESCRIPTION
Closes #286

## What

A new static `/contribute` page (`site/src/pages/contribute.astro`), built from `BaseLayout` + the existing Header/Footer components. Five sections:

1. **Hero** — "Help build the prep tool we all wish existed." Brand-glow background mirroring the homepage hero, with a "First-time contributors welcome" pill.
2. **Ways in** — six-card grid: Bugs, Features, Docs, Lookup sources, Web & SPA, Tests. Each card grounds the shape in a concrete example so a stranger can self-identify.
3. **How it works** — three-step contributor workflow (pick/open an issue → branch + implement → open the PR). Specific about the conventions that block PRs (branch-naming format, `-s` sign-off, `make check` gate). Inline link to the full `docs/contributing.md` for the long version.
4. **Recognition** — two cards: the first-PR celebration norm (links to Discussion #141) and the project's `CITATION.cff` for citations.
5. **Get started** — three brand-tinted CTA cards (good-first-issues, Discussions, full contributing guide). Distinct visual weight from the homepage "Built in the open" section because this is a final-call, not a discovery surface.

Also: switches the header Contribute link from `#contribute` (homepage anchor) to `/contribute` (this new page). The homepage section retains its `id="contribute"` so anyone with an old `/#contribute` deep-link still resolves.

## Why

The site had no on-site landing for contributors. Anyone curious had to click into `docs/contributing.md` on GitHub and parse a long reference document — fine if you're already convinced, lossy if you're still deciding. This page sits between "I might help" and "I'm reading the contributing guide": it tells you what shapes of work matter, what the workflow looks like, what you get out of showing up, and where to go next.

Out of scope (tracked separately): live GitHub-API data on `/contribute` (#287).

## How to verify

```bash
cd site && npm run dev   # localhost:4321
```

- Click **Contribute** in the header — lands on `/contribute`.
- All five sections render in order: hero → Ways in → How it works → Recognition → Get started.
- "Ways in" shows 6 cards; "How it works" shows 3 numbered steps; "Recognition" shows 2 cards; "Get started" shows 3 brand-tinted CTA cards.
- External links resolve correctly:
  - `docs/contributing.md` (in How-it-works sub and in CTA)
  - Discussion #141 (Recognition)
  - `CITATION.cff` (Recognition)
  - `good first issue` label, Discussions, contributing guide (CTAs)
- `npm run build` succeeds; both `/` and `/contribute/index.html` are emitted.

Verified locally with the dev server: DOM read across all sections confirmed structure, headings, card counts, and link targets. `make check` ✓; `cd site && npm run build` ✓.

> Visible UI change — screenshot artifacts must be drag-dropped via the GitHub UI. Happy to drop one as a follow-up comment.