### PR TITLE
feat(web): recent searches history — one-click rerun of prior lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Web: **Recent searches history** — a collapsible **Recent searches**
+  panel below the input editor keeps the last 10 bulk-lookup
+  submissions (timestamp, line count, preview like `Charizard,
+  Pikachu, +3 more`). Click an entry to restore the lines into the
+  editor and rerun automatically; hover an entry for a `×` to delete
+  it individually, or use **Clear all** in the panel header to wipe
+  the history. Persisted via Zustand so it survives a page reload;
+  consecutive duplicate submissions collapse by refreshing the
+  existing entry's timestamp rather than stacking copies.
 - Web: **Lookup timer** — a new **Show lookup timer** toggle in the
   settings drawer (off by default) surfaces wall-clock elapsed time
   during a bulk run: a live ticking clock under the **Look up** button

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,6 +14,7 @@
 import { useCallback, useRef, useState } from 'react'
 import { bulkLookup, lookupLine } from './api/client'
 import { InputEditor } from './components/InputEditor'
+import { RecentRuns } from './components/RecentRuns'
 import { ResultsTable } from './components/ResultsTable'
 import { ExportBar } from './components/ExportBar'
 import { ProcessingQueue } from './components/ProcessingQueue'
@@ -37,6 +38,7 @@ function App() {
     markLineStatus,
     setRunStartedAt,
     setRunEndedAt,
+    pushRecentRun,
   } = useAppStore()
 
   const abortRef = useRef<AbortController | null>(null)
