### PR TITLE
build(deploy): bake a warmed set-image cache into the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,28 @@ COPY README.md ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --extra api --no-dev --frozen
 
+# Bake a warmed set-image cache into the image so the deployed service starts
+# hot. Render's free plan has no persistent disk, so without this every cold
+# start (deploy or post-idle spin-up) pays the full image-download cost on
+# the first set lookup. The warm pass walks pokemontcg.io's set catalog
+# (~200 sets) and persists each logo+symbol — ~20 MB total on disk.
+#
+# `POKEMONTCG_IO_API_KEY` is passed in as a build arg (Render reads it from
+# the service's envVars). When unset (e.g. a local `docker build` with no
+# key), the warm step is skipped cleanly so the image still builds — it just
+# starts with a cold cache.
+#
+# Sits before `COPY api/` and `COPY --from=web-builder` so layer caching
+# isn't invalidated by every api/ or web/ change — only by src/ or deps.
+ARG POKEMONTCG_IO_API_KEY=""
+ENV XDG_CACHE_HOME=/app/.cache
+RUN if [ -n "$POKEMONTCG_IO_API_KEY" ]; then \
+        POKEMONTCG_IO_API_KEY="$POKEMONTCG_IO_API_KEY" \
+            uv run pkmn cache warm-sets; \
+    else \
+        echo "POKEMONTCG_IO_API_KEY not set at build time; skipping cache warm (image will start with a cold cache)"; \
+    fi
+
 # Copy API code and the built SPA from stage 1.
 COPY api/ ./api/
 COPY --from=web-builder /app/web/dist ./web/dist

--- a/render.yaml
+++ b/render.yaml
@@ -8,5 +8,10 @@ services:
     autoDeploy: true
     healthCheckPath: /health
     envVars:
+      # Used at both build time (the Dockerfile's `pkmn cache warm-sets`
+      # step bakes set logos+symbols into the image) and runtime (the API
+      # uses it for live lookups). Render automatically passes envVars to
+      # the Docker build as build args when the Dockerfile declares them
+      # via `ARG`, so a single entry covers both.
       - key: POKEMONTCG_IO_API_KEY
         sync: false


### PR DESCRIPTION
Closes #282

## What

Adds a build-time step to the runtime stage of `Dockerfile` that runs `pkmn cache warm-sets` with `XDG_CACHE_HOME=/app/.cache`, baking the set-logo + symbol catalog into the image. The runtime uvicorn process inherits the same `XDG_CACHE_HOME`, so it reads from the baked cache on first request.

Layered before `COPY api/` and the SPA copy so day-to-day api/ or web/ changes don't invalidate the warm-cache layer — only `src/` or dependency changes do.

```dockerfile
ARG POKEMONTCG_IO_API_KEY=""
ENV XDG_CACHE_HOME=/app/.cache
RUN if [ -n "$POKEMONTCG_IO_API_KEY" ]; then \
        POKEMONTCG_IO_API_KEY="$POKEMONTCG_IO_API_KEY" \
            uv run pkmn cache warm-sets; \
    else \
        echo "POKEMONTCG_IO_API_KEY not set at build time; skipping cache warm (image will start with a cold cache)"; \
    fi
```

When the API key isn't present at build time (e.g. a local `docker build` with no secrets configured), the warm step is skipped cleanly with a clear log message — the image still builds, it just ships with a cold cache. That preserves the local-build UX while making the Render deploy hot.

`render.yaml` gets a comment on the existing `POKEMONTCG_IO_API_KEY` envVar entry noting it now flows to the Docker build too — Render passes envVars as build args automatically when the Dockerfile declares them via `ARG`, so a single entry covers both build and runtime.

## Why

The Render demo serves the SPA with no persistent disk. Every deploy and every cold start after idle wipes the runtime cache, so the first visitor to look up a set after a redeploy waits while ~200 image downloads stream in from pokemontcg.io. With this change the image ships pre-warmed: zero cold-start image-download cost.

Out of scope (tracked separately): persistent storage for the deployed app — that's a v2 concern when we move off free-tier infra.

## Numbers

- A fully-warmed local cache (`~/.cache/mgz-pkmn/images/sets/`) is **20 MB** on disk. The Docker layer will compress further; even uncompressed, this is a negligible image-size bump.
- The warm pass is ~200 serial HTTP requests against pokemontcg.io. Expected build-time cost: ~30–90 s depending on network latency from Render's builders.

## How to verify

After merge, on the next Render deploy:

1. Build log should show `Warming set image cache` and a final line like `200 sets · 200 logos · 200 symbols`. (If the API key isn't set in the Render dashboard, the log will instead show the "skipping cache warm" message — that's the signal to set the env var.)
2. Open the demo and try a Set ID cards export for any set you haven't searched before.
3. Browser DevTools → Network: thumbnails should serve fast (no waterfall of pokemontcg.io image fetches before the page renders).
4. Optional: `gh run view` the build, or check Render's image size — should be ~20 MB larger than the prior image.

If anything fails, the warm step's exit code propagates — Render will mark the deploy failed and we'll see the error in the build log.

## Pre-merge checklist for the maintainer

- Confirm `POKEMONTCG_IO_API_KEY` is set in the Render dashboard for the `mgz-pkmn` service (it almost certainly already is, since the runtime uses it — but `sync: false` means it's secret-only and worth a glance).
- After merge, watch the first deploy's build log for the warm-pass output.