### PR TITLE
feat(site): surface live OSS signals on /contribute via GitHub API at build time

### DIFF
--- a/site/src/lib/github.ts
+++ b/site/src/lib/github.ts
@@ -1,0 +1,201 @@
+/**
+ * Build-time GitHub API helpers for the marketing site.
+ *
+ * Called from Astro frontmatter (top-level `await`) so the SPA stays
+ * client-side-free — the fetched data is baked into the static HTML at
+ * build time. Every helper handles failure (network, rate limit, auth)
+ * by returning an empty result; the caller's template renders nothing
+ * for that bucket and the build still succeeds.
+ *
+ * Authentication: if `GITHUB_TOKEN` is set in the build environment, the
+ * helpers send a `Bearer` token (5000 req/hour). Without it we fall back
+ * to anonymous requests (60 req/hour per IP), which is fine for a single
+ * deploy but will rate-limit aggressive rebuild loops on Render.
+ */
+const OWNER = "mgzwarrior";
+const REPO = "mgz-pkmn";
+const API = "https://api.github.com";
+
+function authHeaders(): Record<string, string> {
+  const token = process.env.GITHUB_TOKEN;
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": `${OWNER}-${REPO}-site-build`,
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+async function safeFetchJson<T>(url: string): Promise<T | null> {
+  try {
+    const res = await fetch(url, { headers: authHeaders() });
+    if (!res.ok) {
+      // Anonymous rate-limited (403) or network/server issue — log to the
+      // build console and move on. The caller renders an empty section.
+      console.warn(
+        `[github] ${url} -> ${res.status} ${res.statusText} (skipping)`,
+      );
+      return null;
+    }
+    return (await res.json()) as T;
+  } catch (err) {
+    console.warn(`[github] ${url} threw ${(err as Error).message} (skipping)`);
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Good-first-issues — open issues labeled `good first issue`.
+// ---------------------------------------------------------------------------
+
+export interface GoodFirstIssue {
+  number: number;
+  title: string;
+  url: string;
+  /** Display label for the issue's `area:*` tag, or null when none. */
+  area: string | null;
+  /** ISO timestamp of when the issue was opened. */
+  createdAt: string;
+}
+
+interface GhIssue {
+  number: number;
+  title: string;
+  html_url: string;
+  created_at: string;
+  pull_request?: unknown;
+  labels: { name: string }[];
+}
+
+export async function fetchGoodFirstIssues(
+  limit = 6,
+): Promise<GoodFirstIssue[]> {
+  const url = `${API}/repos/${OWNER}/${REPO}/issues?labels=good%20first%20issue&state=open&per_page=${limit}`;
+  const data = await safeFetchJson<GhIssue[]>(url);
+  if (!data) return [];
+  return data
+    // The /issues endpoint returns PRs too; filter them out.
+    .filter((i) => !i.pull_request)
+    .map((i) => ({
+      number: i.number,
+      title: i.title,
+      url: i.html_url,
+      area:
+        i.labels
+          .map((l) => l.name)
+          .find((n) => n.startsWith("area:"))
+          ?.replace("area:", "") ?? null,
+      createdAt: i.created_at,
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// Recently merged PRs.
+// ---------------------------------------------------------------------------
+
+export interface RecentPR {
+  number: number;
+  title: string;
+  url: string;
+  authorLogin: string;
+  authorUrl: string;
+  authorAvatarUrl: string;
+  mergedAt: string;
+}
+
+interface GhPull {
+  number: number;
+  title: string;
+  html_url: string;
+  merged_at: string | null;
+  user: {
+    login: string;
+    html_url: string;
+    avatar_url: string;
+  } | null;
+}
+
+export async function fetchRecentMergedPRs(limit = 5): Promise<RecentPR[]> {
+  // Pull a wider window than `limit` because the closed-PR list mixes merged
+  // and just-closed; we filter to merged ones below.
+  const url = `${API}/repos/${OWNER}/${REPO}/pulls?state=closed&sort=updated&direction=desc&per_page=${limit * 2}`;
+  const data = await safeFetchJson<GhPull[]>(url);
+  if (!data) return [];
+  return data
+    .filter((p) => p.merged_at != null && p.user != null)
+    .slice(0, limit)
+    .map((p) => ({
+      number: p.number,
+      title: p.title,
+      url: p.html_url,
+      authorLogin: p.user!.login,
+      authorUrl: p.user!.html_url,
+      authorAvatarUrl: p.user!.avatar_url,
+      mergedAt: p.merged_at!,
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// Contributor avatars.
+// ---------------------------------------------------------------------------
+
+export interface Contributor {
+  login: string;
+  url: string;
+  avatarUrl: string;
+  contributions: number;
+}
+
+interface GhContributor {
+  login: string;
+  html_url: string;
+  avatar_url: string;
+  contributions: number;
+  type: string;
+}
+
+export async function fetchContributors(limit = 12): Promise<Contributor[]> {
+  const url = `${API}/repos/${OWNER}/${REPO}/contributors?per_page=${limit}`;
+  const data = await safeFetchJson<GhContributor[]>(url);
+  if (!data) return [];
+  return data
+    // Skip bots (dependabot, github-actions, etc.) — they're not what the
+    // "contributors" surface is celebrating.
+    .filter((c) => c.type === "User")
+    .slice(0, limit)
+    .map((c) => ({
+      login: c.login,
+      url: c.html_url,
+      avatarUrl: c.avatar_url,
+      contributions: c.contributions,
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// Relative-time formatter shared across the three surfaces.
+// ---------------------------------------------------------------------------
+
+export function relativeTime(iso: string, now: Date = new Date()): string {
+  const then = new Date(iso);
+  const diffSec = Math.max(0, Math.floor((now.getTime() - then.getTime()) / 1000));
+  if (diffSec < 60) return "just now";
+  if (diffSec < 3600) {
+    const m = Math.floor(diffSec / 60);
+    return `${m}m ago`;
+  }
+  if (diffSec < 86400) {
+    const h = Math.floor(diffSec / 3600);
+    return `${h}h ago`;
+  }
+  const d = Math.floor(diffSec / 86400);
+  if (d < 30) return `${d}d ago`;
+  if (d < 365) {
+    const mo = Math.floor(d / 30);
+    return `${mo}mo ago`;
+  }
+  const y = Math.floor(d / 365);
+  return `${y}y ago`;
+}

--- a/site/src/pages/contribute.astro
+++ b/site/src/pages/contribute.astro
@@ -2,8 +2,26 @@
 import BaseLayout from "../layouts/BaseLayout.astro";
 import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
+import {
+  fetchContributors,
+  fetchGoodFirstIssues,
+  fetchRecentMergedPRs,
+  relativeTime,
+} from "../lib/github.ts";
 
 const repoUrl = "https://github.com/mgzwarrior/mgz-pkmn";
+
+// Live OSS signals — pulled at build time so the SPA stays client-side-free.
+// Each helper returns `[]` if the API call fails (network blip, rate limit,
+// no token); the template treats an empty array as "skip this slice" so the
+// page still builds when GitHub is unreachable.
+const [goodFirstIssues, recentPRs, contributors] = await Promise.all([
+  fetchGoodFirstIssues(6),
+  fetchRecentMergedPRs(5),
+  fetchContributors(12),
+]);
+const hasLiveSignals =
+  goodFirstIssues.length > 0 || recentPRs.length > 0 || contributors.length > 0;
 
 const shapes = [
   {
@@ -204,6 +222,144 @@ const ctas = [
         </div>
       </div>
     </section>
+
+    <!-- Live activity — built-time GitHub data. Renders nothing if every
+         API call failed (empty arrays); the surrounding sections still flow
+         correctly because we condition the whole <section> on `hasLiveSignals`. -->
+    {
+      hasLiveSignals && (
+        <section class="border-b border-zinc-900/80 px-6 py-20 sm:py-24">
+          <div class="mx-auto max-w-6xl">
+            <div class="max-w-2xl">
+              <h2 class="text-3xl sm:text-4xl font-bold tracking-tight text-white">
+                What's happening right now.
+              </h2>
+              <p class="mt-4 text-lg text-zinc-400">
+                Pulled at build time from GitHub — refreshes whenever the site
+                redeploys.
+              </p>
+            </div>
+
+            <div class="mt-12 grid gap-8 lg:grid-cols-2">
+              {goodFirstIssues.length > 0 && (
+                <div class="rounded-xl border border-zinc-800 bg-zinc-900/40 p-6">
+                  <div class="flex items-baseline justify-between gap-4">
+                    <h3 class="text-lg font-semibold text-white">
+                      Open starter issues
+                    </h3>
+                    <a
+                      href={`${repoUrl}/labels/good%20first%20issue`}
+                      class="text-xs font-semibold text-brand-400 hover:text-brand-300"
+                    >
+                      see all →
+                    </a>
+                  </div>
+                  <ul class="mt-4 space-y-3">
+                    {goodFirstIssues.map((i) => (
+                      <li class="text-sm">
+                        <a
+                          href={i.url}
+                          class="group flex items-start gap-3 rounded-md px-2 py-1.5 -mx-2 hover:bg-zinc-900/60 transition"
+                        >
+                          <span class="font-mono text-xs text-zinc-500 mt-0.5">
+                            #{i.number}
+                          </span>
+                          <span class="flex-1 text-zinc-200 group-hover:text-white leading-snug">
+                            {i.title}
+                          </span>
+                          {i.area && (
+                            <span class="text-xs rounded-full border border-zinc-800 bg-zinc-950 px-2 py-0.5 text-zinc-400 self-center">
+                              {i.area}
+                            </span>
+                          )}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {recentPRs.length > 0 && (
+                <div class="rounded-xl border border-zinc-800 bg-zinc-900/40 p-6">
+                  <div class="flex items-baseline justify-between gap-4">
+                    <h3 class="text-lg font-semibold text-white">
+                      Recently merged
+                    </h3>
+                    <a
+                      href={`${repoUrl}/pulls?q=is%3Apr+is%3Amerged`}
+                      class="text-xs font-semibold text-brand-400 hover:text-brand-300"
+                    >
+                      see all →
+                    </a>
+                  </div>
+                  <ul class="mt-4 space-y-3">
+                    {recentPRs.map((pr) => (
+                      <li class="text-sm">
+                        <a
+                          href={pr.url}
+                          class="group flex items-start gap-3 rounded-md px-2 py-1.5 -mx-2 hover:bg-zinc-900/60 transition"
+                        >
+                          <img
+                            src={pr.authorAvatarUrl}
+                            alt=""
+                            width="20"
+                            height="20"
+                            class="h-5 w-5 rounded-full mt-0.5"
+                          />
+                          <span class="flex-1 text-zinc-200 group-hover:text-white leading-snug">
+                            {pr.title}
+                          </span>
+                          <span class="text-xs text-zinc-500 self-center">
+                            {relativeTime(pr.mergedAt)}
+                          </span>
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+
+            {contributors.length > 0 && (
+              <div class="mt-8 rounded-xl border border-zinc-800 bg-zinc-900/40 p-6">
+                <div class="flex items-baseline justify-between gap-4">
+                  <h3 class="text-lg font-semibold text-white">Contributors</h3>
+                  <a
+                    href={`${repoUrl}/graphs/contributors`}
+                    class="text-xs font-semibold text-brand-400 hover:text-brand-300"
+                  >
+                    see all →
+                  </a>
+                </div>
+                <p class="mt-2 text-sm text-zinc-400">
+                  Everyone who's landed a commit. Your face goes here when your
+                  first PR merges.
+                </p>
+                <ul class="mt-5 flex flex-wrap gap-3">
+                  {contributors.map((c) => (
+                    <li>
+                      <a
+                        href={c.url}
+                        title={`@${c.login} — ${c.contributions} commit${c.contributions === 1 ? "" : "s"}`}
+                        class="block"
+                      >
+                        <img
+                          src={c.avatarUrl}
+                          alt={`@${c.login}`}
+                          width="44"
+                          height="44"
+                          class="h-11 w-11 rounded-full border-2 border-zinc-800 hover:border-brand-500 transition"
+                        />
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
+        </section>
+      )
+    }
 
     <!-- Get started -->
     <section class="border-b border-zinc-900/80 px-6 py-20 sm:py-24">


### PR DESCRIPTION
Closes #287

## What

Adds a build-time GitHub fetch (no client-side JS — pure server-side static generation) so the `/contribute` page shows a potential contributor what's actually happening in the repo at the moment they land.

A new **"What's happening right now"** section between Recognition and Get started, with three slices:

- **Open starter issues** — list of open issues labelled `good first issue`, with the `area:*` chip pulled out as a small visual tag.
- **Recently merged** — last ~5 merged PRs with author avatar, title, and relative-time.
- **Contributors** — avatar grid for everyone who's landed a commit (bots filtered out).

### `site/src/lib/github.ts` (new)

Three fetch helpers + a shared `relativeTime()` formatter. Each helper:

- Sends `Authorization: Bearer $GITHUB_TOKEN` when the env var is set (5000 req/h ceiling), otherwise falls back to anonymous (60 req/h per IP, fine for a single deploy).
- Wraps the network call in try/catch and a status check; on failure logs to the build console and returns `[]`.
- The page template treats `[]` as "skip this slice" — and a fully-failed fetch hides the entire section via `hasLiveSignals`, so the page still builds cleanly when GitHub is unreachable.

### `site/src/pages/contribute.astro`

Frontmatter awaits all three helpers in parallel; the new section renders inside a `{hasLiveSignals && ...}` guard.

## Why

The earlier contribute work (#283/284/286) gave a stranger a path in but said nothing about whether the project is actually alive. This section turns "is anyone home?" from a guess into a real glance — open work, recent activity, the people behind it. Build-time fetch keeps the static-site model intact: no client-side API key, no runtime cost, no extra request waterfall.

## How to verify

```bash
cd site && npm run build   # build emits dist/contribute/index.html with live data baked in
cd site && npm run dev     # localhost:4321/contribute — same data, but re-fetched
```

- Section appears between Recognition and Get started, titled **"What's happening right now."**
- Starter-issues card shows real `#NNN` issue numbers + titles + area badges; clicking lands on the right GitHub issue.
- Recently-merged card shows the 5 most recent merged PRs with author avatars + relative times.
- Contributors card shows avatar grid; hovering an avatar shows `@login — N commits` and clicks lead to their profile.
- All three card headers have a "see all →" link to the full GitHub view.

Failure handling sanity check: temporarily set `GITHUB_TOKEN=invalid` and rebuild — the warn-log appears in the build output and the section drops entirely (no empty cards). `npm run build` ✓; `make check` ✓.

## Render config

The build works without a token (anonymous 60 req/h is plenty for one deploy), but for headroom under reload-heavy days you may want to add `GITHUB_TOKEN` to the service's envVars in the Render dashboard as a `sync: false` build-time secret. No changes to `render.yaml` are required — env vars set in the dashboard flow into the build environment automatically.