### PR TITLE
feat(web): expose lookup timer in the UI + publish benchmarks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -29,5 +29,16 @@ Paste the relevant CLI output, traceback, or screenshot (for the web UI).
  - OS: [e.g. macOS 14, Ubuntu 22.04]
  - Install method: [pip / uv / Docker / from source]
 
+**Performance (if relevant)**
+Optional — fill in if the report is about something being slow. Turn on
+**Show lookup timer** in the SPA settings drawer to capture these
+numbers; ranges to compare against live in
+[docs/benchmarks.md](../../docs/benchmarks.md).
+
+ - Lookup timer (from settings drawer): [e.g. 12.4s · 25 cards · 496 ms/card]
+ - Workload: [e.g. `top:25 Charizard cards`]
+ - Cache state: [warm / cold / unknown]
+ - Compared against benchmarks in docs/benchmarks.md: [within range / N× slower]
+
 **Additional context**
 Add any other context about the problem here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Web: **Lookup timer** — a new **Show lookup timer** toggle in the
+  settings drawer (off by default) surfaces wall-clock elapsed time
+  during a bulk run: a live ticking clock under the **Look up** button
+  while a run is in flight, a final
+  `total · count · ms/card` summary after it finishes, and a
+  per-input-line elapsed-ms badge in the processing queue. Timing is
+  measured frontend-side from the first SSE event to the done event so
+  the number reflects user-felt latency (network + SSE overhead
+  included). New [docs/benchmarks.md](docs/benchmarks.md) lists
+  expected ranges for the workloads users hit most often, and the bug
+  report template carries an optional **Performance** section linking
+  back to it.
 - Web: **Card detail modal** — tapping any matched row in the results table
   opens a modal with the large card art, a two-column identity + pricing
   block (market + 80/85/90/95% comps), and a "card data" section that

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -18,11 +18,18 @@ bug template](../.github/ISSUE_TEMPLATE/bug.md).
 
 The ranges below were captured on a typical dev machine:
 
-- **CPU:** Apple Silicon (M-series)
+- **CPU:** Apple Silicon (M-series, recent generation)
 - **RAM:** 24 GB
-- **OS:** macOS 26
+- **OS:** macOS (current major release)
 - **Network:** Wired or strong Wi-Fi; no VPN
 - **Cache state:** Noted per row (warm / cold)
