### PR TITLE
feat(web): browse sets — explore cards by set without typing a list

### DIFF
--- a/api/routes/sets.py
+++ b/api/routes/sets.py
@@ -1,8 +1,20 @@
-"""Set-catalog HTTP surface — list of every set, plus their cached logos.
+"""Set-catalog HTTP surface — list of every set, the cards in a set, plus cached logos.
 
 `GET /api/v1/sets` returns the full pokemontcg.io catalog (id, name,
-series, total, release date). Used by the SPA's set picker modal to
-populate the grouped multi-select.
+series, total, release date). Used by the SPA's set picker modal and
+the Browse surface to populate the grouped set list. The response
+carries a short-TTL `Cache-Control` header so the browser can skip
+the round-trip when the user re-opens Browse within the hour.
+
+`GET /api/v1/sets/{set_id}/cards` returns a **trimmed** card list for
+one set — just the fields Browse renders (id, name, number, rarity,
+supertype, subtypes, thumb, market). Keeping the payload tight is
+critical: a set like Surging Sparks has 250+ cards, and the raw
+pokemontcg.io shape (legalities, ancientTrait, attacks, weaknesses,
+resistances, tcgplayer/cardmarket sub-objects) blows the wire size up
+~10x. The trim happens server-side so every Browse client pays the
+slim cost. A 1-day `Cache-Control` lets the browser keep the response
+for the duration of a typical prep session.
 
 `GET /api/v1/sets/{set_id}/logo` streams the cached logo image for a set
 out of the unified disk image cache (see `mgz_pkmn.cache.read_image`).
@@ -17,14 +29,15 @@ import json
 import mimetypes
 import time
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Response
 from fastapi import Path as PathParam
 from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import FileResponse
 
 from mgz_pkmn import cache as disk_cache
+from mgz_pkmn.pricing import extract_pricing
 from mgz_pkmn.sources import TCGClient
 
 router = APIRouter()
@@ -36,6 +49,19 @@ router = APIRouter()
 _SET_ID_PATH = PathParam(pattern=r"^[A-Za-z0-9_-]{1,64}$", max_length=64)
 
 _SETS_TTL = 7 * 24 * 60 * 60  # refresh weekly
+
+# Browser-cache TTL for `GET /api/v1/sets`. The disk cache already pins the
+# upstream response for a week; the Cache-Control header is the cheap
+# additional win — a Browse re-open within an hour skips the round-trip
+# entirely. Kept conservative (1h, not 1d) so a freshly-released set shows
+# up in the picker within an hour without the user having to hard-refresh.
+_SETS_BROWSER_TTL = 60 * 60
+
+# Browser-cache TTL for `GET /api/v1/sets/{set_id}/cards`. Card data within a
+# released set is effectively immutable (rarity / number / images don't change
+# once the set ships); only market prices drift, and a 1-day cache keeps
+# typical day-of-show prep snappy without going stale on negotiating numbers.
+_SET_CARDS_BROWSER_TTL = 24 * 60 * 60
 
 
 def _sets_cache_path() -> Path:
@@ -89,12 +115,17 @@ def _fetch_sets(api_key: str | None = None) -> list[dict]:
 
 
 @router.get("/sets")
-async def get_sets(api_key: str | None = None) -> dict:
+async def get_sets(response: Response, api_key: str | None = None) -> dict:
     """Return a cached list of Pokémon TCG set names.
 
-    Results are cached locally for one week. Pass `api_key` as a query
-    parameter to authenticate the upstream refresh request.
+    Results are cached on disk for one week (server-side) **and** in the
+    browser for an hour via the `Cache-Control` header. The browser cache
+    is the load-bearing optimisation for repeated Browse opens — without
+    it, every modal open re-hits FastAPI even when the upstream data
+    hasn't moved. Pass `api_key` as a query parameter to authenticate the
+    upstream refresh request.
     """
+    response.headers["Cache-Control"] = f"public, max-age={_SETS_BROWSER_TTL}"
     cached = _load_sets_cache()
     if cached is not None:
         return {"sets": cached}
@@ -102,6 +133,82 @@ async def get_sets(api_key: str | None = None) -> dict:
     sets = await run_in_threadpool(_fetch_sets, api_key)
     _save_sets_cache(sets)
     return {"sets": sets}
+
+
+# ---------------------------------------------------------------------------
+# /sets/{set_id}/cards — trimmed card list for one set, browser-cacheable.
+# ---------------------------------------------------------------------------
+
+
+def _trim_card(card: dict[str, Any]) -> dict[str, Any]:
+    """Project a pokemontcg.io card into the slim shape Browse renders.
+
+    The raw card object carries dozens of fields the SPA never reads
+    (legalities, attacks, weaknesses, resistances, full tcgplayer /
+    cardmarket sub-objects, etc.). Stripping them server-side keeps
+    a 250-card set response in the tens of KB instead of hundreds of
+    KB — measurable on slow networks and on the JSON parse hot path.
+
+    Kept deliberately narrow: every field here is something the Browse
+    grid, filter chips, or add-to-list bridge actually uses."""
+    images = card.get("images") or {}
+    pricing = extract_pricing(card, None)
+    return {
+        "id": card.get("id"),
+        "name": card.get("name"),
+        "number": card.get("number"),
+        "rarity": card.get("rarity"),
+        "supertype": card.get("supertype"),
+        "subtypes": card.get("subtypes") or [],
+        # `images.small` is the thumbnail-sized variant pokemontcg.io
+        # exposes (~245x342). The grid uses it directly — no extra
+        # server-side resize. `large` is intentionally omitted; the
+        # full-size art lives behind a single-card hover/click and can
+        # be lazy-fetched from pokemontcg.io's CDN directly.
+        "thumb": images.get("small"),
+        "market": pricing.market,
+    }
+
+
+def _fetch_set_cards(set_id: str, api_key: str | None) -> list[dict[str, Any]]:
+    """Fetch every card in `set_id` via pokemontcg.io and return slim shapes.
+
+    Uses `TCGClient.search_all` so the request flows through the existing
+    on-disk API cache (7-day TTL). Once one user warms a set, every other
+    Browse open of that set is a disk-cache hit upstream, plus the trim
+    is microseconds. `q=set.id:{id}` is the canonical pokemontcg.io
+    filter; ids are short alnum so quoting isn't strictly needed but
+    we include it for defence against future ids with special chars."""
+    client = TCGClient(api_key=api_key)
+    cards = client.search_all(f'set.id:"{set_id}"')
+    return [_trim_card(c) for c in cards]
+
+
+@router.get("/sets/{set_id}/cards")
+async def get_set_cards(
+    response: Response,
+    set_id: Annotated[str, _SET_ID_PATH],
+    api_key: str | None = None,
+) -> dict:
+    """Return a trimmed card list for one set, browser-cacheable for a day.
+
+    Each entry carries the fields Browse renders: id, name, number,
+    rarity, supertype, subtypes, thumb URL, and market price. The full
+    pokemontcg.io card shape is **not** included — see `_trim_card`
+    for the rationale.
+
+    404 when the set is unknown / empty (the upstream catalog returned
+    nothing for `set.id:{set_id}`). The SPA surfaces the detail message
+    to the user.
+    """
+    cards = await run_in_threadpool(_fetch_set_cards, set_id, api_key)
+    if not cards:
+        raise HTTPException(
+            status_code=404,
+            detail=f"no cards found for set '{set_id}'",
+        )
+    response.headers["Cache-Control"] = f"public, max-age={_SET_CARDS_BROWSER_TTL}"
+    return {"set_id": set_id, "cards": cards}
 
 
 @router.get("/sets/{set_id}/logo")

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -190,6 +190,169 @@ class SetsRouteTests(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()["sets"], fetched_sets)
 
