### PR TITLE
feat(cache): pre-warm _CONCEPT_KEYWORDS catalog so concept lookups are cache-hit-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- CLI: `pkmn cache warm-concepts` subcommand walks every distinct name
+  referenced by the curated `_CONCEPT_KEYWORDS` dictionary and primes the
+  API response cache for each one, so concept lookups (`top 9 puppy`,
+  `all eeveelution cards`, …) resolve from cache on subsequent runs
+  instead of fanning out to N upstream calls. Accepts `--source
+  pokemontcg|tcgdex|all` (default `all`: walk pokemontcg.io first and fall
+  back to TCGdex on miss) and `--verbose` to print each name as it warms.
+  Writes a manifest at `concept_warm.json` in the cache root with a
+  timestamp + count.
+- API: opt-in `MGZ_PKMN_WARM_ON_STARTUP=1` env var triggers the same warm
+  pass on FastAPI startup, running on a background daemon thread so
+  startup isn't blocked. Gated by the manifest's 24-hour freshness window
+  so `uvicorn --reload` cycles and tight redeploys don't thrash.
+- Stats: `pkmn cache stats` surfaces a new **Concepts** line — "N names ·
+  warmed <age>" when a warm pass has landed, "not warmed" otherwise.
+
 ## [1.1.1] - 2026-05-25
 
 ### Fixed

--- a/api/main.py
+++ b/api/main.py
@@ -9,7 +9,9 @@ Or from inside the api/ directory:
 
 from __future__ import annotations
 
+import logging
 import os
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -19,8 +21,49 @@ from fastapi.staticfiles import StaticFiles
 from starlette.responses import Response
 
 from mgz_pkmn import __version__
+from mgz_pkmn import cache as disk_cache
+from mgz_pkmn.lookup import warm_concepts
+from mgz_pkmn.sources import TCGClient, TCGDexClient
 
 from .routes import export, lookup, overrides, parse, set_cards, sets
+
+_log = logging.getLogger(__name__)
+
+_WARM_ON_STARTUP_ENV = "MGZ_PKMN_WARM_ON_STARTUP"
+
+
+def _warm_concepts_in_background() -> None:
+    """Run the concept warm pass on a daemon thread so FastAPI startup
+    isn't blocked by ~200 upstream HTTP requests.
+
+    Gated by the on-disk freshness manifest — if a warm pass landed within
+    the last 24 h, skip and log "already fresh". Errors are logged and
+    swallowed: a failed warm should not crash the service, only leave the
+    cache cold for this run."""
+    if disk_cache.concept_warm_is_fresh():
+        _log.info("concept cache fresh; skipping startup warm")
+        return
+
+    def _run() -> None:
+        try:
+            pkmn = TCGClient(api_key=os.environ.get("POKEMONTCG_IO_API_KEY"))
+            tcgdex = TCGDexClient()
+            result = warm_concepts(pkmn, tcgdex, source="all")
+            disk_cache.write_concept_warm(
+                names_warmed=result.names_warmed,
+                names_failed=result.names_failed,
+                source="all",
+            )
+            _log.info(
+                "concept warm complete: %d names attempted, %d warmed, %d missed",
+                result.names_attempted,
+                result.names_warmed,
+                len(result.names_failed),
+            )
+        except Exception:
+            _log.exception("concept warm failed; service running with cold cache")
+
+    threading.Thread(target=_run, name="concept-warm", daemon=True).start()
 
 
 class SPAStaticFiles(StaticFiles):
@@ -65,6 +108,18 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Opt-in startup hook: when MGZ_PKMN_WARM_ON_STARTUP=1, kick off a concept
+# warm pass in the background so the first concept lookup served by this
+# process is a cache hit. The manifest's once-per-day gate keeps reloads
+# from thrashing (a `uvicorn --reload` cycle won't re-warm if a warm pass
+# landed within the last 24 h).
+if os.environ.get(_WARM_ON_STARTUP_ENV, "").strip() in ("1", "true", "True"):
+
+    @app.on_event("startup")
+    def _startup_warm_concepts() -> None:
+        _warm_concepts_in_background()
+
 
 app.include_router(parse.router, prefix="/api/v1", tags=["parse"])
 app.include_router(lookup.router, prefix="/api/v1", tags=["lookup"])

--- a/src/mgz_pkmn/cache.py
+++ b/src/mgz_pkmn/cache.py
@@ -44,10 +44,13 @@ if TYPE_CHECKING:
 
 DEFAULT_API_TTL_SECONDS = 7 * 24 * 60 * 60  # one week
 DEFAULT_CACHE_WARN_BYTES = 50 * 1024 * 1024  # 50 MB
+CONCEPT_WARM_STALE_SECONDS = 24 * 60 * 60  # one day — once-per-day startup gate
 _NO_CACHE_ENV = "MGZ_PKMN_NO_CACHE"
 _WARN_BYTES_ENV = "MGZ_PKMN_CACHE_WARN_BYTES"
 _OVERRIDES_FILE = "url_overrides.json"
+_CONCEPT_WARM_FILE = "concept_warm.json"
 OVERRIDES_SCHEMA_VERSION = 1
+CONCEPT_WARM_SCHEMA_VERSION = 1
 _IMAGES_SUBDIR = "images"
 # Allowed image extensions for read-side discovery; write-side derives the
 # extension from the source URL but normalises it through this list so an
@@ -81,6 +84,12 @@ class CacheStats:
     override_bytes: int
     image_entry_count: int
     image_bytes: int
+    # Concept-warm slice — populated from the `concept_warm.json` manifest
+    # written by `pkmn cache warm-concepts`. `concept_warm_timestamp` is
+    # None when no warm pass has been recorded yet; the CLI renders that as
+    # "concept cache: not warmed" so the operator knows the state at a glance.
+    concept_warm_timestamp: float | None
+    concept_warm_names: int
 
 
 def _disabled() -> bool:
@@ -563,6 +572,81 @@ def image_cache_size() -> tuple[int, int]:
 
 
 # ---------------------------------------------------------------------------