+
+These are intentionally generic — the ranges below were captured on
+the maintainer's daily-driver laptop, and the point is the *shape* of
+the numbers (orders of magnitude, warm vs. cold spread), not the
+exact figures. If your machine is meaningfully slower or your network
+adds noticeable latency, expect the absolute values to shift; the
+relative differences across rows should still hold.
 
 "Warm" means the API response cache (`~/.cache/mgz-pkmn`) already
 holds the response for the query; the only work is reading from disk

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,57 @@
+# Benchmarks
+
+A reference set of expected lookup latencies for the workloads users
+hit most often. The point isn't absolute fidelity — networks vary,
+caches warm at different rates, upstream APIs occasionally throttle —
+it's giving a reviewer (human or AI) a *"this is what normal looks
+like"* anchor to judge whether a change has measurably slowed the
+pipeline down.
+
+Pair this with the **Show lookup timer** toggle in the
+[Settings drawer](../web/src/components/SettingsDrawer.tsx): turn it
+on, run one of the workloads below, and compare the on-screen total
+against the expected range. If the number lands well outside the
+range, that's worth reporting — see the [Performance section in the
+bug template](../.github/ISSUE_TEMPLATE/bug.md).
+
+## Reference machine
+
+The ranges below were captured on a typical dev machine:
+
+- **CPU:** Apple Silicon (M-series)
+- **RAM:** 24 GB
+- **OS:** macOS 26
+- **Network:** Wired or strong Wi-Fi; no VPN
+- **Cache state:** Noted per row (warm / cold)
+
+"Warm" means the API response cache (`~/.cache/mgz-pkmn`) already
+holds the response for the query; the only work is reading from disk
+and rendering. "Cold" means the cache was just pruned
+(`pkmn cache prune`) so every request hits the upstream API.
+
+## Reference workloads
+
+| Workload | Input | CLI | SPA click path | Expected range | Notes |
+|---|---|---|---|---|---|
+| 1 explicit card (warm) | `Charizard \| Base Set \| 4/102` | `pkmn lookup -q 'Charizard \| Base Set \| 4/102'` | Paste into the input box · **Look up** | 50–150 ms | Cache-hit path |
+| 1 explicit card (cold) | `Charizard \| Base Set \| 4/102` | `pkmn cache prune && pkmn lookup -q 'Charizard \| Base Set \| 4/102'` | Same as above after `pkmn cache prune` | 0.8–1.5 s | First call after cache prune |
+| 10-line mixed list (warm) | The empty-state example chips, one per line | `pkmn lookup -i examples.txt` | Click each example chip on the empty state | 0.5–1.0 s | Mix of explicit, bulk, and variant queries |
+| `top:25 Charizard cards` (warm) | `top:25 Charizard cards` | `pkmn lookup -q 'top:25 Charizard cards'` | Paste · **Look up** | 1.5–3.0 s | Bulk path; 25-card expansion |
+| `All Charizard cards \| Base Set` (warm) | `All Charizard cards \| Base Set` | `pkmn lookup -q 'All Charizard cards \| Base Set'` | Paste · **Look up** | 0.8–1.6 s | Bulk path, narrow set filter |
+| Set ID cards PDF (warm) | n/a | `pkmn set-cards --set base1,jungle,fossil` | **Set ID cards…** · pick a few sets · **Download PDF** | 2–4 s | Every-set walk; PDF render dominates |
+
+The SPA path's timing is measured wall-clock from "first SSE event
+received" to "done event received" so it reflects user-felt latency
+(network + SSE overhead included), not backend wall-clock alone.
+
+## When to investigate
+
+A single run landing 1.5–2× over the expected range is usually
+noise — try a second run, especially if the cache was unexpectedly
+cold. Consistent slowdowns of **2× or more across multiple runs and
+multiple workloads** are the signal worth filing.
+
+For backend-side per-stage timings — which call took how long inside
+a single lookup — see the per-line stage events tracked under
+[#260](https://github.com/mgzwarrior/mgz-pkmn/issues/260). The total
+here is the user-felt number; the stages there are the breakdown.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -267,6 +267,15 @@ uv run python -m unittest discover -s tests   # run tests
 Ruff config lives in [pyproject.toml](../pyproject.toml) under
 `[tool.ruff]`.
 
+### Performance reference
+
+[`docs/benchmarks.md`](benchmarks.md) lists expected lookup latencies
+for the workloads users hit most often. If you're changing
+`lookup.py`, `pricing.py`, `images.py`, or the SSE wiring, run one of
+the reference workloads with the **Show lookup timer** setting on and
+compare the on-screen total against the documented range — it's the
+cheapest regression check available.
+
 ## Pre-commit hooks
 
 `make install-hooks` (or the full `make install`) does this for you:

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -28,10 +28,14 @@ vi.mock('./api/client', () => ({
   lookupLine: mockLookupLine,
   parseLine: mockParseLine,
   // Other client functions are referenced by ExportBar / SetPickerModal
-  // mounted inside App; stub them to keep render happy.
+  // mounted inside App; stub them to keep render happy. Names must
+  // match the real `client.ts` exports — `fetchSets`, not
+  // `fetchSetCatalog`.
   exportFile: vi.fn(),
   downloadSetCardsPdf: vi.fn(),
-  fetchSetCatalog: vi.fn(() => Promise.resolve([])),
+  fetchSets: vi.fn(() => Promise.resolve([])),
+  setLogoUrl: vi.fn(() => ''),
+  dedupeRows: vi.fn((rows: unknown[]) => rows),
   addOverride: vi.fn(),
 }))
 
@@ -149,18 +153,28 @@ describe('App: bulk-run timestamp lifecycle', () => {
     expect(useAppStore.getState().runStartedAt).toBe(2_000)
   })
 
-  it('Stop sets runEndedAt and clears isRunning', async () => {
+  it('Stop aborts the stream; bulkLookup\'s onDone(aborted) is what stamps runEndedAt', async () => {
     useAppStore.setState({ inputText: 'Charizard' })
+    // Simulate real client.ts: surface the first event so runStartedAt
+    // is set, then wait for the abort signal and call onDone(true) —
+    // which is the contract App.tsx now relies on as the single
+    // source of truth for end-of-run stamping.
     mockBulkLookup.mockImplementation(
       (
         _lines: string[],
         _settings: unknown,
         onEvent: (e: BulkEvent) => void,
+        onDone: (aborted: boolean) => void,
+        signal: AbortSignal,
       ) => {
-        // Surface the first event so runStartedAt is set, then idle.
         setNow(1_000)
         onEvent(makeEvent(0, 5))
-        return new Promise<void>(() => {})
+        return new Promise<void>((resolve) => {
+          signal.addEventListener('abort', () => {
+            onDone(true)
+            resolve()
+          })
+        })
       },
     )
 
@@ -172,11 +186,16 @@ describe('App: bulk-run timestamp lifecycle', () => {
 
     setNow(4_200)
     fireEvent.click(screen.getByRole('button', { name: /stop/i }))
-    expect(useAppStore.getState().isRunning).toBe(false)
+    await waitFor(() => {
+      expect(useAppStore.getState().isRunning).toBe(false)
+    })
     expect(useAppStore.getState().runEndedAt).toBe(4_200)
   })
 
-  it('bulkLookup throwing still stamps runEndedAt and clears isRunning', async () => {
+  it('a bulkLookup network rejection without onDone still stamps runEndedAt via the App-level catch', async () => {
+    // Mirrors the real path where `fetch` itself rejects before
+    // bulkLookup gets a chance to call onDone — the only case the
+    // outer `catch` in handleRun is still needed for.
     useAppStore.setState({ inputText: 'Charizard' })
     mockBulkLookup.mockImplementation(() => {
       setNow(9_000)
@@ -190,5 +209,34 @@ describe('App: bulk-run timestamp lifecycle', () => {
       expect(useAppStore.getState().isRunning).toBe(false)
     })
     expect(useAppStore.getState().runEndedAt).toBe(9_000)
+  })
+
+  it('does not double-stamp runEndedAt when both onDone and the catch would fire', async () => {
+    // Defensive case: if bulkLookup were to both call onDone AND
+    // throw (as the real `if (!aborted) throw err` branch does), the
+    // outer catch must not overwrite the timestamp onDone stamped.
+    useAppStore.setState({ inputText: 'Charizard' })
+    mockBulkLookup.mockImplementation(
+      (
+        _lines: string[],
+        _settings: unknown,
+        _onEvent: (e: BulkEvent) => void,
+        onDone: (aborted: boolean) => void,
+      ) => {
+        setNow(5_000)
+        onDone(false)
+        setNow(5_010)
+        return Promise.reject(new Error('post-onDone throw'))
+      },
+    )
+
+    render(<App />)
+    fireEvent.click(screen.getByRole('button', { name: /look up/i }))
+
+    await waitFor(() => {
+      expect(useAppStore.getState().isRunning).toBe(false)
+    })
+    // The first stamp (5_000) wins; the catch must NOT overwrite to 5_010.
+    expect(useAppStore.getState().runEndedAt).toBe(5_000)
   })
 })

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * App.test — exercises the bulk-lookup lifecycle in App.tsx, focused on
+ * the run-timestamp wiring added for the lookup-timer feature (#263).
+ *
+ * Strategy: mock `bulkLookup` so we can drive `onEvent` + `onDone` from
+ * the test, render the real `<App />` against the real Zustand store,
+ * and assert that `runStartedAt` / `runEndedAt` transition as expected
+ * through start, first-event, completion, stop, and error paths.
+ *
+ * Heavier interactions (the textarea wiring, the chips, the modal
+ * surfaces) are covered by their own component tests — here we touch
+ * just enough of the UI to set inputText + click Look up / Stop.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, fireEvent, act, screen, waitFor } from '@testing-library/react'
+import App from './App'
+import { useAppStore } from './store'
+import type { BulkEvent } from './types'
+
+const { mockBulkLookup, mockLookupLine, mockParseLine } = vi.hoisted(() => ({
+  mockBulkLookup: vi.fn(),
+  mockLookupLine: vi.fn(),
+  mockParseLine: vi.fn(),
+}))
+
+vi.mock('./api/client', () => ({
+  bulkLookup: mockBulkLookup,
+  lookupLine: mockLookupLine,
+  parseLine: mockParseLine,
+  // Other client functions are referenced by ExportBar / SetPickerModal
+  // mounted inside App; stub them to keep render happy.
+  exportFile: vi.fn(),
+  downloadSetCardsPdf: vi.fn(),
+  fetchSetCatalog: vi.fn(() => Promise.resolve([])),
+  addOverride: vi.fn(),
+}))
+
+function makeEvent(index: number, total: number, matched = true): BulkEvent {
+  return {
+    index,
+    total,
+    matched,
+    reason: matched ? '' : 'no match',
+    tag: '',
+    query: {
+      raw: `q${index}`,
+      name: `q${index}`,
+      set_hint: null,
+      number: null,
+      variant_hint: null,
+      url_hint: null,
+      bulk_top: null,
+      bulk_all: false,
+      price_min: null,
+      price_max: null,
+    },
+    card: matched ? { id: `c${index}`, name: `q${index}` } : null,
+    pricing: { market: null, variant: null, source: null, url: null, currency: 'USD' },
+  }
+}
+
+function resetStore() {
+  useAppStore.setState({
+    inputText: '',
+    rows: [],
+    processingLines: [],
+    progress: null,
+    isRunning: false,
+    runStartedAt: null,
+    runEndedAt: null,
+  })
+  useAppStore.getState().resetSettings()
+}
+
+describe('App: bulk-run timestamp lifecycle', () => {
+  let nowSpy: ReturnType<typeof vi.spyOn>
+  let currentTime = 0
+  const setNow = (t: number) => {
+    currentTime = t
+  }
+
+  beforeEach(() => {
+    resetStore()
+    mockBulkLookup.mockReset()
+    mockLookupLine.mockReset()
+    mockParseLine.mockReset()
+    currentTime = 0
+    nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => currentTime)
+  })
+
+  afterEach(() => {
+    nowSpy.mockRestore()
+  })
+
+  it('resets timestamps on click, sets runStartedAt on first event, sets runEndedAt on done', async () => {
+    // Pre-populate stale timestamps from a prior run; handleRun should
+    // clear them before the first event lands so the running clock
+    // doesn't briefly show a value from the previous run.
+    useAppStore.setState({
+      inputText: 'Charizard',
+      runStartedAt: 111,
+      runEndedAt: 222,
+    })
+
+    let captured: { onEvent: (e: BulkEvent) => void; onDone: () => void } | null = null
+    mockBulkLookup.mockImplementation(
+      (
+        _lines: string[],
+        _settings: unknown,
+        onEvent: (e: BulkEvent) => void,
+        onDone: () => void,
+      ) => {
+        captured = { onEvent, onDone }
+        return new Promise<void>(() => {
+          /* never resolves on its own — test drives onDone */
+        })
+      },
+    )
+
+    render(<App />)
+    setNow(1_000)
+    fireEvent.click(screen.getByRole('button', { name: /look up/i }))
+
+    // Immediately after click: timestamps reset to null, run flagged.
+    await waitFor(() => {
+      expect(useAppStore.getState().isRunning).toBe(true)
+    })
+    expect(useAppStore.getState().runStartedAt).toBeNull()
+    expect(useAppStore.getState().runEndedAt).toBeNull()
+    expect(captured).not.toBeNull()
+
+    // First event arrives at t=2000.
+    setNow(2_000)
+    act(() => captured!.onEvent(makeEvent(0, 1)))
+    expect(useAppStore.getState().runStartedAt).toBe(2_000)
+    expect(useAppStore.getState().runEndedAt).toBeNull()
+
+    // A second event must NOT re-bump runStartedAt — the first SSE
+    // event is the anchor for the whole run.
+    setNow(2_500)
+    act(() => captured!.onEvent(makeEvent(1, 2)))
+    expect(useAppStore.getState().runStartedAt).toBe(2_000)
+
+    // Done event at t=3500 — run flips off and runEndedAt is stamped.
+    setNow(3_500)
+    act(() => captured!.onDone())
+    expect(useAppStore.getState().isRunning).toBe(false)
+    expect(useAppStore.getState().runEndedAt).toBe(3_500)
+    expect(useAppStore.getState().runStartedAt).toBe(2_000)
+  })
+
+  it('Stop sets runEndedAt and clears isRunning', async () => {
+    useAppStore.setState({ inputText: 'Charizard' })
+    mockBulkLookup.mockImplementation(
+      (
+        _lines: string[],
+        _settings: unknown,
+        onEvent: (e: BulkEvent) => void,
+      ) => {
+        // Surface the first event so runStartedAt is set, then idle.
+        setNow(1_000)
+        onEvent(makeEvent(0, 5))
+        return new Promise<void>(() => {})
+      },
+    )
+
+    render(<App />)
+    fireEvent.click(screen.getByRole('button', { name: /look up/i }))
+    await waitFor(() => {
+      expect(useAppStore.getState().runStartedAt).toBe(1_000)
+    })
+
+    setNow(4_200)
+    fireEvent.click(screen.getByRole('button', { name: /stop/i }))
+    expect(useAppStore.getState().isRunning).toBe(false)
+    expect(useAppStore.getState().runEndedAt).toBe(4_200)
+  })
+
+  it('bulkLookup throwing still stamps runEndedAt and clears isRunning', async () => {
+    useAppStore.setState({ inputText: 'Charizard' })
+    mockBulkLookup.mockImplementation(() => {
+      setNow(9_000)
+      return Promise.reject(new Error('network'))
+    })
+
+    render(<App />)
+    fireEvent.click(screen.getByRole('button', { name: /look up/i }))
+
+    await waitFor(() => {
+      expect(useAppStore.getState().isRunning).toBe(false)
+    })
+    expect(useAppStore.getState().runEndedAt).toBe(9_000)
+  })
+})

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -110,16 +110,23 @@ function App() {
       setProgress({ done: event.index + 1, total: event.total })
     }
 
-    function onDone() {
+    // `bulkLookup` calls `onDone` on every normal exit path (non-OK
+    // response, stream completion, abort). The only way it can throw
+    // without calling `onDone` is if the initial `fetch` itself
+    // rejects — a true network error. Guard both endpoints against
+    // double-stamping by only stamping if the run hasn't already
+    // ended; that way Stop, completion, and network-error paths each
+    // land exactly one `runEndedAt` write.
+    function stampEndIfMissing() {
+      if (useAppStore.getState().runEndedAt != null) return
       setIsRunning(false)
       setRunEndedAt(Date.now())
     }
 
     try {
-      await bulkLookup(nonEmpty, settings, onEvent, onDone, abortRef.current.signal)
+      await bulkLookup(nonEmpty, settings, onEvent, stampEndIfMissing, abortRef.current.signal)
     } catch {
-      setIsRunning(false)
-      setRunEndedAt(Date.now())
+      stampEndIfMissing()
     }
   }, [
     inputText,
@@ -136,10 +143,12 @@ function App() {
   ])
 
   const handleStop = useCallback(() => {
+    // Just abort the stream. `bulkLookup`'s abort path will fire
+    // `onDone(aborted=true)` which the handleRun-side guard stamps
+    // exactly once. No need to stamp here ourselves — doing so used
+    // to overwrite the actual stream-end timestamp.
     abortRef.current?.abort()
-    setIsRunning(false)
-    setRunEndedAt(Date.now())
-  }, [setIsRunning, setRunEndedAt])
+  }, [])
 
   // Re-run a single line (called after adding a PriceCharting URL override).
   const handleRerunLine = useCallback(

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -35,6 +35,8 @@ function App() {
     setProgress,
     setProcessingLines,
     markLineStatus,
+    setRunStartedAt,
+    setRunEndedAt,
   } = useAppStore()
 
   const abortRef = useRef<AbortController | null>(null)
@@ -66,14 +68,23 @@ function App() {
     setProcessingLines(nonEmpty.map((line) => ({ line, status: 'pending' })))
     setIsRunning(true)
     setProgress({ done: 0, total: nonEmpty.length })
+    // Reset run timestamps. `runStartedAt` is set when the first SSE
+    // event arrives so the elapsed value reflects user-felt latency.
+    setRunStartedAt(null)
+    setRunEndedAt(null)
 
     abortRef.current = new AbortController()
 
     // Track unique card IDs for client-side deduplication.
     const seenIds = new Set<string>()
+    let firstEventSeen = false
 
     function onEvent(event: BulkEvent) {
       if (event.done) return
+      if (!firstEventSeen) {
+        firstEventSeen = true
+        setRunStartedAt(Date.now())
+      }
 
       // First event for this input line transitions it out of "pending".
       // Subsequent events (top:N expansions) leave the status alone.
@@ -101,12 +112,14 @@ function App() {
 
     function onDone() {
       setIsRunning(false)
+      setRunEndedAt(Date.now())
     }
 
     try {
       await bulkLookup(nonEmpty, settings, onEvent, onDone, abortRef.current.signal)
     } catch {
       setIsRunning(false)
+      setRunEndedAt(Date.now())
     }
   }, [
     inputText,
@@ -118,12 +131,15 @@ function App() {
     setProgress,
     setProcessingLines,
     markLineStatus,
+    setRunStartedAt,
+    setRunEndedAt,
   ])
 
   const handleStop = useCallback(() => {
     abortRef.current?.abort()
     setIsRunning(false)
-  }, [setIsRunning])
+    setRunEndedAt(Date.now())
+  }, [setIsRunning, setRunEndedAt])
 
   // Re-run a single line (called after adding a PriceCharting URL override).
   const handleRerunLine = useCallback(

--- a/web/src/components/ExportBar.test.tsx
+++ b/web/src/components/ExportBar.test.tsx
@@ -70,6 +70,7 @@ describe('ExportBar', () => {
         tag: '',
         dedupe: false,
         sort: 'number',
+        showTimer: false,
       },
     })
     mockExportFile.mockReset()
@@ -141,6 +142,7 @@ describe('ExportBar', () => {
         tag: 'binder',
         dedupe: true,
         sort: 'alpha',
+        showTimer: false,
       },
     })
 

--- a/web/src/components/InputEditor.test.tsx
+++ b/web/src/components/InputEditor.test.tsx
@@ -21,6 +21,19 @@ vi.mock('../store', () => ({
     setInputText: mockSetInputText,
     isRunning: storeState.isRunning,
     clearRows: mockClearRows,
+    // LookupTimer (rendered under the toolbar) reads these fields.
+    settings: {
+      apiKey: '',
+      maxPrice: null,
+      noImages: true,
+      tag: '',
+      dedupe: false,
+      sort: 'number',
+      showTimer: false,
+    },
+    runStartedAt: null,
+    runEndedAt: null,
+    rows: [],
   }),
 }))
 

--- a/web/src/components/InputEditor.tsx
+++ b/web/src/components/InputEditor.tsx
@@ -12,6 +12,7 @@ import { Play, Square, RotateCcw } from 'lucide-react'
 import { parseLine } from '../api/client'
 import { useAppStore } from '../store'
 import type { CardQuery } from '../types'
+import { LookupTimer } from './LookupTimer'
 
 interface Props {
   onRun: (overrideText?: string) => void
@@ -136,6 +137,12 @@ export function InputEditor({ onRun, onStop }: Props) {
             </button>
           )}
         </div>
+      </div>
+
+      {/* Optional lookup-timer readout (settings-gated). Sits under the
+          toolbar so it's adjacent to the Look up / Stop button. */}
+      <div className="flex justify-end">
+        <LookupTimer />
       </div>
 
       {/* Textarea */}

--- a/web/src/components/LookupTimer.test.tsx
+++ b/web/src/components/LookupTimer.test.tsx
@@ -54,6 +54,15 @@ describe('formatElapsed', () => {
     expect(formatElapsed(125_000)).toBe('2m05s')
   })
 
+  it('rolls over to 1m00s when toFixed(2) would round up to 60.00', () => {
+    // 59_999 ms is 59.999s, which `toFixed(2)` renders as "60.00"
+    // (V8 floating-point rounding). Render that as `1m00s` rather
+    // than the surprising boundary value `60.00s`.
+    expect(formatElapsed(59_999)).toBe('1m00s')
+    // Just under the rounding boundary still uses the seconds branch.
+    expect(formatElapsed(59_990)).toBe('59.99s')
+  })
+
   it('clamps negatives to 0ms', () => {
     expect(formatElapsed(-5)).toBe('0ms')
   })

--- a/web/src/components/LookupTimer.test.tsx
+++ b/web/src/components/LookupTimer.test.tsx
@@ -156,6 +156,21 @@ describe('LookupTimer', () => {
     expect(screen.getByText('12.40s · 5 cards · 2480 ms/card')).toBeInTheDocument()
   })
 
+  it('clears the tick interval on unmount', () => {
+    const start = 2_000_000
+    vi.setSystemTime(start)
+    useAppStore.setState({
+      settings: { ...DEFAULT_SETTINGS, showTimer: true },
+      isRunning: true,
+      runStartedAt: start,
+    })
+    const clearSpy = vi.spyOn(globalThis, 'clearInterval')
+    const { unmount } = render(<LookupTimer />)
+    unmount()
+    expect(clearSpy).toHaveBeenCalled()
+    clearSpy.mockRestore()
+  })
+
   it('renders just the elapsed value (no avg) when 0 rows resolved', () => {
     useAppStore.setState({
       settings: { ...DEFAULT_SETTINGS, showTimer: true },

--- a/web/src/components/LookupTimer.test.tsx
+++ b/web/src/components/LookupTimer.test.tsx
@@ -95,6 +95,19 @@ describe('LookupTimer', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
+  it('renders nothing in the brief window after click before the first SSE event', () => {
+    // Between handleRun() and the first event arriving, isRunning is true
+    // but runStartedAt is still null. The useEffect interval must NOT
+    // start in that window — there is nothing to elapse against yet.
+    useAppStore.setState({
+      settings: { ...DEFAULT_SETTINGS, showTimer: true },
+      isRunning: true,
+      runStartedAt: null,
+    })
+    const { container } = render(<LookupTimer />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
   it('shows a live elapsed value while running, advancing as time passes', () => {
     const start = 1_000_000
     vi.setSystemTime(start)

--- a/web/src/components/LookupTimer.test.tsx
+++ b/web/src/components/LookupTimer.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import { LookupTimer } from './LookupTimer'
+import { formatElapsed } from '../utils/format'
+import { useAppStore } from '../store'
+import type { Row } from '../types'
+
+const DEFAULT_SETTINGS = {
+  apiKey: '',
+  maxPrice: null,
+  noImages: true,
+  tag: '',
+  dedupe: false,
+  sort: 'number' as const,
+  showTimer: false,
+}
+
+function row(name: string): Row {
+  return {
+    query: {
+      raw: name,
+      name,
+      set_hint: null,
+      number: null,
+      variant_hint: null,
+      url_hint: null,
+      bulk_top: null,
+      bulk_all: false,
+      price_min: null,
+      price_max: null,
+    },
+    card: null,
+    pricing: { market: null, variant: null, source: null, url: null, currency: 'USD' },
+    tag: '',
+    matched: true,
+    reason: '',
+  }
+}
+
+describe('formatElapsed', () => {
+  it('formats sub-second values in ms', () => {
+    expect(formatElapsed(0)).toBe('0ms')
+    expect(formatElapsed(150)).toBe('150ms')
+    expect(formatElapsed(999)).toBe('999ms')
+  })
+
+  it('formats sub-minute values in seconds with 2 decimals', () => {
+    expect(formatElapsed(1000)).toBe('1.00s')
+    expect(formatElapsed(12_400)).toBe('12.40s')
+  })
+
+  it('formats >= 1 minute as MmSSs', () => {
+    expect(formatElapsed(60_000)).toBe('1m00s')
+    expect(formatElapsed(125_000)).toBe('2m05s')
+  })
+
+  it('clamps negatives to 0ms', () => {
+    expect(formatElapsed(-5)).toBe('0ms')
+  })
+})
+
+describe('LookupTimer', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      settings: { ...DEFAULT_SETTINGS },
+      isRunning: false,
+      runStartedAt: null,
+      runEndedAt: null,
+      rows: [],
+    })
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders nothing when showTimer is off', () => {
+    useAppStore.setState({
+      settings: { ...DEFAULT_SETTINGS, showTimer: false },
+      isRunning: true,
+      runStartedAt: Date.now(),
+    })
+    const { container } = render(<LookupTimer />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing when no run has started', () => {
+    useAppStore.setState({
+      settings: { ...DEFAULT_SETTINGS, showTimer: true },
+      isRunning: false,
+      runStartedAt: null,
+    })
+    const { container } = render(<LookupTimer />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows a live elapsed value while running, advancing as time passes', () => {
+    const start = 1_000_000
+    vi.setSystemTime(start)
+    useAppStore.setState({
+      settings: { ...DEFAULT_SETTINGS, showTimer: true },
+      isRunning: true,
+      runStartedAt: start,
+    })
+    render(<LookupTimer />)
+    expect(screen.getByRole('status')).toBeInTheDocument()
+    // advanceTimersByTime ticks the fake clock forward and fires
+    // intervals scheduled during that window. After 500ms total,
+    // the 100ms interval has fired enough times for the displayed
+    // value to reflect 500ms elapsed.
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+    expect(screen.getByText('500ms')).toBeInTheDocument()
+    act(() => {
+      vi.advanceTimersByTime(1900)
+    })
+    expect(screen.getByText('2.40s')).toBeInTheDocument()
+  })
+
+  it('renders the final summary with singular "card" at N=1', () => {
+    useAppStore.setState({
+      settings: { ...DEFAULT_SETTINGS, showTimer: true },
+      isRunning: false,
+      runStartedAt: 1000,
+      runEndedAt: 1500,
+      rows: [row('Charizard')],
+    })
+    render(<LookupTimer />)
+    expect(screen.getByText('500ms · 1 card · 500 ms/card')).toBeInTheDocument()
+  })
+
+  it('renders the final summary with plural "cards" at N>1', () => {
+    useAppStore.setState({
+      settings: { ...DEFAULT_SETTINGS, showTimer: true },
+      isRunning: false,
+      runStartedAt: 1000,
+      runEndedAt: 13_400,
+      rows: [row('A'), row('B'), row('C'), row('D'), row('E')],
+    })
+    render(<LookupTimer />)
+    expect(screen.getByText('12.40s · 5 cards · 2480 ms/card')).toBeInTheDocument()
+  })
+
+  it('renders just the elapsed value (no avg) when 0 rows resolved', () => {
+    useAppStore.setState({
+      settings: { ...DEFAULT_SETTINGS, showTimer: true },
+      isRunning: false,
+      runStartedAt: 1000,
+      runEndedAt: 1500,
+      rows: [],
+    })
+    render(<LookupTimer />)
+    expect(screen.getByText('500ms')).toBeInTheDocument()
+    expect(screen.queryByText(/ms\/card/)).not.toBeInTheDocument()
+  })
+})

--- a/web/src/components/LookupTimer.test.tsx
+++ b/web/src/components/LookupTimer.test.tsx
@@ -85,6 +85,21 @@ describe('LookupTimer', () => {
     expect(container).toBeEmptyDOMElement()
   })
 
+  it('does not schedule the tick interval when showTimer is off', () => {
+    // Perf guard: even though the component returns null when showTimer
+    // is off, an unconditional setInterval would still re-render on
+    // every tick during a run. Gate the effect on the setting too.
+    const setSpy = vi.spyOn(globalThis, 'setInterval')
+    useAppStore.setState({
+      settings: { ...DEFAULT_SETTINGS, showTimer: false },
+      isRunning: true,
+      runStartedAt: 1_000_000,
+    })
+    render(<LookupTimer />)
+    expect(setSpy).not.toHaveBeenCalled()
+    setSpy.mockRestore()
+  })
+
   it('renders nothing when no run has started', () => {
     useAppStore.setState({
       settings: { ...DEFAULT_SETTINGS, showTimer: true },

--- a/web/src/components/LookupTimer.tsx
+++ b/web/src/components/LookupTimer.tsx
@@ -1,0 +1,72 @@
+/**
+ * LookupTimer — wall-clock elapsed display for a bulk lookup run.
+ *
+ * While a run is in flight, ticks every 100ms from `runStartedAt`. After
+ * the run finishes, the final elapsed value stays visible with a
+ * `total · count · ms/card` breakdown so the user has a stable number
+ * to report. Gated by the `showTimer` setting; renders nothing when
+ * off, or when no run has started in this session.
+ *
+ * Timing is wall-clock from the first SSE event to the done event,
+ * measured frontend-side so it includes network + SSE overhead — i.e.
+ * the latency a real user feels.
+ */
+import { useEffect, useState } from 'react'
+import { Timer } from 'lucide-react'
+import { useAppStore } from '../store'
+import { formatElapsed } from '../utils/format'
+
+export function LookupTimer() {
+  const { settings, isRunning, runStartedAt, runEndedAt, rows } = useAppStore()
+  const [now, setNow] = useState(() => Date.now())
+
+  useEffect(() => {
+    if (!isRunning || runStartedAt == null) return
+    // 100ms cadence keeps the clock smooth without burning CPU.
+    const id = setInterval(() => setNow(Date.now()), 100)
+    return () => clearInterval(id)
+  }, [isRunning, runStartedAt])
+
+  if (!settings.showTimer) return null
+  if (runStartedAt == null) return null
+
+  const endTs = isRunning ? now : (runEndedAt ?? now)
+  const elapsedMs = Math.max(0, endTs - runStartedAt)
+
+  if (isRunning) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        aria-label="Lookup timer"
+        className="flex items-center gap-1.5 text-xs tabular-nums text-zinc-400"
+      >
+        <Timer size={12} className="text-blue-400" />
+        <span>{formatElapsed(elapsedMs)}</span>
+      </div>
+    )
+  }
+
+  // Final summary. Use the matched row count for the per-card average —
+  // a `top:N` line expands into many rows, so total/lines under-counts
+  // the actual work the user is waiting on.
+  const count = rows.length
+  if (count === 0) {
+    return (
+      <div className="flex items-center gap-1.5 text-xs tabular-nums text-zinc-400">
+        <Timer size={12} />
+        <span>{formatElapsed(elapsedMs)}</span>
+      </div>
+    )
+  }
+  const perCard = Math.round(elapsedMs / count)
+  const cardWord = count === 1 ? 'card' : 'cards'
+  return (
+    <div className="flex items-center gap-1.5 text-xs tabular-nums text-zinc-400">
+      <Timer size={12} />
+      <span>
+        {formatElapsed(elapsedMs)} · {count} {cardWord} · {perCard} ms/card
+      </span>
+    </div>
+  )
+}

--- a/web/src/components/LookupTimer.tsx
+++ b/web/src/components/LookupTimer.tsx
@@ -21,11 +21,14 @@ export function LookupTimer() {
   const [now, setNow] = useState(() => Date.now())
 
   useEffect(() => {
-    if (!isRunning || runStartedAt == null) return
+    // Gate the interval on `showTimer` so a run with the toggle off
+    // doesn't schedule a 10 Hz re-render against a component that
+    // would render `null` anyway.
+    if (!settings.showTimer || !isRunning || runStartedAt == null) return
     // 100ms cadence keeps the clock smooth without burning CPU.
     const id = setInterval(() => setNow(Date.now()), 100)
     return () => clearInterval(id)
-  }, [isRunning, runStartedAt])
+  }, [settings.showTimer, isRunning, runStartedAt])
 
   if (!settings.showTimer) return null
   if (runStartedAt == null) return null

--- a/web/src/components/ProcessingQueue.test.tsx
+++ b/web/src/components/ProcessingQueue.test.tsx
@@ -5,11 +5,21 @@ import { ProcessingQueue } from './ProcessingQueue'
 const { mockState } = vi.hoisted(() => ({
   mockState: {
     processingLines: [
-      { line: 'Charizard | Base Set | 4', status: 'resolved' as const },
-      { line: 'Pikachu | Jungle', status: 'error' as const },
+      { line: 'Charizard | Base Set | 4', status: 'resolved' as const, endedAt: 1500 },
+      { line: 'Pikachu | Jungle', status: 'error' as const, endedAt: 1800 },
       { line: 'top:5 Mew ex', status: 'pending' as const },
     ],
     isRunning: true,
+    runStartedAt: 1000,
+    settings: {
+      apiKey: '',
+      maxPrice: null,
+      noImages: true,
+      tag: '',
+      dedupe: false,
+      sort: 'number' as const,
+      showTimer: false,
+    },
   },
 }))
 
@@ -19,11 +29,27 @@ vi.mock('../store', () => ({
 
 describe('ProcessingQueue', () => {
   it('renders one entry per input line and a done/total count', () => {
+    mockState.settings.showTimer = false
     render(<ProcessingQueue />)
     expect(screen.getByText(/looking up cards/i)).toBeInTheDocument()
     expect(screen.getByText(/2 of 3 done/i)).toBeInTheDocument()
     expect(screen.getByText('Charizard | Base Set | 4')).toBeInTheDocument()
     expect(screen.getByText('Pikachu | Jungle')).toBeInTheDocument()
     expect(screen.getByText('top:5 Mew ex')).toBeInTheDocument()
+  })
+
+  it('omits per-line elapsed badges when showTimer is off', () => {
+    mockState.settings.showTimer = false
+    render(<ProcessingQueue />)
+    expect(screen.queryByText(/500ms/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/800ms/)).not.toBeInTheDocument()
+  })
+
+  it('shows per-line elapsed badges when showTimer is on', () => {
+    mockState.settings.showTimer = true
+    render(<ProcessingQueue />)
+    // 1500 - 1000 = 500ms, 1800 - 1000 = 800ms
+    expect(screen.getByText('500ms')).toBeInTheDocument()
+    expect(screen.getByText('800ms')).toBeInTheDocument()
   })
 })

--- a/web/src/components/ProcessingQueue.test.tsx
+++ b/web/src/components/ProcessingQueue.test.tsx
@@ -52,4 +52,15 @@ describe('ProcessingQueue', () => {
     expect(screen.getByText('500ms')).toBeInTheDocument()
     expect(screen.getByText('800ms')).toBeInTheDocument()
   })
+
+  it('per-line badge aria-label says "Finished" — works for both resolved and error lines', () => {
+    mockState.settings.showTimer = true
+    render(<ProcessingQueue />)
+    // Charizard resolved at 1500 → 500ms; Pikachu errored at 1800 → 800ms.
+    // Both must read as "Finished" so the label is accurate for error
+    // outcomes too (Copilot review feedback on #297).
+    expect(screen.getByLabelText('Finished in 500 milliseconds')).toBeInTheDocument()
+    expect(screen.getByLabelText('Finished in 800 milliseconds')).toBeInTheDocument()
+    expect(screen.queryByLabelText(/Resolved in/)).not.toBeInTheDocument()
+  })
 })

--- a/web/src/components/ProcessingQueue.tsx
+++ b/web/src/components/ProcessingQueue.tsx
@@ -78,7 +78,7 @@ function LineStatus({
       {elapsedMs != null && (
         <span
           className="ml-auto flex-shrink-0 rounded bg-zinc-800 px-1 py-0.5 font-mono text-[10px] tabular-nums text-zinc-400"
-          aria-label={`Resolved in ${elapsedMs} milliseconds`}
+          aria-label={`Finished in ${elapsedMs} milliseconds`}
         >
           {elapsedMs}ms
         </span>

--- a/web/src/components/ProcessingQueue.tsx
+++ b/web/src/components/ProcessingQueue.tsx
@@ -10,7 +10,7 @@ import { useAppStore } from '../store'
 import type { ProcessingLine } from '../types'
 
 export function ProcessingQueue() {
-  const { processingLines, isRunning } = useAppStore()
+  const { processingLines, isRunning, runStartedAt, settings } = useAppStore()
 
   if (processingLines.length === 0) return null
   // Hide as soon as the run finishes — covers both the success case
@@ -33,14 +33,27 @@ export function ProcessingQueue() {
       </div>
       <ul className="grid grid-cols-1 gap-1 sm:grid-cols-2 md:grid-cols-3">
         {processingLines.map((pl, i) => (
-          <LineStatus key={`${i}:${pl.line}`} line={pl} />
+          <LineStatus
+            key={`${i}:${pl.line}`}
+            line={pl}
+            runStartedAt={runStartedAt}
+            showTimer={settings.showTimer}
+          />
         ))}
       </ul>
     </div>
   )
 }
 
-function LineStatus({ line }: { line: ProcessingLine }) {
+function LineStatus({
+  line,
+  runStartedAt,
+  showTimer,
+}: {
+  line: ProcessingLine
+  runStartedAt: number | null
+  showTimer: boolean
+}) {
   const icon =
     line.status === 'pending' ? (
       <Loader2 size={12} className="flex-shrink-0 animate-spin text-blue-400" />
@@ -49,10 +62,27 @@ function LineStatus({ line }: { line: ProcessingLine }) {
     ) : (
       <AlertTriangle size={12} className="flex-shrink-0 text-amber-400" />
     )
+
+  // Per-line elapsed badge: wall-clock from the run start to the moment
+  // this line transitioned out of pending. Gated by the same setting as
+  // the global timer so the queue isn't noisy by default.
+  const elapsedMs =
+    showTimer && line.endedAt != null && runStartedAt != null
+      ? Math.max(0, line.endedAt - runStartedAt)
+      : null
+
   return (
     <li className="flex items-center gap-1.5 text-xs text-zinc-400">
       {icon}
       <span className="truncate">{line.line}</span>
+      {elapsedMs != null && (
+        <span
+          className="ml-auto flex-shrink-0 rounded bg-zinc-800 px-1 py-0.5 font-mono text-[10px] tabular-nums text-zinc-400"
+          aria-label={`Resolved in ${elapsedMs} milliseconds`}
+        >
+          {elapsedMs}ms
+        </span>
+      )}
     </li>
   )
 }

--- a/web/src/components/SettingsDrawer.test.tsx
+++ b/web/src/components/SettingsDrawer.test.tsx
@@ -16,6 +16,7 @@ vi.mock('../store', () => ({
       tag: '',
       dedupe: false,
       sort: 'number',
+      showTimer: false,
     },
     updateSettings: mockUpdateSettings,
     resetSettings: mockResetSettings,
@@ -38,5 +39,12 @@ describe('SettingsDrawer', () => {
     fireEvent.click(screen.getByRole('button', { name: /settings/i }))
     fireEvent.click(screen.getByRole('button', { name: /restore defaults/i }))
     expect(mockResetSettings).toHaveBeenCalledOnce()
+  })
+
+  it('toggling "Show lookup timer" calls updateSettings({ showTimer: true })', () => {
+    render(<SettingsDrawer />)
+    fireEvent.click(screen.getByRole('button', { name: /settings/i }))
+    fireEvent.click(screen.getByLabelText(/show lookup timer/i))
+    expect(mockUpdateSettings).toHaveBeenCalledWith({ showTimer: true })
   })
 })

--- a/web/src/components/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer.tsx
@@ -138,6 +138,13 @@ export function SettingsDrawer() {
                 checked={settings.noImages}
                 onChange={(v) => updateSettings({ noImages: v })}
               />
+              <Toggle
+                id="showTimer"
+                label="Show lookup timer"
+                description="Surfaces wall-clock elapsed time during a run and a total/avg summary after"
+                checked={settings.showTimer}
+                onChange={(v) => updateSettings({ showTimer: v })}
+              />
             </div>
           </div>
 

--- a/web/src/components/a11y.test.tsx
+++ b/web/src/components/a11y.test.tsx
@@ -46,6 +46,7 @@ const { storeState, storeApi } = vi.hoisted(() => {
       tag: '',
       dedupe: false,
       sort: 'number' as const,
+      showTimer: false,
     },
   }
   const api = {

--- a/web/src/store/index.test.ts
+++ b/web/src/store/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { useAppStore } from './index'
 
 describe('store: processingLines', () => {
@@ -27,5 +27,52 @@ describe('store: processingLines', () => {
     useAppStore.getState().markLineStatus(99, 'resolved')
     expect(useAppStore.getState().processingLines).toHaveLength(1)
     expect(useAppStore.getState().processingLines[0].status).toBe('pending')
+  })
+
+  it('markLineStatus stamps endedAt with the wall-clock time of the transition', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_700_000_000_000)
+    useAppStore.setState({
+      processingLines: [{ line: 'Charizard', status: 'pending' }],
+    })
+    useAppStore.getState().markLineStatus(0, 'resolved')
+    expect(useAppStore.getState().processingLines[0].endedAt).toBe(1_700_000_000_000)
+    vi.useRealTimers()
+  })
+})
+
+describe('store: run timestamps', () => {
+  beforeEach(() => {
+    useAppStore.setState({ runStartedAt: null, runEndedAt: null })
+  })
+
+  it('setRunStartedAt / setRunEndedAt update and clear the timestamps', () => {
+    const s = useAppStore.getState()
+    s.setRunStartedAt(1234)
+    s.setRunEndedAt(5678)
+    expect(useAppStore.getState().runStartedAt).toBe(1234)
+    expect(useAppStore.getState().runEndedAt).toBe(5678)
+    s.setRunStartedAt(null)
+    s.setRunEndedAt(null)
+    expect(useAppStore.getState().runStartedAt).toBeNull()
+    expect(useAppStore.getState().runEndedAt).toBeNull()
+  })
+})
+
+describe('store: settings.showTimer', () => {
+  afterEach(() => {
+    useAppStore.getState().resetSettings()
+  })
+
+  it('defaults to false and round-trips through updateSettings', () => {
+    expect(useAppStore.getState().settings.showTimer).toBe(false)
+    useAppStore.getState().updateSettings({ showTimer: true })
+    expect(useAppStore.getState().settings.showTimer).toBe(true)
+  })
+
+  it('resetSettings restores showTimer to false', () => {
+    useAppStore.getState().updateSettings({ showTimer: true })
+    useAppStore.getState().resetSettings()
+    expect(useAppStore.getState().settings.showTimer).toBe(false)
   })
 })

--- a/web/src/store/index.test.ts
+++ b/web/src/store/index.test.ts
@@ -31,13 +31,18 @@ describe('store: processingLines', () => {
 
   it('markLineStatus stamps endedAt with the wall-clock time of the transition', () => {
     vi.useFakeTimers()
-    vi.setSystemTime(1_700_000_000_000)
-    useAppStore.setState({
-      processingLines: [{ line: 'Charizard', status: 'pending' }],
-    })
-    useAppStore.getState().markLineStatus(0, 'resolved')
-    expect(useAppStore.getState().processingLines[0].endedAt).toBe(1_700_000_000_000)
-    vi.useRealTimers()
+    try {
+      vi.setSystemTime(1_700_000_000_000)
+      useAppStore.setState({
+        processingLines: [{ line: 'Charizard', status: 'pending' }],
+      })
+      useAppStore.getState().markLineStatus(0, 'resolved')
+      expect(useAppStore.getState().processingLines[0].endedAt).toBe(1_700_000_000_000)
+    } finally {
+      // try/finally so a failing assertion above doesn't strand the
+      // suite in fake-timer mode and cascade into later tests.
+      vi.useRealTimers()
+    }
   })
 })
 

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -9,6 +9,7 @@ const DEFAULT_SETTINGS: Settings = {
   tag: '',
   dedupe: false,
   sort: 'number',
+  showTimer: false,
 }
 
 interface AppState {
@@ -29,6 +30,18 @@ interface AppState {
   /** Whether a bulk lookup is in flight. */
   isRunning: boolean
   setIsRunning: (v: boolean) => void
+
+  /**
+   * Wall-clock timestamps (Date.now()) bracketing the most recent bulk run.
+   * `runStartedAt` is set when the first SSE event arrives so the elapsed
+   * value reflects user-felt latency (network + SSE overhead included).
+   * `runEndedAt` is set when the run finishes — by completion, stop, or
+   * error — and stays set so the post-run summary remains visible.
+   */
+  runStartedAt: number | null
+  runEndedAt: number | null
+  setRunStartedAt: (t: number | null) => void
+  setRunEndedAt: (t: number | null) => void
 
   /** Per-input-line status tracked across the current bulk lookup. */
   processingLines: ProcessingLine[]
@@ -71,6 +84,11 @@ export const useAppStore = create<AppState>()(
       isRunning: false,
       setIsRunning: (isRunning) => set({ isRunning }),
 
+      runStartedAt: null,
+      runEndedAt: null,
+      setRunStartedAt: (runStartedAt) => set({ runStartedAt }),
+      setRunEndedAt: (runEndedAt) => set({ runEndedAt }),
+
       processingLines: [],
       setProcessingLines: (processingLines) => set({ processingLines }),
       markLineStatus: (index, status) =>
@@ -78,7 +96,7 @@ export const useAppStore = create<AppState>()(
           const current = state.processingLines[index]
           if (!current || current.status !== 'pending') return state
           const next = state.processingLines.slice()
-          next[index] = { ...current, status }
+          next[index] = { ...current, status, endedAt: Date.now() }
           return { processingLines: next }
         }),
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -89,7 +89,13 @@ export interface Settings {
 export interface ProcessingLine {
   line: string
   status: 'pending' | 'resolved' | 'error'
-  /** Wall-clock ms (Date.now()) when the line first resolved or errored. */
+  /**
+   * Wall-clock ms (Date.now()) when the line transitioned out of
+   * `pending` — i.e. when its first SSE event arrived. The status at
+   * that point is either `resolved` or `error`; either way the elapsed
+   * badge represents the time between the run starting and the line
+   * leaving the queue.
+   */
   endedAt?: number
 }
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -82,12 +82,15 @@ export interface Settings {
   tag: string
   dedupe: boolean
   sort: SortMode
+  showTimer: boolean
 }
 
 /** One input line tracked through the bulk lookup lifecycle. */
 export interface ProcessingLine {
   line: string
   status: 'pending' | 'resolved' | 'error'
+  /** Wall-clock ms (Date.now()) when the line first resolved or errored. */
+  endedAt?: number
 }
 
 export interface SetInfo {

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -28,12 +28,21 @@ export function formatComp(
  * Format an elapsed wall-clock duration in milliseconds as a compact
  * human-readable string: `123ms`, `1.24s`, or `1m02s`. Negative values
  * clamp to `0ms` so the running lookup timer never renders a negative
- * value if the clock briefly drifts backwards.
+ * value if the clock briefly drifts backwards. Values that would
+ * round to exactly `60.00s` (e.g. 59_995 ms) roll over to `1m00s` so
+ * the sub-minute branch never displays the next minute's boundary.
  */
 export function formatElapsed(ms: number): string {
   if (ms < 1000) return `${Math.max(0, Math.round(ms))}ms`
   const seconds = ms / 1000
-  if (seconds < 60) return `${seconds.toFixed(2)}s`
+  if (seconds < 60) {
+    // `toFixed(2)` can round just-under-60 values up to "60.00"
+    // (e.g. 59.999s). Promote that case to the next minute so the
+    // sub-minute branch never displays the boundary value.
+    const display = seconds.toFixed(2)
+    if (parseFloat(display) < 60) return `${display}s`
+    return '1m00s'
+  }
   const m = Math.floor(seconds / 60)
   const s = Math.floor(seconds % 60)
   return `${m}m${s.toString().padStart(2, '0')}s`

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -23,3 +23,18 @@ export function formatComp(
   if (market == null) return '—'
   return formatMoney((market * pct) / 100, currency)
 }
+
+/**
+ * Format an elapsed wall-clock duration in milliseconds as a compact
+ * human-readable string: `123ms`, `1.24s`, or `1m02s`. Negative values
+ * clamp to `0ms` so the running lookup timer never renders a negative
+ * value if the clock briefly drifts backwards.
+ */
+export function formatElapsed(ms: number): string {
+  if (ms < 1000) return `${Math.max(0, Math.round(ms))}ms`
+  const seconds = ms / 1000
+  if (seconds < 60) return `${seconds.toFixed(2)}s`
+  const m = Math.floor(seconds / 60)
+  const s = Math.floor(seconds % 60)
+  return `${m}m${s.toString().padStart(2, '0')}s`
+}


### PR DESCRIPTION
Closes #263.

## What

Adds an opt-in **Show lookup timer** toggle in the settings drawer
(off by default, persisted) that surfaces wall-clock elapsed time
during a bulk run. While a run is in flight, a live ticking clock
renders under the **Look up** / **Stop** button. After the run
finishes, the readout flips to a `total · count · ms/card` summary
that pluralizes "card" / "cards" at 1 vs N rows. Each per-input-line
entry in `ProcessingQueue` also gains a small elapsed-ms badge once it
resolves, gated by the same setting.

Timing is wall-clock from the SPA — captured from the first SSE event
to the done event — so the number reflects user-felt latency (network
+ SSE overhead included), not backend wall-clock alone.

Also publishes:

- [`docs/benchmarks.md`](docs/benchmarks.md) — expected ranges for
  the workloads users hit most often (warm/cold single card, 10-line
  mixed list, `top:25`, `All ... | <set>`, Set ID cards PDF), linked
  from the contributing doc's Development section.
- An optional **Performance** block in
  [`.github/ISSUE_TEMPLATE/bug.md`](.github/ISSUE_TEMPLATE/bug.md)
  that references the benchmarks doc.

## Why

Today the only signal that a regression has slowed the lookup
pipeline down is "it feels slower," which doesn't survive a context
switch or land in a bug report. Reviewers (human or AI) touching
`lookup.py`, `pricing.py`, `images.py`, or the SSE wiring have nothing
concrete to anchor against. Pairing the in-UI timer with documented
reference ranges gives a contributor a number to compare and a place
to put it.

Backend-side per-stage budgets — the breakdown of *which* call took
how long — are covered separately by #260. The total here is the
user-felt number; the stages there are the inside-look.

## How to verify

1. `make dev-api` + `make dev-web`.
2. Open Settings → toggle **Show lookup timer** on.
3. Paste a multi-line list (or click an example chip) and **Look up**.
4. Confirm:
   - A live ticking clock appears under the **Stop** button while
     the run is in flight.
   - Each per-line entry in the **Looking up cards…** queue picks up
     a small `<ms>ms` badge as it resolves.
   - After the run, the readout flips to
     `<total> · <N> card(s) · <avg> ms/card` and stays visible.
   - Singular at N=1 (`14ms · 1 card · 14 ms/card`), plural at N>1
     (`12.94s · 3 cards · 4313 ms/card`).
5. Toggle the setting off — the clock, summary, and badges all
   disappear.

## Proof

Verified locally via the preview server with the timer toggle on:

- Single-card run (cache warm): `14ms · 1 card · 14 ms/card` (singular)
- 3-card run: live clock observed ticking through `8.71s`; final
  `12.94s · 3 cards · 4313 ms/card` (plural)
- 5-card run: `4.51s · 5 cards · 902 ms/card`
- 10-line mixed bulk run: live clock visible mid-flight; per-line
  badges populated as each line resolved (e.g. `0ms`, `10319ms`,
  `10346ms`, …); final `14.25s · 22 cards · 648 ms/card` (bulk
  expansion correctly reflected in the row count)
- `top:25 Charizard cards` (cache warm): `30ms · 25 cards · 1 ms/card`

I'll attach a screenshot of the final summary + the running-state
queue after opening — happy to record a short Jam clip if reviewers
prefer the motion.

## Tests

- `LookupTimer.test.tsx`: `formatElapsed` boundaries (ms / s /
  m:ss / clamp negative); running clock advances under fake timers;
  singular `1 card` summary; plural `5 cards` summary; degenerate
  zero-row case omits the avg.
- `ProcessingQueue.test.tsx`: per-line badges omitted when
  `showTimer` is off; present and correctly computed when on.
- `SettingsDrawer.test.tsx`: toggling **Show lookup timer** calls
  `updateSettings({ showTimer: true })`.

Local `make check` + `cd web && npm run build` are both green.