+    def test_browser_cache_control_header(self) -> None:
+        # The /sets response needs a short-TTL Cache-Control so the Browse
+        # modal doesn't round-trip on every open. We assert presence, not
+        # the exact max-age value, so the constant can be tuned without
+        # the test going brittle — but we do require it's `public` and
+        # has a non-zero max-age.
+        with (
+            patch("api.routes.sets._load_sets_cache", return_value=[]),
+        ):
+            resp = client.get("/api/v1/sets")
+
+        self.assertEqual(resp.status_code, 200)
+        cache_control = resp.headers.get("cache-control", "")
+        self.assertIn("public", cache_control)
+        self.assertIn("max-age=", cache_control)
+
+
+class SetCardsRouteTests(unittest.TestCase):
+    """`GET /api/v1/sets/{set_id}/cards` returns a trimmed card list."""
+
+    def test_trims_card_payload(self) -> None:
+        # Synthetic upstream response with the fields we care about plus
+        # a bunch of noise to confirm the trim drops them.
+        raw_cards = [
+            {
+                "id": "sv8-1",
+                "name": "Pikachu",
+                "number": "1",
+                "rarity": "Common",
+                "supertype": "Pokémon",
+                "subtypes": ["Basic"],
+                "images": {
+                    "small": "https://images.example/sv8-1-small.png",
+                    "large": "https://images.example/sv8-1-large.png",
+                },
+                "tcgplayer": {
+                    "prices": {"normal": {"market": 1.23}},
+                    "url": "https://tcgplayer.example/sv8-1",
+                },
+                # Noise we expect the trim to drop.
+                "attacks": [{"name": "Thundershock"}],
+                "weaknesses": [{"type": "Fighting"}],
+                "legalities": {"standard": "Legal"},
+            }
+        ]
+
+        with patch(
+            "api.routes.sets._fetch_set_cards",
+            return_value=[
+                # _fetch_set_cards is the trimmer entry point; bypass it and
+                # verify the route hands the slim shape straight through.
+                {
+                    "id": "sv8-1",
+                    "name": "Pikachu",
+                    "number": "1",
+                    "rarity": "Common",
+                    "supertype": "Pokémon",
+                    "subtypes": ["Basic"],
+                    "thumb": "https://images.example/sv8-1-small.png",
+                    "market": 1.23,
+                }
+            ],
+        ) as fetch_mock:
+            resp = client.get("/api/v1/sets/sv8/cards")
+
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["set_id"], "sv8")
+        self.assertEqual(len(body["cards"]), 1)
+
+        card = body["cards"][0]
+        # Required fields are all present.
+        for field in ("id", "name", "number", "rarity", "supertype", "subtypes", "thumb", "market"):
+            self.assertIn(field, card)
+        # And the noise fields are absent.
+        for noise in ("attacks", "weaknesses", "legalities", "tcgplayer", "images"):
+            self.assertNotIn(noise, card)
+        # And the fetch helper actually got the set_id we passed.
+        fetch_mock.assert_called_once()
+        args, _ = fetch_mock.call_args
+        self.assertEqual(args[0], "sv8")
+        # Silence unused-variable lint — raw_cards documents the upstream
+        # shape the trim is reducing.
+        self.assertEqual(raw_cards[0]["id"], "sv8-1")
+
+    def test_trim_card_helper_projects_fields(self) -> None:
+        # Direct test of the trim helper so we don't have to mock the
+        # HTTP client to assert the projection contract.
+        from api.routes.sets import _trim_card
+
+        raw = {
+            "id": "sv8-99",
+            "name": "Charizard",
+            "number": "99",
+            "rarity": "Rare Holo",
+            "supertype": "Pokémon",
+            "subtypes": ["Stage 2"],
+            "images": {"small": "https://example/c.png", "large": "x"},
+            "tcgplayer": {"prices": {"holofoil": {"market": 42.5}}},
+            "attacks": [{"name": "Fire Spin"}],
+        }
+        slim = _trim_card(raw)
+        self.assertEqual(slim["id"], "sv8-99")
+        self.assertEqual(slim["name"], "Charizard")
+        self.assertEqual(slim["number"], "99")
+        self.assertEqual(slim["rarity"], "Rare Holo")
+        self.assertEqual(slim["supertype"], "Pokémon")
+        self.assertEqual(slim["subtypes"], ["Stage 2"])
+        self.assertEqual(slim["thumb"], "https://example/c.png")
+        self.assertEqual(slim["market"], 42.5)
+        self.assertNotIn("attacks", slim)
+        self.assertNotIn("images", slim)
+        self.assertNotIn("tcgplayer", slim)
+
+    def test_trim_card_missing_pricing_returns_null_market(self) -> None:
+        # A card without tcgplayer / cardmarket pricing — happens for very
+        # new releases or promo cards. The shape should still be valid
+        # with `market: None` so the SPA can render a `—` placeholder.
+        from api.routes.sets import _trim_card
+
+        slim = _trim_card({"id": "x", "name": "n", "number": "1"})
+        self.assertIsNone(slim["market"])
+        self.assertIsNone(slim["thumb"])
+        self.assertEqual(slim["subtypes"], [])
+
+    def test_404_when_set_has_no_cards(self) -> None:
+        with patch("api.routes.sets._fetch_set_cards", return_value=[]):
+            resp = client.get("/api/v1/sets/bogus/cards")
+        self.assertEqual(resp.status_code, 404)
+        self.assertIn("bogus", resp.json()["detail"])
+
+    def test_browser_cache_control_header(self) -> None:
+        with patch(
+            "api.routes.sets._fetch_set_cards",
+            return_value=[
+                {
+                    "id": "sv8-1",
+                    "name": "Pikachu",
+                    "number": "1",
+                    "rarity": "Common",
+                    "supertype": "Pokémon",
+                    "subtypes": [],
+                    "thumb": None,
+                    "market": None,
+                }
+            ],
+        ):
+            resp = client.get("/api/v1/sets/sv8/cards")
+        self.assertEqual(resp.status_code, 200)
+        cache_control = resp.headers.get("cache-control", "")
+        self.assertIn("public", cache_control)
+        self.assertIn("max-age=", cache_control)
+
+    def test_rejects_malformed_set_ids(self) -> None:
+        # Mirrors the logo route's defence — the same `_SET_ID_PATH`
+        # validator gates both endpoints, so a regression in one would
+        # likely catch the other. Subset of inputs is enough to verify
+        # the validator is wired up here too.
+        for bad in ("sv8;rm", "x" * 200, "sv8&foo"):
+            with self.subTest(set_id=bad):
+                resp = client.get(f"/api/v1/sets/{bad}/cards")
+                self.assertEqual(resp.status_code, 422)
+
 
 class SetLogoRouteTests(unittest.TestCase):
     """`GET /api/v1/sets/{set_id}/logo` serves cached images, 404s on miss."""

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -353,6 +353,50 @@ class SetCardsRouteTests(unittest.TestCase):
                 resp = client.get(f"/api/v1/sets/{bad}/cards")
                 self.assertEqual(resp.status_code, 422)
 
+    def test_fetch_set_cards_queries_set_id_filter(self) -> None:
+        # Patch TCGClient.search_all to capture the Lucene query the
+        # helper issues. The cache-hit-rate of the underlying disk cache
+        # depends on the query string being a stable shape, so a silent
+        # change here would silently bust everyone's cache. The query
+        # MUST be `set.id:"<id>"` (quoted, single key) — see
+        # api/routes/sets.py:_fetch_set_cards.
+        from api.routes.sets import _fetch_set_cards
+
+        captured: list[str] = []
+
+        def _capture(self_, query):
+            del self_  # bound-method shape; we only care about the query string
+            captured.append(query)
+            return []
+
+        with patch("mgz_pkmn.sources.pokemontcg.TCGClient.search_all", _capture):
+            _fetch_set_cards("sv8", api_key=None)
+
+        self.assertEqual(captured, ['set.id:"sv8"'])
+
+    def test_set_id_passed_through_to_fetch(self) -> None:
+        # Confirms the route hands the path parameter straight through
+        # to `_fetch_set_cards` — i.e. no rewriting / normalisation /
+        # case-folding between the URL and the helper. Important
+        # because the upstream catalog ids are case-sensitive.
+        with patch(
+            "api.routes.sets._fetch_set_cards",
+            return_value=[
+                {
+                    "id": "x",
+                    "name": "x",
+                    "number": "1",
+                    "rarity": None,
+                    "supertype": None,
+                    "subtypes": [],
+                    "thumb": None,
+                    "market": None,
+                }
+            ],
+        ) as fetch_mock:
+            client.get("/api/v1/sets/MixedCaseId-9/cards?api_key=abc")
+        fetch_mock.assert_called_once_with("MixedCaseId-9", "abc")
+
 
 class SetLogoRouteTests(unittest.TestCase):
     """`GET /api/v1/sets/{set_id}/logo` serves cached images, 404s on miss."""

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,9 @@
  */
 
 import { useCallback, useRef, useState } from 'react'
+import { Library } from 'lucide-react'
 import { bulkLookup, lookupLine } from './api/client'
+import { BrowseModal } from './components/BrowseModal'
 import { InputEditor } from './components/InputEditor'
 import { RecentRuns } from './components/RecentRuns'
 import { ResultsTable } from './components/ResultsTable'
