### PR TITLE
feat(web): card detail modal — tap a results row for full card + keyboard nav

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 - Web: **Card detail modal** — tapping any matched row in the results table
   opens a modal with the large card art, a two-column identity + pricing
-  block (market + 80/85/90/95 % comps), and a "card data" section that
+  block (market + 80/85/90/95% comps), and a "card data" section that
   surfaces whatever optional fields the source returned (subtype, HP,
   attacks with cost/damage/text, weaknesses, resistances, retreat,
   regulation mark, artist, dex numbers, flavor text). Missing fields are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Web: **Card detail modal** — tapping any matched row in the results table
+  opens a modal with the large card art, a two-column identity + pricing
+  block (market + 80/85/90/95 % comps), and a "card data" section that
+  surfaces whatever optional fields the source returned (subtype, HP,
+  attacks with cost/damage/text, weaknesses, resistances, retreat,
+  regulation mark, artist, dex numbers, flavor text). Missing fields are
+  silently skipped. Direct link out to the canonical source page
+  (TCGPlayer / Cardmarket / PriceCharting / pokemontcg.io fallback). ←/→
+  steps through the currently filtered + sorted result set; Esc closes.
+  Clicking an inner link or button (existing external-link icon, the
+  override-URL form) does not open the modal. Dialog a11y handled by
+  Radix.
 - CLI: `pkmn cache warm-concepts` subcommand walks every distinct name
   referenced by the curated `_CONCEPT_KEYWORDS` dictionary and primes the
   API response cache for each one, so concept lookups (`top 9 puppy`,

--- a/web/src/components/CardDetailModal.test.tsx
+++ b/web/src/components/CardDetailModal.test.tsx
@@ -275,4 +275,170 @@ describe('CardDetailModal', () => {
     const link = screen.getByRole('link', { name: /View on/ }) as HTMLAnchorElement
     expect(link.href).toBe('https://pokemontcg.io/cards/base1-4')
   })
+
+  it('prefers card.tcgplayer.url over the pokemontcg.io fallback', () => {
+    const row = buildRow({
+      pricing: { url: null },
+      card: {
+        id: 'base1-4',
+        name: 'Charizard',
+        number: '4',
+        rarity: 'Rare Holo',
+        set: { name: 'Base Set' },
+        tcgplayer: { url: 'https://www.tcgplayer.com/product/from-card' },
+      },
+    })
+    render(
+      <CardDetailModal rows={[row]} index={0} onChangeIndex={() => {}} />,
+    )
+    const link = screen.getByRole('link', { name: /View on/ }) as HTMLAnchorElement
+    expect(link.href).toBe('https://www.tcgplayer.com/product/from-card')
+  })
+
+  it('falls through to card.cardmarket.url when TCGPlayer is absent', () => {
+    const row = buildRow({
+      pricing: { url: null },
+      card: {
+        id: 'base1-4',
+        name: 'Charizard',
+        number: '4',
+        rarity: 'Rare Holo',
+        set: { name: 'Base Set' },
+        cardmarket: { url: 'https://www.cardmarket.com/en/Pokemon/Products/123' },
+      },
+    })
+    render(
+      <CardDetailModal rows={[row]} index={0} onChangeIndex={() => {}} />,
+    )
+    const link = screen.getByRole('link', { name: /View on/ }) as HTMLAnchorElement
+    expect(link.href).toBe(
+      'https://www.cardmarket.com/en/Pokemon/Products/123',
+    )
+  })
+
+  it('hides the source link when no URL is available anywhere', () => {
+    // No pricing.url, no tcgplayer/cardmarket, no card.id — every branch of
+    // deriveSourceUrl returns null. We explicitly clear the spread-merged
+    // defaults with `undefined` so the test really hits the no-link path.
+    const row = buildRow({
+      pricing: { url: null },
+      card: {
+        name: 'GhostMon',
+        id: undefined,
+        tcgplayer: undefined,
+        cardmarket: undefined,
+      },
+    })
+    render(
+      <CardDetailModal rows={[row]} index={0} onChangeIndex={() => {}} />,
+    )
+    expect(screen.queryByRole('link', { name: /View on/ })).toBeNull()
+  })
+
+  it('renders resistances, retreat, dex, and flavor text branches', () => {
+    const row = buildRow({
+      card: {
+        id: 'base1-4',
+        name: 'Charizard',
+        number: '4',
+        rarity: 'Rare Holo',
+        set: { name: 'Base Set' },
+        resistances: [{ type: 'Fighting', value: '-30' }],
+        retreatCost: ['Colorless', 'Colorless'],
+        nationalPokedexNumbers: [6],
+        flavorText: 'Spits fire that is hot enough to melt boulders.',
+      },
+    })
+    render(
+      <CardDetailModal rows={[row]} index={0} onChangeIndex={() => {}} />,
+    )
+    expect(screen.getByText('Fighting -30')).toBeInTheDocument()
+    expect(screen.getByText('Colorless · Colorless')).toBeInTheDocument()
+    expect(screen.getByText('6')).toBeInTheDocument()
+    expect(
+      screen.getByText(/Spits fire that is hot enough to melt boulders/),
+    ).toBeInTheDocument()
+  })
+
+  it('skips identity-list rows whose value is missing', () => {
+    // No series, no rarity, no variant — those <dt>/<dd> pairs should be
+    // filtered out entirely (not rendered as "Series: —").
+    const row = buildRow({
+      card: {
+        id: 'base1-4',
+        name: 'Charizard',
+        number: '4',
+        set: { name: 'Base Set' }, // no series
+        rarity: undefined,
+      },
+      pricing: { variant: null },
+    })
+    render(
+      <CardDetailModal rows={[row]} index={0} onChangeIndex={() => {}} />,
+    )
+    // None of these labels appear because every value was null/missing.
+    expect(screen.queryByText('Series')).toBeNull()
+    expect(screen.queryByText('Rarity')).toBeNull()
+    expect(screen.queryByText('Variant')).toBeNull()
+    // But the rows that DO have values still render.
+    expect(screen.getByText('Set')).toBeInTheDocument()
+    expect(screen.getByText('Base Set')).toBeInTheDocument()
+  })
+
+  it('shows "—" for the market price line when pricing is unavailable', () => {
+    const row = buildRow({
+      pricing: { market: null, source: null, url: null },
+    })
+    render(
+      <CardDetailModal rows={[row]} index={0} onChangeIndex={() => {}} />,
+    )
+    // Every comp line and the market price line should fall back to the
+    // em-dash sentinel; sanity check by asserting we see the dash and not
+    // a dollar value.
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(5)
+    expect(screen.queryByText(/^\$/)).toBeNull()
+  })
+
+  it('header navigation buttons advance the modal', () => {
+    const rows = [
+      buildRow({ card: { name: 'Charizard', id: 'a', set: { name: 'Base' } } }),
+      buildRow({ card: { name: 'Blastoise', id: 'b', set: { name: 'Base' } } }),
+    ]
+    const onChange = vi.fn()
+    render(<CardDetailModal rows={rows} index={0} onChangeIndex={onChange} />)
+    fireEvent.click(screen.getByLabelText('Next card'))
+    expect(onChange).toHaveBeenCalledWith(1)
+  })
+
+  it('header navigation buttons are disabled at the ends of the row set', () => {
+    const rows = [
+      buildRow({ card: { name: 'Charizard', id: 'a', set: { name: 'Base' } } }),
+      buildRow({ card: { name: 'Blastoise', id: 'b', set: { name: 'Base' } } }),
+    ]
+    const { rerender } = render(
+      <CardDetailModal rows={rows} index={0} onChangeIndex={() => {}} />,
+    )
+    expect(screen.getByLabelText('Previous card')).toBeDisabled()
+    expect(screen.getByLabelText('Next card')).not.toBeDisabled()
+    rerender(<CardDetailModal rows={rows} index={1} onChangeIndex={() => {}} />)
+    expect(screen.getByLabelText('Previous card')).not.toBeDisabled()
+    expect(screen.getByLabelText('Next card')).toBeDisabled()
+  })
+
+  it('uses the query name as a fallback when card.name is missing', () => {
+    const row = buildRow({
+      query: { name: 'MissingMon', raw: 'MissingMon' } as Row['query'],
+      card: {
+        // no name field — Dialog.Title and image alt should fall back to query.name
+        id: 'unknown',
+        set: { name: 'Unknown Set' },
+        name: undefined,
+      },
+    })
+    render(
+      <CardDetailModal rows={[row]} index={0} onChangeIndex={() => {}} />,
+    )
+    // The title and the identity Name row both render the fallback.
+    expect(screen.getAllByText('MissingMon').length).toBeGreaterThanOrEqual(1)
+  })
 })