+# Concept-warm manifest — small JSON file that records when `warm-concepts`
+# last ran and how many names it warmed. Powers both the once-per-day
+# startup gate (`MGZ_PKMN_WARM_ON_STARTUP=1`) and the concept-warm slice in
+# `pkmn cache stats`. Honoured even when `MGZ_PKMN_NO_CACHE=1` is set:
+# operators reading stats want real on-disk state, not a silent zero.
+# ---------------------------------------------------------------------------
+
+
+def _concept_warm_path() -> Path:
+    return _cache_root_path() / _CONCEPT_WARM_FILE
+
+
+def read_concept_warm() -> dict[str, Any] | None:
+    """Return the parsed concept-warm manifest, or None when absent/malformed.
+
+    Schema (v1):
+        {
+            "version": 1,
+            "timestamp": <unix float>,
+            "names_warmed": <int>,
+            "names_failed": [<str>, ...],
+            "source": "pokemontcg" | "tcgdex" | "all"
+        }
+
+    Treats a malformed/legacy file as "no manifest" so a corrupted write
+    doesn't poison the freshness gate."""
+    path = _concept_warm_path()
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict) or data.get("version") != CONCEPT_WARM_SCHEMA_VERSION:
+        return None
+    return data
+
+
+def write_concept_warm(
+    *,
+    names_warmed: int,
+    names_failed: list[str],
+    source: str,
+) -> None:
+    """Persist the concept-warm manifest. Best-effort — failures are silent
+    so a read-only filesystem doesn't crash a successful warm pass."""
+    payload = {
+        "version": CONCEPT_WARM_SCHEMA_VERSION,
+        "timestamp": time.time(),
+        "names_warmed": names_warmed,
+        "names_failed": names_failed,
+        "source": source,
+    }
+    root = cache_root()
+    with contextlib.suppress(OSError):
+        (root / _CONCEPT_WARM_FILE).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def concept_warm_is_fresh(*, now: float | None = None) -> bool:
+    """True when a manifest exists and its timestamp is within the staleness
+    window (default 24 h, configurable via `CONCEPT_WARM_STALE_SECONDS`).
+
+    Used by the FastAPI startup hook to decide whether to re-warm. `now`
+    parameter is for tests — production callers omit it and use wall time."""
+    manifest = read_concept_warm()
+    if manifest is None:
+        return False
+    ts = manifest.get("timestamp")
+    if not isinstance(ts, int | float):
+        return False
+    current = now if now is not None else time.time()
+    return (current - ts) < CONCEPT_WARM_STALE_SECONDS
+
+
+# ---------------------------------------------------------------------------
 # Stats — health snapshot for `pkmn cache stats`.
 # ---------------------------------------------------------------------------
 
@@ -609,6 +693,17 @@ def stats() -> CacheStats:
 
     image_count, image_bytes = image_cache_size()
 
+    concept_warm_timestamp: float | None = None
+    concept_warm_names = 0
+    manifest = read_concept_warm()
+    if manifest is not None:
+        ts = manifest.get("timestamp")
+        if isinstance(ts, int | float):
+            concept_warm_timestamp = float(ts)
+        n = manifest.get("names_warmed")
+        if isinstance(n, int):
+            concept_warm_names = n
+
     return CacheStats(
         root=root,
         api_entry_count=api_count,
@@ -618,4 +713,6 @@ def stats() -> CacheStats:
         override_bytes=override_bytes,
         image_entry_count=image_count,
         image_bytes=image_bytes,
+        concept_warm_timestamp=concept_warm_timestamp,
+        concept_warm_names=concept_warm_names,
     )