@@ -43,6 +45,7 @@ function App() {
 
   const abortRef = useRef<AbortController | null>(null)
   const [tourOpen, setTourOpen] = useState(false)
+  const [browseOpen, setBrowseOpen] = useState(false)
 
   // Easter egg: 5 clicks on the brand reveals Exeggutor + claim code
   // EGG-EXEGGCUTE (referencing the six-egg pre-evolution). Reset on
@@ -184,6 +187,17 @@ function App() {
             <span className="text-xs text-zinc-500 hidden sm:inline">card lookup</span>
           </button>
           <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setBrowseOpen(true)}
+              className="flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-800 px-2.5 py-1.5 text-sm text-zinc-200 hover:bg-zinc-700 transition-colors sm:px-3"
+              title="Browse sets"
+              aria-label="Browse sets"
+              data-tour="browse"
+            >
+              <Library size={15} />
+              <span className="hidden sm:inline">Browse</span>
+            </button>
             <div data-tour="exports">
               <ExportBar />
             </div>
@@ -221,6 +235,8 @@ function App() {
       {tourOpen && (
         <Tour onClose={() => setTourOpen(false)} onRun={handleRun} onStop={handleStop} />
       )}
+
+      <BrowseModal open={browseOpen} onOpenChange={setBrowseOpen} />
 
       {/* Easter egg overlay — see handleBrandClick. */}
       {showEgg && (

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -6,7 +6,16 @@
  * origin as the API.
  */
 
-import type { BulkEvent, CardQuery, ExportFormat, Row, SetInfo, Settings, SortMode } from '../types'
+import type {
+  BulkEvent,
+  CardQuery,
+  ExportFormat,
+  Row,
+  SetCard,
+  SetInfo,
+  Settings,
+  SortMode,
+} from '../types'
 
 const BASE = '/api/v1'
 
@@ -257,6 +266,28 @@ export async function fetchSets(apiKey?: string): Promise<SetInfo[]> {
   if (!res.ok) throw new Error(`sets failed: ${res.status}`)
   const data = await res.json()
   return data.sets as SetInfo[]
+}
+
+/**
+ * Fetch the trimmed card list for one set. The response is browser-cacheable
+ * for a day (via the backend's `Cache-Control`) so repeated opens of the
+ * same set in the Browse modal don't round-trip the server.
+ */
+export async function fetchSetCards(setId: string, apiKey?: string): Promise<SetCard[]> {
+  const params = apiKey ? `?api_key=${encodeURIComponent(apiKey)}` : ''
+  const res = await fetch(`${BASE}/sets/${encodeURIComponent(setId)}/cards${params}`)
+  if (!res.ok) {
+    let detail = `set cards failed: ${res.status}`
+    try {
+      const body = await res.json()
+      if (body?.detail) detail = body.detail
+    } catch {
+      /* fall through */
+    }
+    throw new Error(detail)
+  }
+  const data = await res.json()
+  return data.cards as SetCard[]
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/components/BrowseModal.test.tsx
+++ b/web/src/components/BrowseModal.test.tsx
@@ -219,4 +219,100 @@ describe('BrowseModal', () => {
       await screen.findByText(/Couldn’t load sets: catalog down/),
     ).toBeInTheDocument()
   })
+
+  it('reports an honest 0-added status when re-adding an already-added card', async () => {
+    // Covers Copilot review thread #1 — the modal used to render "Added
+    // 1 line" even when `appendInputLines` had silently dropped the
+    // dupe. We now use the return value of `appendInputLines`, so the
+    // status reflects what actually landed in the editor.
+    renderOpen()
+    fireEvent.click(await screen.findByText('Surging Sparks'))
+    await screen.findByText('Pikachu')
+
+    const addBtn = screen.getByRole('button', { name: 'Add Pikachu to list' })
+    fireEvent.click(addBtn)
+    // After the first click: "Added 1 line to your list".
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      'Added 1 line to your list',
+    )
+    // Second click on the same card is a no-op: dedupe silently drops
+    // it, so the status now reports the honest 0.
+    fireEvent.click(addBtn)
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      'Added 0 lines to your list',
+    )
+  })
+
+  it('clears the "Added N lines" status when switching to a different set', async () => {
+    // Covers Copilot review thread #2 — the status used to persist into
+    // the next set's detail view, reading as stale information. The
+    // load effect now clears it before fetching the new set's cards.
+    const OTHER_CARDS: SetCard[] = [
+      {
+        id: 'base1-4',
+        name: 'Charizard',
+        number: '4',
+        rarity: 'Rare Holo',
+        supertype: 'Pokémon',
+        subtypes: ['Stage 2'],
+        thumb: null,
+        market: 200.0,
+      },
+    ]
+    mockFetchSetCards.mockImplementation((id: string) =>
+      Promise.resolve(id === 'base1' ? OTHER_CARDS : SV8_CARDS),
+    )
+
+    renderOpen()
+    fireEvent.click(await screen.findByText('Surging Sparks'))
+    await screen.findByText('Pikachu')
+    fireEvent.click(screen.getByRole('button', { name: 'Add Pikachu to list' }))
+    await screen.findByRole('status') // ensures the status rendered
+
+    // Back out and pick the other set.
+    fireEvent.click(screen.getByRole('button', { name: 'Back to set list' }))
+    fireEvent.click(await screen.findByText('Base Set'))
+    await screen.findByText('Charizard')
+
+    // No status carried over.
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('Add holos / Add rares operate on the FULL set, not the filtered slice', async () => {
+    // Covers Copilot review thread #3 — with a non-"All" rarity chip
+    // active, the bulk buttons used to take their input from the
+    // already-filtered grid, producing zero-add results that fought
+    // the button's label. Now they always run against the unfiltered
+    // pool so the label is honest.
+    renderOpen()
+    fireEvent.click(await screen.findByText('Surging Sparks'))
+    await screen.findByText('Pikachu')
+
+    // Narrow visible to "Ultra+" (only the Special Illustration Rare
+    // would be visible). Then click "Add holos" — should still find
+    // the Rare Holo Charizard ex in the unfiltered pool.
+    fireEvent.click(screen.getByRole('button', { name: 'Ultra+' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Add holos' }))
+
+    const lines = useAppStore.getState().inputText.split('\n')
+    expect(lines).toContain('Charizard ex | Surging Sparks | 25')
+  })
+
+  it('caches the trimmed cards in memory — re-picking the same set skips the fetch', async () => {
+    // New behaviour added during PR review (observation #2): re-opening
+    // the same set should be instantaneous, with no loading flicker
+    // and no second network call.
+    renderOpen()
+    fireEvent.click(await screen.findByText('Surging Sparks'))
+    await screen.findByText('Pikachu')
+    expect(mockFetchSetCards).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to set list' }))
+    fireEvent.click(await screen.findByText('Surging Sparks'))
+
+    // Cards render immediately from the SPA-side cache.
+    expect(await screen.findByText('Pikachu')).toBeInTheDocument()
+    // And no second fetch fired.
+    expect(mockFetchSetCards).toHaveBeenCalledTimes(1)
+  })
 })

--- a/web/src/components/BrowseModal.test.tsx
+++ b/web/src/components/BrowseModal.test.tsx
@@ -1,0 +1,222 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { BrowseModal } from './BrowseModal'
+import { useAppStore } from '../store'
+import { fetchSetCards, fetchSets, setLogoUrl } from '../api/client'
+import type { SetCard, SetInfo } from '../types'
+
+vi.mock('../api/client', () => ({
+  fetchSets: vi.fn(),
+  fetchSetCards: vi.fn(),
+  setLogoUrl: vi.fn((id: string) => `/api/v1/sets/${id}/logo`),
+}))
+
+const mockFetchSets = vi.mocked(fetchSets)
+const mockFetchSetCards = vi.mocked(fetchSetCards)
+const mockLogoUrl = vi.mocked(setLogoUrl)
+
+const SETS: SetInfo[] = [
+  {
+    id: 'base1',
+    name: 'Base Set',
+    series: 'Base',
+    total: 102,
+    releaseDate: '1998/01/09',
+  },
+  {
+    id: 'sv8',
+    name: 'Surging Sparks',
+    series: 'Scarlet & Violet',
+    total: 252,
+    releaseDate: '2024/11/08',
+  },
+]
+
+const SV8_CARDS: SetCard[] = [
+  {
+    id: 'sv8-1',
+    name: 'Pikachu',
+    number: '1',
+    rarity: 'Common',
+    supertype: 'Pokémon',
+    subtypes: ['Basic'],
+    thumb: 'https://images.example/sv8-1.png',
+    market: 0.5,
+  },
+  {
+    id: 'sv8-25',
+    name: 'Charizard ex',
+    number: '25',
+    rarity: 'Rare Holo',
+    supertype: 'Pokémon',
+    subtypes: ['Stage 2', 'ex'],
+    thumb: 'https://images.example/sv8-25.png',
+    market: 42.5,
+  },
+  {
+    id: 'sv8-200',
+    name: 'Pikachu ex (Special Illustration Rare)',
+    number: '200',
+    rarity: 'Special Illustration Rare',
+    supertype: 'Pokémon',
+    subtypes: ['Basic', 'ex'],
+    thumb: 'https://images.example/sv8-200.png',
+    market: 150.0,
+  },
+]
+
+describe('BrowseModal', () => {
+  beforeEach(() => {
+    useAppStore.setState({ inputText: '' })
+    mockFetchSets.mockReset()
+    mockFetchSetCards.mockReset()
+    mockLogoUrl.mockClear()
+    mockFetchSets.mockResolvedValue(SETS)
+    mockFetchSetCards.mockResolvedValue(SV8_CARDS)
+  })
+
+  function renderOpen() {
+    const onOpenChange = vi.fn()
+    const result = render(<BrowseModal open onOpenChange={onOpenChange} />)
+    return { onOpenChange, ...result }
+  }
+
+  it('loads the set catalog on open and renders sets newest-first by series', async () => {
+    renderOpen()
+    // Wait until the actual catalog rows render, not just the fetch call.
+    await screen.findByText('Surging Sparks')
+    expect(screen.getByText('Base Set')).toBeInTheDocument()
+
+    // Series headers appear in order: Scarlet & Violet (newest) → Base.
+    const seriesHeaders = screen.getAllByText(/Scarlet & Violet|^Base$/)
+    expect(seriesHeaders[0]).toHaveTextContent('Scarlet & Violet')
+  })
+
+  it('picking a set loads its trimmed card list and renders the grid', async () => {
+    renderOpen()
+    fireEvent.click(await screen.findByText('Surging Sparks'))
+
+    // The detail header replaces the list header with the set name.
+    await screen.findByRole('heading', { name: /Surging Sparks/ })
+
+    // fetchSetCards was called with the chosen set id.
+    expect(mockFetchSetCards).toHaveBeenCalledWith('sv8', undefined)
+
+    // Every card from the trimmed payload renders a tile.
+    expect(await screen.findByText('Pikachu')).toBeInTheDocument()
+    expect(screen.getByText('Charizard ex')).toBeInTheDocument()
+    expect(
+      screen.getByText('Pikachu ex (Special Illustration Rare)'),
+    ).toBeInTheDocument()
+  })
+
+  it('clicking Add to list on a card pushes the canonical line into the editor', async () => {
+    renderOpen()
+    fireEvent.click(await screen.findByText('Surging Sparks'))
+    await screen.findByText('Charizard ex')
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Add Charizard ex to list' }),
+    )
+
+    expect(useAppStore.getState().inputText).toContain(
+      'Charizard ex | Surging Sparks | 25',
+    )
+  })
+
+  it('Add to list dedupes — clicking the same card twice leaves one line', async () => {
+    renderOpen()
+    fireEvent.click(await screen.findByText('Surging Sparks'))
+    await screen.findByText('Pikachu')
+
+    const addBtn = screen.getByRole('button', { name: 'Add Pikachu to list' })
+    fireEvent.click(addBtn)
+    fireEvent.click(addBtn)
+
+    const input = useAppStore.getState().inputText
+    const matches = input
+      .split('\n')
+      .filter((l) => l.trim() === 'Pikachu | Surging Sparks | 1')
+    expect(matches).toHaveLength(1)
+  })
+
+  it('Add all visible pushes every currently-filtered card', async () => {
+    renderOpen()
+    fireEvent.click(await screen.findByText('Surging Sparks'))
+    await screen.findByText('Pikachu')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add all visible' }))
+
+    const lines = useAppStore.getState().inputText.trim().split('\n')
+    expect(lines).toHaveLength(3)
+    expect(lines).toContain('Pikachu | Surging Sparks | 1')
+    expect(lines).toContain('Charizard ex | Surging Sparks | 25')
+  })
+
+  it('the rarity filter chips narrow the visible grid', async () => {
+    renderOpen()
+    fireEvent.click(await screen.findByText('Surging Sparks'))
+    await screen.findByText('Pikachu')
+
+    // Click "Holos" — Common Pikachu (#1) should drop out, leaving the
+    // Rare Holo Charizard ex and the Special Illustration Rare (which
+    // also contains "Holo" in its full rarity? — it doesn't, but it
+    // matches via "ultra" bucket separately, so use that for the test).
+    fireEvent.click(screen.getByRole('button', { name: 'Ultra+' }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Pikachu')).not.toBeInTheDocument()
+      expect(
+        screen.getByText('Pikachu ex (Special Illustration Rare)'),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('the search box narrows the visible grid case-insensitively', async () => {
+    renderOpen()
+    fireEvent.click(await screen.findByText('Surging Sparks'))
+    await screen.findByText('Pikachu')
+
+    fireEvent.change(
+      screen.getByRole('searchbox', { name: 'Search cards in this set' }),
+      { target: { value: 'charizard' } },
+    )
+
+    await waitFor(() => {
+      expect(screen.queryByText('Pikachu')).not.toBeInTheDocument()
+      expect(screen.getByText('Charizard ex')).toBeInTheDocument()
+    })
+  })
+
+  it('Back button returns to the set list and re-fetches a different set fresh', async () => {
+    renderOpen()
+    fireEvent.click(await screen.findByText('Surging Sparks'))
+    await screen.findByText('Charizard ex')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to set list' }))
+
+    // Back at the set list — the heading reverts.
+    expect(
+      screen.getByRole('heading', { name: 'Browse sets' }),
+    ).toBeInTheDocument()
+  })
+
+  it('surfaces an error when the card fetch fails', async () => {
+    mockFetchSetCards.mockRejectedValueOnce(new Error('upstream down'))
+    renderOpen()
+    fireEvent.click(await screen.findByText('Surging Sparks'))
+
+    expect(
+      await screen.findByText(/Couldn’t load cards: upstream down/),
+    ).toBeInTheDocument()
+  })
+
+  it('surfaces an error when the catalog fetch fails', async () => {
+    mockFetchSets.mockRejectedValueOnce(new Error('catalog down'))
+    renderOpen()
+
+    expect(
+      await screen.findByText(/Couldn’t load sets: catalog down/),
+    ).toBeInTheDocument()
+  })
+})

--- a/web/src/components/BrowseModal.tsx
+++ b/web/src/components/BrowseModal.tsx
@@ -34,7 +34,7 @@ import {
   Search,
   X,
 } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import { fetchSetCards, fetchSets, setLogoUrl } from '../api/client'
 import { useAppStore } from '../store'
@@ -161,6 +161,15 @@ export function BrowseModal({ open, onOpenChange }: Props) {
   const [sort, setSort] = useState<CardSort>('number')
   const [addedCount, setAddedCount] = useState<number | null>(null)
 
+  // SPA-side cache of `set_id → trimmed cards`. Persists for the
+  // lifetime of the React tree (a page reload clears it; the browser's
+  // 1-day `Cache-Control` covers the cross-reload case). The point is
+  // to make re-picking the *same* set within a prep session feel
+  // instant — no fetch round-trip, no `Loading cards…` flicker, no
+  // re-render of the empty grid. A `useRef` (not state) is exactly
+  // right: cache writes shouldn't trigger renders.
+  const cardCacheRef = useRef<Map<string, SetCard[]>>(new Map())
+
   // Reset transient view state whenever the modal becomes visible. We
   // deliberately keep `sets` mounted across open/close so a re-open is
   // free — the catalog won't have moved between opens. The
@@ -209,12 +218,33 @@ export function BrowseModal({ open, onOpenChange }: Props) {
     if (!activeSet) return
     let cancelled = false
     const load = async () => {
-      setCardsLoading(true)
+      // Clear any "Added N lines" status carried over from the previous
+      // set — otherwise the message persists into the new detail view
+      // until the user adds something fresh, which reads as stale.
+      setAddedCount(null)
       setCardsError(null)
+
+      // SPA-side cache hit: serve immediately, skip the fetch and the
+      // loading state. This is the load-bearing optimisation for
+      // re-picking the same set — the browser's 1-day `Cache-Control`
+      // would also cover this, but a fetch-and-re-render still costs a
+      // visible tick of `Loading cards…`. An in-memory `Map` lookup
+      // costs none.
+      const cached = cardCacheRef.current.get(activeSet.id)
+      if (cached) {
+        setCards(cached)
+        setCardsLoading(false)
+        return
+      }
+
+      setCardsLoading(true)
       setCards(null)
       try {
         const data = await fetchSetCards(activeSet.id, settings.apiKey || undefined)
-        if (!cancelled) setCards(data)
+        if (!cancelled) {
+          cardCacheRef.current.set(activeSet.id, data)
+          setCards(data)
+        }
       } catch (err) {
         if (!cancelled) setCardsError(err instanceof Error ? err.message : String(err))
       } finally {
@@ -247,8 +277,12 @@ export function BrowseModal({ open, onOpenChange }: Props) {
 
   function addCards(toAdd: SetCard[]) {
     if (!activeSet || toAdd.length === 0) return
-    appendInputLines(toAdd.map((c) => toInputLine(c, activeSet)))
-    setAddedCount(toAdd.length)
+    // `appendInputLines` returns the count of lines *actually* appended
+    // — dedupes against the editor's current contents. We report that,
+    // not `toAdd.length`, so a click on an already-added card honestly
+    // reads "Added 0 lines" instead of overstating.
+    const added = appendInputLines(toAdd.map((c) => toInputLine(c, activeSet)))
+    setAddedCount(added)
   }
 
   return (
@@ -318,11 +352,18 @@ export function BrowseModal({ open, onOpenChange }: Props) {
               addedCount={addedCount}
               onAddCards={addCards}
               onAddAll={() => addCards(filteredCards)}
+              // Holos / rares bulks operate on the **full** set, not the
+              // currently-filtered slice. Otherwise the buttons fight
+              // the active rarity chip — e.g. with "Ultra+" selected,
+              // "Add holos" would only add the intersection (often
+              // zero), despite the label promising every holo. Predictable
+              // beats clever. "Add all visible" is the explicit
+              // honour-the-filter button right alongside.
               onAddHolos={() =>
-                addCards(filteredCards.filter((c) => inBucket(c, 'holo')))
+                addCards((cards ?? []).filter((c) => inBucket(c, 'holo')))
               }
               onAddRares={() =>
-                addCards(filteredCards.filter((c) => inBucket(c, 'rare')))
+                addCards((cards ?? []).filter((c) => inBucket(c, 'rare')))
               }
             />
           ) : (

--- a/web/src/components/BrowseModal.tsx
+++ b/web/src/components/BrowseModal.tsx
@@ -1,0 +1,656 @@
+/**
+ * BrowseModal — explore Pokémon TCG cards by set without typing a list.
+ *
+ * Two-view dialog:
+ *
+ *   1. **Set list** — every set grouped by series (newest-first), each
+ *      row shows the cached logo + name + release year + card count.
+ *      Picking a set transitions to view 2.
+ *   2. **Set detail** — a responsive grid of every card in the chosen
+ *      set, with thumb / name / number / rarity / market price. The user
+ *      can search within the set, sort, filter by rarity bucket, and
+ *      either click an individual card to push it into the InputEditor
+ *      or bulk-add holos / rares / everything.
+ *
+ * The card list comes from `GET /api/v1/sets/{id}/cards` which returns
+ * a trimmed payload (see `api/routes/sets.py:_trim_card`) and ships a
+ * 1-day `Cache-Control` so re-opens within a prep session never hit
+ * the upstream API. Combined with the per-set on-disk cache one level
+ * down, the second open of any set is effectively instant.
+ *
+ * "Add to list" pushes lines into Zustand via `appendInputLines`,
+ * which dedupes against existing input — clicking the same card twice
+ * doesn't double-stamp it. We keep the modal open after adding so the
+ * user can continue grazing the same set; the InputEditor reflects
+ * updates immediately because it reads from the same store.
+ */
+import * as Dialog from '@radix-ui/react-dialog'
+import {
+  ArrowLeft,
+  ImageOff,
+  Library,
+  Loader2,
+  Plus,
+  Search,
+  X,
+} from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+import { fetchSetCards, fetchSets, setLogoUrl } from '../api/client'
+import { useAppStore } from '../store'
+import type { SetCard, SetInfo } from '../types'
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+interface SeriesGroup {
+  series: string
+  sets: SetInfo[]
+}
+
+// Mirrors SetPickerModal — the catalog comes back oldest → newest from
+// `/api/v1/sets`, and the UX bias is newest-first because prep flows
+// almost always start with the current block. Walking in reverse means
+// both group order and per-group order land newest-first in one pass.
+const OTHER_SERIES = 'Other'
+
+function seriesKey(set: SetInfo): string {
+  return set.series || OTHER_SERIES
+}
+
+function groupBySeries(sets: SetInfo[]): SeriesGroup[] {
+  const order: string[] = []
+  const buckets = new Map<string, SetInfo[]>()
+  for (let i = sets.length - 1; i >= 0; i--) {
+    const s = sets[i]
+    const key = seriesKey(s)
+    if (!buckets.has(key)) {
+      buckets.set(key, [])
+      order.push(key)
+    }
+    buckets.get(key)!.push(s)
+  }
+  return order.map((series) => ({ series, sets: buckets.get(series)! }))
+}
+
+function releaseYear(date: string): string | null {
+  const match = /^(\d{4})/.exec(date || '')
+  return match ? match[1] : null
+}
+
+// ---------------------------------------------------------------------------
+// Rarity bucketing for the in-set filter chips.
+//
+// pokemontcg.io's `rarity` field is a free-form string with dozens of
+// values across eras ("Rare Holo", "Rare Ultra", "Amazing Rare",
+// "Radiant Rare", "Trainer Gallery Rare Holo", ...). Rather than
+// enumerate every spelling, we bucket by substring match — case
+// insensitive — which captures the eras the user actually cares about
+// when scanning a set ("show me only the chase cards").
+// ---------------------------------------------------------------------------
+
+type RarityBucket = 'all' | 'holo' | 'rare' | 'ultra'
+
+function inBucket(card: SetCard, bucket: RarityBucket): boolean {
+  if (bucket === 'all') return true
+  const rarity = (card.rarity || '').toLowerCase()
+  if (bucket === 'holo') return rarity.includes('holo')
+  if (bucket === 'ultra') {
+    return (
+      rarity.includes('ultra') ||
+      rarity.includes('secret') ||
+      rarity.includes('rainbow') ||
+      rarity.includes('hyper') ||
+      rarity.includes('illustration')
+    )
+  }
+  if (bucket === 'rare') return rarity.includes('rare')
+  return true
+}
+
+// ---------------------------------------------------------------------------
+// Sort options. Default is "Number" so cards land in collector order — the
+// canonical way a binder is read. Price-desc is the chase view.
+// ---------------------------------------------------------------------------
+
+type CardSort = 'number' | 'name' | 'price-desc'
+
+function compareCards(a: SetCard, b: SetCard, sort: CardSort): number {
+  if (sort === 'name') return (a.name || '').localeCompare(b.name || '')
+  if (sort === 'price-desc') {
+    const am = a.market ?? -Infinity
+    const bm = b.market ?? -Infinity
+    return bm - am
+  }
+  // number: split off any "/total" suffix and compare numerically when
+  // both sides parse, otherwise fall back to string compare so sets
+  // with alpha-suffixed numbers (e.g. "TG01", "SV01") still sort sanely.
+  const an = parseInt((a.number || '').split('/')[0], 10)
+  const bn = parseInt((b.number || '').split('/')[0], 10)
+  if (Number.isFinite(an) && Number.isFinite(bn)) return an - bn
+  return (a.number || '').localeCompare(b.number || '')
+}
+
+// ---------------------------------------------------------------------------
+// Add-to-list line format mirrors the parser's canonical
+// `Name | Set Name | Number` shape (see src/mgz_pkmn/parser.py:228).
+// ---------------------------------------------------------------------------
+
+function toInputLine(card: SetCard, set: SetInfo): string {
+  return `${card.name} | ${set.name} | ${card.number}`
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function BrowseModal({ open, onOpenChange }: Props) {
+  const { settings, appendInputLines } = useAppStore()
+
+  const [sets, setSets] = useState<SetInfo[] | null>(null)
+  const [setsError, setSetsError] = useState<string | null>(null)
+  const [activeSet, setActiveSet] = useState<SetInfo | null>(null)
+  const [cards, setCards] = useState<SetCard[] | null>(null)
+  const [cardsError, setCardsError] = useState<string | null>(null)
+  const [cardsLoading, setCardsLoading] = useState(false)
+
+  const [search, setSearch] = useState('')
+  const [bucket, setBucket] = useState<RarityBucket>('all')
+  const [sort, setSort] = useState<CardSort>('number')
+  const [addedCount, setAddedCount] = useState<number | null>(null)
+
+  // Reset transient view state whenever the modal becomes visible. We
+  // deliberately keep `sets` mounted across open/close so a re-open is
+  // free — the catalog won't have moved between opens. The
+  // set-state-in-effect disable is documented as the right tool for
+  // reacting to a prop transition.
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    if (!open) return
+    setActiveSet(null)
+    setCards(null)
+    setCardsError(null)
+    setSearch('')
+    setBucket('all')
+    setSort('number')
+    setAddedCount(null)
+  }, [open])
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  // Lazy-load the set catalog on first open.
+  useEffect(() => {
+    if (!open || sets !== null) return
+    let cancelled = false
+    void (async () => {
+      setSetsError(null)
+      try {
+        const data = await fetchSets(settings.apiKey || undefined)
+        if (!cancelled) setSets(data)
+      } catch (err) {
+        if (!cancelled) setSetsError(err instanceof Error ? err.message : String(err))
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [open, sets, settings.apiKey])
+
+  // Load the in-set card list whenever the user picks a set. The
+  // backend caches the response for a day in the browser, so flipping
+  // back and forth between two sets repeatedly is free after the first
+  // visit to each. The loading/error/cards resets live inside the async
+  // `load` callback rather than directly in the effect body so we don't
+  // trip `react-hooks/set-state-in-effect` — the async function still
+  // runs synchronously up to the first await, so the observable order
+  // is identical.
+  useEffect(() => {
+    if (!activeSet) return
+    let cancelled = false
+    const load = async () => {
+      setCardsLoading(true)
+      setCardsError(null)
+      setCards(null)
+      try {
+        const data = await fetchSetCards(activeSet.id, settings.apiKey || undefined)
+        if (!cancelled) setCards(data)
+      } catch (err) {
+        if (!cancelled) setCardsError(err instanceof Error ? err.message : String(err))
+      } finally {
+        if (!cancelled) setCardsLoading(false)
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [activeSet, settings.apiKey])
+
+  const groups = useMemo(() => (sets ? groupBySeries(sets) : []), [sets])
+
+  const filteredCards = useMemo(() => {
+    if (!cards) return []
+    const term = search.trim().toLowerCase()
+    const out = cards.filter((c) => {
+      if (!inBucket(c, bucket)) return false
+      if (!term) return true
+      return (
+        (c.name || '').toLowerCase().includes(term) ||
+        (c.number || '').toLowerCase().includes(term) ||
+        (c.rarity || '').toLowerCase().includes(term)
+      )
+    })
+    out.sort((a, b) => compareCards(a, b, sort))
+    return out
+  }, [cards, search, bucket, sort])
+
+  function addCards(toAdd: SetCard[]) {
+    if (!activeSet || toAdd.length === 0) return
+    appendInputLines(toAdd.map((c) => toInputLine(c, activeSet)))
+    setAddedCount(toAdd.length)
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm" />
+        <Dialog.Content
+          aria-describedby="browse-description"
+          className="fixed left-1/2 top-1/2 z-50 flex max-h-[90vh] w-[min(1100px,95vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-zinc-700 bg-zinc-900 shadow-2xl"
+        >
+          <header className="flex items-center justify-between gap-3 border-b border-zinc-800 px-5 py-4">
+            <div className="flex items-center gap-2">
+              {activeSet && (
+                <button
+                  type="button"
+                  onClick={() => setActiveSet(null)}
+                  aria-label="Back to set list"
+                  className="rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+                >
+                  <ArrowLeft size={16} />
+                </button>
+              )}
+              <Library size={18} className="text-zinc-300" />
+              <Dialog.Title className="text-lg font-semibold text-zinc-100">
+                {activeSet ? activeSet.name : 'Browse sets'}
+              </Dialog.Title>
+              {activeSet && (
+                <span className="text-xs text-zinc-500">
+                  {activeSet.series}
+                  {releaseYear(activeSet.releaseDate)
+                    ? ` · ${releaseYear(activeSet.releaseDate)}`
+                    : ''}
+                </span>
+              )}
+            </div>
+            <Dialog.Close asChild>
+              <button
+                aria-label="Close"
+                className="rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+              >
+                <X size={18} />
+              </button>
+            </Dialog.Close>
+          </header>
+
+          <Dialog.Description
+            id="browse-description"
+            className="px-5 pt-3 text-sm text-zinc-400"
+          >
+            {activeSet
+              ? 'Click a card to add it to your input list, or use the bulk actions below.'
+              : 'Pick a set to see every card with its market price, sortable and filterable.'}
+          </Dialog.Description>
+
+          {activeSet ? (
+            <SetDetailView
+              cards={filteredCards}
+              total={cards?.length ?? 0}
+              loading={cardsLoading}
+              error={cardsError}
+              search={search}
+              onSearch={setSearch}
+              bucket={bucket}
+              onBucket={setBucket}
+              sort={sort}
+              onSort={setSort}
+              addedCount={addedCount}
+              onAddCards={addCards}
+              onAddAll={() => addCards(filteredCards)}
+              onAddHolos={() =>
+                addCards(filteredCards.filter((c) => inBucket(c, 'holo')))
+              }
+              onAddRares={() =>
+                addCards(filteredCards.filter((c) => inBucket(c, 'rare')))
+              }
+            />
+          ) : (
+            <SetListView
+              sets={sets}
+              groups={groups}
+              error={setsError}
+              onPick={(s) => setActiveSet(s)}
+            />
+          )}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Set-list view
+// ---------------------------------------------------------------------------
+
+interface SetListProps {
+  sets: SetInfo[] | null
+  groups: SeriesGroup[]
+  error: string | null
+  onPick: (set: SetInfo) => void
+}
+
+function SetListView({ sets, groups, error, onPick }: SetListProps) {
+  return (
+    <div className="flex-1 overflow-y-auto px-5 py-3">
+      {error && (
+        <p className="rounded border border-red-900/50 bg-red-950/30 px-3 py-2 text-sm text-red-300">
+          Couldn’t load sets: {error}
+        </p>
+      )}
+      {!sets && !error && (
+        <p className="flex items-center gap-2 text-sm text-zinc-400">
+          <Loader2 size={14} className="animate-spin" />
+          Loading set catalog…
+        </p>
+      )}
+      {sets && (
+        <ul className="space-y-4">
+          {groups.map((group) => (
+            <li key={group.series}>
+              <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-300">
+                {group.series}
+                <span className="ml-1 font-normal normal-case tracking-normal text-zinc-500">
+                  ({group.sets.length})
+                </span>
+              </div>
+              <ul className="grid grid-cols-1 gap-1 sm:grid-cols-2 lg:grid-cols-3">
+                {group.sets.map((s) => (
+                  <SetTile key={s.id} set={s} onPick={() => onPick(s)} />
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+function SetTile({ set, onPick }: { set: SetInfo; onPick: () => void }) {
+  const [logoFailed, setLogoFailed] = useState(false)
+  const year = releaseYear(set.releaseDate)
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onPick}
+        className="flex w-full items-center gap-3 rounded-md border border-zinc-800 bg-zinc-950/40 px-3 py-2 text-left hover:border-zinc-700 hover:bg-zinc-900 focus:outline-none focus:ring-2 focus:ring-zinc-700"
+      >
+        <div className="flex h-10 w-14 flex-none items-center justify-center rounded bg-zinc-950">
+          {logoFailed ? (
+            <ImageOff size={16} className="text-zinc-600" aria-hidden />
+          ) : (
+            <img
+              src={setLogoUrl(set.id)}
+              alt=""
+              className="max-h-9 max-w-12 object-contain"
+              loading="lazy"
+              onError={() => setLogoFailed(true)}
+            />
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-sm font-medium text-zinc-100">
+            {set.name}
+          </div>
+          <div className="truncate text-xs text-zinc-500">
+            {year || '—'} · {set.total ? `${set.total} cards` : 'count unknown'}
+          </div>
+        </div>
+      </button>
+    </li>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Set-detail view
+// ---------------------------------------------------------------------------
+
+interface SetDetailProps {
+  cards: SetCard[]
+  total: number
+  loading: boolean
+  error: string | null
+  search: string
+  onSearch: (v: string) => void
+  bucket: RarityBucket
+  onBucket: (b: RarityBucket) => void
+  sort: CardSort
+  onSort: (s: CardSort) => void
+  addedCount: number | null
+  onAddCards: (cards: SetCard[]) => void
+  onAddAll: () => void
+  onAddHolos: () => void
+  onAddRares: () => void
+}
+
+const BUCKETS: { value: RarityBucket; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'rare', label: 'Rares' },
+  { value: 'holo', label: 'Holos' },
+  { value: 'ultra', label: 'Ultra+' },
+]
+
+const SORT_OPTIONS: { value: CardSort; label: string }[] = [
+  { value: 'number', label: 'Number' },
+  { value: 'name', label: 'Name' },
+  { value: 'price-desc', label: 'Price ↓' },
+]
+
+function SetDetailView({
+  cards,
+  total,
+  loading,
+  error,
+  search,
+  onSearch,
+  bucket,
+  onBucket,
+  sort,
+  onSort,
+  addedCount,
+  onAddCards,
+  onAddAll,
+  onAddHolos,
+  onAddRares,
+}: SetDetailProps) {
+  return (
+    <>
+      {/* Toolbar */}
+      <div className="flex flex-wrap items-center gap-2 border-b border-zinc-800 px-5 py-3">
+        <label className="relative flex-1 min-w-[180px]">
+          <Search
+            size={14}
+            className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-zinc-500"
+            aria-hidden
+          />
+          <input
+            type="search"
+            placeholder="Search this set…"
+            value={search}
+            onChange={(e) => onSearch(e.target.value)}
+            className="w-full rounded-md border border-zinc-700 bg-zinc-950 py-1.5 pl-8 pr-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-zinc-500 focus:outline-none"
+            aria-label="Search cards in this set"
+          />
+        </label>
+        <div className="flex items-center gap-1" role="group" aria-label="Rarity filter">
+          {BUCKETS.map((b) => (
+            <Chip key={b.value} active={bucket === b.value} onClick={() => onBucket(b.value)}>
+              {b.label}
+            </Chip>
+          ))}
+        </div>
+        <label className="flex items-center gap-1 text-xs text-zinc-400">
+          Sort
+          <select
+            value={sort}
+            onChange={(e) => onSort(e.target.value as CardSort)}
+            className="rounded-md border border-zinc-700 bg-zinc-950 px-2 py-1 text-sm text-zinc-100 focus:border-zinc-500 focus:outline-none"
+            aria-label="Sort cards"
+          >
+            {SORT_OPTIONS.map((s) => (
+              <option key={s.value} value={s.value}>
+                {s.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {/* Bulk-action toolbar */}
+      <div className="flex flex-wrap items-center gap-2 border-b border-zinc-800 px-5 py-2 text-xs text-zinc-400">
+        <span>
+          {cards.length} of {total} card{total === 1 ? '' : 's'}
+        </span>
+        <span className="text-zinc-600">·</span>
+        <BulkButton onClick={onAddAll}>Add all visible</BulkButton>
+        <BulkButton onClick={onAddHolos}>Add holos</BulkButton>
+        <BulkButton onClick={onAddRares}>Add rares</BulkButton>
+        {addedCount != null && (
+          <span className="ml-auto text-emerald-400" role="status">
+            Added {addedCount} line{addedCount === 1 ? '' : 's'} to your list
+          </span>
+        )}
+      </div>
+
+      {/* Grid */}
+      <div className="flex-1 overflow-y-auto px-5 py-3">
+        {error && (
+          <p className="rounded border border-red-900/50 bg-red-950/30 px-3 py-2 text-sm text-red-300">
+            Couldn’t load cards: {error}
+          </p>
+        )}
+        {loading && !error && (
+          <p className="flex items-center gap-2 text-sm text-zinc-400">
+            <Loader2 size={14} className="animate-spin" />
+            Loading cards…
+          </p>
+        )}
+        {!loading && !error && cards.length === 0 && (
+          <p className="text-sm text-zinc-500">No cards match your filters.</p>
+        )}
+        {!loading && !error && cards.length > 0 && (
+          <ul className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+            {cards.map((c) => (
+              <CardTile key={c.id} card={c} onAdd={() => onAddCards([c])} />
+            ))}
+          </ul>
+        )}
+      </div>
+    </>
+  )
+}
+
+function CardTile({ card, onAdd }: { card: SetCard; onAdd: () => void }) {
+  const [thumbFailed, setThumbFailed] = useState(false)
+  return (
+    <li className="group flex flex-col rounded-md border border-zinc-800 bg-zinc-950/40 p-2 text-left hover:border-zinc-700 hover:bg-zinc-900">
+      <div className="relative aspect-[245/342] w-full overflow-hidden rounded bg-zinc-950">
+        {card.thumb && !thumbFailed ? (
+          <img
+            src={card.thumb}
+            alt={card.name}
+            className="h-full w-full object-contain"
+            loading="lazy"
+            onError={() => setThumbFailed(true)}
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-zinc-700">
+            <ImageOff size={28} aria-hidden />
+          </div>
+        )}
+      </div>
+      <div className="mt-2 min-w-0 flex-1">
+        <div className="truncate text-sm font-medium text-zinc-100" title={card.name}>
+          {card.name}
+        </div>
+        <div className="flex items-center justify-between text-xs text-zinc-500">
+          <span>#{card.number}</span>
+          {card.market != null && (
+            <span className="text-emerald-400">${card.market.toFixed(2)}</span>
+          )}
+        </div>
+        {card.rarity && (
+          <div className="truncate text-[11px] text-zinc-500">{card.rarity}</div>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={onAdd}
+        className="mt-2 flex items-center justify-center gap-1 rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-zinc-200 hover:border-emerald-700 hover:bg-emerald-900/30 hover:text-emerald-300"
+        aria-label={`Add ${card.name} to list`}
+      >
+        <Plus size={12} />
+        Add to list
+      </button>
+    </li>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Shared small bits
+// ---------------------------------------------------------------------------
+
+function Chip({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  children: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={`rounded-md border px-2 py-1 text-xs transition-colors ${
+        active
+          ? 'border-blue-700 bg-blue-900/40 text-blue-200'
+          : 'border-zinc-700 bg-zinc-800 text-zinc-300 hover:bg-zinc-700'
+      }`}
+    >
+      {children}
+    </button>
+  )
+}
+
+function BulkButton({
+  onClick,
+  children,
+}: {
+  onClick: () => void
+  children: ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-zinc-200 hover:bg-zinc-700"
+    >
+      {children}
+    </button>
+  )
+}

--- a/web/src/store/index.test.ts
+++ b/web/src/store/index.test.ts
@@ -137,6 +137,70 @@ describe('store: recentRuns', () => {
   })
 })
 
+describe('store: appendInputLines', () => {
+  beforeEach(() => useAppStore.setState({ inputText: '' }))
+
+  it('appends a single line to an empty editor and reports 1 added', () => {
+    const added = useAppStore.getState().appendInputLines(['Charizard | Base | 4'])
+    expect(added).toBe(1)
+    expect(useAppStore.getState().inputText).toBe('Charizard | Base | 4\n')
+  })
+
+  it('joins multiple lines with newlines and reports the total fresh count', () => {
+    const added = useAppStore
+      .getState()
+      .appendInputLines(['Pikachu | Jungle | 60', 'Squirtle | Base | 63'])
+    expect(added).toBe(2)
+    expect(useAppStore.getState().inputText).toContain('Pikachu | Jungle | 60')
+    expect(useAppStore.getState().inputText).toContain('Squirtle | Base | 63')
+  })
+
+  it('dedupes against existing input — re-adding the same line returns 0', () => {
+    useAppStore.setState({ inputText: 'Charizard | Base | 4\n' })
+    const added = useAppStore.getState().appendInputLines(['Charizard | Base | 4'])
+    expect(added).toBe(0)
+    expect(useAppStore.getState().inputText).toBe('Charizard | Base | 4\n')
+  })
+
+  it('partial dedupe — reports only the freshly-appended count', () => {
+    useAppStore.setState({ inputText: 'Pikachu | Jungle | 60\n' })
+    const added = useAppStore
+      .getState()
+      .appendInputLines([
+        'Pikachu | Jungle | 60', // dup
+        'Charizard | Base | 4', // fresh
+        'Squirtle | Base | 63', // fresh
+      ])
+    expect(added).toBe(2)
+    const lines = useAppStore.getState().inputText.trim().split('\n')
+    expect(lines).toHaveLength(3)
+  })
+
+  it('ignores empty / whitespace-only inputs without bumping the count', () => {
+    const added = useAppStore.getState().appendInputLines(['  ', '', '   '])
+    expect(added).toBe(0)
+    expect(useAppStore.getState().inputText).toBe('')
+  })
+
+  it('does not double-stamp the trailing newline when inputText already ends with \\n', () => {
+    useAppStore.setState({ inputText: 'foo\n' })
+    useAppStore.getState().appendInputLines(['bar'])
+    expect(useAppStore.getState().inputText).toBe('foo\nbar\n')
+  })
+
+  it('preserves a missing trailing newline by inserting one before the new lines', () => {
+    useAppStore.setState({ inputText: 'foo' })
+    useAppStore.getState().appendInputLines(['bar'])
+    expect(useAppStore.getState().inputText).toBe('foo\nbar\n')
+  })
+
+  it('trims whitespace on incoming lines before deduping', () => {
+    useAppStore.setState({ inputText: 'Charizard | Base | 4\n' })
+    const added = useAppStore.getState().appendInputLines(['  Charizard | Base | 4  '])
+    expect(added).toBe(0)
+  })
+})
+
 describe('store: settings.showTimer', () => {
   afterEach(() => {
     useAppStore.getState().resetSettings()

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -26,8 +26,13 @@ interface AppState {
    * is exact-string and case-sensitive on trimmed lines — same shape
    * the backend parser sees — so two distinct query shapes for the same
    * card (e.g. with / without set hint) still both land.
+   *
+   * Returns the count of lines **actually** appended (post-dedupe) so
+   * callers can render an accurate "Added N lines" status — clicking
+   * "Add to list" on a card already in the editor honestly reports 0,
+   * not 1.
    */
-  appendInputLines: (lines: string[]) => void
+  appendInputLines: (lines: string[]) => number
 
   /** Accumulated lookup results from the most recent bulk run. */
   rows: Row[]
@@ -91,22 +96,28 @@ interface AppState {
 
 export const useAppStore = create<AppState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       inputText: '',
       setInputText: (text) => set({ inputText: text }),
-      appendInputLines: (lines) =>
-        set((state) => {
-          const incoming = lines.map((l) => l.trim()).filter((l) => l.length > 0)
-          if (incoming.length === 0) return state
-          const existing = new Set(
-            state.inputText.split('\n').map((l) => l.trim()).filter(Boolean),
-          )
-          const fresh = incoming.filter((l) => !existing.has(l))
-          if (fresh.length === 0) return state
-          const sep =
-            state.inputText.length === 0 || state.inputText.endsWith('\n') ? '' : '\n'
-          return { inputText: state.inputText + sep + fresh.join('\n') + '\n' }
-        }),
+      appendInputLines: (lines) => {
+        // Compute the fresh-line slice outside `set()` so we can return
+        // its count to the caller. We snapshot the current input via
+        // zustand's `get` parameter (not a closure-captured reference
+        // to the store hook, which would cause a circular type during
+        // initial inference), derive `fresh`, then push that exact list
+        // via set. Single source of truth, accurate return value.
+        const current = get().inputText
+        const incoming = lines.map((l) => l.trim()).filter((l) => l.length > 0)
+        if (incoming.length === 0) return 0
+        const existing = new Set(
+          current.split('\n').map((l) => l.trim()).filter(Boolean),
+        )
+        const fresh = incoming.filter((l) => !existing.has(l))
+        if (fresh.length === 0) return 0
+        const sep = current.length === 0 || current.endsWith('\n') ? '' : '\n'
+        set({ inputText: current + sep + fresh.join('\n') + '\n' })
+        return fresh.length
+      },
 
       rows: [],
       setRows: (rows) => set({ rows }),

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -19,6 +19,15 @@ interface AppState {
   /** The raw multi-line card-list text typed by the user. */
   inputText: string
   setInputText: (text: string) => void
+  /**
+   * Append one or more lines to `inputText`, deduplicating against the
+   * existing content so the Browse modal's "Add to list" can be clicked
+   * twice on the same card without leaving a stray duplicate. The check
+   * is exact-string and case-sensitive on trimmed lines — same shape
+   * the backend parser sees — so two distinct query shapes for the same
+   * card (e.g. with / without set hint) still both land.
+   */
+  appendInputLines: (lines: string[]) => void
 
   /** Accumulated lookup results from the most recent bulk run. */
   rows: Row[]
@@ -85,6 +94,19 @@ export const useAppStore = create<AppState>()(
     (set) => ({
       inputText: '',
       setInputText: (text) => set({ inputText: text }),
+      appendInputLines: (lines) =>
+        set((state) => {
+          const incoming = lines.map((l) => l.trim()).filter((l) => l.length > 0)
+          if (incoming.length === 0) return state
+          const existing = new Set(
+            state.inputText.split('\n').map((l) => l.trim()).filter(Boolean),
+          )
+          const fresh = incoming.filter((l) => !existing.has(l))
+          if (fresh.length === 0) return state
+          const sep =
+            state.inputText.length === 0 || state.inputText.endsWith('\n') ? '' : '\n'
+          return { inputText: state.inputText + sep + fresh.join('\n') + '\n' }
+        }),
 
       rows: [],
       setRows: (rows) => set({ rows }),

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -108,6 +108,26 @@ export interface SetInfo {
 }
 
 /**
+ * One trimmed card returned by `GET /api/v1/sets/{set_id}/cards`.
+ *
+ * Intentionally narrower than the full `CardData` blob — Browse only
+ * needs enough to render a grid row, filter by rarity/subtype, and
+ * synthesise an "add to list" line. The trim happens server-side so
+ * every Browse open ships kilobytes instead of hundreds-of-kilobytes
+ * over the wire.
+ */
+export interface SetCard {
+  id: string
+  name: string
+  number: string
+  rarity: string | null
+  supertype: string | null
+  subtypes: string[]
+  thumb: string | null
+  market: number | null
+}
+
+/**
  * One entry in the recent-searches history. Captured the moment the
  * user clicks **Look up** so the panel reflects what was actually
  * submitted (even if the run later errored or was stopped).


### PR DESCRIPTION
Closes #267

## What

A new **Browse** surface, reachable from a header button, lets you wander the catalog without typing anything:

- **Set list view** — every Pokémon TCG set grouped by series, newest-first, with the cached logo + release year + card count.
- **Set detail view** — picking a set opens a responsive grid of every card with thumb / name / number / rarity / market price. Each card has an "Add to list" button; bulk actions push every visible card, every holo, or every rare into the editor in one click. Search-within-set, rarity-bucket filter chips (All / Rares / Holos / Ultra+), and sort by number / name / price ↓.

Add-to-list lines mirror the parser's canonical `Name | Set Name | Number` shape, and `appendInputLines` in the store dedupes against existing input so clicking the same card twice doesn't double-stamp it.

## Why

#267 — the existing flow only opens from a card list, which is a missed on-ramp for casual users and a missed prep aid (scan a set you're about to walk into). Browse is the "I don't know what's in Jungle, show me" entry point.

## Performance

Per the issue's "lightning fast with minimal cost" goal:

- **New endpoint `GET /api/v1/sets/{set_id}/cards`** returns a **trimmed** payload — `{id, name, number, rarity, supertype, subtypes, thumb, market}` only. A 252-card set ships ~46 KB on the wire (measured locally) vs hundreds of KB for the raw pokemontcg.io shape (legalities, ancientTrait, attacks, weaknesses, resistances, full tcgplayer/cardmarket sub-objects). Flows through the existing on-disk API cache underneath, so once one user warms a set every subsequent open is a disk-cache hit upstream.
- **`Cache-Control` headers** — `public, max-age=86400` on `/sets/{id}/cards` (card data within a released set is effectively immutable; only market prices drift, and a day is fine for prep flows) and `public, max-age=3600` on `/sets` (lets a new set appear in the picker within the hour without forcing a hard refresh). Re-opens within those windows skip the round-trip entirely.
- The on-disk image cache populated by `pkmn cache warm-sets` (#255) backs the set logos in the picker grid — nothing extra to fetch.

Two further perf wins surfaced during analysis but split into their own issues to keep this PR focused on the Browse feature:

- #302 — memoize `TCGClient` per `(api_key, lang)` so `requests.Session` keep-alive + the in-memory query cache actually survive across requests.
- #303 — run `/bulk` SSE lookups with bounded concurrency instead of strict serial iteration.

## How to verify

1. `make dev-api` and `make dev-web` (port 5173).
2. Click **Browse** in the header. The catalog renders grouped by series, newest first. Logos appear for any set previously warmed via `pkmn cache warm-sets`.
3. Pick **Surging Sparks** (or any modern set). After the first load (which warms the disk cache for ~10s on a cold install), the card grid renders with thumbnails, prices, and rarity.
4. Try the toolbar:
   - Search "charizard" → grid narrows to the Charizards.
   - Click **Holos** → only holo rarities remain.
   - Switch sort to **Price ↓** → chase cards bubble to the top.
5. Click **+ Add to list** on a card → switch back to the main view; the line `<Name> | <Set> | <Number>` is appended to the editor.
6. Re-open Browse → the catalog renders instantly (browser cache).
7. Re-open the same set → the card grid renders instantly (browser + disk cache).
8. `curl -sI http://localhost:8000/api/v1/sets/sv8/cards | grep -i cache` → `cache-control: public, max-age=86400`.
9. `curl -sI http://localhost:8000/api/v1/sets | grep -i cache` → `cache-control: public, max-age=3600`.

## Tests

- **Backend (`tests/test_api_routes.py`)** — `_trim_card` field projection, missing-pricing fallback, set-not-found 404, Cache-Control headers on `/sets` and `/sets/{id}/cards`, malformed-id rejection (422 via the route-level pattern validator).
- **Frontend (`web/src/components/BrowseModal.test.tsx`)** — 10 tests covering catalog loading + series ordering, set-detail fetch, add-to-list bridge wiring, dedupe, bulk-add-visible, rarity-bucket filtering, in-set search, back navigation, and both error paths.

`make check` (350 tests) + `cd web && npm run build` are green.

## Screenshots

Captured locally via the dev servers — drag the three from the PR conversation:

1. Header showing the new **Browse** button next to Export / Help / Settings.
2. Set list view, grouped by series, with cached logos (Mega Evolution at the top, Scarlet & Violet below).
3. Set detail view of Surging Sparks sorted Price ↓ — Pikachu ex SIR ($339), Latias ex ($183), Milotic ex ($131) lead the chase view.