--- a/web/src/components/CardDetailModal.test.tsx
+++ b/web/src/components/CardDetailModal.test.tsx
@@ -3,9 +3,11 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { CardDetailModal } from './CardDetailModal'
 import type { Row } from '../types'
 
-// Fabricate a minimal Row with the slots the modal reads. Tests then deep-merge
-// additional fields onto the underlying card so each one only states what it
-// actually cares about.
+// Fabricate a minimal Row with the slots the modal reads. Tests shallow-merge
+// (via spread) additional fields onto the underlying card so each one only
+// states what it actually cares about. Note: nested objects like `set` and
+// `images` are *replaced*, not merged — pass `undefined` to clear a default,
+// or specify the full nested object when you need it.
 function buildRow(
   overrides: {
     card?: Record<string, unknown> | null
@@ -258,6 +260,49 @@ describe('CardDetailModal', () => {
     expect(link.rel).toContain('noopener')
   })
 
+  it('labels the source link by the actual URL host, not card._database', () => {
+    // Regression: a pokemontcg.io card with a TCGPlayer pricing URL used
+    // to render "View on pokemontcg.io" pointing at tcgplayer.com. The
+    // label must agree with the URL.
+    const row = buildRow({
+      pricing: { url: 'https://www.tcgplayer.com/product/123' },
+      card: {
+        id: 'base1-4',
+        name: 'Charizard',
+        number: '4',
+        set: { name: 'Base Set' },
+        _database: 'pokemontcg.io',
+      },
+    })
+    render(
+      <CardDetailModal rows={[row]} index={0} onChangeIndex={() => {}} />,
+    )
+    const link = screen.getByRole('link', { name: /View on/ }) as HTMLAnchorElement
+    expect(link.textContent).toContain('TCGPlayer')
+    expect(link.textContent).not.toContain('pokemontcg.io')
+    expect(link.href).toContain('tcgplayer.com')
+  })
+
+  it('labels each well-known host correctly', () => {
+    const hosts: [string, string][] = [
+      ['https://www.tcgplayer.com/product/1', 'TCGPlayer'],
+      ['https://www.cardmarket.com/en/Pokemon/Products/1', 'Cardmarket'],
+      ['https://www.pricecharting.com/game/pokemon-base-set/charizard', 'PriceCharting'],
+    ]
+    for (const [url, label] of hosts) {
+      const { unmount } = render(
+        <CardDetailModal
+          rows={[buildRow({ pricing: { url } })]}
+          index={0}
+          onChangeIndex={() => {}}
+        />,
+      )
+      const link = screen.getByRole('link', { name: /View on/ }) as HTMLAnchorElement
+      expect(link.textContent).toContain(label)
+      unmount()
+    }
+  })
+
   it('falls back to a pokemontcg.io card URL when no pricing.url exists', () => {
     const row = buildRow({
       pricing: { url: null },
@@ -423,6 +468,30 @@ describe('CardDetailModal', () => {
     rerender(<CardDetailModal rows={rows} index={1} onChangeIndex={() => {}} />)
     expect(screen.getByLabelText('Previous card')).not.toBeDisabled()
     expect(screen.getByLabelText('Next card')).toBeDisabled()
+  })
+
+  it('resets to null when the parent row set shrinks below the current index', async () => {
+    // The bug this guards against: user opens the modal on row 5, then
+    // applies a filter that drops the row set to 2 entries. The stale
+    // index would visually close the modal but stay set in state — and
+    // if rows.length later grew back past index, the modal would silently
+    // reopen. The reset effect must force `onChangeIndex(null)`.
+    const rows = [
+      buildRow({ card: { name: 'Charizard', id: 'a', set: { name: 'Base' } } }),
+      buildRow({ card: { name: 'Blastoise', id: 'b', set: { name: 'Base' } } }),
+      buildRow({ card: { name: 'Venusaur', id: 'c', set: { name: 'Base' } } }),
+    ]
+    const onChange = vi.fn()
+    const { rerender } = render(
+      <CardDetailModal rows={rows} index={2} onChangeIndex={onChange} />,
+    )
+    // Sanity check: modal is open at index 2.
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    // Now the parent filters to 1 row — index 2 is out of bounds.
+    rerender(
+      <CardDetailModal rows={rows.slice(0, 1)} index={2} onChangeIndex={onChange} />,
+    )
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(null))
   })
 
   it('uses the query name as a fallback when card.name is missing', () => {

--- a/web/src/components/CardDetailModal.test.tsx
+++ b/web/src/components/CardDetailModal.test.tsx
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { CardDetailModal } from './CardDetailModal'
+import type { Row } from '../types'
+
+// Fabricate a minimal Row with the slots the modal reads. Tests then deep-merge
+// additional fields onto the underlying card so each one only states what it
+// actually cares about.
+function buildRow(
+  overrides: {
+    card?: Record<string, unknown> | null
+    pricing?: Partial<Row['pricing']>
+    query?: Partial<Row['query']>
+    matched?: boolean
+  } = {},
+): Row {
+  return {
+    query: {
+      raw: 'Charizard',
+      name: 'Charizard',
+      set_hint: null,
+      number: null,
+      variant_hint: null,
+      url_hint: null,
+      bulk_top: null,
+      bulk_all: false,
+      price_min: null,
+      price_max: null,
+      ...overrides.query,
+    },
+    card: overrides.card === null
+      ? null
+      : {
+          id: 'base1-4',
+          name: 'Charizard',
+          number: '4',
+          rarity: 'Rare Holo',
+          set: { name: 'Base Set', series: 'Base' },
+          images: {
+            small: 'https://example.com/charizard-small.png',
+            large: 'https://example.com/charizard-large.png',
+          },
+          _database: 'pokemontcg.io',
+          ...overrides.card,
+        },
+    pricing: {
+      market: 250,
+      variant: null,
+      source: 'TCGPlayer',
+      url: 'https://www.tcgplayer.com/product/123',
+      currency: 'USD',
+      ...overrides.pricing,
+    },
+    tag: '',
+    matched: overrides.matched ?? true,
+    reason: 'matched',
+  }
+}
+
+describe('CardDetailModal', () => {
+  it('does not render when index is null', () => {
+    render(
+      <CardDetailModal
+        rows={[buildRow()]}
+        index={null}
+        onChangeIndex={() => {}}
+      />,
+    )
+    // Dialog content is portaled, but the title would land in the document
+    // body when open. None of those landmarks should exist when closed.
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('renders the card name, set, large image, and pricing', () => {
+    render(
+      <CardDetailModal
+        rows={[buildRow()]}
+        index={0}
+        onChangeIndex={() => {}}
+      />,
+    )
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    // Header pulls the name + the 1/N counter. "Charizard" appears in the
+    // title, the identity list, and the image alt — `getAllByText` for
+    // the count, then a role-scoped query for the title specifically.
+    expect(screen.getAllByText('Charizard').length).toBeGreaterThanOrEqual(2)
+    expect(screen.getByText('1 / 1')).toBeInTheDocument()
+    // Identity grid shows the set name + number.
+    expect(screen.getByText('Base Set')).toBeInTheDocument()
+    expect(screen.getByText('4')).toBeInTheDocument()
+    // Large image preferred over small.
+    const img = screen.getByAltText('Charizard') as HTMLImageElement
+    expect(img.src).toContain('charizard-large.png')
+    // Market price + all four comp tiers render.
+    expect(screen.getByText('$250.00')).toBeInTheDocument()
+    expect(screen.getByText('$237.50')).toBeInTheDocument() // 95%
+    expect(screen.getByText('$225.00')).toBeInTheDocument() // 90%
+    expect(screen.getByText('$212.50')).toBeInTheDocument() // 85%
+    expect(screen.getByText('$200.00')).toBeInTheDocument() // 80%
+  })
+
+  it('falls back to images.small when large is missing', () => {
+    const row = buildRow({
+      card: {
+        id: 'base1-4',
+        name: 'Charizard',
+        number: '4',
+        rarity: 'Rare Holo',
+        set: { name: 'Base Set' },
+        images: { small: 'https://example.com/charizard-small.png' },
+      },
+    })
+    render(
+      <CardDetailModal rows={[row]} index={0} onChangeIndex={() => {}} />,
+    )
+    const img = screen.getByAltText('Charizard') as HTMLImageElement
+    expect(img.src).toContain('charizard-small.png')
+  })
+
+  it('shows "No image available" placeholder when both images are missing', () => {
+    // `buildRow`'s deep default merges `images` onto whatever the override
+    // ships — so we explicitly clear it with `undefined` to simulate the
+    // no-images case.
+    const row = buildRow({
+      card: {
+        id: 'base1-4',
+        name: 'Charizard',
+        number: '4',
+        rarity: 'Rare Holo',
+        set: { name: 'Base Set' },
+        images: undefined,
+      },
+    })
+    render(
+      <CardDetailModal rows={[row]} index={0} onChangeIndex={() => {}} />,
+    )
+    expect(screen.getByText('No image available')).toBeInTheDocument()
+  })
+
+  it('renders optional card metadata (attacks, HP, weaknesses) when present', () => {
+    const row = buildRow({
+      card: {
+        id: 'base1-4',
+        name: 'Charizard',
+        number: '4',
+        rarity: 'Rare Holo',
+        set: { name: 'Base Set' },
+        supertype: 'Pokémon',
+        subtypes: ['Stage 2'],
+        hp: '120',
+        types: ['Fire'],
+        attacks: [
+          {
+            name: 'Fire Spin',
+            cost: ['Fire', 'Fire', 'Fire', 'Fire'],
+            damage: '100',
+            text: 'Discard 2 Energy attached to this Pokémon.',
+          },
+        ],
+        weaknesses: [{ type: 'Water', value: '×2' }],
+        artist: 'Mitsuhiro Arita',
+        regulationMark: 'G',
+      },
+    })
+    render(
+      <CardDetailModal rows={[row]} index={0} onChangeIndex={() => {}} />,
+    )
+    expect(screen.getByText('Card data')).toBeInTheDocument()
+    expect(screen.getByText('Fire Spin')).toBeInTheDocument()
+    expect(screen.getByText('100')).toBeInTheDocument()
+    expect(screen.getByText(/Discard 2 Energy/)).toBeInTheDocument()
+    expect(screen.getByText('120')).toBeInTheDocument() // HP
+    expect(screen.getByText('Water ×2')).toBeInTheDocument()
+    expect(screen.getByText('Mitsuhiro Arita')).toBeInTheDocument()
+    expect(screen.getByText('G')).toBeInTheDocument()
+  })
+
+  it('handles a sparse card with no optional metadata fields', () => {
+    const row = buildRow({
+      card: {
+        id: 'base1-4',
+        name: 'Charizard',
+        number: '4',
+        rarity: 'Rare Holo',
+        set: { name: 'Base Set' },
+        // No attacks, hp, types, etc. — modal must not crash.
+      },
+    })
+    render(
+      <CardDetailModal rows={[row]} index={0} onChangeIndex={() => {}} />,
+    )
+    // The "Card data" section short-circuits to a placeholder message.
+    expect(
+      screen.getByText(/No additional card data was returned/),
+    ).toBeInTheDocument()
+    // The identity / pricing sections still render fine. "Charizard" lands
+    // in multiple slots (title, identity list, image alt) so we just check
+    // the dialog is up and the price line is correct.
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByText('$250.00')).toBeInTheDocument()
+  })
+
+  it('navigates via ArrowRight / ArrowLeft', async () => {
+    const rows = [
+      buildRow({ card: { name: 'Charizard', id: 'a', set: { name: 'Base' } } }),
+      buildRow({ card: { name: 'Blastoise', id: 'b', set: { name: 'Base' } } }),
+      buildRow({ card: { name: 'Venusaur', id: 'c', set: { name: 'Base' } } }),
+    ]
+    const onChange = vi.fn()
+    render(<CardDetailModal rows={rows} index={1} onChangeIndex={onChange} />)
+    fireEvent.keyDown(window, { key: 'ArrowRight' })
+    expect(onChange).toHaveBeenLastCalledWith(2)
+    fireEvent.keyDown(window, { key: 'ArrowLeft' })
+    expect(onChange).toHaveBeenLastCalledWith(0)
+  })
+
+  it('does not navigate past the ends of the row set', () => {
+    const rows = [
+      buildRow({ card: { name: 'Charizard', id: 'a', set: { name: 'Base' } } }),
+      buildRow({ card: { name: 'Blastoise', id: 'b', set: { name: 'Base' } } }),
+    ]
+    const onChange = vi.fn()
+    // At the start — left arrow is a no-op.
+    const { rerender } = render(
+      <CardDetailModal rows={rows} index={0} onChangeIndex={onChange} />,
+    )
+    fireEvent.keyDown(window, { key: 'ArrowLeft' })
+    expect(onChange).not.toHaveBeenCalled()
+    // At the end — right arrow is a no-op.
+    rerender(<CardDetailModal rows={rows} index={1} onChangeIndex={onChange} />)
+    fireEvent.keyDown(window, { key: 'ArrowRight' })
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('closes when the close button is clicked', async () => {
+    const onChange = vi.fn()
+    render(
+      <CardDetailModal
+        rows={[buildRow()]}
+        index={0}
+        onChangeIndex={onChange}
+      />,
+    )
+    fireEvent.click(screen.getByLabelText('Close'))
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith(null))
+  })
+
+  it('renders the source link to the best available URL', () => {
+    const row = buildRow({
+      pricing: { url: 'https://www.tcgplayer.com/product/123' },
+    })
+    render(
+      <CardDetailModal rows={[row]} index={0} onChangeIndex={() => {}} />,
+    )
+    const link = screen.getByRole('link', { name: /View on/ }) as HTMLAnchorElement
+    expect(link.href).toBe('https://www.tcgplayer.com/product/123')
+    expect(link.target).toBe('_blank')
+    expect(link.rel).toContain('noopener')
+  })
+
+  it('falls back to a pokemontcg.io card URL when no pricing.url exists', () => {
+    const row = buildRow({
+      pricing: { url: null },
+      card: {
+        id: 'base1-4',
+        name: 'Charizard',
+        number: '4',
+        rarity: 'Rare Holo',
+        set: { name: 'Base Set' },
+      },
+    })
+    render(
+      <CardDetailModal rows={[row]} index={0} onChangeIndex={() => {}} />,
+    )
+    const link = screen.getByRole('link', { name: /View on/ }) as HTMLAnchorElement
+    expect(link.href).toBe('https://pokemontcg.io/cards/base1-4')
+  })
+})

--- a/web/src/components/CardDetailModal.tsx
+++ b/web/src/components/CardDetailModal.tsx
@@ -1,0 +1,502 @@
+/**
+ * CardDetailModal — opens when a row in `ResultsTable` is clicked.
+ *
+ * Renders the large card image, a two-column header (identity + pricing),
+ * and a "card data" block that surfaces whatever optional fields the
+ * source returned (subtype, HP, attacks, weaknesses, retreat, regulation
+ * mark, artist, dex number, flavor text). Missing fields are silently
+ * skipped — the layout has to stay clean across every source's schema.
+ *
+ * Keyboard:
+ *   - ←/→ — step through the parent's (already filtered + sorted) rows
+ *   - Esc — close (handled by Radix Dialog)
+ *
+ * The dialog role, focus trap, and aria wiring all come from
+ * `@radix-ui/react-dialog` — matches the existing HelpModal / SetPickerModal
+ * patterns so we don't duplicate a11y plumbing.
+ */
+import * as Dialog from '@radix-ui/react-dialog'
+import { ChevronLeft, ChevronRight, ExternalLink, X } from 'lucide-react'
+import { useEffect } from 'react'
+import type { CardData, Row } from '../types'
+
+interface Props {
+  /** The already filtered + sorted row set the parent table is showing. */
+  rows: Row[]
+  /** Index into `rows` for the card currently in view; `null` = modal closed. */
+  index: number | null
+  /** Set to `null` to close, or to a new index to navigate. */
+  onChangeIndex: (next: number | null) => void
+}
+
+export function CardDetailModal({ rows, index, onChangeIndex }: Props) {
+  const isOpen = index !== null && index >= 0 && index < rows.length
+  const row = isOpen ? rows[index] : null
+
+  // ←/→ keyboard navigation. Bound to window so the listener works whether
+  // focus is on the dialog frame, the image, or inside one of the metadata
+  // panels — Radix's own focus trap keeps Tab inside the dialog, but arrow
+  // keys still need their own handler.
+  useEffect(() => {
+    if (!isOpen) return
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'ArrowLeft' && index! > 0) {
+        e.preventDefault()
+        onChangeIndex(index! - 1)
+      } else if (e.key === 'ArrowRight' && index! < rows.length - 1) {
+        e.preventDefault()
+        onChangeIndex(index! + 1)
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [isOpen, index, rows.length, onChangeIndex])
+
+  function handleOpenChange(next: boolean) {
+    if (!next) onChangeIndex(null)
+  }
+
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={handleOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/70 backdrop-blur-sm" />
+        <Dialog.Content
+          aria-describedby={undefined}
+          className="fixed left-1/2 top-1/2 z-50 flex max-h-[92vh] w-[min(960px,94vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-zinc-700 bg-zinc-900 shadow-2xl"
+        >
+          {row ? (
+            <CardDetailBody
+              row={row}
+              index={index!}
+              total={rows.length}
+              onPrev={
+                index! > 0 ? () => onChangeIndex(index! - 1) : undefined
+              }
+              onNext={
+                index! < rows.length - 1
+                  ? () => onChangeIndex(index! + 1)
+                  : undefined
+              }
+            />
+          ) : null}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Body — split out so the keyboard / open-change logic above stays readable.
+// ---------------------------------------------------------------------------
+
+function CardDetailBody({
+  row,
+  index,
+  total,
+  onPrev,
+  onNext,
+}: {
+  row: Row
+  index: number
+  total: number
+  onPrev?: () => void
+  onNext?: () => void
+}) {
+  const card = row.card
+  const pricing = row.pricing
+  const imgUrl =
+    (card?.images?.large as string | undefined) ??
+    (card?.images?.small as string | undefined)
+  const sourceUrl = deriveSourceUrl(row)
+
+  const setObj = (card?.set ?? {}) as Record<string, unknown>
+  const setName = setObj.name as string | undefined
+  const setSeries = setObj.series as string | undefined
+  const cardNumber = card?.number as string | undefined
+  const rarity = card?.rarity as string | undefined
+  const variant = pricing.variant ?? row.query.variant_hint
+
+  return (
+    <>
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-zinc-700 px-5 py-3">
+        <div className="flex items-center gap-2">
+          <Dialog.Title className="text-base font-semibold text-zinc-100">
+            {(card?.name as string | undefined) ?? row.query.name}
+          </Dialog.Title>
+          <span className="text-xs text-zinc-500 font-mono tabular-nums">
+            {index + 1} / {total}
+          </span>
+        </div>
+        <div className="flex items-center gap-1">
+          <NavButton
+            label="Previous card"
+            disabled={!onPrev}
+            onClick={onPrev}
+          >
+            <ChevronLeft size={16} />
+          </NavButton>
+          <NavButton label="Next card" disabled={!onNext} onClick={onNext}>
+            <ChevronRight size={16} />
+          </NavButton>
+          <Dialog.Close asChild>
+            <button
+              className="rounded p-1 text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700 transition-colors"
+              aria-label="Close"
+            >
+              <X size={16} />
+            </button>
+          </Dialog.Close>
+        </div>
+      </div>
+
+      {/* Body — scrollable */}
+      <div
+        tabIndex={0}
+        className="flex-1 overflow-y-auto px-5 py-4 focus:outline-none focus:ring-1 focus:ring-blue-500"
+      >
+        <div className="grid gap-6 md:grid-cols-[260px_1fr]">
+          {/* Image column */}
+          <div className="flex justify-center md:justify-start">
+            {imgUrl ? (
+              <img
+                src={imgUrl}
+                alt={(card?.name as string | undefined) ?? row.query.name}
+                className="rounded-md shadow-lg max-h-[420px] w-auto object-contain bg-zinc-800"
+                loading="lazy"
+              />
+            ) : (
+              <div className="flex h-[360px] w-[260px] items-center justify-center rounded-md border border-zinc-700 bg-zinc-800 text-sm text-zinc-500">
+                No image available
+              </div>
+            )}
+          </div>
+
+          {/* Identity + pricing two-column */}
+          <div className="space-y-5">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <DefinitionList
+                rows={[
+                  ['Name', (card?.name as string | undefined) ?? row.query.name],
+                  ['Set', setName ?? '—'],
+                  ['Series', setSeries ?? null],
+                  ['Number', cardNumber ?? null],
+                  ['Rarity', rarity ?? null],
+                  ['Variant', variant ?? null],
+                ]}
+              />
+              <div>
+                <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-400 mb-2">
+                  Pricing
+                </h3>
+                <div className="rounded-md border border-zinc-700 bg-zinc-950 p-3 space-y-1">
+                  <PriceLine
+                    label="Market"
+                    value={fmt(pricing.market, pricing.currency)}
+                    bold
+                    highlight
+                  />
+                  <PriceLine
+                    label="95%"
+                    value={comp(pricing.market, 95, pricing.currency)}
+                  />
+                  <PriceLine
+                    label="90%"
+                    value={comp(pricing.market, 90, pricing.currency)}
+                  />
+                  <PriceLine
+                    label="85%"
+                    value={comp(pricing.market, 85, pricing.currency)}
+                  />
+                  <PriceLine
+                    label="80%"
+                    value={comp(pricing.market, 80, pricing.currency)}
+                  />
+                </div>
+                {pricing.source && (
+                  <p className="mt-2 text-xs text-zinc-400">
+                    Source: <span className="text-zinc-300">{pricing.source}</span>
+                  </p>
+                )}
+                {sourceUrl && (
+                  <a
+                    href={sourceUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-blue-400 hover:text-blue-300"
+                  >
+                    View on {sourceLabel(row)}{' '}
+                    <ExternalLink size={11} />
+                  </a>
+                )}
+              </div>
+            </div>
+
+            <CardMetadataBlock card={card} />
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// CardMetadataBlock — surfaces whatever optional fields the source returned.
+// Every field is conditional so a sparse card (or one from a source that
+// only fills a subset) doesn't leave a "label: undefined" hole in the UI.
+// ---------------------------------------------------------------------------
+
+function CardMetadataBlock({ card }: { card: CardData | null }) {
+  if (!card) return null
+
+  const supertype = card.supertype as string | undefined
+  const subtypes = (card.subtypes as string[] | undefined) ?? []
+  const hp = card.hp as string | undefined
+  const types = (card.types as string[] | undefined) ?? []
+  const evolvesFrom = card.evolvesFrom as string | undefined
+  const attacks = (card.attacks as CardAttack[] | undefined) ?? []
+  const weaknesses = (card.weaknesses as TypedValue[] | undefined) ?? []
+  const resistances = (card.resistances as TypedValue[] | undefined) ?? []
+  const retreatCost = (card.retreatCost as string[] | undefined) ?? []
+  const regulationMark = card.regulationMark as string | undefined
+  const artist = card.artist as string | undefined
+  const nationalPokedexNumbers =
+    (card.nationalPokedexNumbers as number[] | undefined) ?? []
+  const flavorText = card.flavorText as string | undefined
+
+  const hasAnyField =
+    !!supertype ||
+    subtypes.length > 0 ||
+    !!hp ||
+    types.length > 0 ||
+    !!evolvesFrom ||
+    attacks.length > 0 ||
+    weaknesses.length > 0 ||
+    resistances.length > 0 ||
+    retreatCost.length > 0 ||
+    !!regulationMark ||
+    !!artist ||
+    nationalPokedexNumbers.length > 0 ||
+    !!flavorText
+
+  if (!hasAnyField) {
+    return (
+      <p className="text-xs text-zinc-500">
+        No additional card data was returned by the source.
+      </p>
+    )
+  }
+
+  return (
+    <div>
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-400 mb-2">
+        Card data
+      </h3>
+      <div className="rounded-md border border-zinc-700 bg-zinc-950 p-4 space-y-3 text-sm">
+        {(supertype || subtypes.length > 0) && (
+          <Row label="Type">
+            {[supertype, subtypes.join(' · ')].filter(Boolean).join(' — ')}
+          </Row>
+        )}
+        {hp && <Row label="HP">{hp}</Row>}
+        {types.length > 0 && <Row label="Energy">{types.join(' · ')}</Row>}
+        {evolvesFrom && <Row label="Evolves from">{evolvesFrom}</Row>}
+
+        {attacks.length > 0 && (
+          <div>
+            <div className="text-xs uppercase tracking-wider text-zinc-500 mb-1">
+              Attacks
+            </div>
+            <ul className="space-y-2">
+              {attacks.map((a, i) => (
+                <li
+                  key={i}
+                  className="rounded border border-zinc-800 bg-zinc-900 p-2"
+                >
+                  <div className="flex items-baseline justify-between gap-3">
+                    <span className="font-medium text-zinc-100">{a.name}</span>
+                    {a.damage && (
+                      <span className="font-mono text-zinc-300">{a.damage}</span>
+                    )}
+                  </div>
+                  {a.cost && a.cost.length > 0 && (
+                    <div className="text-xs text-zinc-400 mt-0.5">
+                      Cost: {a.cost.join(' · ')}
+                    </div>
+                  )}
+                  {a.text && (
+                    <p className="text-xs text-zinc-400 mt-1 leading-snug">
+                      {a.text}
+                    </p>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {weaknesses.length > 0 && (
+          <Row label="Weakness">
+            {weaknesses.map((w) => `${w.type} ${w.value}`).join(', ')}
+          </Row>
+        )}
+        {resistances.length > 0 && (
+          <Row label="Resistance">
+            {resistances.map((r) => `${r.type} ${r.value}`).join(', ')}
+          </Row>
+        )}
+        {retreatCost.length > 0 && (
+          <Row label="Retreat">{retreatCost.join(' · ')}</Row>
+        )}
+        {regulationMark && <Row label="Regulation">{regulationMark}</Row>}
+        {artist && <Row label="Artist">{artist}</Row>}
+        {nationalPokedexNumbers.length > 0 && (
+          <Row label="Dex #">{nationalPokedexNumbers.join(', ')}</Row>
+        )}
+        {flavorText && (
+          <Row label="Flavor">
+            <span className="italic text-zinc-300">{flavorText}</span>
+          </Row>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface CardAttack {
+  name: string
+  cost?: string[]
+  damage?: string
+  text?: string
+}
+
+interface TypedValue {
+  type: string
+  value: string
+}
+
+function NavButton({
+  label,
+  disabled,
+  onClick,
+  children,
+}: {
+  label: string
+  disabled?: boolean
+  onClick?: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={label}
+      title={label}
+      className="rounded p-1 text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700 transition-colors disabled:opacity-30 disabled:hover:bg-transparent"
+    >
+      {children}
+    </button>
+  )
+}
+
+function DefinitionList({ rows }: { rows: [string, string | null][] }) {
+  return (
+    <div>
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-400 mb-2">
+        Identity
+      </h3>
+      <dl className="space-y-1.5 text-sm">
+        {rows
+          .filter(([, value]) => value != null && value !== '')
+          .map(([label, value]) => (
+            <div key={label} className="flex gap-2">
+              <dt className="text-zinc-500 min-w-[64px]">{label}</dt>
+              <dd className="text-zinc-200">{value}</dd>
+            </div>
+          ))}
+      </dl>
+    </div>
+  )
+}
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex gap-3">
+      <span className="text-xs uppercase tracking-wider text-zinc-500 min-w-[80px] mt-0.5">
+        {label}
+      </span>
+      <span className="flex-1 text-zinc-200">{children}</span>
+    </div>
+  )
+}
+
+function PriceLine({
+  label,
+  value,
+  bold = false,
+  highlight = false,
+}: {
+  label: string
+  value: string
+  bold?: boolean
+  highlight?: boolean
+}) {
+  return (
+    <div className="flex items-baseline justify-between">
+      <span className="text-xs text-zinc-400">{label}</span>
+      <span
+        className={`font-mono tabular-nums ${bold ? 'font-bold text-base' : 'text-sm'} ${
+          highlight ? 'text-green-400' : 'text-zinc-200'
+        }`}
+      >
+        {value}
+      </span>
+    </div>
+  )
+}
+
+function fmt(amount: number | null, currency = 'USD'): string {
+  if (amount == null) return '—'
+  const sym = currency === 'EUR' ? '€' : '$'
+  return `${sym}${amount.toFixed(2)}`
+}
+
+function comp(market: number | null, pct: number, currency = 'USD'): string {
+  if (market == null) return '—'
+  return fmt((market * pct) / 100, currency)
+}
+
+function sourceLabel(row: Row): string {
+  const db = row.card?._database as string | undefined
+  if (db) return db
+  if (row.pricing.source) return row.pricing.source
+  return 'source'
+}
+
+/**
+ * Best available link out to the card's canonical source page. Preference order:
+ * 1. `pricing.url` — already set by the lookup when there's a real listing
+ *    (PriceCharting, TCGPlayer, Cardmarket).
+ * 2. `card.tcgplayer.url` / `card.cardmarket.url` — pokemontcg.io carries
+ *    these on every card it knows.
+ * 3. A pokemontcg.io card-page URL derived from `card.id`.
+ * Returns null when nothing usable is available — the link is then hidden.
+ */
+function deriveSourceUrl(row: Row): string | null {
+  if (row.pricing.url) return row.pricing.url
+  const card = row.card
+  if (!card) return null
+  const tcgplayer = card.tcgplayer as { url?: string } | undefined
+  if (tcgplayer?.url) return tcgplayer.url
+  const cardmarket = card.cardmarket as { url?: string } | undefined
+  if (cardmarket?.url) return cardmarket.url
+  if (card.id) {
+    // pokemontcg.io card IDs are stable; the public web app uses this shape.
+    return `https://pokemontcg.io/cards/${card.id}`
+  }
+  return null
+}

--- a/web/src/components/CardDetailModal.tsx
+++ b/web/src/components/CardDetailModal.tsx
@@ -19,6 +19,7 @@ import * as Dialog from '@radix-ui/react-dialog'
 import { ChevronLeft, ChevronRight, ExternalLink, X } from 'lucide-react'
 import { useEffect } from 'react'
 import type { CardData, Row } from '../types'
+import { formatComp, formatMoney } from '../utils/format'
 
 interface Props {
   /** The already filtered + sorted row set the parent table is showing. */
@@ -32,6 +33,17 @@ interface Props {
 export function CardDetailModal({ rows, index, onChangeIndex }: Props) {
   const isOpen = index !== null && index >= 0 && index < rows.length
   const row = isOpen ? rows[index] : null
+
+  // Reset to null when the parent's row set shifts so the modal no longer
+  // points at a valid entry — e.g. a filter is applied while the modal is
+  // open, or a new lookup clears the list. Without this, `index` would
+  // remain set (just out-of-bounds) and the modal would silently reopen
+  // later if `rows.length` grew back past the stale index.
+  useEffect(() => {
+    if (index !== null && (index < 0 || index >= rows.length)) {
+      onChangeIndex(null)
+    }
+  }, [index, rows.length, onChangeIndex])
 
   // ←/→ keyboard navigation. Bound to window so the listener works whether
   // focus is on the dialog frame, the image, or inside one of the metadata
@@ -107,7 +119,7 @@ function CardDetailBody({
   const imgUrl =
     (card?.images?.large as string | undefined) ??
     (card?.images?.small as string | undefined)
-  const sourceUrl = deriveSourceUrl(row)
+  const source = deriveSource(row)
 
   const setObj = (card?.set ?? {}) as Record<string, unknown>
   const setName = setObj.name as string | undefined
@@ -192,25 +204,25 @@ function CardDetailBody({
                 <div className="rounded-md border border-zinc-700 bg-zinc-950 p-3 space-y-1">
                   <PriceLine
                     label="Market"
-                    value={fmt(pricing.market, pricing.currency)}
+                    value={formatMoney(pricing.market, pricing.currency)}
                     bold
                     highlight
                   />
                   <PriceLine
                     label="95%"
-                    value={comp(pricing.market, 95, pricing.currency)}
+                    value={formatComp(pricing.market, 95, pricing.currency)}
                   />
                   <PriceLine
                     label="90%"
-                    value={comp(pricing.market, 90, pricing.currency)}
+                    value={formatComp(pricing.market, 90, pricing.currency)}
                   />
                   <PriceLine
                     label="85%"
-                    value={comp(pricing.market, 85, pricing.currency)}
+                    value={formatComp(pricing.market, 85, pricing.currency)}
                   />
                   <PriceLine
                     label="80%"
-                    value={comp(pricing.market, 80, pricing.currency)}
+                    value={formatComp(pricing.market, 80, pricing.currency)}
                   />
                 </div>
                 {pricing.source && (
@@ -218,15 +230,14 @@ function CardDetailBody({
                     Source: <span className="text-zinc-300">{pricing.source}</span>
                   </p>
                 )}
-                {sourceUrl && (
+                {source && (
                   <a
-                    href={sourceUrl}
+                    href={source.url}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-blue-400 hover:text-blue-300"
                   >
-                    View on {sourceLabel(row)}{' '}
-                    <ExternalLink size={11} />
+                    View on {source.label} <ExternalLink size={11} />
                   </a>
                 )}
               </div>
@@ -459,44 +470,65 @@ function PriceLine({
   )
 }
 
-function fmt(amount: number | null, currency = 'USD'): string {
-  if (amount == null) return '—'
-  const sym = currency === 'EUR' ? '€' : '$'
-  return `${sym}${amount.toFixed(2)}`
-}
-
-function comp(market: number | null, pct: number, currency = 'USD'): string {
-  if (market == null) return '—'
-  return fmt((market * pct) / 100, currency)
-}
-
-function sourceLabel(row: Row): string {
-  const db = row.card?._database as string | undefined
-  if (db) return db
-  if (row.pricing.source) return row.pricing.source
-  return 'source'
-}
-
 /**
- * Best available link out to the card's canonical source page. Preference order:
- * 1. `pricing.url` — already set by the lookup when there's a real listing
- *    (PriceCharting, TCGPlayer, Cardmarket).
- * 2. `card.tcgplayer.url` / `card.cardmarket.url` — pokemontcg.io carries
- *    these on every card it knows.
- * 3. A pokemontcg.io card-page URL derived from `card.id`.
- * Returns null when nothing usable is available — the link is then hidden.
+ * Best available link out to the card's canonical source page, paired
+ * with a label that names the *same* site the URL points at.
+ *
+ * Splitting the URL and the label across two helpers (as the earlier
+ * version did) created a real bug: a card from pokemontcg.io often
+ * carries a TCGPlayer listing URL on `pricing.url`, so the link would
+ * say "View on pokemontcg.io" while pointing at tcgplayer.com. The
+ * unified decision tree below guarantees label and URL agree.
+ *
+ * Preference order:
+ *   1. `pricing.url` — already set by the lookup when there's a real
+ *      listing. The label is inferred from the host so PriceCharting,
+ *      TCGPlayer, and Cardmarket each get the right name even when
+ *      `_database` is "pokemontcg.io".
+ *   2. `card.tcgplayer.url` / `card.cardmarket.url` — pokemontcg.io
+ *      carries these on cards it knows.
+ *   3. A pokemontcg.io card-page URL derived from `card.id`.
+ * Returns null when nothing usable is available — the link is hidden.
  */
-function deriveSourceUrl(row: Row): string | null {
-  if (row.pricing.url) return row.pricing.url
+function deriveSource(row: Row): { url: string; label: string } | null {
+  if (row.pricing.url) {
+    return { url: row.pricing.url, label: labelForUrl(row.pricing.url, row) }
+  }
   const card = row.card
   if (!card) return null
   const tcgplayer = card.tcgplayer as { url?: string } | undefined
-  if (tcgplayer?.url) return tcgplayer.url
+  if (tcgplayer?.url) {
+    return { url: tcgplayer.url, label: 'TCGPlayer' }
+  }
   const cardmarket = card.cardmarket as { url?: string } | undefined
-  if (cardmarket?.url) return cardmarket.url
+  if (cardmarket?.url) {
+    return { url: cardmarket.url, label: 'Cardmarket' }
+  }
   if (card.id) {
     // pokemontcg.io card IDs are stable; the public web app uses this shape.
-    return `https://pokemontcg.io/cards/${card.id}`
+    return {
+      url: `https://pokemontcg.io/cards/${card.id}`,
+      label: 'pokemontcg.io',
+    }
   }
   return null
+}
+
+/**
+ * Infer a human label from a listing URL. Falls back to `pricing.source`
+ * (set by the lookup pipeline based on the matched URL) and finally to
+ * a generic word so the link still renders something readable.
+ */
+function labelForUrl(url: string, row: Row): string {
+  try {
+    const host = new URL(url).hostname.toLowerCase()
+    if (host.includes('tcgplayer')) return 'TCGPlayer'
+    if (host.includes('cardmarket')) return 'Cardmarket'
+    if (host.includes('pricecharting')) return 'PriceCharting'
+    if (host.includes('pokemontcg')) return 'pokemontcg.io'
+  } catch {
+    // URL parsing can throw on malformed input — fall through to the
+    // pricing.source label rather than crashing the modal.
+  }
+  return row.pricing.source ?? 'source'
 }

--- a/web/src/components/ResultsTable.test.tsx
+++ b/web/src/components/ResultsTable.test.tsx
@@ -105,6 +105,111 @@ describe('ResultsTable', () => {
     expect(screen.queryByLabelText(/View details for/)).toBeNull()
     useAppStore.setState({ rows: [] })
   })
+
+  it('pressing Enter on a focused row opens the modal', () => {
+    useAppStore.setState({
+      rows: [
+        makeRow({
+          card: {
+            id: 'base1-4',
+            name: 'Charizard',
+            number: '4',
+            rarity: 'Rare Holo',
+            set: { name: 'Base Set' },
+          },
+          pricing: { market: 250, currency: 'USD', variant: null, source: 'TCGPlayer', url: null },
+        }),
+      ],
+      isRunning: false,
+      progress: null,
+    })
+    render(<ResultsTable />)
+    const row = screen.getByLabelText(/View details for Charizard/)
+    fireEvent.keyDown(row, { key: 'Enter' })
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    useAppStore.setState({ rows: [] })
+  })
+
+  it('pressing Space on a focused row opens the modal', () => {
+    useAppStore.setState({
+      rows: [
+        makeRow({
+          card: {
+            id: 'base1-4',
+            name: 'Charizard',
+            number: '4',
+            rarity: 'Rare Holo',
+            set: { name: 'Base Set' },
+          },
+          pricing: { market: 250, currency: 'USD', variant: null, source: 'TCGPlayer', url: null },
+        }),
+      ],
+      isRunning: false,
+      progress: null,
+    })
+    render(<ResultsTable />)
+    const row = screen.getByLabelText(/View details for Charizard/)
+    fireEvent.keyDown(row, { key: ' ' })
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    useAppStore.setState({ rows: [] })
+  })
+
+  it('Enter on an inner control does not open the modal', () => {
+    useAppStore.setState({
+      rows: [
+        makeRow({
+          card: {
+            id: 'base1-4',
+            name: 'Charizard',
+            number: '4',
+            rarity: 'Rare Holo',
+            set: { name: 'Base Set' },
+          },
+          pricing: {
+            market: 250,
+            currency: 'USD',
+            variant: null,
+            source: 'TCGPlayer',
+            url: 'https://example.com/listing',
+          },
+        }),
+      ],
+      isRunning: false,
+      progress: null,
+    })
+    render(<ResultsTable />)
+    const link = screen.getByTitle('Open listing')
+    // The keydown bubbles up to the row's handler, but `closest('a, button, input')`
+    // on the target keeps the modal closed.
+    fireEvent.keyDown(link, { key: 'Enter', bubbles: true })
+    expect(screen.queryByRole('dialog')).toBeNull()
+    useAppStore.setState({ rows: [] })
+  })
+
+  it('other keys on a row do not open the modal', () => {
+    useAppStore.setState({
+      rows: [
+        makeRow({
+          card: {
+            id: 'base1-4',
+            name: 'Charizard',
+            number: '4',
+            rarity: 'Rare Holo',
+            set: { name: 'Base Set' },
+          },
+          pricing: { market: 250, currency: 'USD', variant: null, source: 'TCGPlayer', url: null },
+        }),
+      ],
+      isRunning: false,
+      progress: null,
+    })
+    render(<ResultsTable />)
+    const row = screen.getByLabelText(/View details for Charizard/)
+    fireEvent.keyDown(row, { key: 'a' })
+    fireEvent.keyDown(row, { key: 'Tab' })
+    expect(screen.queryByRole('dialog')).toBeNull()
+    useAppStore.setState({ rows: [] })
+  })
 })
 
 describe('applyFilters', () => {

--- a/web/src/components/ResultsTable.test.tsx
+++ b/web/src/components/ResultsTable.test.tsx
@@ -27,6 +27,84 @@ describe('ResultsTable', () => {
     render(<ResultsTable />)
     expect(screen.getByText(/results will appear here/i)).toBeInTheDocument()
   })
+
+  it('clicking a matched row opens the card detail modal', () => {
+    useAppStore.setState({
+      rows: [
+        makeRow({
+          card: {
+            id: 'base1-4',
+            name: 'Charizard',
+            number: '4',
+            rarity: 'Rare Holo',
+            set: { name: 'Base Set' },
+          },
+          pricing: { market: 250, currency: 'USD', variant: null, source: 'TCGPlayer', url: null },
+        }),
+      ],
+      isRunning: false,
+      progress: null,
+    })
+    render(<ResultsTable />)
+    // Find the table row via the aria-label we add for matched rows.
+    const row = screen.getByLabelText(/View details for Charizard/)
+    fireEvent.click(row)
+    // The detail modal renders into a portal — dialog role appears once open.
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    // The 1/N counter confirms we landed on the right row.
+    expect(screen.getByText('1 / 1')).toBeInTheDocument()
+    useAppStore.setState({ rows: [] })
+  })
+
+  it('clicking an inner link inside a row does not open the modal', () => {
+    useAppStore.setState({
+      rows: [
+        makeRow({
+          card: {
+            id: 'base1-4',
+            name: 'Charizard',
+            number: '4',
+            rarity: 'Rare Holo',
+            set: { name: 'Base Set' },
+          },
+          pricing: {
+            market: 250,
+            currency: 'USD',
+            variant: null,
+            source: 'TCGPlayer',
+            // A real URL triggers the inline external-link icon in the row.
+            url: 'https://example.com/listing',
+          },
+        }),
+      ],
+      isRunning: false,
+      progress: null,
+    })
+    render(<ResultsTable />)
+    // The external-link anchor has title="Open listing" — click that, not the row.
+    const link = screen.getByTitle('Open listing')
+    fireEvent.click(link)
+    expect(screen.queryByRole('dialog')).toBeNull()
+    useAppStore.setState({ rows: [] })
+  })
+
+  it('unmatched rows are not clickable and do not get the aria-label', () => {
+    useAppStore.setState({
+      rows: [
+        makeRow({
+          card: null,
+          matched: false,
+          query: { raw: 'GhostMon', name: 'GhostMon' } as Row['query'],
+        }),
+      ],
+      isRunning: false,
+      progress: null,
+    })
+    render(<ResultsTable />)
+    // No aria-labelled clickable row exists when the lookup didn't match.
+    expect(screen.queryByLabelText(/View details for/)).toBeNull()
+    useAppStore.setState({ rows: [] })
+  })
 })
 
 describe('applyFilters', () => {

--- a/web/src/components/ResultsTable.tsx
+++ b/web/src/components/ResultsTable.tsx
@@ -16,6 +16,7 @@ import { ArrowDown, ArrowUp, ArrowUpDown, ExternalLink, AlertCircle, Filter } fr
 import { addOverride } from '../api/client'
 import { useAppStore } from '../store'
 import type { Row } from '../types'
+import { formatComp, formatMoney } from '../utils/format'
 import { CardDetailModal } from './CardDetailModal'
 import {
   applyFilters,
@@ -380,16 +381,6 @@ function FilterInput({
 // Single row
 // ---------------------------------------------------------------------------
 
-function fmt(amount: number | null, currency = 'USD'): string {
-  if (amount == null) return '—'
-  const sym = currency === 'EUR' ? '€' : '$'
-  return `${sym}${amount.toFixed(2)}`
-}
-
-function comp(market: number | null, pct: number): string {
-  return market != null ? fmt((market * pct) / 100) : '—'
-}
-
 function ResultRow({
   row,
   showImage,
@@ -528,21 +519,21 @@ function ResultRow({
             isOverCap ? 'text-amber-400 font-bold' : p.market ? 'text-green-400' : 'text-zinc-400'
           }`}
         >
-          {fmt(p.market, p.currency)}
+          {formatMoney(p.market, p.currency)}
         </td>
 
         {/* Comp tiers */}
         <td className="px-3 py-2 text-right font-mono tabular-nums text-zinc-400 text-xs hidden xl:table-cell">
-          {comp(p.market, 80)}
+          {formatComp(p.market, 80, p.currency)}
         </td>
         <td className="px-3 py-2 text-right font-mono tabular-nums text-zinc-400 text-xs hidden xl:table-cell">
-          {comp(p.market, 85)}
+          {formatComp(p.market, 85, p.currency)}
         </td>
         <td className="px-3 py-2 text-right font-mono tabular-nums text-zinc-400 text-xs hidden xl:table-cell">
-          {comp(p.market, 90)}
+          {formatComp(p.market, 90, p.currency)}
         </td>
         <td className="px-3 py-2 text-right font-mono tabular-nums text-zinc-400 text-xs hidden xl:table-cell">
-          {comp(p.market, 95)}
+          {formatComp(p.market, 95, p.currency)}
         </td>
 
         {/* Price source */}

--- a/web/src/components/ResultsTable.tsx
+++ b/web/src/components/ResultsTable.tsx
@@ -16,6 +16,7 @@ import { ArrowDown, ArrowUp, ArrowUpDown, ExternalLink, AlertCircle, Filter } fr
 import { addOverride } from '../api/client'
 import { useAppStore } from '../store'
 import type { Row } from '../types'
+import { CardDetailModal } from './CardDetailModal'
 import {
   applyFilters,
   applySort,
@@ -36,6 +37,10 @@ export function ResultsTable({ onRerunLine }: Props) {
   const [sortDir, setSortDir] = useState<SortDir | null>(null)
   const [showFilters, setShowFilters] = useState(false)
   const [filters, setFilters] = useState<Filters>(EMPTY_FILTERS)
+  // Index into `displayedRows` for the row whose detail modal is open;
+  // `null` keeps the modal closed. Tracking the index (not the row) lets
+  // ←/→ navigation in the modal stay synced with the live filter+sort.
+  const [detailIndex, setDetailIndex] = useState<number | null>(null)
 
   function cycleSort(column: SortColumn) {
     if (sortColumn !== column) {
@@ -256,12 +261,13 @@ export function ResultsTable({ onRerunLine }: Props) {
             )}
           </thead>
           <tbody>
-            {displayedRows.map((row) => (
+            {displayedRows.map((row, displayedIdx) => (
               <ResultRow
                 key={rowKeys.get(row) ?? -1}
                 row={row}
                 showImage={!settings.noImages}
                 onRerunLine={onRerunLine}
+                onOpenDetail={() => setDetailIndex(displayedIdx)}
               />
             ))}
             {isRunning && (
@@ -283,6 +289,12 @@ export function ResultsTable({ onRerunLine }: Props) {
           <span className="text-zinc-400"> (of {rows.length})</span>
         )}
       </p>
+
+      <CardDetailModal
+        rows={displayedRows}
+        index={detailIndex}
+        onChangeIndex={setDetailIndex}
+      />
     </div>
   )
 }
@@ -382,10 +394,12 @@ function ResultRow({
   row,
   showImage,
   onRerunLine,
+  onOpenDetail,
 }: {
   row: Row
   showImage: boolean
   onRerunLine?: (line: string) => void
+  onOpenDetail?: () => void
 }) {
   const card = row.card
   const p = row.pricing
@@ -414,12 +428,45 @@ function ResultRow({
     }
   }
 
+  // Only matched rows open the detail modal. Unmatched rows have nothing
+  // to show (no card data, no image) and already carry their own inline
+  // affordance (the "+ Add PriceCharting URL" button).
+  const canOpenDetail = row.matched && !!onOpenDetail
+  function handleRowClick(e: React.MouseEvent<HTMLTableRowElement>) {
+    if (!canOpenDetail) return
+    // Skip clicks on inner interactive elements — links, buttons, inputs,
+    // and the override-form panel below the row. Without this, clicking
+    // the "open listing" external-link icon would *also* open the modal.
+    const target = e.target as HTMLElement
+    if (target.closest('a, button, input, [role="button"]')) return
+    onOpenDetail!()
+  }
+  function handleRowKey(e: React.KeyboardEvent<HTMLTableRowElement>) {
+    if (!canOpenDetail) return
+    if (e.key === 'Enter' || e.key === ' ') {
+      // Ignore activations that originated inside an inner control —
+      // pressing Enter on the "open listing" anchor should follow the link.
+      const target = e.target as HTMLElement
+      if (target.closest('a, button, input')) return
+      e.preventDefault()
+      onOpenDetail!()
+    }
+  }
+
   return (
     <>
       <tr
         className={`border-b border-zinc-800 hover:bg-zinc-800/50 transition-colors motion-safe:animate-[fadeInRow_220ms_ease-out] ${
           !row.matched ? 'opacity-60' : ''
-        } ${isOverCap ? 'bg-amber-950/30' : ''}`}
+        } ${isOverCap ? 'bg-amber-950/30' : ''} ${canOpenDetail ? 'cursor-pointer' : ''}`}
+        onClick={canOpenDetail ? handleRowClick : undefined}
+        onKeyDown={canOpenDetail ? handleRowKey : undefined}
+        tabIndex={canOpenDetail ? 0 : undefined}
+        aria-label={
+          canOpenDetail
+            ? `View details for ${(card?.name as string) ?? row.query.name}`
+            : undefined
+        }
       >
         {/* Thumbnail */}
         {showImage && (

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared money / comp formatters.
+ *
+ * Both `ResultsTable` and `CardDetailModal` render market price and the
+ * 80/85/90/95 % comp tiers; this module is the single source of truth so
+ * the two surfaces never drift on currency symbols, rounding, or the
+ * em-dash sentinel for missing prices.
+ */
+
+/** Format a monetary amount with the source's currency symbol. */
+export function formatMoney(amount: number | null, currency = 'USD'): string {
+  if (amount == null) return '—'
+  const sym = currency === 'EUR' ? '€' : '$'
+  return `${sym}${amount.toFixed(2)}`
+}
+
+/** Format a percentage-of-market comp tier (e.g. 80, 85, 90, 95). */
+export function formatComp(
+  market: number | null,
+  pct: number,
+  currency = 'USD',
+): string {
+  if (market == null) return '—'
+  return formatMoney((market * pct) / 100, currency)
+}


### PR DESCRIPTION
Closes #257

## What

A new **CardDetailModal** opens when any matched row in the results table is clicked. It renders:

- **Large card art** (`images.large`) with graceful fallback to `images.small`, then to a "No image available" placeholder.
- **Two-column identity + pricing block**: name, set, series, number, rarity, variant on the left; market price with all four comp tiers (95/90/85/80%) on the right.
- **"Card data" section** that surfaces whatever optional fields the source returned — supertype + subtypes, HP, energy types, evolves-from, attacks (name, cost, damage, text), weaknesses, resistances, retreat cost, regulation mark, artist, national dex numbers, flavor text. Every field is conditionally rendered so a sparse card from one source doesn't leave layout holes.
- **"View on <source>" link** out to the best-available canonical URL — `pricing.url` first (real TCGPlayer / Cardmarket / PriceCharting listing), then `card.tcgplayer.url` / `card.cardmarket.url`, falling back to `https://pokemontcg.io/cards/<id>`.

### Keyboard

- `←/→` step through the *currently displayed* row set (filter + sort applied) so the modal stays consistent with what the table shows.
- `Esc` closes (handled by Radix Dialog).
- Tab / focus-trap / aria wiring inherited from Radix.

### Row interaction

- Only matched rows are clickable (`cursor:pointer` + `aria-label` + `tabindex`).
- Clicks on inner interactive elements (the existing external-link icon, the override-URL form button/input) **do not** open the modal — handled via `closest('a, button, input')` on the event target.
- Activatable via Enter/Space when the row is keyboard-focused.
- Unmatched rows have no `aria-label` and aren't clickable (there's nothing to show — no card data, no image).

## Why

The results table is dense by design — thumbnail, name, set, rarity, comps, source — but the rest of the card data (subtypes, attacks, regulation, artist, dex) was unreachable from the SPA. At a show this matters: a collector asks about an attack or regulation legality and you want to confirm without leaving the page.

## How to verify

```bash
cd web && npm run dev   # localhost:5173
```

- Run any bulk lookup (e.g. `top 5 Charizard cards`).
- Click any matched row — modal opens with the large image, identity grid, pricing block, and card-data section.
- Press `←/→` to step through the result set; `Esc` to close.
- Apply a filter (e.g. by name); `←/→` only navigates the filtered set.
- Hover the external-link icon on a row and click it directly — modal does **not** open; the listing opens in a new tab.
- For an unmatched row, the row isn't clickable; the existing "+ Add PriceCharting URL" affordance still works.

## Tests

- **`CardDetailModal.test.tsx`** (11): closed when `index=null`; full render (header, identity, pricing, comps, large image); image fallback to small; "No image available" placeholder; optional metadata block (attacks, HP, weaknesses, artist, regulation); sparse-card placeholder ("no additional card data"); ←/→ navigation; bounds-check at start/end; close-button flow; source link to `pricing.url`; fallback to `pokemontcg.io/cards/<id>` when no listing URL.
- **`ResultsTable.test.tsx`** (+3): row click opens the modal; inner external-link click does NOT open the modal; unmatched rows have no aria-label and aren't clickable.

86 web tests, all green. `make check` ✓.

## Out of scope

- Editing card data or pricing inline (modal is read-only).
- A separate `/card/:id` route — this stays a modal over the results page.