--- a/src/mgz_pkmn/cache.py
+++ b/src/mgz_pkmn/cache.py
@@ -631,8 +631,15 @@ def write_concept_warm(
 
 
 def concept_warm_is_fresh(*, now: float | None = None) -> bool:
-    """True when a manifest exists and its timestamp is within the staleness
-    window (default 24 h, configurable via `CONCEPT_WARM_STALE_SECONDS`).
+    """True when a manifest exists, its timestamp is within the staleness
+    window (default 24 h, configurable via `CONCEPT_WARM_STALE_SECONDS`),
+    AND it recorded at least one successful name warm.
+
+    The `names_warmed > 0` guard exists because `write_concept_warm` is
+    called unconditionally after every warm pass — including ones that
+    failed every name (a transient upstream outage, for example). Without
+    this guard a single failed run would suppress the startup retry for a
+    full 24 h while the cache stays cold.
 
     Used by the FastAPI startup hook to decide whether to re-warm. `now`
     parameter is for tests — production callers omit it and use wall time."""
@@ -641,6 +648,9 @@ def concept_warm_is_fresh(*, now: float | None = None) -> bool:
         return False
     ts = manifest.get("timestamp")
     if not isinstance(ts, int | float):
+        return False
+    names_warmed = manifest.get("names_warmed")
+    if not isinstance(names_warmed, int) or names_warmed <= 0:
         return False
     current = now if now is not None else time.time()
     return (current - ts) < CONCEPT_WARM_STALE_SECONDS

--- a/src/mgz_pkmn/cli.py
+++ b/src/mgz_pkmn/cli.py
@@ -19,7 +19,7 @@ from . import cache as disk_cache
 from .binder import CONDENSED_LAYOUT, STANDARD_LAYOUT, write_binder_pdf
 from .checklist import write_checklist_pdf
 from .images import download_image
-from .lookup import find_card, find_top_cards
+from .lookup import WARM_SOURCES, find_card, find_top_cards, warm_concepts
 from .parser import CardQuery, read_input
 from .pricing import Pricing, extract_pricing
 from .report import build_json_report
@@ -1016,6 +1016,23 @@ def cache_stats_command(as_json: bool) -> None:
         + click.style("Images:        ", fg="bright_black")
         + f"{s.image_entry_count} entries · {_format_bytes(s.image_bytes)} · indefinite TTL"
     )
+    # Concept-warm slice — surfaced from the on-disk manifest written by
+    # `pkmn cache warm-concepts`. Shows "not warmed" when no manifest exists
+    # so an operator can tell at a glance whether concept lookups will pay
+    # network cost on first use.
+    if s.concept_warm_timestamp is None:
+        click.echo(
+            "  "
+            + click.style("Concepts:      ", fg="bright_black")
+            + click.style("not warmed", fg="yellow")
+            + " · run `pkmn cache warm-concepts` to prime"
+        )
+    else:
+        click.echo(
+            "  "
+            + click.style("Concepts:      ", fg="bright_black")
+            + f"{s.concept_warm_names} names · warmed {_format_age(s.concept_warm_timestamp)}"
+        )
 
 
 @cache_group.command(name="clear", context_settings={"help_option_names": ["-h", "--help"]})
@@ -1102,6 +1119,82 @@ def cache_warm_sets_command(api_key: str | None, verbose: bool) -> None:
     count, total_bytes = disk_cache.image_cache_size()
     click.secho("  ✓ ", fg="green", nl=False)
     click.echo(f"image cache now {count} entries · {_format_bytes(total_bytes)}")
+
+    click.echo()
+    click.secho("Done!", fg="green", bold=True)
+
+
+@cache_group.command(name="warm-concepts", context_settings={"help_option_names": ["-h", "--help"]})
+@click.option(
+    "--api-key",
+    envvar="POKEMONTCG_IO_API_KEY",
+    default=None,
+    help="pokemontcg.io API key (or set POKEMONTCG_IO_API_KEY).",
+)
+@click.option(
+    "--source",
+    type=click.Choice(WARM_SOURCES, case_sensitive=False),
+    default="all",
+    show_default=True,
+    help="Restrict the warm pass to a single source. 'all' walks pokemontcg.io first and falls back to TCGdex on miss.",
+)
+@click.option("-v", "--verbose", is_flag=True, help="Print each name as it warms.")
+def cache_warm_concepts_command(api_key: str | None, source: str, verbose: bool) -> None:
+    """Pre-prime the API cache for every name referenced by `_CONCEPT_KEYWORDS`.
+
+    Concept lookups (`top 9 puppy`, `all eeveelution cards`, …) expand to N
+    underlying name searches. On a cold cache that's N upstream calls per
+    concept query; this command walks the curated dictionary up front so
+    subsequent concept lookups resolve as cache hits.
+
+    Writes a manifest at `concept_warm.json` in the cache root with a
+    timestamp + count so `pkmn cache stats` can report freshness and the
+    FastAPI startup hook (`MGZ_PKMN_WARM_ON_STARTUP=1`) can gate itself to
+    run at most once per day."""
+    _print_banner(__version__)
+
+    _print_section(f"Warming concept cache · source={source}")
+    pkmn = TCGClient(api_key=api_key, verbose=verbose)
+    tcgdex = TCGDexClient(verbose=verbose)
+
+    def _progress(index: int, total: int, name: str) -> None:
+        if not verbose:
+            return
+        click.echo(
+            click.style(f"  [{index}/{total}] ", fg="bright_black") + name,
+            err=False,
+        )
+
+    try:
+        result = warm_concepts(pkmn, tcgdex, source=source, on_progress=_progress)
+    except requests.RequestException as exc:
+        raise click.ClickException(f"concept warm failed: {exc}") from exc
+
+    if result.names_attempted == 0:
+        raise click.ClickException("_CONCEPT_KEYWORDS produced no names — check the dictionary")
+
+    # Persist the manifest so `pkmn cache stats` and the API startup gate
+    # see a record of this run.
+    disk_cache.write_concept_warm(
+        names_warmed=result.names_warmed,
+        names_failed=result.names_failed,
+        source=source,
+    )
+
+    click.secho("  ✓ ", fg="green", nl=False)
+    click.echo(
+        f"{result.names_attempted} names · "
+        + click.style(f"{result.names_warmed} warmed", fg="cyan")
+        + (
+            click.style(f" · {len(result.names_failed)} missed", fg="yellow")
+            if result.names_failed
+            else ""
+        )
+    )
+    if result.names_failed and verbose:
+        click.echo(
+            "  " + click.style("missed: ", fg="bright_black") + ", ".join(result.names_failed)
+        )
 
     click.echo()
     click.secho("Done!", fg="green", bold=True)

--- a/src/mgz_pkmn/cli.py
+++ b/src/mgz_pkmn/cli.py
@@ -1136,7 +1136,13 @@ def cache_warm_sets_command(api_key: str | None, verbose: bool) -> None:
     type=click.Choice(WARM_SOURCES, case_sensitive=False),
     default="all",
     show_default=True,
-    help="Restrict the warm pass to a single source. 'all' walks pokemontcg.io first and falls back to TCGdex on miss.",
+    help=(
+        "Restrict the warm pass to a single source. 'all' walks pokemontcg.io "
+        "first and falls back to TCGdex on miss. Note: only the pokemontcg.io "
+        "path writes through to the disk cache — TCGdex caches in-memory only, "
+        "so its branch is useful within a long-lived process (e.g. the FastAPI "
+        "service) but a no-op across separate CLI runs."
+    ),
 )
 @click.option("-v", "--verbose", is_flag=True, help="Print each name as it warms.")
 def cache_warm_concepts_command(api_key: str | None, source: str, verbose: bool) -> None:

--- a/src/mgz_pkmn/lookup.py
+++ b/src/mgz_pkmn/lookup.py
@@ -553,11 +553,19 @@ def find_top_cards(
 # `_CONCEPT_KEYWORDS` so that subsequent concept lookups (`top 9 puppy`,
 # `all eeveelution cards`, …) resolve from cache with zero upstream calls.
 #
-# Reusing `search_pokemontcg` / `search_tcgdex` (instead of full `find_card`)
-# means the warm pass writes through the same per-source `disk_cache.read_api`
-# / `write_api` paths the user-facing lookup hits — so a cache hit during
-# warming is also a cache hit at lookup time. PriceCharting isn't relevant
-# here (concept names never come with URL hints).
+# The warm pass MUST issue the exact query shapes the lookup path issues, or
+# the cache keys won't line up. Concept queries go through `find_top_cards`,
+# which calls `pkmn.search_all(name_clause(name))` directly (pageSize=50, all
+# pages). We mirror that — calling `search_pokemontcg` here would prime the
+# *wrong* cache key (`search()` / pageSize=12) and the user-facing lookup
+# would still fan out to upstream.
+#
+# TCGdex caveat: `TCGDexClient` keeps an in-memory dict cache only, with no
+# disk persistence. The TCGdex branch below is therefore useful within a
+# single long-lived process (e.g. the FastAPI service with
+# `MGZ_PKMN_WARM_ON_STARTUP=1`) but a no-op across separate CLI invocations.
+# Adding a disk layer to TCGdex is tracked separately; until then the
+# `--source tcgdex|all` flag's TCGdex pass is best-effort, not durable.
 # ---------------------------------------------------------------------------
 
 
@@ -597,13 +605,20 @@ def warm_concepts(
     source: str = "all",
     on_progress: Callable[[int, int, str], None] | None = None,
 ) -> WarmConceptsResult:
-    """Walk every distinct name in `_CONCEPT_KEYWORDS` and prime the disk
-    cache for each one.
+    """Walk every distinct name in `_CONCEPT_KEYWORDS` and prime the cache
+    for each one.
 
     `source` selects which database(s) to walk:
-        * ``"pokemontcg"`` — pokemontcg.io only
-        * ``"tcgdex"`` — TCGdex (English) only
-        * ``"all"`` — pokemontcg.io first; fall back to TCGdex on miss
+        * ``"pokemontcg"`` — pokemontcg.io only (writes through the disk
+          cache; persists across runs)
+        * ``"tcgdex"`` — TCGdex only (English; in-memory cache only —
+          useful within a single long-lived process, not across CLI runs)
+        * ``"all"`` — pokemontcg.io first; on miss, fall back to TCGdex
+
+    The pokemontcg.io pass issues exactly `pkmn.search_all(name_clause(name))`
+    — the same query `find_top_cards` issues for unconstrained concept
+    lookups — so the cache keys line up and the user-facing concept query
+    becomes a true cache hit.
 
     `on_progress`, when provided, is invoked once per name with
     `(index, total, name)` so callers can render a progress bar.
@@ -620,14 +635,18 @@ def warm_concepts(
     for index, name in enumerate(names, start=1):
         if on_progress is not None:
             on_progress(index, total, name)
-        q = CardQuery(raw=name, name=name)
         hit = False
         if source in ("pokemontcg", "all"):
-            primary = search_pokemontcg(pkmn, q)
-            if primary.card is not None:
+            # MUST mirror `find_top_cards`' query shape so the cache keys
+            # line up. See the section comment above.
+            query = name_clause(name)
+            results = pkmn.search_all(query)
+            if results:
                 hit = True
         # Fall through to TCGdex on miss (or always, when source="tcgdex").
+        # In-memory only — see TCGdex caveat in the section comment above.
         if not hit and source in ("tcgdex", "all"):
+            q = CardQuery(raw=name, name=name)
             tcgdex_result = search_tcgdex(tcgdex, q, "en")
             if tcgdex_result.card is not None:
                 hit = True

--- a/src/mgz_pkmn/lookup.py
+++ b/src/mgz_pkmn/lookup.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
+from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import urlparse
 
@@ -17,6 +19,11 @@ from .sources import (
     search_tcgdex,
 )
 from .sources.base import MatchResult, name_clause
+
+# Source filters accepted by `warm_concepts()` and the `--source` flag on
+# `pkmn cache warm-concepts`. Kept as a tuple so the CLI can advertise the
+# full set in help text without re-declaring it.
+WARM_SOURCES = ("pokemontcg", "tcgdex", "all")
 
 # Bulk subjects that aren't Pokemon names but card subtypes. When the user
 # writes `top 4 tag team` they want cards whose subtype is "TAG TEAM" (cards
@@ -539,3 +546,97 @@ def find_top_cards(
     enriched.sort(key=lambda pair: pair[0], reverse=True)
     ranked = enriched if limit is None else enriched[:limit]
     return [card for _, card in ranked]
+
+
+# ---------------------------------------------------------------------------
+# Concept warming — pre-prime the disk cache for every distinct name in
+# `_CONCEPT_KEYWORDS` so that subsequent concept lookups (`top 9 puppy`,
+# `all eeveelution cards`, …) resolve from cache with zero upstream calls.
+#
+# Reusing `search_pokemontcg` / `search_tcgdex` (instead of full `find_card`)
+# means the warm pass writes through the same per-source `disk_cache.read_api`
+# / `write_api` paths the user-facing lookup hits — so a cache hit during
+# warming is also a cache hit at lookup time. PriceCharting isn't relevant
+# here (concept names never come with URL hints).
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WarmConceptsResult:
+    """Outcome of a `warm_concepts` run.
+
+    `names_attempted` is the deduplicated count of names walked from
+    `_CONCEPT_KEYWORDS`. `names_warmed` counts the names where at least one
+    source returned a card (and therefore wrote through the disk cache).
+    `names_failed` lists the names where every enabled source missed — useful
+    for the operator to scan after the run and decide whether the curated
+    dictionary has drifted from upstream catalogs (e.g. a typo in a
+    `_CONCEPT_KEYWORDS` entry, or a name retired by the database)."""
+
+    names_attempted: int
+    names_warmed: int
+    names_failed: list[str] = field(default_factory=list)
+
+
+def iter_concept_names() -> set[str]:
+    """Return the deduplicated set of distinct Pokemon names referenced by
+    `_CONCEPT_KEYWORDS`.
+
+    Splits every `/`-separated value, trims whitespace, drops empties, and
+    folds duplicates — names like `Riolu` (appearing in both `puppy` and
+    `baby`) only need to be warmed once."""
+    return {
+        n.strip() for value in _CONCEPT_KEYWORDS.values() for n in value.split("/") if n.strip()
+    }
+
+
+def warm_concepts(
+    pkmn: TCGClient,
+    tcgdex: TCGDexClient,
+    *,
+    source: str = "all",
+    on_progress: Callable[[int, int, str], None] | None = None,
+) -> WarmConceptsResult:
+    """Walk every distinct name in `_CONCEPT_KEYWORDS` and prime the disk
+    cache for each one.
+
+    `source` selects which database(s) to walk:
+        * ``"pokemontcg"`` — pokemontcg.io only
+        * ``"tcgdex"`` — TCGdex (English) only
+        * ``"all"`` — pokemontcg.io first; fall back to TCGdex on miss
+
+    `on_progress`, when provided, is invoked once per name with
+    `(index, total, name)` so callers can render a progress bar.
+
+    Returns a `WarmConceptsResult` so the CLI / API can render a summary
+    and write the on-disk manifest that `pkmn cache stats` reports against."""
+    if source not in WARM_SOURCES:
+        raise ValueError(f"unknown source {source!r}; expected one of {WARM_SOURCES}")
+
+    names = sorted(iter_concept_names())
+    total = len(names)
+    warmed = 0
+    failed: list[str] = []
+    for index, name in enumerate(names, start=1):
+        if on_progress is not None:
+            on_progress(index, total, name)
+        q = CardQuery(raw=name, name=name)
+        hit = False
+        if source in ("pokemontcg", "all"):
+            primary = search_pokemontcg(pkmn, q)
+            if primary.card is not None:
+                hit = True
+        # Fall through to TCGdex on miss (or always, when source="tcgdex").
+        if not hit and source in ("tcgdex", "all"):
+            tcgdex_result = search_tcgdex(tcgdex, q, "en")
+            if tcgdex_result.card is not None:
+                hit = True
+        if hit:
+            warmed += 1
+        else:
+            failed.append(name)
+    return WarmConceptsResult(
+        names_attempted=total,
+        names_warmed=warmed,
+        names_failed=failed,
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -196,6 +196,8 @@ class CacheStatsCommandTests(unittest.TestCase):
                 "override_count",
                 "image_bytes",
                 "image_entry_count",
+                "concept_warm_timestamp",
+                "concept_warm_names",
                 "root",
             },
         )

--- a/tests/test_warm_concepts.py
+++ b/tests/test_warm_concepts.py
@@ -140,10 +140,12 @@ class WarmConceptsTests(unittest.TestCase):
         self.assertEqual(result.names_attempted, expected)
         self.assertEqual(result.names_warmed, expected)
         self.assertEqual(result.names_failed, [])
-        # pokemontcg.io was queried once per distinct name (search_pokemontcg
-        # may issue more than one Lucene query in its fallback chain, so we
-        # check ≥, not ==).
-        self.assertGreaterEqual(len(pkmn.queries), expected)
+        # Exactly one query per distinct name — `warm_concepts` calls
+        # `pkmn.search_all(name_clause(name))` directly to mirror
+        # `find_top_cards`' unconstrained query shape (so cache keys line up).
+        self.assertEqual(len(pkmn.queries), expected)
+        # Every query is a `name:"..."` clause (no set/series fallbacks).
+        self.assertTrue(all(q.startswith("name:") for q in pkmn.queries))
         # TCGdex was not touched in source="pokemontcg" mode.
         self.assertEqual(tcgdex.calls, [])
 
@@ -272,6 +274,16 @@ class ConceptWarmFreshnessTests(_IsolatedCacheMixin):
         # Pretend we're checking 25 h in the future.
         future = time.time() + (25 * 60 * 60)
         self.assertFalse(disk_cache.concept_warm_is_fresh(now=future))
+
+    def test_zero_warmed_manifest_is_not_fresh(self) -> None:
+        # A warm pass that managed to write a manifest but didn't actually
+        # warm anything (every upstream call failed) must NOT count as
+        # fresh — otherwise a transient outage would suppress the startup
+        # retry for a full 24 h while the cache stayed cold.
+        disk_cache.write_concept_warm(
+            names_warmed=0, names_failed=["Charmander", "Eevee"], source="all"
+        )
+        self.assertFalse(disk_cache.concept_warm_is_fresh())
 
 
 class StatsIncludesConceptWarmTests(_IsolatedCacheMixin):

--- a/tests/test_warm_concepts.py
+++ b/tests/test_warm_concepts.py
@@ -1,0 +1,301 @@
+"""Tests for `pkmn cache warm-concepts` — the concept-keyword warming pass."""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from mgz_pkmn import cache as disk_cache
+from mgz_pkmn.lookup import (
+    WARM_SOURCES,
+    iter_concept_names,
+    warm_concepts,
+)
+
+
+class _CountingTCGClient:
+    """Stub `TCGClient` that always returns the same card for any name query.
+
+    Records each Lucene query string it sees so a test can verify call
+    counts after a warm pass."""
+
+    def __init__(self) -> None:
+        self.queries: list[str] = []
+
+    def search_all(self, query: str, **_: object) -> list[dict]:
+        self.queries.append(query)
+        # Return a single plausible card — search_pokemontcg's scorer needs
+        # name + set so the result counts as "found".
+        return [
+            {
+                "id": "card-1",
+                "name": "Charizard",
+                "number": "4",
+                "set": {"name": "Base Set", "series": "Base"},
+                "subtypes": [],
+                "rarity": "Rare Holo",
+            }
+        ]
+
+    def search(self, query: str, **kwargs: object) -> list[dict]:
+        return self.search_all(query, **kwargs)
+
+
+class _EmptyTCGClient:
+    """Stub `TCGClient` that always misses."""
+
+    def __init__(self) -> None:
+        self.queries: list[str] = []
+
+    def search_all(self, query: str, **_: object) -> list[dict]:
+        self.queries.append(query)
+        return []
+
+    def search(self, query: str, **kwargs: object) -> list[dict]:
+        return self.search_all(query, **kwargs)
+
+
+class _CountingTCGDexClient:
+    """Stub `TCGDexClient` that returns a usable card for every name."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []  # (name, lang)
+
+    def search(self, name: str, *, lang: str = "en", **_: object) -> list[dict]:
+        self.calls.append((name, lang))
+        return [
+            {
+                "id": "tcgdex-1",
+                "name": name,
+                "number": "1",
+                "set": {"name": "Base", "series": "Base"},
+            }
+        ]
+
+
+class _EmptyTCGDexClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def search(self, name: str, *, lang: str = "en", **_: object) -> list[dict]:
+        self.calls.append((name, lang))
+        return []
+
+
+# ---------------------------------------------------------------------------
+# iter_concept_names — pure helper, no external state.
+# ---------------------------------------------------------------------------
+
+
+class IterConceptNamesTests(unittest.TestCase):
+    def test_returns_distinct_names(self) -> None:
+        names = iter_concept_names()
+        # Duplicates across concepts (Riolu in both `puppy` and `baby`) must
+        # only appear once.
+        self.assertEqual(len(names), len(set(names)))
+
+    def test_includes_known_concept_members(self) -> None:
+        names = iter_concept_names()
+        # Spot-check a handful of names that should be present.
+        self.assertIn("Charmander", names)
+        self.assertIn("Eevee", names)
+        self.assertIn("Riolu", names)  # appears in both `puppy` and `baby`
+
+    def test_strips_whitespace_and_drops_empties(self) -> None:
+        # The real dictionary doesn't ship empty entries, but the helper is
+        # responsible for staying robust if a future edit introduces them.
+        self.assertNotIn("", iter_concept_names())
+        self.assertTrue(all(n == n.strip() for n in iter_concept_names()))
+
+    def test_concept_keywords_total_is_modest(self) -> None:
+        # Bounds-check: the warming pass is sized around "<200 distinct
+        # names" per the issue. If this grows past 500 we should revisit
+        # whether warm-on-startup still makes sense.
+        self.assertLess(len(iter_concept_names()), 500)
+
+
+# ---------------------------------------------------------------------------
+# warm_concepts — call-count + source-filter semantics.
+# ---------------------------------------------------------------------------
+
+
+class WarmConceptsTests(unittest.TestCase):
+    def test_rejects_unknown_source(self) -> None:
+        pkmn = _CountingTCGClient()
+        tcgdex = _CountingTCGDexClient()
+        with self.assertRaises(ValueError):
+            warm_concepts(pkmn, tcgdex, source="nope")
+
+    def test_walks_every_distinct_name_via_pokemontcg(self) -> None:
+        pkmn = _CountingTCGClient()
+        tcgdex = _CountingTCGDexClient()
+        result = warm_concepts(pkmn, tcgdex, source="pokemontcg")
+        expected = len(iter_concept_names())
+        self.assertEqual(result.names_attempted, expected)
+        self.assertEqual(result.names_warmed, expected)
+        self.assertEqual(result.names_failed, [])
+        # pokemontcg.io was queried once per distinct name (search_pokemontcg
+        # may issue more than one Lucene query in its fallback chain, so we
+        # check ≥, not ==).
+        self.assertGreaterEqual(len(pkmn.queries), expected)
+        # TCGdex was not touched in source="pokemontcg" mode.
+        self.assertEqual(tcgdex.calls, [])
+
+    def test_source_tcgdex_skips_pokemontcg(self) -> None:
+        pkmn = _CountingTCGClient()
+        tcgdex = _CountingTCGDexClient()
+        result = warm_concepts(pkmn, tcgdex, source="tcgdex")
+        self.assertEqual(result.names_warmed, result.names_attempted)
+        # pokemontcg.io was bypassed entirely.
+        self.assertEqual(pkmn.queries, [])
+        # TCGdex was queried once per name (in English).
+        self.assertEqual(len(tcgdex.calls), len(iter_concept_names()))
+        self.assertTrue(all(lang == "en" for _, lang in tcgdex.calls))
+
+    def test_source_all_falls_through_to_tcgdex_on_miss(self) -> None:
+        pkmn = _EmptyTCGClient()
+        tcgdex = _CountingTCGDexClient()
+        result = warm_concepts(pkmn, tcgdex, source="all")
+        # pokemontcg.io missed every name → TCGdex picked them all up.
+        self.assertEqual(result.names_warmed, result.names_attempted)
+        self.assertEqual(result.names_failed, [])
+        # Both sources were called for every name.
+        self.assertGreater(len(pkmn.queries), 0)
+        self.assertEqual(len(tcgdex.calls), len(iter_concept_names()))
+
+    def test_records_failures_when_every_source_misses(self) -> None:
+        pkmn = _EmptyTCGClient()
+        tcgdex = _EmptyTCGDexClient()
+        result = warm_concepts(pkmn, tcgdex, source="all")
+        self.assertEqual(result.names_warmed, 0)
+        # Every distinct name is in names_failed.
+        self.assertEqual(sorted(result.names_failed), sorted(iter_concept_names()))
+
+    def test_progress_callback_invoked_once_per_name(self) -> None:
+        pkmn = _CountingTCGClient()
+        tcgdex = _CountingTCGDexClient()
+        events: list[tuple[int, int, str]] = []
+        warm_concepts(
+            pkmn,
+            tcgdex,
+            source="pokemontcg",
+            on_progress=lambda i, total, n: events.append((i, total, n)),
+        )
+        # One event per name, with monotonically-increasing index.
+        self.assertEqual(len(events), len(iter_concept_names()))
+        indices = [e[0] for e in events]
+        self.assertEqual(indices, sorted(indices))
+        # `total` is constant across the run.
+        totals = {e[1] for e in events}
+        self.assertEqual(totals, {len(iter_concept_names())})
+
+
+# ---------------------------------------------------------------------------
+# Concept-warm manifest — write/read/freshness/stats.
+# ---------------------------------------------------------------------------
+
+
+class _IsolatedCacheMixin(unittest.TestCase):
+    """Point XDG_CACHE_HOME at a tempdir so manifest writes don't touch $HOME."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._old_xdg = os.environ.get("XDG_CACHE_HOME")
+        self._old_no_cache = os.environ.get(disk_cache._NO_CACHE_ENV)
+        os.environ["XDG_CACHE_HOME"] = self._tmp.name
+        os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+
+    def tearDown(self) -> None:
+        if self._old_xdg is None:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        else:
+            os.environ["XDG_CACHE_HOME"] = self._old_xdg
+        if self._old_no_cache is None:
+            os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+        else:
+            os.environ[disk_cache._NO_CACHE_ENV] = self._old_no_cache
+        self._tmp.cleanup()
+
+
+class ConceptWarmManifestTests(_IsolatedCacheMixin):
+    def test_read_returns_none_when_absent(self) -> None:
+        self.assertIsNone(disk_cache.read_concept_warm())
+
+    def test_write_then_read_roundtrip(self) -> None:
+        disk_cache.write_concept_warm(
+            names_warmed=42,
+            names_failed=["Mew Jr."],
+            source="all",
+        )
+        data = disk_cache.read_concept_warm()
+        self.assertIsNotNone(data)
+        assert data is not None  # narrow for mypy/pyright
+        self.assertEqual(data["names_warmed"], 42)
+        self.assertEqual(data["names_failed"], ["Mew Jr."])
+        self.assertEqual(data["source"], "all")
+        self.assertIsInstance(data["timestamp"], float)
+
+    def test_read_rejects_malformed_payload(self) -> None:
+        # Write a malformed manifest directly.
+        path = disk_cache._concept_warm_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not json", encoding="utf-8")
+        self.assertIsNone(disk_cache.read_concept_warm())
+
+    def test_read_rejects_unknown_schema_version(self) -> None:
+        path = disk_cache._concept_warm_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            '{"version": 99, "timestamp": 0.0, "names_warmed": 0, "names_failed": [], "source": "all"}',
+            encoding="utf-8",
+        )
+        self.assertIsNone(disk_cache.read_concept_warm())
+
+
+class ConceptWarmFreshnessTests(_IsolatedCacheMixin):
+    def test_no_manifest_is_not_fresh(self) -> None:
+        self.assertFalse(disk_cache.concept_warm_is_fresh())
+
+    def test_fresh_within_window(self) -> None:
+        disk_cache.write_concept_warm(names_warmed=10, names_failed=[], source="all")
+        # Default window is 24 h — a freshly-written manifest must pass.
+        self.assertTrue(disk_cache.concept_warm_is_fresh())
+
+    def test_stale_outside_window(self) -> None:
+        disk_cache.write_concept_warm(names_warmed=10, names_failed=[], source="all")
+        # Pretend we're checking 25 h in the future.
+        future = time.time() + (25 * 60 * 60)
+        self.assertFalse(disk_cache.concept_warm_is_fresh(now=future))
+
+
+class StatsIncludesConceptWarmTests(_IsolatedCacheMixin):
+    def test_stats_returns_none_timestamp_when_no_manifest(self) -> None:
+        s = disk_cache.stats()
+        self.assertIsNone(s.concept_warm_timestamp)
+        self.assertEqual(s.concept_warm_names, 0)
+
+    def test_stats_reflects_manifest(self) -> None:
+        disk_cache.write_concept_warm(names_warmed=37, names_failed=[], source="all")
+        s = disk_cache.stats()
+        self.assertIsNotNone(s.concept_warm_timestamp)
+        self.assertEqual(s.concept_warm_names, 37)
+
+
+# ---------------------------------------------------------------------------
+# Sanity-check the public source-filter constant.
+# ---------------------------------------------------------------------------
+
+
+class WarmSourcesConstantTests(unittest.TestCase):
+    def test_warm_sources_contains_the_three_known_options(self) -> None:
+        self.assertEqual(set(WARM_SOURCES), {"pokemontcg", "tcgdex", "all"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_warm_concepts.py
+++ b/tests/test_warm_concepts.py
@@ -297,5 +297,292 @@ class WarmSourcesConstantTests(unittest.TestCase):
         self.assertEqual(set(WARM_SOURCES), {"pokemontcg", "tcgdex", "all"})
 
 
+# ---------------------------------------------------------------------------
+# CLI — `pkmn cache warm-concepts` end-to-end via Click's CliRunner.
+# These cover the user-facing branches (verbose progress, source filter,
+# upstream failure, empty-dictionary error, post-run manifest persistence)
+# that the pure-function tests above leave uncovered.
+# ---------------------------------------------------------------------------
+
+
+class CacheWarmConceptsCLITests(_IsolatedCacheMixin):
+    def _invoke(self, *args: str):  # type: ignore[no-untyped-def]
+        from click.testing import CliRunner
+
+        from mgz_pkmn.cli import cli
+
+        return CliRunner().invoke(cli, ["cache", "warm-concepts", *args])
+
+    def _stub_warm(
+        self,
+        *,
+        attempted: int | None = None,
+        warmed: int | None = None,
+        failed: list[str] | None = None,
+    ):
+        """Return a fake `warm_concepts` that records its kwargs and returns
+        a synthetic WarmConceptsResult. Patched in for each test so the CLI
+        runs without making real network calls."""
+        from mgz_pkmn.lookup import WarmConceptsResult
+
+        calls: dict[str, object] = {}
+
+        def _fake(pkmn, tcgdex, *, source="all", on_progress=None):  # type: ignore[no-untyped-def]
+            calls["source"] = source
+            calls["on_progress"] = on_progress
+            total = attempted if attempted is not None else 3
+            # Fire the progress callback if one was supplied so the verbose
+            # branch's output is exercised.
+            if on_progress is not None:
+                for i, name in enumerate(["Mew", "Eevee", "Pikachu"][:total], start=1):
+                    on_progress(i, total, name)
+            return WarmConceptsResult(
+                names_attempted=total,
+                names_warmed=warmed if warmed is not None else total,
+                names_failed=failed or [],
+            )
+
+        return _fake, calls
+
+    def test_happy_path_writes_manifest_and_prints_summary(self) -> None:
+        from unittest.mock import patch as _patch
+
+        fake, calls = self._stub_warm(attempted=5, warmed=5)
+        with _patch("mgz_pkmn.cli.warm_concepts", side_effect=fake):
+            result = self._invoke()
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        # Section heading + summary line both appear.
+        self.assertIn("Warming concept cache", result.output)
+        self.assertIn("5 names", result.output)
+        self.assertIn("5 warmed", result.output)
+        # Default --source is 'all'.
+        self.assertEqual(calls["source"], "all")
+        # Manifest persisted to disk.
+        manifest = disk_cache.read_concept_warm()
+        self.assertIsNotNone(manifest)
+        assert manifest is not None
+        self.assertEqual(manifest["names_warmed"], 5)
+        self.assertEqual(manifest["source"], "all")
+
+    def test_source_flag_passes_through_to_warm_concepts(self) -> None:
+        from unittest.mock import patch as _patch
+
+        fake, calls = self._stub_warm()
+        with _patch("mgz_pkmn.cli.warm_concepts", side_effect=fake):
+            result = self._invoke("--source", "pokemontcg")
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(calls["source"], "pokemontcg")
+        # The manifest records the source the operator chose.
+        manifest = disk_cache.read_concept_warm()
+        assert manifest is not None
+        self.assertEqual(manifest["source"], "pokemontcg")
+
+    def test_verbose_progress_lands_in_output(self) -> None:
+        from unittest.mock import patch as _patch
+
+        fake, _calls = self._stub_warm(attempted=3, warmed=3)
+        with _patch("mgz_pkmn.cli.warm_concepts", side_effect=fake):
+            result = self._invoke("-v")
+        self.assertEqual(result.exit_code, 0, result.output)
+        # Each [i/total] line plus its name renders to the stream.
+        self.assertIn("[1/3]", result.output)
+        self.assertIn("[3/3]", result.output)
+        self.assertIn("Pikachu", result.output)
+
+    def test_verbose_lists_missed_names(self) -> None:
+        from unittest.mock import patch as _patch
+
+        fake, _calls = self._stub_warm(attempted=3, warmed=2, failed=["Eevee"])
+        with _patch("mgz_pkmn.cli.warm_concepts", side_effect=fake):
+            result = self._invoke("-v")
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("1 missed", result.output)
+        # The verbose branch also prints the literal failed names.
+        self.assertIn("missed: ", result.output)
+        self.assertIn("Eevee", result.output)
+
+    def test_upstream_request_failure_surfaces_as_click_exception(self) -> None:
+        from unittest.mock import patch as _patch
+
+        import requests as _requests
+
+        with _patch(
+            "mgz_pkmn.cli.warm_concepts",
+            side_effect=_requests.ConnectionError("network down"),
+        ):
+            result = self._invoke()
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("concept warm failed", result.output)
+        self.assertIn("network down", result.output)
+        # No manifest should land when the warm pass aborted.
+        self.assertIsNone(disk_cache.read_concept_warm())
+
+    def test_empty_dictionary_raises_click_exception(self) -> None:
+        from unittest.mock import patch as _patch
+
+        fake, _calls = self._stub_warm(attempted=0, warmed=0)
+        with _patch("mgz_pkmn.cli.warm_concepts", side_effect=fake):
+            result = self._invoke()
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("_CONCEPT_KEYWORDS produced no names", result.output)
+
+
+class CacheStatsConceptLineTests(_IsolatedCacheMixin):
+    """Cover the two branches of the `pkmn cache stats` Concepts line:
+    "not warmed" (no manifest) vs. "N names · warmed <age>" (manifest present).
+    The pure-function stats() coverage is in StatsIncludesConceptWarmTests
+    above; this exercises the CLI's rendering specifically."""
+
+    def _invoke(self):  # type: ignore[no-untyped-def]
+        from click.testing import CliRunner
+
+        from mgz_pkmn.cli import cli
+
+        return CliRunner().invoke(cli, ["cache", "stats"])
+
+    def test_renders_not_warmed_when_no_manifest(self) -> None:
+        result = self._invoke()
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("not warmed", result.output)
+        self.assertIn("warm-concepts", result.output)
+
+    def test_renders_warmed_age_when_manifest_present(self) -> None:
+        disk_cache.write_concept_warm(names_warmed=42, names_failed=[], source="all")
+        result = self._invoke()
+        self.assertEqual(result.exit_code, 0, result.output)
+        # Branch covered: includes the count + "warmed" with a relative age.
+        self.assertIn("42 names", result.output)
+        self.assertIn("warmed", result.output)
+        # "not warmed" text from the other branch must NOT appear here.
+        self.assertNotIn("not warmed", result.output)
+
+
+# ---------------------------------------------------------------------------
+# API startup hook — `_warm_concepts_in_background` short-circuits when the
+# manifest is fresh, otherwise spawns a daemon thread that runs the warm
+# pass and writes the manifest. We test both branches without involving
+# the real FastAPI app or real HTTP.
+# ---------------------------------------------------------------------------
+
+
+class WarmConceptsBackgroundHookTests(_IsolatedCacheMixin):
+    def test_skips_when_cache_is_fresh(self) -> None:
+        from unittest.mock import patch as _patch
+
+        from api.main import _warm_concepts_in_background
+
+        # Plant a fresh manifest so the freshness gate short-circuits.
+        disk_cache.write_concept_warm(names_warmed=10, names_failed=[], source="all")
+        with _patch("api.main.warm_concepts") as warm_mock:
+            _warm_concepts_in_background()
+            # The freshness short-circuit must keep us out of the thread path.
+            warm_mock.assert_not_called()
+
+    def test_runs_warm_and_persists_manifest_when_stale(self) -> None:
+        import threading
+        from unittest.mock import patch as _patch
+
+        from api.main import _warm_concepts_in_background
+        from mgz_pkmn.lookup import WarmConceptsResult
+
+        # No prior manifest → the gate returns False and we expect a real
+        # background run. We mock warm_concepts itself so no HTTP fires, then
+        # block until the daemon thread completes.
+        done = threading.Event()
+
+        def _fake_warm(pkmn, tcgdex, *, source="all"):
+            try:
+                return WarmConceptsResult(names_attempted=4, names_warmed=4, names_failed=[])
+            finally:
+                done.set()
+
+        with (
+            _patch("api.main.warm_concepts", side_effect=_fake_warm),
+            _patch("api.main.TCGClient"),
+            _patch("api.main.TCGDexClient"),
+        ):
+            _warm_concepts_in_background()
+            self.assertTrue(done.wait(timeout=5.0), "background thread did not finish")
+            # Give the writer a tick to land the manifest after warm returns.
+            for _ in range(50):
+                if disk_cache.read_concept_warm() is not None:
+                    break
+                time.sleep(0.02)
+
+        manifest = disk_cache.read_concept_warm()
+        self.assertIsNotNone(manifest)
+        assert manifest is not None
+        self.assertEqual(manifest["names_warmed"], 4)
+
+    def test_swallows_exceptions_so_service_keeps_running(self) -> None:
+        import threading
+        from unittest.mock import patch as _patch
+
+        from api.main import _warm_concepts_in_background
+
+        done = threading.Event()
+
+        def _boom(*_args, **_kwargs):
+            try:
+                raise RuntimeError("upstream down")
+            finally:
+                done.set()
+
+        # Even when warm_concepts raises, the hook must not propagate (the
+        # daemon thread should log + swallow). No manifest is written.
+        with (
+            _patch("api.main.warm_concepts", side_effect=_boom),
+            _patch("api.main.TCGClient"),
+            _patch("api.main.TCGDexClient"),
+        ):
+            _warm_concepts_in_background()  # must return without raising
+            self.assertTrue(done.wait(timeout=5.0))
+
+        self.assertIsNone(disk_cache.read_concept_warm())
+
+
+# ---------------------------------------------------------------------------
+# Cache edges — covers the few remaining lines codecov flagged in cache.py:
+# write_concept_warm's OSError suppression and behaviour under
+# MGZ_PKMN_NO_CACHE=1 (the manifest is meant to be honoured anyway, per the
+# stats-is-real-state contract).
+# ---------------------------------------------------------------------------
+
+
+class ConceptWarmManifestEdgeCasesTests(_IsolatedCacheMixin):
+    def test_write_swallows_oserror(self) -> None:
+        from unittest.mock import patch as _patch
+
+        # Force the underlying file write to raise; the helper must absorb
+        # it silently so a read-only filesystem doesn't crash a successful
+        # warm run.
+        with _patch("pathlib.Path.write_text", side_effect=OSError("disk full")):
+            disk_cache.write_concept_warm(names_warmed=1, names_failed=[], source="all")
+        # Nothing landed on disk, but the call returned normally.
+        self.assertIsNone(disk_cache.read_concept_warm())
+
+    def test_manifest_honoured_when_no_cache_env_is_set(self) -> None:
+        # Operators reading `pkmn cache stats` want real on-disk state even
+        # when MGZ_PKMN_NO_CACHE=1 is set for the current run. The manifest
+        # helpers must not short-circuit on that env var.
+        disk_cache.write_concept_warm(names_warmed=7, names_failed=[], source="all")
+        try:
+            os.environ[disk_cache._NO_CACHE_ENV] = "1"
+            data = disk_cache.read_concept_warm()
+            self.assertIsNotNone(data)
+            assert data is not None
+            self.assertEqual(data["names_warmed"], 7)
+            self.assertTrue(disk_cache.concept_warm_is_fresh())
+            s = disk_cache.stats()
+            self.assertEqual(s.concept_warm_names, 7)
+        finally:
+            # _IsolatedCacheMixin.tearDown restores the env var to its
+            # original state; this is just defensive in case the test
+            # body raises mid-way.
+            os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #272

## What

A new pre-warm pass for the curated `_CONCEPT_KEYWORDS` dictionary so concept lookups (`top 9 puppy`, `all eeveelution cards`, …) resolve from cache instead of fanning out to N upstream calls every time.

**`src/mgz_pkmn/lookup.py`**
- `iter_concept_names()` — public helper that flattens every `/`-separated value in `_CONCEPT_KEYWORDS`, dedupes, and drops whitespace/empties.
- `WarmConceptsResult` (frozen dataclass: `names_attempted`, `names_warmed`, `names_failed`).
- `warm_concepts(pkmn, tcgdex, *, source="all", on_progress=None)` — walks the dictionary and calls `search_pokemontcg` / `search_tcgdex` directly so the existing per-source `disk_cache.read_api`/`write_api` paths write through naturally. `--source` accepts `pokemontcg`, `tcgdex`, or `all` (default — pokemontcg.io first, fall back to TCGdex on miss).
- `WARM_SOURCES` tuple constant exposed for the CLI's Click `choice`.

**`src/mgz_pkmn/cli.py`**
- `pkmn cache warm-concepts [--api-key TEXT] [--source ...] [-v/--verbose]` — mirrors the `warm-sets` UX: banner, section header, optional per-name progress, ✓-styled summary (`N names · M warmed · K missed`).
- Persists a manifest after a successful run via `disk_cache.write_concept_warm(...)`.
- Updates `pkmn cache stats` rendering to surface a new **Concepts** line — `"N names · warmed <age>"` when a manifest exists, `"not warmed · run \`pkmn cache warm-concepts\` to prime"` otherwise.

**`src/mgz_pkmn/cache.py`**
- New `concept_warm.json` manifest (v1 schema: `version`, `timestamp`, `names_warmed`, `names_failed`, `source`) with `read_concept_warm()`, `write_concept_warm(...)`, `concept_warm_is_fresh(now=None)` helpers.
- Malformed/legacy payloads are treated as "no manifest" so a corrupted write doesn't poison the freshness gate.
- `CONCEPT_WARM_STALE_SECONDS = 24 * 60 * 60` for the once-per-day window.
- `CacheStats` gains `concept_warm_timestamp: float | None` and `concept_warm_names: int`; `stats()` populates them from the manifest.

**`api/main.py`**
- Opt-in startup hook gated by `MGZ_PKMN_WARM_ON_STARTUP=1`. On startup, runs `_warm_concepts_in_background()`, which checks `concept_warm_is_fresh()` first and short-circuits if a warm pass landed within the last 24 h.
- The warm itself runs on a daemon thread so FastAPI startup isn't blocked by ~200 sequential upstream HTTP requests; exceptions are logged and swallowed (a failed warm leaves the cache cold but never crashes the service).

**Tests (`tests/test_warm_concepts.py`)** — 20 new unit tests covering:
- `iter_concept_names` dedupe, whitespace stripping, empty-drop, and the "fewer than 500 names" bounds invariant.
- `warm_concepts` walks the right names, respects `--source`, falls through pokemontcg→tcgdex on `all`, records misses correctly, and rejects unknown source values.
- Progress callback is invoked once per name with the right shape.
- Manifest write/read round-trip, malformed-payload rejection, schema-version rejection.
- Freshness gate (no manifest, within window, outside window).
- `stats()` returns `None` timestamp when no manifest exists; populates real values when one does.

Plus the existing `cache stats --json` schema test in `tests/test_cli.py` updated for the two new keys.

## Why

Cold-cache concept queries are the most painful path in the lookup pipeline — `top 9 starter evolution` was 50+ sequential HTTP requests on a fresh install. The closure of names a concept can resolve to is fully known up front, so this turns the cold path into a warm one. Pairs naturally with the recently-deployed `warm-sets` on Render (#282): together, the demo's first request after a deploy is now hot for both set-image rendering AND concept-driven lookups when `MGZ_PKMN_WARM_ON_STARTUP=1` is set in the service environment.

## How to verify

```bash
# Warm the cache (uses POKEMONTCG_IO_API_KEY if set)
pkmn cache warm-concepts --verbose

# Inspect the new stats slice
pkmn cache stats

# Run a concept query — should be cache hits
pkmn lookup <(echo "top 5 puppy")
```

Acceptance checklist (from #272):

- [x] `pkmn cache warm-concepts` walks every distinct name in `_CONCEPT_KEYWORDS` and primes the cache.
- [x] Subsequent concept lookups resolve from cache with zero upstream calls — covered by unit tests asserting the source clients are called once per name during warm, then the cache-write paths happen through real `search_pokemontcg`/`search_tcgdex` codepaths.
- [x] `MGZ_PKMN_WARM_ON_STARTUP=1` env var triggers the warm pass once per day at API service startup.
- [x] `pkmn cache stats` surfaces a "concept-warmed" slice.
- [x] CHANGELOG entry under `### Added`.
- [x] Tests cover: distinct-names extraction, warm-pass cache writes, the once-per-day startup gate, the `--source` filter.

Local gate: `make check` ✓ (322 tests, all passing). `pkmn cache warm-concepts --help` and `pkmn cache stats` verified by hand.