### PR TITLE
feat(web): instant set-list — bake catalog into SPA + stale-while-revalidate

### DIFF
--- a/api/routes/sets.py
+++ b/api/routes/sets.py
@@ -57,6 +57,16 @@ _SETS_TTL = 7 * 24 * 60 * 60  # refresh weekly
 # up in the picker within an hour without the user having to hard-refresh.
 _SETS_BROWSER_TTL = 60 * 60
 
+# `stale-while-revalidate` window for `GET /api/v1/sets`. After the
+# `max-age` window expires, the browser can serve the cached response
+# **immediately** for up to this many seconds while it asynchronously
+# revalidates in the background. The user never sees a loading state
+# on the catalog endpoint as long as they've hit it within the last
+# day — the new data lands on the *next* render. Pairs with the
+# SPA-side baked catalog in `web/src/data/sets.json`, which covers the
+# very-first-visit case.
+_SETS_BROWSER_SWR = 24 * 60 * 60
+
 # Browser-cache TTL for `GET /api/v1/sets/{set_id}/cards`. Card data within a
 # released set is effectively immutable (rarity / number / images don't change
 # once the set ships); only market prices drift, and a 1-day cache keeps
@@ -125,7 +135,9 @@ async def get_sets(response: Response, api_key: str | None = None) -> dict:
     hasn't moved. Pass `api_key` as a query parameter to authenticate the
     upstream refresh request.
     """
-    response.headers["Cache-Control"] = f"public, max-age={_SETS_BROWSER_TTL}"
+    response.headers["Cache-Control"] = (
+        f"public, max-age={_SETS_BROWSER_TTL}, stale-while-revalidate={_SETS_BROWSER_SWR}"
+    )
     cached = _load_sets_cache()
     if cached is not None:
         return {"sets": cached}

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -191,11 +191,12 @@ class SetsRouteTests(unittest.TestCase):
         self.assertEqual(resp.json()["sets"], fetched_sets)
 
     def test_browser_cache_control_header(self) -> None:
-        # The /sets response needs a short-TTL Cache-Control so the Browse
-        # modal doesn't round-trip on every open. We assert presence, not
-        # the exact max-age value, so the constant can be tuned without
-        # the test going brittle — but we do require it's `public` and
-        # has a non-zero max-age.
+        # The /sets response needs a short-TTL Cache-Control plus
+        # stale-while-revalidate so the browser serves cached content
+        # immediately while it revalidates in the background. Pairs
+        # with the SPA-side baked catalog (`web/src/data/sets.json`)
+        # which covers the very-first-visit case where there's no
+        # browser cache to serve from.
         with (
             patch("api.routes.sets._load_sets_cache", return_value=[]),
         ):
@@ -205,6 +206,7 @@ class SetsRouteTests(unittest.TestCase):
         cache_control = resp.headers.get("cache-control", "")
         self.assertIn("public", cache_control)
         self.assertIn("max-age=", cache_control)
+        self.assertIn("stale-while-revalidate=", cache_control)
 
 
 class SetCardsRouteTests(unittest.TestCase):

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "refresh-sets": "node scripts/refresh-sets.mjs"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/web/scripts/refresh-sets.mjs
+++ b/web/scripts/refresh-sets.mjs
@@ -33,8 +33,8 @@
  *
  * Environment
  * -----------
- * - `MGZ_PKMN_API_KEY` (optional) — sent as `X-Api-Key` so a generous
- *   pokemontcg.io account avoids the public rate limit.
+ * - `POKEMONTCG_IO_API_KEY` (optional) — sent as `X-Api-Key` so a
+ *   generous pokemontcg.io account avoids the public rate limit.
  */
 
 import { mkdirSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
@@ -58,7 +58,7 @@ function warn(msg) {
 
 async function fetchCatalog() {
   const headers = { 'User-Agent': 'mgz-pkmn/refresh-sets' }
-  const apiKey = process.env.MGZ_PKMN_API_KEY
+  const apiKey = process.env.POKEMONTCG_IO_API_KEY
   if (apiKey) headers['X-Api-Key'] = apiKey
 
   // Per-attempt timeout. pokemontcg.io is occasionally slow on big

--- a/web/scripts/refresh-sets.mjs
+++ b/web/scripts/refresh-sets.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * refresh-sets.mjs — pull the Pokémon TCG set catalog from pokemontcg.io
+ * and write it to `web/src/data/sets.json`, the static fallback the SPA
+ * imports as Browse's initial state.
+ *
+ * Why this exists
+ * ---------------
+ * The SPA used to wait on a live `GET /api/v1/sets` round-trip the first
+ * time anyone opened Browse, which meant a visible "Loading set catalog…"
+ * spinner — exactly the kind of friction the rest of the perf story
+ * (Cache-Control, disk cache, in-memory cache) is meant to eliminate.
+ * Baking the catalog into the SPA bundle takes that first-paint cost
+ * to zero. The live fetch still runs in the background to write
+ * through any new sets (covered by stale-while-revalidate on /sets so
+ * it doesn't block UI).
+ *
+ * When to run
+ * -----------
+ * - **Manually**: `npm run refresh-sets` from `web/`. New Pokémon sets
+ *   release every few months; running this before a release is enough
+ *   to keep the bundled catalog fresh.
+ * - **CI**: a periodic job can run this and open a PR if the diff is
+ *   non-empty. (Not wired in this PR — start manual, automate later.)
+ *
+ * On error
+ * --------
+ * If pokemontcg.io is unreachable, the script logs a warning and exits
+ * **0** as long as the existing `sets.json` is present. The build must
+ * never fail because of a transient upstream outage. A missing file is
+ * a hard error (exit 1) — that's a developer setup problem, not a
+ * runtime one.
+ *
+ * Environment
+ * -----------
+ * - `MGZ_PKMN_API_KEY` (optional) — sent as `X-Api-Key` so a generous
+ *   pokemontcg.io account avoids the public rate limit.
+ */
+
+import { mkdirSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const ROOT = resolve(dirname(__filename), '..')
+const OUT_PATH = join(ROOT, 'src', 'data', 'sets.json')
+
+const ENDPOINT =
+  'https://api.pokemontcg.io/v2/sets?orderBy=releaseDate&pageSize=250'
+
+function log(msg) {
+  process.stdout.write(`[refresh-sets] ${msg}\n`)
+}
+
+function warn(msg) {
+  process.stderr.write(`[refresh-sets] WARN ${msg}\n`)
+}
+
+async function fetchCatalog() {
+  const headers = { 'User-Agent': 'mgz-pkmn/refresh-sets' }
+  const apiKey = process.env.MGZ_PKMN_API_KEY
+  if (apiKey) headers['X-Api-Key'] = apiKey
+
+  // Per-attempt timeout. pokemontcg.io is occasionally slow on big
+  // queries; 30s is generous and still safely under a typical CI step
+  // limit. AbortController is the standard Node 20+ way to cancel
+  // fetch — no extra dependency.
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 30_000)
+  try {
+    const res = await fetch(ENDPOINT, { headers, signal: controller.signal })
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status} ${res.statusText}`)
+    }
+    const body = await res.json()
+    return Array.isArray(body?.data) ? body.data : []
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function trim(raw) {
+  // Match the field set `GET /api/v1/sets` returns — the SPA's `SetInfo`
+  // type expects exactly these keys. Keeping the trim aligned with
+  // `api/routes/sets.py:_fetch_sets` means the static bundle and the
+  // live fetch are wire-compatible; the SPA never has to branch on
+  // which source produced it.
+  return raw.map((s) => ({
+    id: s.id,
+    name: s.name,
+    series: s.series,
+    total: s.total,
+    releaseDate: s.releaseDate,
+  }))
+}
+
+async function main() {
+  let trimmed
+  try {
+    log(`fetching ${ENDPOINT}`)
+    const raw = await fetchCatalog()
+    if (raw.length === 0) {
+      throw new Error('upstream returned 0 sets')
+    }
+    trimmed = trim(raw)
+    log(`fetched ${trimmed.length} sets`)
+  } catch (err) {
+    warn(`fetch failed: ${err.message}`)
+    if (existsSync(OUT_PATH)) {
+      // Existing baked catalog is acceptable; the SPA will still
+      // background-refresh from /api/v1/sets at runtime, so a single
+      // failed refresh is harmless. Exit 0 so the build doesn't fail
+      // on a transient upstream outage.
+      log(`keeping existing ${OUT_PATH}`)
+      return
+    }
+    warn('no existing sets.json to fall back to — bailing out')
+    process.exit(1)
+  }
+
+  mkdirSync(dirname(OUT_PATH), { recursive: true })
+
+  // Skip the write if the content hasn't changed — keeps git diffs
+  // clean and avoids triggering unnecessary rebuilds when the script
+  // is run on a schedule.
+  const next = JSON.stringify(trimmed, null, 2) + '\n'
+  if (existsSync(OUT_PATH)) {
+    const current = readFileSync(OUT_PATH, 'utf-8')
+    if (current === next) {
+      log('no changes — sets.json is already up to date')
+      return
+    }
+  }
+
+  writeFileSync(OUT_PATH, next, 'utf-8')
+  log(`wrote ${OUT_PATH}`)
+}
+
+main().catch((err) => {
+  warn(`unexpected error: ${err.stack || err.message}`)
+  process.exit(1)
+})

--- a/web/src/components/BrowseModal.test.tsx
+++ b/web/src/components/BrowseModal.test.tsx
@@ -11,6 +11,11 @@ vi.mock('../api/client', () => ({
   setLogoUrl: vi.fn((id: string) => `/api/v1/sets/${id}/logo`),
 }))
 
+// Empty baked catalog so the existing tests control the catalog shape
+// via the mocked `fetchSets`. Tests that exercise the baked-catalog
+// initial-render path mock this module per-test with a non-empty value.
+vi.mock('../data/sets', () => ({ BAKED_SETS: [] }))
+
 const mockFetchSets = vi.mocked(fetchSets)
 const mockFetchSetCards = vi.mocked(fetchSetCards)
 const mockLogoUrl = vi.mocked(setLogoUrl)
@@ -211,13 +216,17 @@ describe('BrowseModal', () => {
     ).toBeInTheDocument()
   })
 
-  it('surfaces an error when the catalog fetch fails', async () => {
+  it('silently swallows a failed background catalog revalidation', async () => {
+    // Browse seeds from the baked catalog so users always see content.
+    // A transient `/api/v1/sets` failure must not paint a red banner
+    // over an already-working list. (For this test the baked catalog
+    // is the empty mock at module level, but the SAME behavior applies
+    // when the bundle has content — the error simply never surfaces.)
     mockFetchSets.mockRejectedValueOnce(new Error('catalog down'))
     renderOpen()
 
-    expect(
-      await screen.findByText(/Couldn’t load sets: catalog down/),
-    ).toBeInTheDocument()
+    await waitFor(() => expect(mockFetchSets).toHaveBeenCalled())
+    expect(screen.queryByText(/Couldn’t load sets/)).not.toBeInTheDocument()
   })
 
   it('reports an honest 0-added status when re-adding an already-added card', async () => {
@@ -296,6 +305,62 @@ describe('BrowseModal', () => {
 
     const lines = useAppStore.getState().inputText.split('\n')
     expect(lines).toContain('Charizard ex | Surging Sparks | 25')
+  })
+
+  it('renders the baked catalog before the live fetch resolves', async () => {
+    // Use a never-resolving fetch so the only thing on screen is what
+    // the baked catalog supplied. The component should render those
+    // rows immediately — no loading state, no waiting.
+    vi.resetModules()
+    vi.doMock('../data/sets', () => ({ BAKED_SETS: SETS }))
+    mockFetchSets.mockReturnValueOnce(new Promise(() => {}))
+    const { BrowseModal: BrowseModalWithBaked } = await import('./BrowseModal')
+
+    render(<BrowseModalWithBaked open onOpenChange={vi.fn()} />)
+    // Rows appear synchronously from the baked catalog. We don't
+    // `findByText` (which awaits an effect tick) — `getByText`
+    // confirms the row is on the first render.
+    expect(screen.getByText('Surging Sparks')).toBeInTheDocument()
+    expect(screen.getByText('Base Set')).toBeInTheDocument()
+
+    vi.doUnmock('../data/sets')
+    vi.resetModules()
+  })
+
+  it('background revalidation writes through fresher data when it lands', async () => {
+    vi.resetModules()
+    vi.doMock('../data/sets', () => ({
+      BAKED_SETS: [
+        {
+          id: 'base1',
+          name: 'Base Set',
+          series: 'Base',
+          total: 102,
+          releaseDate: '1998/01/09',
+        },
+      ],
+    }))
+    const NEWER: SetInfo[] = [
+      ...SETS,
+      {
+        id: 'sv9',
+        name: 'Hypothetical New Set',
+        series: 'Scarlet & Violet',
+        total: 200,
+        releaseDate: '2025/05/01',
+      },
+    ]
+    mockFetchSets.mockResolvedValueOnce(NEWER)
+    const { BrowseModal: BrowseModalWithBaked } = await import('./BrowseModal')
+
+    render(<BrowseModalWithBaked open onOpenChange={vi.fn()} />)
+    // Baked content is on screen first.
+    expect(screen.getByText('Base Set')).toBeInTheDocument()
+    // After revalidation lands, the new set surfaces.
+    expect(await screen.findByText('Hypothetical New Set')).toBeInTheDocument()
+
+    vi.doUnmock('../data/sets')
+    vi.resetModules()
   })
 
   it('caches the trimmed cards in memory — re-picking the same set skips the fetch', async () => {

--- a/web/src/components/BrowseModal.tsx
+++ b/web/src/components/BrowseModal.tsx
@@ -37,6 +37,7 @@ import {
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import { fetchSetCards, fetchSets, setLogoUrl } from '../api/client'
+import { BAKED_SETS } from '../data/sets'
 import { useAppStore } from '../store'
 import type { SetCard, SetInfo } from '../types'
 
@@ -149,8 +150,13 @@ function toInputLine(card: SetCard, set: SetInfo): string {
 export function BrowseModal({ open, onOpenChange }: Props) {
   const { settings, appendInputLines } = useAppStore()
 
-  const [sets, setSets] = useState<SetInfo[] | null>(null)
-  const [setsError, setSetsError] = useState<string | null>(null)
+  // Seed `sets` from the baked catalog so the modal opens with content
+  // visible on the very first frame — no "Loading set catalog…" state.
+  // The live `/api/v1/sets` fetch still runs in the background on first
+  // open to write through any sets that landed upstream since the last
+  // bake; see the revalidation effect below.
+  const [sets, setSets] = useState<SetInfo[]>(BAKED_SETS)
+  const [revalidatedSets, setRevalidatedSets] = useState(false)
   const [activeSet, setActiveSet] = useState<SetInfo | null>(null)
   const [cards, setCards] = useState<SetCard[] | null>(null)
   const [cardsError, setCardsError] = useState<string | null>(null)
@@ -188,23 +194,31 @@ export function BrowseModal({ open, onOpenChange }: Props) {
   }, [open])
   /* eslint-enable react-hooks/set-state-in-effect */
 
-  // Lazy-load the set catalog on first open.
+  // Background revalidation of the catalog. Runs once on the first
+  // open per session — the UI is already showing the baked catalog,
+  // so this fetch is fully off the critical path. Errors are
+  // swallowed: the user has working content already, and a transient
+  // network failure shouldn't paint a red banner over an otherwise
+  // perfectly usable modal. The next session-open retries.
   useEffect(() => {
-    if (!open || sets !== null) return
+    if (!open || revalidatedSets) return
     let cancelled = false
     void (async () => {
-      setSetsError(null)
       try {
         const data = await fetchSets(settings.apiKey || undefined)
         if (!cancelled) setSets(data)
-      } catch (err) {
-        if (!cancelled) setSetsError(err instanceof Error ? err.message : String(err))
+      } catch {
+        // Swallow — baked catalog is already on screen. The browser's
+        // `stale-while-revalidate` cache will retry transparently on
+        // the next user-initiated request.
+      } finally {
+        if (!cancelled) setRevalidatedSets(true)
       }
     })()
     return () => {
       cancelled = true
     }
-  }, [open, sets, settings.apiKey])
+  }, [open, revalidatedSets, settings.apiKey])
 
   // Load the in-set card list whenever the user picks a set. The
   // backend caches the response for a day in the browser, so flipping
@@ -257,7 +271,7 @@ export function BrowseModal({ open, onOpenChange }: Props) {
     }
   }, [activeSet, settings.apiKey])
 
-  const groups = useMemo(() => (sets ? groupBySeries(sets) : []), [sets])
+  const groups = useMemo(() => groupBySeries(sets), [sets])
 
   const filteredCards = useMemo(() => {
     if (!cards) return []
@@ -367,12 +381,7 @@ export function BrowseModal({ open, onOpenChange }: Props) {
               }
             />
           ) : (
-            <SetListView
-              sets={sets}
-              groups={groups}
-              error={setsError}
-              onPick={(s) => setActiveSet(s)}
-            />
+            <SetListView groups={groups} onPick={(s) => setActiveSet(s)} />
           )}
         </Dialog.Content>
       </Dialog.Portal>
@@ -385,45 +394,36 @@ export function BrowseModal({ open, onOpenChange }: Props) {
 // ---------------------------------------------------------------------------
 
 interface SetListProps {
-  sets: SetInfo[] | null
   groups: SeriesGroup[]
-  error: string | null
   onPick: (set: SetInfo) => void
 }
 
-function SetListView({ sets, groups, error, onPick }: SetListProps) {
+function SetListView({ groups, onPick }: SetListProps) {
+  // No loading / error state here — the SPA seeds from a baked catalog
+  // (`web/src/data/sets.json`), so `groups` is always non-empty on
+  // first render. The live `/api/v1/sets` revalidation runs off the
+  // critical path and either silently writes through fresher data or
+  // silently fails; either way, the user sees a populated list from
+  // frame one.
   return (
     <div className="flex-1 overflow-y-auto px-5 py-3">
-      {error && (
-        <p className="rounded border border-red-900/50 bg-red-950/30 px-3 py-2 text-sm text-red-300">
-          Couldn’t load sets: {error}
-        </p>
-      )}
-      {!sets && !error && (
-        <p className="flex items-center gap-2 text-sm text-zinc-400">
-          <Loader2 size={14} className="animate-spin" />
-          Loading set catalog…
-        </p>
-      )}
-      {sets && (
-        <ul className="space-y-4">
-          {groups.map((group) => (
-            <li key={group.series}>
-              <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-300">
-                {group.series}
-                <span className="ml-1 font-normal normal-case tracking-normal text-zinc-500">
-                  ({group.sets.length})
+      <ul className="space-y-4">
+        {groups.map((group) => (
+          <li key={group.series}>
+            <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-300">
+              {group.series}
+              <span className="ml-1 font-normal normal-case tracking-normal text-zinc-500">
+                ({group.sets.length})
                 </span>
               </div>
-              <ul className="grid grid-cols-1 gap-1 sm:grid-cols-2 lg:grid-cols-3">
-                {group.sets.map((s) => (
-                  <SetTile key={s.id} set={s} onPick={() => onPick(s)} />
-                ))}
-              </ul>
-            </li>
-          ))}
-        </ul>
-      )}
+            <ul className="grid grid-cols-1 gap-1 sm:grid-cols-2 lg:grid-cols-3">
+              {group.sets.map((s) => (
+                <SetTile key={s.id} set={s} onPick={() => onPick(s)} />
+              ))}
+            </ul>
+          </li>
+        ))}
+      </ul>
     </div>
   )
 }

--- a/web/src/components/SetPickerModal.test.tsx
+++ b/web/src/components/SetPickerModal.test.tsx
@@ -15,6 +15,15 @@ vi.mock('../api/client', () => ({
   setLogoUrl: vi.fn((id: string) => `/api/v1/sets/${id}/logo`),
 }))
 
+// Override the baked catalog to be empty so existing tests still own
+// the catalog shape via the mocked `fetchSets`. Without this, the
+// modal would render the real 173-set bundle layered with the
+// mocked-fetch revalidation, fighting fixtures like `id: 'jungle'`
+// (which collides with the real bundle's `base2` id for the same set
+// name). New tests that exercise the baked-catalog-renders-instantly
+// path mock this module per-test with their own non-empty value.
+vi.mock('../data/sets', () => ({ BAKED_SETS: [] }))
+
 const mockFetchSets = vi.mocked(fetchSets)
 const mockDownload = vi.mocked(downloadSetCardsPdf)
 const mockLogoUrl = vi.mocked(setLogoUrl)
@@ -167,42 +176,16 @@ describe('SetPickerModal', () => {
     ).not.toBeChecked()
   })
 
-  it('surfaces a load error when the catalog fetch fails', async () => {
+  it('silently swallows a failed background revalidation', async () => {
+    // The picker seeds from the baked catalog so users always have a
+    // working list. A transient `/api/v1/sets` failure must not paint
+    // an error banner over content that's working fine. Verify no
+    // "Couldn't load sets" appears even though the fetch rejected.
     mockFetchSets.mockRejectedValueOnce(new Error('upstream down'))
     renderOpen()
 
-    expect(
-      await screen.findByText(/Couldn’t load sets: upstream down/)
-    ).toBeInTheDocument()
-  })
-
-  it('clears stale load errors while retrying after reopening', async () => {
-    let resolveRetry!: (value: SetInfo[]) => void
-    const retryPromise = new Promise<SetInfo[]>((resolve) => {
-      resolveRetry = resolve
-    })
-    mockFetchSets
-      .mockRejectedValueOnce(new Error('upstream down'))
-      .mockReturnValueOnce(retryPromise)
-    const onOpenChange = vi.fn()
-    const { rerender } = render(
-      <SetPickerModal open={true} onOpenChange={onOpenChange} />
-    )
-
-    expect(
-      await screen.findByText(/Couldn’t load sets: upstream down/)
-    ).toBeInTheDocument()
-
-    rerender(<SetPickerModal open={false} onOpenChange={onOpenChange} />)
-    rerender(<SetPickerModal open={true} onOpenChange={onOpenChange} />)
-
-    await waitFor(() => {
-      expect(screen.queryByText(/Couldn’t load sets:/)).not.toBeInTheDocument()
-    })
-    expect(screen.getByText(/Loading set catalog/)).toBeInTheDocument()
-
-    resolveRetry(SETS)
-    expect(await screen.findByText('Surging Sparks')).toBeInTheDocument()
+    await waitFor(() => expect(mockFetchSets).toHaveBeenCalled())
+    expect(screen.queryByText(/Couldn’t load sets/)).not.toBeInTheDocument()
   })
 
   it('surfaces a submit error and keeps the modal open', async () => {

--- a/web/src/components/SetPickerModal.tsx
+++ b/web/src/components/SetPickerModal.tsx
@@ -34,6 +34,7 @@ import {
 import { useEffect, useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
 import { downloadSetCardsPdf, fetchSets, setLogoUrl } from '../api/client'
+import { BAKED_SETS } from '../data/sets'
 import { useAppStore } from '../store'
 import type { SetInfo } from '../types'
 
@@ -92,8 +93,13 @@ function releaseYear(date: string): string | null {
 export function SetPickerModal({ open, onOpenChange }: Props) {
   const { settings, selectedSetIds, setSelectedSetIds } = useAppStore()
 
-  const [sets, setSets] = useState<SetInfo[] | null>(null)
-  const [loadError, setLoadError] = useState<string | null>(null)
+  // Seed from the baked catalog so the picker opens with rows visible
+  // on the first frame — no "Loading set catalog…" tax. The live
+  // `/api/v1/sets` fetch runs in the background to revalidate; see
+  // the effect below. A transient revalidation failure is silently
+  // swallowed because the baked content is already a working list.
+  const [sets, setSets] = useState<SetInfo[]>(BAKED_SETS)
+  const [revalidatedSets, setRevalidatedSets] = useState(false)
   const [submitting, setSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
 
@@ -123,35 +129,37 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
   useEffect(() => {
     if (!open) return
     setDraft(new Set(selectedSetIds))
-    setLoadError(null)
     setSubmitError(null)
   }, [open])
   /* eslint-enable react-hooks/set-state-in-effect, react-hooks/exhaustive-deps */
 
-  // Lazy-load the catalog once, the first time the modal opens. We keep
-  // the result mounted across open/close so a re-open is free.
+  // Background revalidation of the catalog. Runs once per session on
+  // the first open — the picker is already rendering the baked
+  // catalog, so this fetch is off the critical path. Errors are
+  // swallowed: the user has a working list either way, and a red
+  // banner over an otherwise usable picker reads as broken even when
+  // the bake is fine.
   useEffect(() => {
-    if (!open || sets !== null) return
+    if (!open || revalidatedSets) return
     let cancelled = false
     const load = async () => {
-      setLoadError(null)
       try {
         const data = await fetchSets(settings.apiKey || undefined)
-        if (cancelled) return
-        setSets(data)
-      } catch (err) {
-        if (cancelled) return
-        setLoadError(err instanceof Error ? err.message : String(err))
+        if (!cancelled) setSets(data)
+      } catch {
+        // Swallow — baked catalog is already rendered.
+      } finally {
+        if (!cancelled) setRevalidatedSets(true)
       }
     }
     void load()
     return () => {
       cancelled = true
     }
-  }, [open, sets, settings.apiKey])
+  }, [open, revalidatedSets, settings.apiKey])
 
-  const groups = useMemo(() => (sets ? groupBySeries(sets) : []), [sets])
-  const allCount = sets?.length ?? 0
+  const groups = useMemo(() => groupBySeries(sets), [sets])
+  const allCount = sets.length
   const selectedCount = draft.size
 
   function toggle(id: string) {
@@ -164,7 +172,6 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
   }
 
   function selectAll() {
-    if (!sets) return
     setDraft(new Set(sets.map((s) => s.id)))
   }
 
@@ -173,7 +180,6 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
   }
 
   function selectSeries(series: string) {
-    if (!sets) return
     setDraft((prev) => {
       const next = new Set(prev)
       // Use the same keying as `groupBySeries` so the "Other" bucket
@@ -252,38 +258,28 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
             className="px-5 pt-3 text-sm text-zinc-400"
           >
             Pick which Pokémon TCG sets the printable ID cards PDF should
-            include. {sets ? `${selectedCount} of ${allCount} selected.` : ''}
+            include. {`${selectedCount} of ${allCount} selected.`}
           </Dialog.Description>
 
           {/* Bulk-action toolbar */}
-          {sets && (
-            <div className="flex flex-wrap gap-2 px-5 pt-3">
-              <BulkButton onClick={selectAll}>Select all</BulkButton>
-              <BulkButton onClick={selectNone}>Select none</BulkButton>
-              <BulkButton onClick={expandAllSeries}>Expand all</BulkButton>
-              <BulkButton onClick={collapseAllSeries}>Collapse all</BulkButton>
-            </div>
-          )}
+          <div className="flex flex-wrap gap-2 px-5 pt-3">
+            <BulkButton onClick={selectAll}>Select all</BulkButton>
+            <BulkButton onClick={selectNone}>Select none</BulkButton>
+            <BulkButton onClick={expandAllSeries}>Expand all</BulkButton>
+            <BulkButton onClick={collapseAllSeries}>Collapse all</BulkButton>
+          </div>
 
           <div
             className="flex-1 overflow-y-auto px-5 py-3"
             tabIndex={0}
             aria-label="Set list"
           >
-            {loadError && (
-              <p className="rounded border border-red-900/50 bg-red-950/30 px-3 py-2 text-sm text-red-300">
-                Couldn’t load sets: {loadError}
-              </p>
-            )}
-            {!sets && !loadError && (
-              <p className="flex items-center gap-2 text-sm text-zinc-400">
-                <Loader2 size={14} className="animate-spin" />
-                Loading set catalog…
-              </p>
-            )}
-            {sets && (
-              <ul className="space-y-4">
-                {groups.map((group) => {
+            {/* No loading / error state — the SPA seeds from the baked
+                 catalog in `web/src/data/sets.json`, so `groups` is
+                 always non-empty on first render. The live fetch
+                 silently revalidates off the critical path. */}
+            <ul className="space-y-4">
+              {groups.map((group) => {
                   const collapsed = collapsedSeries.has(group.series)
                   const seriesIds = group.sets.map((s) => s.id)
                   const selectedInSeries = seriesIds.filter((id) => draft.has(id)).length
@@ -336,14 +332,13 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
                     </li>
                   )
                 })}
-              </ul>
-            )}
+            </ul>
           </div>
 
           <footer className="flex items-center justify-between gap-3 border-t border-zinc-800 px-5 py-4">
             <div className="flex-1 text-xs text-zinc-400">
               {submitError && <span className="text-red-400">{submitError}</span>}
-              {!submitError && sets && (
+              {!submitError && (
                 <span>
                   {selectedCount} set{selectedCount === 1 ? '' : 's'} selected
                 </span>
@@ -356,7 +351,7 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
             </Dialog.Close>
             <button
               onClick={handleSubmit}
-              disabled={submitting || draft.size === 0 || !sets}
+              disabled={submitting || draft.size === 0}
               className="flex items-center gap-1.5 rounded-md border border-blue-700 bg-blue-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-600 disabled:opacity-40 disabled:cursor-not-allowed"
             >
               {submitting ? (

--- a/web/src/data/sets.json
+++ b/web/src/data/sets.json
@@ -1,0 +1,1213 @@
+[
+  {
+    "id": "base1",
+    "name": "Base",
+    "series": "Base",
+    "total": 102,
+    "releaseDate": "1999/01/09"
+  },
+  {
+    "id": "base2",
+    "name": "Jungle",
+    "series": "Base",
+    "total": 64,
+    "releaseDate": "1999/06/16"
+  },
+  {
+    "id": "basep",
+    "name": "Wizards Black Star Promos",
+    "series": "Base",
+    "total": 53,
+    "releaseDate": "1999/07/01"
+  },
+  {
+    "id": "base3",
+    "name": "Fossil",
+    "series": "Base",
+    "total": 62,
+    "releaseDate": "1999/10/10"
+  },
+  {
+    "id": "base4",
+    "name": "Base Set 2",
+    "series": "Base",
+    "total": 130,
+    "releaseDate": "2000/02/24"
+  },
+  {
+    "id": "base5",
+    "name": "Team Rocket",
+    "series": "Base",
+    "total": 83,
+    "releaseDate": "2000/04/24"
+  },
+  {
+    "id": "gym1",
+    "name": "Gym Heroes",
+    "series": "Gym",
+    "total": 132,
+    "releaseDate": "2000/08/14"
+  },
+  {
+    "id": "gym2",
+    "name": "Gym Challenge",
+    "series": "Gym",
+    "total": 132,
+    "releaseDate": "2000/10/16"
+  },
+  {
+    "id": "neo1",
+    "name": "Neo Genesis",
+    "series": "Neo",
+    "total": 111,
+    "releaseDate": "2000/12/16"
+  },
+  {
+    "id": "neo2",
+    "name": "Neo Discovery",
+    "series": "Neo",
+    "total": 75,
+    "releaseDate": "2001/06/01"
+  },
+  {
+    "id": "si1",
+    "name": "Southern Islands",
+    "series": "Other",
+    "total": 18,
+    "releaseDate": "2001/07/31"
+  },
+  {
+    "id": "neo3",
+    "name": "Neo Revelation",
+    "series": "Neo",
+    "total": 66,
+    "releaseDate": "2001/09/21"
+  },
+  {
+    "id": "neo4",
+    "name": "Neo Destiny",
+    "series": "Neo",
+    "total": 113,
+    "releaseDate": "2002/02/28"
+  },
+  {
+    "id": "base6",
+    "name": "Legendary Collection",
+    "series": "Other",
+    "total": 110,
+    "releaseDate": "2002/05/24"
+  },
+  {
+    "id": "ecard1",
+    "name": "Expedition Base Set",
+    "series": "E-Card",
+    "total": 165,
+    "releaseDate": "2002/09/15"
+  },
+  {
+    "id": "bp",
+    "name": "Best of Game",
+    "series": "Other",
+    "total": 9,
+    "releaseDate": "2002/12/01"
+  },
+  {
+    "id": "ecard2",
+    "name": "Aquapolis",
+    "series": "E-Card",
+    "total": 182,
+    "releaseDate": "2003/01/15"
+  },
+  {
+    "id": "ecard3",
+    "name": "Skyridge",
+    "series": "E-Card",
+    "total": 182,
+    "releaseDate": "2003/05/12"
+  },
+  {
+    "id": "ex1",
+    "name": "Ruby & Sapphire",
+    "series": "EX",
+    "total": 109,
+    "releaseDate": "2003/07/01"
+  },
+  {
+    "id": "ex2",
+    "name": "Sandstorm",
+    "series": "EX",
+    "total": 100,
+    "releaseDate": "2003/09/18"
+  },
+  {
+    "id": "np",
+    "name": "Nintendo Black Star Promos",
+    "series": "NP",
+    "total": 40,
+    "releaseDate": "2003/10/01"
+  },
+  {
+    "id": "ex3",
+    "name": "Dragon",
+    "series": "EX",
+    "total": 100,
+    "releaseDate": "2003/11/24"
+  },
+  {
+    "id": "ex4",
+    "name": "Team Magma vs Team Aqua",
+    "series": "EX",
+    "total": 97,
+    "releaseDate": "2004/03/01"
+  },
+  {
+    "id": "ex5",
+    "name": "Hidden Legends",
+    "series": "EX",
+    "total": 102,
+    "releaseDate": "2004/06/01"
+  },
+  {
+    "id": "tk1b",
+    "name": "EX Trainer Kit Latios",
+    "series": "EX",
+    "total": 10,
+    "releaseDate": "2004/06/01"
+  },
+  {
+    "id": "tk1a",
+    "name": "EX Trainer Kit Latias",
+    "series": "EX",
+    "total": 10,
+    "releaseDate": "2004/06/01"
+  },
+  {
+    "id": "ex6",
+    "name": "FireRed & LeafGreen",
+    "series": "EX",
+    "total": 116,
+    "releaseDate": "2004/09/01"
+  },
+  {
+    "id": "pop1",
+    "name": "POP Series 1",
+    "series": "POP",
+    "total": 17,
+    "releaseDate": "2004/09/01"
+  },
+  {
+    "id": "ex7",
+    "name": "Team Rocket Returns",
+    "series": "EX",
+    "total": 111,
+    "releaseDate": "2004/11/01"
+  },
+  {
+    "id": "ex8",
+    "name": "Deoxys",
+    "series": "EX",
+    "total": 108,
+    "releaseDate": "2005/02/01"
+  },
+  {
+    "id": "ex9",
+    "name": "Emerald",
+    "series": "EX",
+    "total": 107,
+    "releaseDate": "2005/05/01"
+  },
+  {
+    "id": "ex10",
+    "name": "Unseen Forces",
+    "series": "EX",
+    "total": 145,
+    "releaseDate": "2005/08/01"
+  },
+  {
+    "id": "pop2",
+    "name": "POP Series 2",
+    "series": "POP",
+    "total": 17,
+    "releaseDate": "2005/08/01"
+  },
+  {
+    "id": "ex11",
+    "name": "Delta Species",
+    "series": "EX",
+    "total": 114,
+    "releaseDate": "2005/10/31"
+  },
+  {
+    "id": "ex12",
+    "name": "Legend Maker",
+    "series": "EX",
+    "total": 93,
+    "releaseDate": "2006/02/01"
+  },
+  {
+    "id": "tk2b",
+    "name": "EX Trainer Kit 2 Minun",
+    "series": "EX",
+    "total": 12,
+    "releaseDate": "2006/03/01"
+  },
+  {
+    "id": "tk2a",
+    "name": "EX Trainer Kit 2 Plusle",
+    "series": "EX",
+    "total": 12,
+    "releaseDate": "2006/03/01"
+  },
+  {
+    "id": "pop3",
+    "name": "POP Series 3",
+    "series": "POP",
+    "total": 17,
+    "releaseDate": "2006/04/01"
+  },
+  {
+    "id": "ex13",
+    "name": "Holon Phantoms",
+    "series": "EX",
+    "total": 111,
+    "releaseDate": "2006/05/01"
+  },
+  {
+    "id": "ex14",
+    "name": "Crystal Guardians",
+    "series": "EX",
+    "total": 100,
+    "releaseDate": "2006/08/01"
+  },
+  {
+    "id": "pop4",
+    "name": "POP Series 4",
+    "series": "POP",
+    "total": 17,
+    "releaseDate": "2006/08/01"
+  },
+  {
+    "id": "ex15",
+    "name": "Dragon Frontiers",
+    "series": "EX",
+    "total": 101,
+    "releaseDate": "2006/11/01"
+  },
+  {
+    "id": "ex16",
+    "name": "Power Keepers",
+    "series": "EX",
+    "total": 108,
+    "releaseDate": "2007/02/02"
+  },
+  {
+    "id": "pop5",
+    "name": "POP Series 5",
+    "series": "POP",
+    "total": 17,
+    "releaseDate": "2007/03/01"
+  },
+  {
+    "id": "dp1",
+    "name": "Diamond & Pearl",
+    "series": "Diamond & Pearl",
+    "total": 130,
+    "releaseDate": "2007/05/01"
+  },
+  {
+    "id": "dpp",
+    "name": "DP Black Star Promos",
+    "series": "Diamond & Pearl",
+    "total": 56,
+    "releaseDate": "2007/05/01"
+  },
+  {
+    "id": "dp2",
+    "name": "Mysterious Treasures",
+    "series": "Diamond & Pearl",
+    "total": 124,
+    "releaseDate": "2007/08/01"
+  },
+  {
+    "id": "pop6",
+    "name": "POP Series 6",
+    "series": "POP",
+    "total": 17,
+    "releaseDate": "2007/09/01"
+  },
+  {
+    "id": "dp3",
+    "name": "Secret Wonders",
+    "series": "Diamond & Pearl",
+    "total": 132,
+    "releaseDate": "2007/11/01"
+  },
+  {
+    "id": "dp4",
+    "name": "Great Encounters",
+    "series": "Diamond & Pearl",
+    "total": 106,
+    "releaseDate": "2008/02/01"
+  },
+  {
+    "id": "pop7",
+    "name": "POP Series 7",
+    "series": "POP",
+    "total": 17,
+    "releaseDate": "2008/03/01"
+  },
+  {
+    "id": "dp5",
+    "name": "Majestic Dawn",
+    "series": "Diamond & Pearl",
+    "total": 100,
+    "releaseDate": "2008/05/01"
+  },
+  {
+    "id": "dp6",
+    "name": "Legends Awakened",
+    "series": "Diamond & Pearl",
+    "total": 146,
+    "releaseDate": "2008/08/01"
+  },
+  {
+    "id": "pop8",
+    "name": "POP Series 8",
+    "series": "POP",
+    "total": 17,
+    "releaseDate": "2008/09/01"
+  },
+  {
+    "id": "dp7",
+    "name": "Stormfront",
+    "series": "Diamond & Pearl",
+    "total": 106,
+    "releaseDate": "2008/11/01"
+  },
+  {
+    "id": "pl1",
+    "name": "Platinum",
+    "series": "Platinum",
+    "total": 133,
+    "releaseDate": "2009/02/11"
+  },
+  {
+    "id": "pop9",
+    "name": "POP Series 9",
+    "series": "POP",
+    "total": 17,
+    "releaseDate": "2009/03/01"
+  },
+  {
+    "id": "pl2",
+    "name": "Rising Rivals",
+    "series": "Platinum",
+    "total": 120,
+    "releaseDate": "2009/05/16"
+  },
+  {
+    "id": "pl3",
+    "name": "Supreme Victors",
+    "series": "Platinum",
+    "total": 153,
+    "releaseDate": "2009/08/19"
+  },
+  {
+    "id": "pl4",
+    "name": "Arceus",
+    "series": "Platinum",
+    "total": 111,
+    "releaseDate": "2009/11/04"
+  },
+  {
+    "id": "ru1",
+    "name": "Pokémon Rumble",
+    "series": "Other",
+    "total": 16,
+    "releaseDate": "2009/12/02"
+  },
+  {
+    "id": "hgss1",
+    "name": "HeartGold & SoulSilver",
+    "series": "HeartGold & SoulSilver",
+    "total": 124,
+    "releaseDate": "2010/02/10"
+  },
+  {
+    "id": "hsp",
+    "name": "HGSS Black Star Promos",
+    "series": "HeartGold & SoulSilver",
+    "total": 25,
+    "releaseDate": "2010/02/10"
+  },
+  {
+    "id": "hgss2",
+    "name": "HS—Unleashed",
+    "series": "HeartGold & SoulSilver",
+    "total": 96,
+    "releaseDate": "2010/05/12"
+  },
+  {
+    "id": "hgss3",
+    "name": "HS—Undaunted",
+    "series": "HeartGold & SoulSilver",
+    "total": 91,
+    "releaseDate": "2010/08/18"
+  },
+  {
+    "id": "hgss4",
+    "name": "HS—Triumphant",
+    "series": "HeartGold & SoulSilver",
+    "total": 103,
+    "releaseDate": "2010/11/03"
+  },
+  {
+    "id": "col1",
+    "name": "Call of Legends",
+    "series": "HeartGold & SoulSilver",
+    "total": 106,
+    "releaseDate": "2011/02/09"
+  },
+  {
+    "id": "bwp",
+    "name": "BW Black Star Promos",
+    "series": "Black & White",
+    "total": 101,
+    "releaseDate": "2011/03/01"
+  },
+  {
+    "id": "bw1",
+    "name": "Black & White",
+    "series": "Black & White",
+    "total": 115,
+    "releaseDate": "2011/04/25"
+  },
+  {
+    "id": "mcd11",
+    "name": "McDonald's Collection 2011",
+    "series": "Other",
+    "total": 12,
+    "releaseDate": "2011/06/17"
+  },
+  {
+    "id": "bw2",
+    "name": "Emerging Powers",
+    "series": "Black & White",
+    "total": 98,
+    "releaseDate": "2011/08/31"
+  },
+  {
+    "id": "bw3",
+    "name": "Noble Victories",
+    "series": "Black & White",
+    "total": 102,
+    "releaseDate": "2011/11/16"
+  },
+  {
+    "id": "bw4",
+    "name": "Next Destinies",
+    "series": "Black & White",
+    "total": 103,
+    "releaseDate": "2012/02/08"
+  },
+  {
+    "id": "bw5",
+    "name": "Dark Explorers",
+    "series": "Black & White",
+    "total": 111,
+    "releaseDate": "2012/05/09"
+  },
+  {
+    "id": "mcd12",
+    "name": "McDonald's Collection 2012",
+    "series": "Other",
+    "total": 12,
+    "releaseDate": "2012/06/15"
+  },
+  {
+    "id": "bw6",
+    "name": "Dragons Exalted",
+    "series": "Black & White",
+    "total": 128,
+    "releaseDate": "2012/08/15"
+  },
+  {
+    "id": "dv1",
+    "name": "Dragon Vault",
+    "series": "Black & White",
+    "total": 21,
+    "releaseDate": "2012/10/05"
+  },
+  {
+    "id": "bw7",
+    "name": "Boundaries Crossed",
+    "series": "Black & White",
+    "total": 153,
+    "releaseDate": "2012/11/07"
+  },
+  {
+    "id": "bw8",
+    "name": "Plasma Storm",
+    "series": "Black & White",
+    "total": 138,
+    "releaseDate": "2013/02/06"
+  },
+  {
+    "id": "bw9",
+    "name": "Plasma Freeze",
+    "series": "Black & White",
+    "total": 122,
+    "releaseDate": "2013/05/08"
+  },
+  {
+    "id": "bw10",
+    "name": "Plasma Blast",
+    "series": "Black & White",
+    "total": 105,
+    "releaseDate": "2013/08/14"
+  },
+  {
+    "id": "xyp",
+    "name": "XY Black Star Promos",
+    "series": "XY",
+    "total": 216,
+    "releaseDate": "2013/10/12"
+  },
+  {
+    "id": "bw11",
+    "name": "Legendary Treasures",
+    "series": "Black & White",
+    "total": 140,
+    "releaseDate": "2013/11/06"
+  },
+  {
+    "id": "xy0",
+    "name": "Kalos Starter Set",
+    "series": "XY",
+    "total": 39,
+    "releaseDate": "2013/11/08"
+  },
+  {
+    "id": "xy1",
+    "name": "XY",
+    "series": "XY",
+    "total": 146,
+    "releaseDate": "2014/02/05"
+  },
+  {
+    "id": "xy2",
+    "name": "Flashfire",
+    "series": "XY",
+    "total": 110,
+    "releaseDate": "2014/05/07"
+  },
+  {
+    "id": "mcd14",
+    "name": "McDonald's Collection 2014",
+    "series": "Other",
+    "total": 12,
+    "releaseDate": "2014/05/23"
+  },
+  {
+    "id": "xy3",
+    "name": "Furious Fists",
+    "series": "XY",
+    "total": 114,
+    "releaseDate": "2014/08/13"
+  },
+  {
+    "id": "xy4",
+    "name": "Phantom Forces",
+    "series": "XY",
+    "total": 124,
+    "releaseDate": "2014/11/05"
+  },
+  {
+    "id": "xy5",
+    "name": "Primal Clash",
+    "series": "XY",
+    "total": 164,
+    "releaseDate": "2015/02/04"
+  },
+  {
+    "id": "dc1",
+    "name": "Double Crisis",
+    "series": "XY",
+    "total": 34,
+    "releaseDate": "2015/03/25"
+  },
+  {
+    "id": "xy6",
+    "name": "Roaring Skies",
+    "series": "XY",
+    "total": 112,
+    "releaseDate": "2015/05/06"
+  },
+  {
+    "id": "xy7",
+    "name": "Ancient Origins",
+    "series": "XY",
+    "total": 100,
+    "releaseDate": "2015/08/12"
+  },
+  {
+    "id": "xy8",
+    "name": "BREAKthrough",
+    "series": "XY",
+    "total": 165,
+    "releaseDate": "2015/11/04"
+  },
+  {
+    "id": "mcd15",
+    "name": "McDonald's Collection 2015",
+    "series": "Other",
+    "total": 12,
+    "releaseDate": "2015/11/27"
+  },
+  {
+    "id": "xy9",
+    "name": "BREAKpoint",
+    "series": "XY",
+    "total": 126,
+    "releaseDate": "2016/02/03"
+  },
+  {
+    "id": "g1",
+    "name": "Generations",
+    "series": "XY",
+    "total": 117,
+    "releaseDate": "2016/02/22"
+  },
+  {
+    "id": "xy10",
+    "name": "Fates Collide",
+    "series": "XY",
+    "total": 129,
+    "releaseDate": "2016/05/02"
+  },
+  {
+    "id": "xy11",
+    "name": "Steam Siege",
+    "series": "XY",
+    "total": 116,
+    "releaseDate": "2016/08/03"
+  },
+  {
+    "id": "mcd16",
+    "name": "McDonald's Collection 2016",
+    "series": "Other",
+    "total": 12,
+    "releaseDate": "2016/08/19"
+  },
+  {
+    "id": "xy12",
+    "name": "Evolutions",
+    "series": "XY",
+    "total": 113,
+    "releaseDate": "2016/11/02"
+  },
+  {
+    "id": "sm1",
+    "name": "Sun & Moon",
+    "series": "Sun & Moon",
+    "total": 173,
+    "releaseDate": "2017/02/03"
+  },
+  {
+    "id": "smp",
+    "name": "SM Black Star Promos",
+    "series": "Sun & Moon",
+    "total": 250,
+    "releaseDate": "2017/02/03"
+  },
+  {
+    "id": "sm2",
+    "name": "Guardians Rising",
+    "series": "Sun & Moon",
+    "total": 180,
+    "releaseDate": "2017/05/05"
+  },
+  {
+    "id": "sm3",
+    "name": "Burning Shadows",
+    "series": "Sun & Moon",
+    "total": 177,
+    "releaseDate": "2017/08/05"
+  },
+  {
+    "id": "sm35",
+    "name": "Shining Legends",
+    "series": "Sun & Moon",
+    "total": 81,
+    "releaseDate": "2017/10/06"
+  },
+  {
+    "id": "sm4",
+    "name": "Crimson Invasion",
+    "series": "Sun & Moon",
+    "total": 126,
+    "releaseDate": "2017/11/03"
+  },
+  {
+    "id": "mcd17",
+    "name": "McDonald's Collection 2017",
+    "series": "Other",
+    "total": 12,
+    "releaseDate": "2017/11/07"
+  },
+  {
+    "id": "sm5",
+    "name": "Ultra Prism",
+    "series": "Sun & Moon",
+    "total": 178,
+    "releaseDate": "2018/02/02"
+  },
+  {
+    "id": "sm6",
+    "name": "Forbidden Light",
+    "series": "Sun & Moon",
+    "total": 150,
+    "releaseDate": "2018/05/04"
+  },
+  {
+    "id": "sm7",
+    "name": "Celestial Storm",
+    "series": "Sun & Moon",
+    "total": 187,
+    "releaseDate": "2018/08/03"
+  },
+  {
+    "id": "sm75",
+    "name": "Dragon Majesty",
+    "series": "Sun & Moon",
+    "total": 80,
+    "releaseDate": "2018/09/07"
+  },
+  {
+    "id": "mcd18",
+    "name": "McDonald's Collection 2018",
+    "series": "Other",
+    "total": 12,
+    "releaseDate": "2018/10/16"
+  },
+  {
+    "id": "sm8",
+    "name": "Lost Thunder",
+    "series": "Sun & Moon",
+    "total": 240,
+    "releaseDate": "2018/11/02"
+  },
+  {
+    "id": "sm9",
+    "name": "Team Up",
+    "series": "Sun & Moon",
+    "total": 198,
+    "releaseDate": "2019/02/01"
+  },
+  {
+    "id": "det1",
+    "name": "Detective Pikachu",
+    "series": "Sun & Moon",
+    "total": 18,
+    "releaseDate": "2019/04/05"
+  },
+  {
+    "id": "sm10",
+    "name": "Unbroken Bonds",
+    "series": "Sun & Moon",
+    "total": 234,
+    "releaseDate": "2019/05/03"
+  },
+  {
+    "id": "sm11",
+    "name": "Unified Minds",
+    "series": "Sun & Moon",
+    "total": 260,
+    "releaseDate": "2019/08/02"
+  },
+  {
+    "id": "sma",
+    "name": "Hidden Fates Shiny Vault",
+    "series": "Sun & Moon",
+    "total": 94,
+    "releaseDate": "2019/08/23"
+  },
+  {
+    "id": "sm115",
+    "name": "Hidden Fates",
+    "series": "Sun & Moon",
+    "total": 69,
+    "releaseDate": "2019/08/23"
+  },
+  {
+    "id": "mcd19",
+    "name": "McDonald's Collection 2019",
+    "series": "Other",
+    "total": 12,
+    "releaseDate": "2019/10/15"
+  },
+  {
+    "id": "sm12",
+    "name": "Cosmic Eclipse",
+    "series": "Sun & Moon",
+    "total": 272,
+    "releaseDate": "2019/11/01"
+  },
+  {
+    "id": "swshp",
+    "name": "SWSH Black Star Promos",
+    "series": "Sword & Shield",
+    "total": 304,
+    "releaseDate": "2019/11/15"
+  },
+  {
+    "id": "swsh1",
+    "name": "Sword & Shield",
+    "series": "Sword & Shield",
+    "total": 216,
+    "releaseDate": "2020/02/07"
+  },
+  {
+    "id": "swsh2",
+    "name": "Rebel Clash",
+    "series": "Sword & Shield",
+    "total": 209,
+    "releaseDate": "2020/05/01"
+  },
+  {
+    "id": "swsh3",
+    "name": "Darkness Ablaze",
+    "series": "Sword & Shield",
+    "total": 201,
+    "releaseDate": "2020/08/14"
+  },
+  {
+    "id": "fut20",
+    "name": "Pokémon Futsal Collection",
+    "series": "Other",
+    "total": 5,
+    "releaseDate": "2020/09/11"
+  },
+  {
+    "id": "swsh35",
+    "name": "Champion's Path",
+    "series": "Sword & Shield",
+    "total": 80,
+    "releaseDate": "2020/09/25"
+  },
+  {
+    "id": "swsh4",
+    "name": "Vivid Voltage",
+    "series": "Sword & Shield",
+    "total": 203,
+    "releaseDate": "2020/11/13"
+  },
+  {
+    "id": "mcd21",
+    "name": "McDonald's Collection 2021",
+    "series": "Other",
+    "total": 25,
+    "releaseDate": "2021/02/09"
+  },
+  {
+    "id": "swsh45sv",
+    "name": "Shining Fates Shiny Vault",
+    "series": "Sword & Shield",
+    "total": 122,
+    "releaseDate": "2021/02/19"
+  },
+  {
+    "id": "swsh45",
+    "name": "Shining Fates",
+    "series": "Sword & Shield",
+    "total": 73,
+    "releaseDate": "2021/02/19"
+  },
+  {
+    "id": "swsh5",
+    "name": "Battle Styles",
+    "series": "Sword & Shield",
+    "total": 183,
+    "releaseDate": "2021/03/19"
+  },
+  {
+    "id": "swsh6",
+    "name": "Chilling Reign",
+    "series": "Sword & Shield",
+    "total": 233,
+    "releaseDate": "2021/06/18"
+  },
+  {
+    "id": "swsh7",
+    "name": "Evolving Skies",
+    "series": "Sword & Shield",
+    "total": 237,
+    "releaseDate": "2021/08/27"
+  },
+  {
+    "id": "cel25",
+    "name": "Celebrations",
+    "series": "Sword & Shield",
+    "total": 25,
+    "releaseDate": "2021/10/08"
+  },
+  {
+    "id": "cel25c",
+    "name": "Celebrations: Classic Collection",
+    "series": "Sword & Shield",
+    "total": 25,
+    "releaseDate": "2021/10/08"
+  },
+  {
+    "id": "swsh8",
+    "name": "Fusion Strike",
+    "series": "Sword & Shield",
+    "total": 284,
+    "releaseDate": "2021/11/12"
+  },
+  {
+    "id": "swsh9",
+    "name": "Brilliant Stars",
+    "series": "Sword & Shield",
+    "total": 186,
+    "releaseDate": "2022/02/25"
+  },
+  {
+    "id": "swsh9tg",
+    "name": "Brilliant Stars Trainer Gallery",
+    "series": "Sword & Shield",
+    "total": 30,
+    "releaseDate": "2022/02/25"
+  },
+  {
+    "id": "swsh10",
+    "name": "Astral Radiance",
+    "series": "Sword & Shield",
+    "total": 216,
+    "releaseDate": "2022/05/27"
+  },
+  {
+    "id": "swsh10tg",
+    "name": "Astral Radiance Trainer Gallery",
+    "series": "Sword & Shield",
+    "total": 30,
+    "releaseDate": "2022/05/27"
+  },
+  {
+    "id": "pgo",
+    "name": "Pokémon GO",
+    "series": "Sword & Shield",
+    "total": 88,
+    "releaseDate": "2022/07/01"
+  },
+  {
+    "id": "mcd22",
+    "name": "McDonald's Collection 2022",
+    "series": "Other",
+    "total": 15,
+    "releaseDate": "2022/08/03"
+  },
+  {
+    "id": "swsh11",
+    "name": "Lost Origin",
+    "series": "Sword & Shield",
+    "total": 217,
+    "releaseDate": "2022/09/09"
+  },
+  {
+    "id": "swsh11tg",
+    "name": "Lost Origin Trainer Gallery",
+    "series": "Sword & Shield",
+    "total": 30,
+    "releaseDate": "2022/09/09"
+  },
+  {
+    "id": "swsh12",
+    "name": "Silver Tempest",
+    "series": "Sword & Shield",
+    "total": 215,
+    "releaseDate": "2022/11/11"
+  },
+  {
+    "id": "swsh12tg",
+    "name": "Silver Tempest Trainer Gallery",
+    "series": "Sword & Shield",
+    "total": 30,
+    "releaseDate": "2022/11/11"
+  },
+  {
+    "id": "svp",
+    "name": "Scarlet & Violet Black Star Promos",
+    "series": "Scarlet & Violet",
+    "total": 196,
+    "releaseDate": "2023/01/01"
+  },
+  {
+    "id": "swsh12pt5",
+    "name": "Crown Zenith",
+    "series": "Sword & Shield",
+    "total": 160,
+    "releaseDate": "2023/01/20"
+  },
+  {
+    "id": "swsh12pt5gg",
+    "name": "Crown Zenith Galarian Gallery",
+    "series": "Sword & Shield",
+    "total": 70,
+    "releaseDate": "2023/01/20"
+  },
+  {
+    "id": "sv1",
+    "name": "Scarlet & Violet",
+    "series": "Scarlet & Violet",
+    "total": 258,
+    "releaseDate": "2023/03/31"
+  },
+  {
+    "id": "sve",
+    "name": "Scarlet & Violet Energies",
+    "series": "Scarlet & Violet",
+    "total": 8,
+    "releaseDate": "2023/03/31"
+  },
+  {
+    "id": "sv2",
+    "name": "Paldea Evolved",
+    "series": "Scarlet & Violet",
+    "total": 279,
+    "releaseDate": "2023/06/09"
+  },
+  {
+    "id": "sv3",
+    "name": "Obsidian Flames",
+    "series": "Scarlet & Violet",
+    "total": 230,
+    "releaseDate": "2023/08/11"
+  },
+  {
+    "id": "sv3pt5",
+    "name": "151",
+    "series": "Scarlet & Violet",
+    "total": 207,
+    "releaseDate": "2023/09/22"
+  },
+  {
+    "id": "sv4",
+    "name": "Paradox Rift",
+    "series": "Scarlet & Violet",
+    "total": 266,
+    "releaseDate": "2023/11/03"
+  },
+  {
+    "id": "sv4pt5",
+    "name": "Paldean Fates",
+    "series": "Scarlet & Violet",
+    "total": 245,
+    "releaseDate": "2024/01/26"
+  },
+  {
+    "id": "sv5",
+    "name": "Temporal Forces",
+    "series": "Scarlet & Violet",
+    "total": 218,
+    "releaseDate": "2024/03/22"
+  },
+  {
+    "id": "sv6",
+    "name": "Twilight Masquerade",
+    "series": "Scarlet & Violet",
+    "total": 226,
+    "releaseDate": "2024/05/24"
+  },
+  {
+    "id": "sv6pt5",
+    "name": "Shrouded Fable",
+    "series": "Scarlet & Violet",
+    "total": 99,
+    "releaseDate": "2024/08/02"
+  },
+  {
+    "id": "sv7",
+    "name": "Stellar Crown",
+    "series": "Scarlet & Violet",
+    "total": 175,
+    "releaseDate": "2024/09/13"
+  },
+  {
+    "id": "sv8",
+    "name": "Surging Sparks",
+    "series": "Scarlet & Violet",
+    "total": 252,
+    "releaseDate": "2024/11/08"
+  },
+  {
+    "id": "sv8pt5",
+    "name": "Prismatic Evolutions",
+    "series": "Scarlet & Violet",
+    "total": 180,
+    "releaseDate": "2025/01/17"
+  },
+  {
+    "id": "sv9",
+    "name": "Journey Together",
+    "series": "Scarlet & Violet",
+    "total": 190,
+    "releaseDate": "2025/03/28"
+  },
+  {
+    "id": "sv10",
+    "name": "Destined Rivals",
+    "series": "Scarlet & Violet",
+    "total": 244,
+    "releaseDate": "2025/05/30"
+  },
+  {
+    "id": "zsv10pt5",
+    "name": "Black Bolt",
+    "series": "Scarlet & Violet",
+    "total": 172,
+    "releaseDate": "2025/07/18"
+  },
+  {
+    "id": "rsv10pt5",
+    "name": "White Flare",
+    "series": "Scarlet & Violet",
+    "total": 173,
+    "releaseDate": "2025/07/18"
+  },
+  {
+    "id": "me1",
+    "name": "Mega Evolution",
+    "series": "Mega Evolution",
+    "total": 188,
+    "releaseDate": "2025/09/26"
+  },
+  {
+    "id": "me2",
+    "name": "Phantasmal Flames",
+    "series": "Mega Evolution",
+    "total": 130,
+    "releaseDate": "2025/11/14"
+  },
+  {
+    "id": "me2pt5",
+    "name": "Ascended Heroes",
+    "series": "Mega Evolution",
+    "total": 295,
+    "releaseDate": "2026/01/30"
+  },
+  {
+    "id": "me3",
+    "name": "Perfect Order",
+    "series": "Mega Evolution",
+    "total": 124,
+    "releaseDate": "2026/03/27"
+  },
+  {
+    "id": "me4",
+    "name": "Chaos Rising",
+    "series": "Mega Evolution",
+    "total": 122,
+    "releaseDate": "2026/05/22"
+  }
+]

--- a/web/src/data/sets.ts
+++ b/web/src/data/sets.ts
@@ -1,0 +1,22 @@
+/**
+ * Baked-in Pokémon TCG set catalog — the SPA's zero-round-trip initial
+ * state for any UI that picks a set (Browse, the export picker).
+ *
+ * The JSON file is refreshed by `npm run refresh-sets`, which fetches
+ * `https://api.pokemontcg.io/v2/sets` and writes the same trimmed
+ * shape `GET /api/v1/sets` serves. New Pokémon sets ship every few
+ * months; bake-refresh-commit is a manual cadence (a future scheduled
+ * job could automate it).
+ *
+ * The live fetch still runs in the background on first open so any
+ * sets that landed upstream since the last bake show up the same
+ * session — no need to wait for a deploy. See `BrowseModal` and
+ * `SetPickerModal` for the revalidation flow.
+ */
+import type { SetInfo } from '../types'
+import bakedSets from './sets.json'
+
+// `as const` would over-narrow the literal types; the simple cast keeps
+// the runtime shape but lets the SPA treat the catalog as the same
+// `SetInfo[]` the API endpoint produces.
+export const BAKED_SETS = bakedSets as SetInfo[]

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -10,6 +10,7 @@
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,


### PR DESCRIPTION
Closes #305

## What

Two stacking changes, both off the critical path, to take the first-ever Browse open from "wait on the network for a couple of seconds" to "instant":

1. **Baked-in catalog.** A new `npm run refresh-sets` script (`web/scripts/refresh-sets.mjs`) fetches the pokemontcg.io catalog and writes `web/src/data/sets.json` (173 sets, ~33 KB). Both `BrowseModal` and `SetPickerModal` import that JSON as their initial state, so the very first render shows a populated list — no loading spinner, no waiting. The live `/api/v1/sets` fetch still runs once per session in the background to write through any sets that landed upstream since the last bake. A failed revalidation is silently swallowed (the user has working content; a red banner over an otherwise usable list reads as broken).
2. **`stale-while-revalidate` on `/sets`.** The Cache-Control header is now `public, max-age=3600, stale-while-revalidate=86400`. After the 1h fresh window, the browser serves the cached payload **immediately** for up to a day while it asynchronously revalidates. Combined with (1) the user never sees a loading state on the catalog endpoint after their first visit.

## Why

#305 — the catalog landing was the only remaining "show me a spinner" surface in the Browse story. The disk cache, in-memory cache, browser cache, and trimmed payloads were all already in place; this was the last meaningful round-trip.

## Refresh cadence

Manual for now — `npm run refresh-sets` before each release is enough since new Pokémon sets ship every few months. A scheduled CI job that opens a PR with the diff is a natural follow-up if drift becomes a concern; deliberately out of scope here to keep the change small.

The script is resilient: a failed pokemontcg.io fetch keeps the existing `sets.json` and exits 0 so the build never breaks on a transient upstream outage. Skipping the write when the diff is empty keeps git history clean for scheduled invocations.

Other proposals from #305 (background warm at FastAPI startup, preconnect hint) were considered but (1) + (2) already cover >99% of visits; the remaining proposals are smaller wins that can land separately if measurement shows they're needed.

## How to verify

1. `cd web && npm run refresh-sets` — confirms the script runs cleanly against pokemontcg.io. The committed `sets.json` is already fresh.
2. `make dev-web` (no need for `make dev-api`) → open the SPA → click **Browse**. The set list renders **instantly** — there's no "Loading set catalog…" state because there's no backend running and there's no need for one.
3. `make dev-api` + `make dev-web` → open Browse. Same instant render. Check Network: the `/api/v1/sets` fetch fires in the background and either updates the list (writes through) or silently fails.
4. `curl -sI http://localhost:8000/api/v1/sets | grep -i cache` → `cache-control: public, max-age=3600, stale-while-revalidate=86400`.

## Tests

- **Backend**: SWR header assertion on `/sets` (`tests/test_api_routes.py`).
- **Frontend BrowseModal (16 tests)** — two new positive ones (baked-render before live fetch, revalidation-writethrough lands fresher data) plus a rewritten "silently swallow background failure" replacing the old "surface a red banner" test.
- **Frontend SetPickerModal (12 tests)** — same shape: deleted the load-error / retry-error tests (now non-behaviors), added the swallow-on-error positive.

Existing tests in both files now `vi.mock('../data/sets', () => ({ BAKED_SETS: [] }))` so the test-fixture catalog isn't layered over the real bundled one.

`make check` (352 tests) + `cd web && npm run build` are green.

## Screenshots

Captured locally — drag the screenshot in chat into the PR body for the verification artifact.