@@ -72,6 +74,10 @@ function App() {
     // event arrives so the elapsed value reflects user-felt latency.
     setRunStartedAt(null)
     setRunEndedAt(null)
+    // Record the submission in the recent-searches history. We do
+    // this at click time (not on completion) so a run the user stops
+    // or that errors still leaves a re-runnable entry behind.
+    pushRecentRun(nonEmpty)
 
     abortRef.current = new AbortController()
 
@@ -140,6 +146,7 @@ function App() {
     markLineStatus,
     setRunStartedAt,
     setRunEndedAt,
+    pushRecentRun,
   ])
 
   const handleStop = useCallback(() => {
@@ -195,6 +202,9 @@ function App() {
             Card list
           </h2>
           <InputEditor onRun={handleRun} onStop={handleStop} />
+          <div className="mt-3">
+            <RecentRuns onRun={handleRun} />
+          </div>
         </section>
 
         <section data-tour="results">

--- a/web/src/components/RecentRuns.test.tsx
+++ b/web/src/components/RecentRuns.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { RecentRuns } from './RecentRuns'
+import { useAppStore } from '../store'
+import type { RecentRun } from '../types'
+
+function makeRun(id: string, lines: string[], savedAt = 1_700_000_000_000): RecentRun {
+  return { id, savedAt, lines }
+}
+
+function resetStore() {
+  useAppStore.setState({
+    recentRuns: [],
+    inputText: '',
+    isRunning: false,
+  })
+}
+
+describe('RecentRuns', () => {
+  beforeEach(resetStore)
+
+  it('renders nothing when there are no recent runs', () => {
+    const { container } = render(<RecentRuns onRun={vi.fn()} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders each entry with its line count and a preview summary', () => {
+    useAppStore.setState({
+      recentRuns: [
+        makeRun('r1', ['Charizard', 'Pikachu', 'Squirtle', 'Mew', 'Bulbasaur']),
+        makeRun('r2', ['Lugia']),
+      ],
+    })
+    render(<RecentRuns onRun={vi.fn()} />)
+
+    expect(screen.getByText('5 lines')).toBeInTheDocument()
+    expect(screen.getByText('Charizard, Pikachu, +3 more')).toBeInTheDocument()
+
+    // Singular for one-line runs; no "+N more" tail.
+    expect(screen.getByText('1 line')).toBeInTheDocument()
+    expect(screen.getByText('Lugia')).toBeInTheDocument()
+  })
+
+  it('clicking an entry restores the lines and calls onRun with the joined text', () => {
+    const onRun = vi.fn()
+    useAppStore.setState({
+      recentRuns: [makeRun('r1', ['Charizard', 'Pikachu'])],
+    })
+    render(<RecentRuns onRun={onRun} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Rerun search/i }))
+
+    expect(useAppStore.getState().inputText).toBe('Charizard\nPikachu')
+    expect(onRun).toHaveBeenCalledWith('Charizard\nPikachu')
+  })
+
+  it('rerun is a no-op while a run is already in flight', () => {
+    const onRun = vi.fn()
+    useAppStore.setState({
+      isRunning: true,
+      recentRuns: [makeRun('r1', ['Charizard'])],
+    })
+    render(<RecentRuns onRun={onRun} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /Rerun search/i }))
+    expect(onRun).not.toHaveBeenCalled()
+    expect(useAppStore.getState().inputText).toBe('')
+  })
+
+  it('per-row delete drops just that entry', () => {
+    useAppStore.setState({
+      recentRuns: [
+        makeRun('r1', ['Charizard']),
+        makeRun('r2', ['Pikachu']),
+      ],
+    })
+    render(<RecentRuns onRun={vi.fn()} />)
+    fireEvent.click(screen.getByLabelText('Delete recent search: Charizard'))
+
+    const remaining = useAppStore.getState().recentRuns.map((r) => r.id)
+    expect(remaining).toEqual(['r2'])
+  })
+
+  it('Clear all wipes the whole list', () => {
+    useAppStore.setState({
+      recentRuns: [
+        makeRun('r1', ['Charizard']),
+        makeRun('r2', ['Pikachu']),
+      ],
+    })
+    render(<RecentRuns onRun={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: /clear all/i }))
+    expect(useAppStore.getState().recentRuns).toHaveLength(0)
+  })
+
+  it('collapse toggle hides the entries but keeps the header counter', () => {
+    useAppStore.setState({
+      recentRuns: [makeRun('r1', ['Charizard'])],
+    })
+    render(<RecentRuns onRun={vi.fn()} />)
+    const region = screen.getByRole('region', { name: /Recent searches/i })
+
+    expect(within(region).getByText('Charizard')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /Recent searches/i }))
+    expect(within(region).queryByText('Charizard')).not.toBeInTheDocument()
+    // Header counter is still rendered.
+    expect(within(region).getByText('(1)')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/RecentRuns.tsx
+++ b/web/src/components/RecentRuns.tsx
@@ -1,0 +1,125 @@
+/**
+ * RecentRuns — a collapsible panel under the input editor showing the
+ * last N (default 10) bulk-lookup submissions. Entries are clickable:
+ * one click restores the list into the editor and triggers a lookup
+ * via the parent's `onRun` callback. A small × on hover deletes a
+ * single entry; **Clear all** in the header wipes the whole list.
+ *
+ * The panel renders nothing when there are no entries — the
+ * empty-state example chips already cover the "what do I do?"
+ * moment, and an empty Recent panel would just be noise.
+ */
+import { useState } from 'react'
+import { History, X, ChevronDown, ChevronUp } from 'lucide-react'
+import { useAppStore } from '../store'
+import { formatRelativeTime } from '../utils/format'
+import type { RecentRun } from '../types'
+
+interface Props {
+  onRun: (overrideText: string) => void
+}
+
+/** How many of an entry's lines we show inline before the `+N more` tail. */
+const PREVIEW_LIMIT = 2
+
+export function RecentRuns({ onRun }: Props) {
+  const { recentRuns, removeRecentRun, clearRecentRuns, isRunning, setInputText } = useAppStore()
+  const [collapsed, setCollapsed] = useState(false)
+
+  if (recentRuns.length === 0) return null
+
+  const handleRerun = (run: RecentRun) => {
+    if (isRunning) return
+    const text = run.lines.join('\n')
+    setInputText(text)
+    onRun(text)
+  }
+
+  return (
+    <section
+      aria-label="Recent searches"
+      className="flex flex-col gap-2 rounded-md border border-zinc-800 bg-zinc-900/40 px-3 py-2"
+    >
+      <header className="flex items-center justify-between">
+        <button
+          type="button"
+          onClick={() => setCollapsed((c) => !c)}
+          aria-expanded={!collapsed}
+          className="flex items-center gap-1.5 rounded text-xs font-medium text-zinc-400 hover:text-zinc-200"
+        >
+          <History size={12} />
+          Recent searches
+          <span className="text-zinc-500">({recentRuns.length})</span>
+          {collapsed ? <ChevronDown size={12} /> : <ChevronUp size={12} />}
+        </button>
+        {!collapsed && (
+          <button
+            type="button"
+            onClick={clearRecentRuns}
+            className="rounded px-1.5 py-0.5 text-xs text-zinc-500 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
+          >
+            Clear all
+          </button>
+        )}
+      </header>
+      {!collapsed && (
+        <ul className="flex flex-col gap-1">
+          {recentRuns.map((run) => (
+            <RecentRunRow
+              key={run.id}
+              run={run}
+              disabled={isRunning}
+              onRerun={() => handleRerun(run)}
+              onDelete={() => removeRecentRun(run.id)}
+            />
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}
+
+function RecentRunRow({
+  run,
+  disabled,
+  onRerun,
+  onDelete,
+}: {
+  run: RecentRun
+  disabled: boolean
+  onRerun: () => void
+  onDelete: () => void
+}) {
+  const preview = run.lines.slice(0, PREVIEW_LIMIT).join(', ')
+  const extra = run.lines.length - PREVIEW_LIMIT
+  const summary = extra > 0 ? `${preview}, +${extra} more` : preview
+  const lineWord = run.lines.length === 1 ? 'line' : 'lines'
+
+  return (
+    <li className="group flex items-center gap-2 rounded border border-transparent hover:border-zinc-700 hover:bg-zinc-800/60 transition-colors">
+      <button
+        type="button"
+        onClick={onRerun}
+        disabled={disabled}
+        aria-label={`Rerun search from ${formatRelativeTime(run.savedAt)}: ${summary}`}
+        className="flex-1 min-w-0 flex items-center gap-2 px-2 py-1 text-left text-xs disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <span className="flex-shrink-0 tabular-nums text-zinc-500">
+          {formatRelativeTime(run.savedAt)}
+        </span>
+        <span className="flex-shrink-0 rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] tabular-nums text-zinc-400">
+          {run.lines.length} {lineWord}
+        </span>
+        <span className="truncate font-mono text-zinc-300">{summary}</span>
+      </button>
+      <button
+        type="button"
+        onClick={onDelete}
+        aria-label={`Delete recent search: ${summary}`}
+        className="flex-shrink-0 rounded p-1 text-zinc-500 opacity-0 group-hover:opacity-100 hover:text-zinc-200 hover:bg-zinc-700 transition-opacity"
+      >
+        <X size={12} />
+      </button>
+    </li>
+  )
+}

--- a/web/src/components/RecentRuns.tsx
+++ b/web/src/components/RecentRuns.tsx
@@ -116,7 +116,7 @@ function RecentRunRow({
         type="button"
         onClick={onDelete}
         aria-label={`Delete recent search: ${summary}`}
-        className="flex-shrink-0 rounded p-1 text-zinc-500 opacity-0 group-hover:opacity-100 hover:text-zinc-200 hover:bg-zinc-700 transition-opacity"
+        className="flex-shrink-0 rounded p-1 text-zinc-500 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 focus-visible:opacity-100 hover:text-zinc-200 hover:bg-zinc-700 transition-opacity"
       >
         <X size={12} />
       </button>

--- a/web/src/store/index.test.ts
+++ b/web/src/store/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
-import { useAppStore } from './index'
+import { useAppStore, RECENT_RUNS_LIMIT } from './index'
 
 describe('store: processingLines', () => {
   beforeEach(() => useAppStore.setState({ processingLines: [] }))
@@ -61,6 +61,79 @@ describe('store: run timestamps', () => {
     s.setRunEndedAt(null)
     expect(useAppStore.getState().runStartedAt).toBeNull()
     expect(useAppStore.getState().runEndedAt).toBeNull()
+  })
+})
+
+describe('store: recentRuns', () => {
+  beforeEach(() => useAppStore.setState({ recentRuns: [] }))
+
+  it('pushRecentRun prepends a new entry with an id, savedAt, and the lines', () => {
+    useAppStore.getState().pushRecentRun(['Charizard', 'Pikachu'])
+    const [first] = useAppStore.getState().recentRuns
+    expect(first.lines).toEqual(['Charizard', 'Pikachu'])
+    expect(typeof first.id).toBe('string')
+    expect(first.id.length).toBeGreaterThan(0)
+    expect(typeof first.savedAt).toBe('number')
+  })
+
+  it('pushRecentRun ignores an empty submission', () => {
+    useAppStore.getState().pushRecentRun([])
+    expect(useAppStore.getState().recentRuns).toHaveLength(0)
+  })
+
+  it('pushRecentRun collapses consecutive duplicates by refreshing savedAt', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(1_000)
+      useAppStore.getState().pushRecentRun(['Charizard', 'Pikachu'])
+      const original = useAppStore.getState().recentRuns[0]
+
+      vi.setSystemTime(2_000)
+      useAppStore.getState().pushRecentRun(['Charizard', 'Pikachu'])
+
+      const runs = useAppStore.getState().recentRuns
+      expect(runs).toHaveLength(1)
+      expect(runs[0].id).toBe(original.id)
+      expect(runs[0].savedAt).toBe(2_000)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it(`pushRecentRun caps history at RECENT_RUNS_LIMIT (${RECENT_RUNS_LIMIT})`, () => {
+    const push = useAppStore.getState().pushRecentRun
+    for (let i = 0; i < RECENT_RUNS_LIMIT + 5; i++) {
+      push([`card-${i}`])
+    }
+    const runs = useAppStore.getState().recentRuns
+    expect(runs).toHaveLength(RECENT_RUNS_LIMIT)
+    // Newest first; the most-recently-pushed entry sits at the head.
+    expect(runs[0].lines).toEqual([`card-${RECENT_RUNS_LIMIT + 4}`])
+    // The oldest entries got evicted, so card-0..card-4 are gone.
+    const surviving = new Set(runs.map((r) => r.lines[0]))
+    for (let i = 0; i < 5; i++) {
+      expect(surviving.has(`card-${i}`)).toBe(false)
+    }
+  })
+
+  it('removeRecentRun drops the entry by id', () => {
+    const push = useAppStore.getState().pushRecentRun
+    push(['a'])
+    push(['b'])
+    push(['c'])
+    const target = useAppStore.getState().recentRuns[1]
+    useAppStore.getState().removeRecentRun(target.id)
+    const lines = useAppStore.getState().recentRuns.map((r) => r.lines[0])
+    expect(lines).not.toContain(target.lines[0])
+    expect(lines).toHaveLength(2)
+  })
+
+  it('clearRecentRuns empties the list', () => {
+    const push = useAppStore.getState().pushRecentRun
+    push(['a'])
+    push(['b'])
+    useAppStore.getState().clearRecentRuns()
+    expect(useAppStore.getState().recentRuns).toHaveLength(0)
   })
 })
 

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -1,6 +1,9 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import type { ProcessingLine, Row, Settings } from '../types'
+import type { ProcessingLine, RecentRun, Row, Settings } from '../types'
+
+/** Cap on `recentRuns` so persisted localStorage stays small. */
+export const RECENT_RUNS_LIMIT = 10
 
 const DEFAULT_SETTINGS: Settings = {
   apiKey: '',
@@ -65,6 +68,16 @@ interface AppState {
    */
   selectedSetIds: string[]
   setSelectedSetIds: (ids: string[]) => void
+
+  /**
+   * History of recently submitted card-list runs. Newest first.
+   * Capped at `RECENT_RUNS_LIMIT` so persisted localStorage stays
+   * small.
+   */
+  recentRuns: RecentRun[]
+  pushRecentRun: (lines: string[]) => void
+  removeRecentRun: (id: string) => void
+  clearRecentRuns: () => void
 }
 
 export const useAppStore = create<AppState>()(
@@ -107,6 +120,38 @@ export const useAppStore = create<AppState>()(
 
       selectedSetIds: [],
       setSelectedSetIds: (ids) => set({ selectedSetIds: ids }),
+
+      recentRuns: [],
+      pushRecentRun: (lines) =>
+        set((state) => {
+          if (lines.length === 0) return state
+          // Collapse consecutive duplicates: if the user just re-runs
+          // the same list (or clicks the same chip twice), don't
+          // record the same lines back-to-back — bump the existing
+          // entry's savedAt instead so the chronological order
+          // still makes sense.
+          const head = state.recentRuns[0]
+          const sameAsHead =
+            head && head.lines.length === lines.length &&
+            head.lines.every((l, i) => l === lines[i])
+          if (sameAsHead) {
+            const refreshed: RecentRun = { ...head, savedAt: Date.now() }
+            return { recentRuns: [refreshed, ...state.recentRuns.slice(1)] }
+          }
+          const next: RecentRun = {
+            id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+            savedAt: Date.now(),
+            lines,
+          }
+          return {
+            recentRuns: [next, ...state.recentRuns].slice(0, RECENT_RUNS_LIMIT),
+          }
+        }),
+      removeRecentRun: (id) =>
+        set((state) => ({
+          recentRuns: state.recentRuns.filter((r) => r.id !== id),
+        })),
+      clearRecentRuns: () => set({ recentRuns: [] }),
     }),
     {
       name: 'mgz-pkmn-settings',
@@ -115,6 +160,7 @@ export const useAppStore = create<AppState>()(
         inputText: state.inputText,
         settings: state.settings,
         selectedSetIds: state.selectedSetIds,
+        recentRuns: state.recentRuns,
       }),
       // Merge persisted state with defaults so new settings fields (e.g.
       // `sort`, added later) fall back to the initial value rather than

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -106,3 +106,17 @@ export interface SetInfo {
   total: number
   releaseDate: string
 }
+
+/**
+ * One entry in the recent-searches history. Captured the moment the
+ * user clicks **Look up** so the panel reflects what was actually
+ * submitted (even if the run later errored or was stopped).
+ */
+export interface RecentRun {
+  /** Stable id used as the React key and the delete target. */
+  id: string
+  /** Wall-clock ms (Date.now()) when the run was submitted. */
+  savedAt: number
+  /** The non-empty, non-comment lines the user submitted. */
+  lines: string[]
+}

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -32,6 +32,28 @@ export function formatComp(
  * round to exactly `60.00s` (e.g. 59_995 ms) roll over to `1m00s` so
  * the sub-minute branch never displays the next minute's boundary.
  */
+/**
+ * Format a wall-clock timestamp as a compact relative-time string
+ * suitable for the recent-searches panel: `just now`, `5m ago`,
+ * `2h ago`, `3d ago`, or an absolute `MMM D` for older entries. The
+ * `now` argument is injectable so tests can pin the boundary cases.
+ */
+export function formatRelativeTime(timestamp: number, now: number = Date.now()): string {
+  const delta = Math.max(0, now - timestamp)
+  const seconds = delta / 1000
+  if (seconds < 45) return 'just now'
+  const minutes = seconds / 60
+  if (minutes < 60) return `${Math.round(minutes)}m ago`
+  const hours = minutes / 60
+  if (hours < 24) return `${Math.round(hours)}h ago`
+  const days = hours / 24
+  if (days < 7) return `${Math.round(days)}d ago`
+  return new Date(timestamp).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
 export function formatElapsed(ms: number): string {
   if (ms < 1000) return `${Math.max(0, Math.round(ms))}ms`
   const seconds = ms / 1000

--- a/web/src/utils/format.ts
+++ b/web/src/utils/format.ts
@@ -25,6 +25,32 @@ export function formatComp(
 }
 
 /**
+ * Format a wall-clock timestamp as a compact relative-time string
+ * suitable for the recent-searches panel: `just now`, `5m ago`,
+ * `2h ago`, `3d ago`, or an absolute `MMM D` for older entries. The
+ * `now` argument is injectable so tests can pin the boundary cases.
+ *
+ * Buckets use `Math.floor` with a floor of 1 so just-under-boundary
+ * values (e.g. 59.6 minutes) never round up into the next unit's
+ * range and render `60m ago`.
+ */
+export function formatRelativeTime(timestamp: number, now: number = Date.now()): string {
+  const delta = Math.max(0, now - timestamp)
+  const seconds = delta / 1000
+  if (seconds < 45) return 'just now'
+  const minutes = seconds / 60
+  if (minutes < 60) return `${Math.max(1, Math.floor(minutes))}m ago`
+  const hours = minutes / 60
+  if (hours < 24) return `${Math.max(1, Math.floor(hours))}h ago`
+  const days = hours / 24
+  if (days < 7) return `${Math.max(1, Math.floor(days))}d ago`
+  return new Date(timestamp).toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+/**
  * Format an elapsed wall-clock duration in milliseconds as a compact
  * human-readable string: `123ms`, `1.24s`, or `1m02s`. Negative values
  * clamp to `0ms` so the running lookup timer never renders a negative
@@ -32,28 +58,6 @@ export function formatComp(
  * round to exactly `60.00s` (e.g. 59_995 ms) roll over to `1m00s` so
  * the sub-minute branch never displays the next minute's boundary.
  */
-/**
- * Format a wall-clock timestamp as a compact relative-time string
- * suitable for the recent-searches panel: `just now`, `5m ago`,
- * `2h ago`, `3d ago`, or an absolute `MMM D` for older entries. The
- * `now` argument is injectable so tests can pin the boundary cases.
- */
-export function formatRelativeTime(timestamp: number, now: number = Date.now()): string {
-  const delta = Math.max(0, now - timestamp)
-  const seconds = delta / 1000
-  if (seconds < 45) return 'just now'
-  const minutes = seconds / 60
-  if (minutes < 60) return `${Math.round(minutes)}m ago`
-  const hours = minutes / 60
-  if (hours < 24) return `${Math.round(hours)}h ago`
-  const days = hours / 24
-  if (days < 7) return `${Math.round(days)}d ago`
-  return new Date(timestamp).toLocaleDateString(undefined, {
-    month: 'short',
-    day: 'numeric',
-  })
-}
-
 export function formatElapsed(ms: number): string {
   if (ms < 1000) return `${Math.max(0, Math.round(ms))}ms`
   const seconds = ms / 1000


### PR DESCRIPTION
Closes #264.

## What

Adds a collapsible **Recent searches** panel under the input editor
showing the last 10 bulk-lookup submissions. Each entry carries:

- A relative timestamp (`just now`, `5m ago`, `2h ago`, `3d ago`)
- A line-count badge (`4 lines` / `1 line` with correct pluralization)
- A `Charizard, Pikachu, +3 more` preview built from the first two lines

One click on a row restores the lines into the editor and reruns the
lookup. Hover a row for a `×` to delete it; **Clear all** in the
panel header wipes the whole list.

Backed by a new Zustand slice (`recentRuns`, `pushRecentRun`,
`removeRecentRun`, `clearRecentRuns`) capped at `RECENT_RUNS_LIMIT`
(10) and persisted via the existing `partialize` middleware so the
history survives a page reload. Consecutive duplicate submissions
collapse by refreshing the head entry's `savedAt` rather than
stacking copies — re-running the same list twice in a row doesn't
clutter the panel.

## Why

Iterating on a card list — "did I forget Mew? what about Mewtwo?" —
meant retyping or re-pasting the same lines over and over. The SPA
had zero memory of past runs. The Recent panel sits adjacent to the
input editor and turns "I just had that list" into a one-click
rerun.

`pushRecentRun` is wired into `handleRun` at click time (not on
completion), so a run the user stops or that errors still leaves a
re-runnable entry behind — exactly when you want to come back to it.

## How to verify

1. `make dev-api` + `make dev-web`.
2. Submit a few different card lists.
3. Confirm:
   - A **Recent searches (N)** panel renders below the textarea.
   - Each entry shows a relative timestamp, line count, and preview.
   - Clicking an entry restores the lines and reruns the lookup.
   - Hover an entry → the `×` appears, click deletes just that entry.
   - **Clear all** in the header wipes the list.
   - Collapse arrow hides entries while keeping the header counter.
   - Reload the page — the history is still there.
   - Submit the same list twice — only one entry is recorded.

## Proof

Verified locally via the preview server:

- 2 distinct submissions → 2 panel entries, newest at top
- Click rerun on the older Pikachu entry → lines restored, lookup ran
- Delete on the 4-line entry → removed cleanly
- Clear all → list emptied
- Reload after a fresh submission → entry persisted

Screenshot from the running preview attached after open. Happy to
add a Jam clip if reviewers prefer the motion.

## Tests

- `store/index.test.ts`: prepends new entries with `id`/`savedAt`;
  ignores empty submissions; collapses consecutive duplicates by
  refreshing `savedAt`; caps at `RECENT_RUNS_LIMIT`; `removeRecentRun`
  drops by id; `clearRecentRuns` empties.
- `components/RecentRuns.test.tsx`: renders nothing on empty list;
  per-entry line-count + preview rendering; click restores +
  triggers `onRun`; no-op while a run is already in flight; per-row
  delete; clear-all; collapse hides entries but keeps the counter.

All 141 web tests pass; `make check` + `npm run build` green.