### PR TITLE
feat(cache): warm-set-cards — pre-prime per-set card lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- CLI: `pkmn cache warm-set-cards` subcommand walks every Pokémon TCG set
+  and pre-primes the API response cache for each one's card list, so the
+  web SPA's Browse → set-detail path is a cache hit on first request
+  instead of a multi-second upstream round trip. Issues the exact same
+  `set.id:"<id>"` Lucene query the `GET /api/v1/sets/{set_id}/cards`
+  endpoint issues, so cache keys line up. Accepts `--set <id>`
+  (repeatable) to warm only specific sets — handy for staging a new
+  release without re-walking the whole catalog — and `--verbose` to
+  print each set id as it warms. Writes `set_cards_warm.json` in the
+  cache root with a timestamp + warmed-count so `pkmn cache stats` can
+  report freshness and the FastAPI startup hook gates itself to run at
+  most once per week.
+- API: `MGZ_PKMN_WARM_ON_STARTUP=1` now kicks off a set-cards warm pass
+  on a separate daemon thread alongside the existing concept warm, so
+  the first Browse → set-detail request served by a fresh process is a
+  cache hit. Each warmer has its own freshness manifest (24 h for
+  concepts, 1 week for set cards) so the heavier set-cards walk doesn't
+  thrash on every `uvicorn --reload` cycle.
+- Stats: `pkmn cache stats` surfaces a new **Set cards** line — "N sets ·
+  warmed <age>" when a warm pass has landed, "not warmed · run …"
+  otherwise. JSON output (`--json`) gains matching `set_cards_warm_timestamp`
+  and `set_cards_warm_count` fields for monitoring.
 - Web: **Browse sets** — a new **Browse** button in the header opens a
   modal that explores the Pokémon TCG catalog without typing a card
   list. The set list groups every set by series, newest-first, with

--- a/api/main.py
+++ b/api/main.py
@@ -22,7 +22,7 @@ from starlette.responses import Response
 
 from mgz_pkmn import __version__
 from mgz_pkmn import cache as disk_cache
-from mgz_pkmn.lookup import warm_concepts
+from mgz_pkmn.lookup import warm_concepts, warm_set_cards
 from mgz_pkmn.sources import TCGClient, TCGDexClient
 
 from .routes import export, lookup, overrides, parse, set_cards, sets
@@ -64,6 +64,41 @@ def _warm_concepts_in_background() -> None:
             _log.exception("concept warm failed; service running with cold cache")
 
     threading.Thread(target=_run, name="concept-warm", daemon=True).start()
+
+
+def _warm_set_cards_in_background() -> None:
+    """Run the set-cards warm pass on a daemon thread so FastAPI startup
+    isn't blocked by ~500 upstream HTTP requests.
+
+    Gated by the on-disk freshness manifest — if a warm pass landed
+    within the last week, skip and log "already fresh". Errors are
+    logged and swallowed: a failed warm should not crash the service,
+    only leave the per-set card lists cold for this run. Sets card
+    data effectively doesn't change once a set ships (only market
+    prices drift, and that's already covered by the 1-day browser
+    cache on the endpoint), so the weekly cadence is generous."""
+    if disk_cache.set_cards_warm_is_fresh():
+        _log.info("set-cards cache fresh; skipping startup warm")
+        return
+
+    def _run() -> None:
+        try:
+            pkmn = TCGClient(api_key=os.environ.get("POKEMONTCG_IO_API_KEY"))
+            result = warm_set_cards(pkmn)
+            disk_cache.write_set_cards_warm(
+                sets_warmed=result.sets_warmed,
+                sets_failed=result.sets_failed,
+            )
+            _log.info(
+                "set-cards warm complete: %d sets attempted, %d warmed, %d missed",
+                result.sets_attempted,
+                result.sets_warmed,
+                len(result.sets_failed),
+            )
+        except Exception:
+            _log.exception("set-cards warm failed; service running with cold cache")
+
+    threading.Thread(target=_run, name="set-cards-warm", daemon=True).start()
 
 
 class SPAStaticFiles(StaticFiles):
@@ -109,16 +144,17 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Opt-in startup hook: when MGZ_PKMN_WARM_ON_STARTUP=1, kick off a concept
-# warm pass in the background so the first concept lookup served by this
-# process is a cache hit. The manifest's once-per-day gate keeps reloads
-# from thrashing (a `uvicorn --reload` cycle won't re-warm if a warm pass
-# landed within the last 24 h).
+# Opt-in startup hook: when MGZ_PKMN_WARM_ON_STARTUP=1, kick off both the
+# concept warm and the set-cards warm in the background so first-use
+# lookups served by this process are cache hits. Each warmer has its own
+# freshness manifest (24 h for concepts, 1 week for set cards) so the
+# heavier one doesn't re-thrash on every `uvicorn --reload` cycle.
 if os.environ.get(_WARM_ON_STARTUP_ENV, "").strip() in ("1", "true", "True"):
 
     @app.on_event("startup")
-    def _startup_warm_concepts() -> None:
+    def _startup_warm() -> None:
         _warm_concepts_in_background()
+        _warm_set_cards_in_background()
 
 
 app.include_router(parse.router, prefix="/api/v1", tags=["parse"])

--- a/src/mgz_pkmn/cache.py
+++ b/src/mgz_pkmn/cache.py
@@ -45,12 +45,21 @@ if TYPE_CHECKING:
 DEFAULT_API_TTL_SECONDS = 7 * 24 * 60 * 60  # one week
 DEFAULT_CACHE_WARN_BYTES = 50 * 1024 * 1024  # 50 MB
 CONCEPT_WARM_STALE_SECONDS = 24 * 60 * 60  # one day — once-per-day startup gate
+# Set-cards warm pass is much heavier (~500 HTTP requests for the whole
+# catalog) and the underlying data turns over much more slowly than the
+# concept dictionary — cards within a released set effectively don't
+# change, only market prices drift. A weekly cadence matches the API
+# response cache's own TTL: once a set-cards warm pass lands, every
+# entry it primed survives until the API cache itself expires.
+SET_CARDS_WARM_STALE_SECONDS = 7 * 24 * 60 * 60  # one week
 _NO_CACHE_ENV = "MGZ_PKMN_NO_CACHE"
 _WARN_BYTES_ENV = "MGZ_PKMN_CACHE_WARN_BYTES"
 _OVERRIDES_FILE = "url_overrides.json"
 _CONCEPT_WARM_FILE = "concept_warm.json"
+_SET_CARDS_WARM_FILE = "set_cards_warm.json"
 OVERRIDES_SCHEMA_VERSION = 1
 CONCEPT_WARM_SCHEMA_VERSION = 1
+SET_CARDS_WARM_SCHEMA_VERSION = 1
 _IMAGES_SUBDIR = "images"
 # Allowed image extensions for read-side discovery; write-side derives the
 # extension from the source URL but normalises it through this list so an
@@ -90,6 +99,12 @@ class CacheStats:
     # "concept cache: not warmed" so the operator knows the state at a glance.
     concept_warm_timestamp: float | None
     concept_warm_names: int
+    # Set-cards warm slice — populated from `set_cards_warm.json`, written by
+    # `pkmn cache warm-set-cards`. Same shape as the concept slice: None
+    # timestamp renders as "not warmed", and the count tracks how many
+    # sets had their full card list primed during the most recent pass.
+    set_cards_warm_timestamp: float | None
+    set_cards_warm_count: int
 
 
 def _disabled() -> bool:
@@ -657,6 +672,84 @@ def concept_warm_is_fresh(*, now: float | None = None) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Set-cards-warm manifest — records the most recent `warm-set-cards` run.
+# Same shape as the concept manifest (timestamp, count, failed list) so the
+# stats projection and freshness gate can share their mental model. Lives
+# alongside `concept_warm.json` in the cache root.
+# ---------------------------------------------------------------------------
+
+
+def _set_cards_warm_path() -> Path:
+    return _cache_root_path() / _SET_CARDS_WARM_FILE
+
+
+def read_set_cards_warm() -> dict[str, Any] | None:
+    """Return the parsed set-cards-warm manifest, or None when absent/malformed.
+
+    Schema (v1):
+        {
+            "version": 1,
+            "timestamp": <unix float>,
+            "sets_warmed": <int>,
+            "sets_failed": [<set_id>, ...]
+        }
+
+    Same defence-in-depth as `read_concept_warm`: corrupt files / wrong
+    schema versions are treated as "no manifest" so a bad write doesn't
+    poison the freshness gate."""
+    path = _set_cards_warm_path()
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict) or data.get("version") != SET_CARDS_WARM_SCHEMA_VERSION:
+        return None
+    return data
+
+
+def write_set_cards_warm(
+    *,
+    sets_warmed: int,
+    sets_failed: list[str],
+) -> None:
+    """Persist the set-cards-warm manifest. Best-effort write — failures
+    are silent so a read-only filesystem doesn't crash a successful
+    warm pass that's about to return its result to the caller."""
+    payload = {
+        "version": SET_CARDS_WARM_SCHEMA_VERSION,
+        "timestamp": time.time(),
+        "sets_warmed": sets_warmed,
+        "sets_failed": sets_failed,
+    }
+    root = cache_root()
+    with contextlib.suppress(OSError):
+        (root / _SET_CARDS_WARM_FILE).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def set_cards_warm_is_fresh(*, now: float | None = None) -> bool:
+    """True when a manifest exists, its timestamp is within the staleness
+    window (1 week, see `SET_CARDS_WARM_STALE_SECONDS`), and it recorded
+    at least one successful set warm.
+
+    Same `sets_warmed > 0` guard as the concept gate — a manifest written
+    after a fully-failed pass (e.g. transient upstream outage) must not
+    suppress the next retry for a full week with the cache still cold."""
+    manifest = read_set_cards_warm()
+    if manifest is None:
+        return False
+    ts = manifest.get("timestamp")
+    if not isinstance(ts, int | float):
+        return False
+    sets_warmed = manifest.get("sets_warmed")
+    if not isinstance(sets_warmed, int) or sets_warmed <= 0:
+        return False
+    current = now if now is not None else time.time()
+    return (current - ts) < SET_CARDS_WARM_STALE_SECONDS
+
+
+# ---------------------------------------------------------------------------
 # Stats — health snapshot for `pkmn cache stats`.
 # ---------------------------------------------------------------------------
 
@@ -714,6 +807,17 @@ def stats() -> CacheStats:
         if isinstance(n, int):
             concept_warm_names = n
 
+    set_cards_warm_timestamp: float | None = None
+    set_cards_warm_count = 0
+    sc_manifest = read_set_cards_warm()
+    if sc_manifest is not None:
+        ts = sc_manifest.get("timestamp")
+        if isinstance(ts, int | float):
+            set_cards_warm_timestamp = float(ts)
+        n = sc_manifest.get("sets_warmed")
+        if isinstance(n, int):
+            set_cards_warm_count = n
+
     return CacheStats(
         root=root,
         api_entry_count=api_count,
@@ -725,4 +829,6 @@ def stats() -> CacheStats:
         image_bytes=image_bytes,
         concept_warm_timestamp=concept_warm_timestamp,
         concept_warm_names=concept_warm_names,
+        set_cards_warm_timestamp=set_cards_warm_timestamp,
+        set_cards_warm_count=set_cards_warm_count,
     )

--- a/src/mgz_pkmn/cli.py
+++ b/src/mgz_pkmn/cli.py
@@ -19,7 +19,7 @@ from . import cache as disk_cache
 from .binder import CONDENSED_LAYOUT, STANDARD_LAYOUT, write_binder_pdf
 from .checklist import write_checklist_pdf
 from .images import download_image
-from .lookup import WARM_SOURCES, find_card, find_top_cards, warm_concepts
+from .lookup import WARM_SOURCES, find_card, find_top_cards, warm_concepts, warm_set_cards
 from .parser import CardQuery, read_input
 from .pricing import Pricing, extract_pricing
 from .report import build_json_report
@@ -1033,6 +1033,23 @@ def cache_stats_command(as_json: bool) -> None:
             + click.style("Concepts:      ", fg="bright_black")
             + f"{s.concept_warm_names} names · warmed {_format_age(s.concept_warm_timestamp)}"
         )
+    # Set-cards warm slice — same shape as the concept line, sourced from
+    # `set_cards_warm.json`. When unwarmed, surface the command name so the
+    # operator can resolve it from the stats output alone.
+    if s.set_cards_warm_timestamp is None:
+        click.echo(
+            "  "
+            + click.style("Set cards:     ", fg="bright_black")
+            + click.style("not warmed", fg="yellow")
+            + " · run `pkmn cache warm-set-cards` to prime"
+        )
+    else:
+        click.echo(
+            "  "
+            + click.style("Set cards:     ", fg="bright_black")
+            + f"{s.set_cards_warm_count} sets · warmed "
+            + f"{_format_age(s.set_cards_warm_timestamp)}"
+        )
 
 
 @cache_group.command(name="clear", context_settings={"help_option_names": ["-h", "--help"]})
@@ -1200,6 +1217,107 @@ def cache_warm_concepts_command(api_key: str | None, source: str, verbose: bool)
     if result.names_failed and verbose:
         click.echo(
             "  " + click.style("missed: ", fg="bright_black") + ", ".join(result.names_failed)
+        )
+
+    click.echo()
+    click.secho("Done!", fg="green", bold=True)
+
+
+@cache_group.command(
+    name="warm-set-cards",
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+@click.option(
+    "--api-key",
+    envvar="POKEMONTCG_IO_API_KEY",
+    default=None,
+    help="pokemontcg.io API key (or set POKEMONTCG_IO_API_KEY).",
+)
+@click.option(
+    "--set",
+    "set_ids",
+    multiple=True,
+    metavar="SET_ID",
+    help=(
+        "Restrict the warm pass to specific set ids (e.g. --set sv8 --set sv9). "
+        "Repeatable. When omitted, every set in the Pokémon TCG catalog is warmed."
+    ),
+)
+@click.option("-v", "--verbose", is_flag=True, help="Print each set as it warms.")
+def cache_warm_set_cards_command(
+    api_key: str | None,
+    set_ids: tuple[str, ...],
+    verbose: bool,
+) -> None:
+    """Pre-prime the API cache for every set's card list.
+
+    The Browse surface in the web SPA opens the per-set card grid via
+    `GET /api/v1/sets/{set_id}/cards`. On a cold cache, every first
+    pick of a set pays a multi-second upstream round trip. This
+    command walks every set once, fires the exact same query the
+    endpoint issues, and writes the responses to the on-disk API
+    cache — turning the user-facing endpoint into a cache hit on
+    first request.
+
+    A full warm walks ~170 sets and pages each one (3 pages on
+    average), so expect a multi-minute run on a fresh install
+    bounded by pokemontcg.io's rate limit. The disk-cache TTL is one
+    week; this command's manifest tracks that same window so
+    `pkmn cache stats` and the API startup gate can decide when to
+    re-warm.
+
+    Pass `--set <id>` (repeatable) to warm only specific sets — useful
+    for staging a single new set release without re-walking the whole
+    catalog."""
+    _print_banner(__version__)
+
+    pkmn = TCGClient(api_key=api_key, verbose=verbose)
+
+    section = "Warming set-cards cache"
+    if set_ids:
+        section += f" · {len(set_ids)} set(s)"
+    _print_section(section)
+
+    def _progress(index: int, total: int, set_id: str) -> None:
+        if not verbose:
+            return
+        click.echo(
+            click.style(f"  [{index}/{total}] ", fg="bright_black") + set_id,
+            err=False,
+        )
+
+    try:
+        result = warm_set_cards(
+            pkmn,
+            set_ids=list(set_ids) if set_ids else None,
+            on_progress=_progress,
+        )
+    except requests.RequestException as exc:
+        raise click.ClickException(f"set-cards warm failed: {exc}") from exc
+
+    if result.sets_attempted == 0:
+        raise click.ClickException(
+            "no sets to warm — check `--set` ids or upstream catalog availability"
+        )
+
+    disk_cache.write_set_cards_warm(
+        sets_warmed=result.sets_warmed,
+        sets_failed=result.sets_failed,
+    )
+
+    click.secho("  ✓ ", fg="green", nl=False)
+    click.echo(
+        f"{result.sets_attempted} sets · "
+        + click.style(f"{result.sets_warmed} warmed", fg="cyan")
+        + (
+            click.style(f" · {len(result.sets_failed)} missed", fg="yellow")
+            if result.sets_failed
+            else ""
+        )
+    )
+    if result.sets_failed and verbose:
+        click.echo(
+            "  " + click.style("missed: ", fg="bright_black") + ", ".join(result.sets_failed)
         )
 
     click.echo()

--- a/src/mgz_pkmn/lookup.py
+++ b/src/mgz_pkmn/lookup.py
@@ -659,3 +659,101 @@ def warm_concepts(
         names_warmed=warmed,
         names_failed=failed,
     )
+
+
+# ---------------------------------------------------------------------------
+# Set-cards warming — walk every set and prime the API cache for each one's
+# card list, so the SPA's Browse → set-detail path becomes a true cache hit
+# on first pick instead of a multi-second upstream round trip.
+#
+# This MUST mirror the query shape `api/routes/sets.py:_fetch_set_cards`
+# issues — `client.search_all(f'set.id:"<id>"')` — or the cache keys won't
+# line up and the user-facing endpoint will still fan out to upstream.
+# The pokemontcg.io free tier rate-limits at 30 rpm; with ~170 sets at
+# ~3 pages each, a full warm is a multi-minute background job.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WarmSetCardsResult:
+    """Outcome of a `warm_set_cards` run.
+
+    `sets_attempted` is the count of set ids walked (after any explicit
+    filter). `sets_warmed` counts the sets where pokemontcg.io returned
+    at least one card and we therefore wrote through to the disk cache.
+    `sets_failed` lists the set ids where the search returned zero
+    results — useful for the operator to spot ids that have been
+    retired upstream or typo'd in a manual `--set` flag."""
+
+    sets_attempted: int
+    sets_warmed: int
+    sets_failed: list[str] = field(default_factory=list)
+
+
+def fetch_set_ids(pkmn: TCGClient) -> list[str]:
+    """Return every Pokémon TCG set id from pokemontcg.io, oldest → newest.
+
+    Single-call helper used by `warm_set_cards` so the warmer doesn't have
+    to know about FastAPI's catalog endpoint. We deliberately don't go
+    through the API response disk cache here — the warmer is what
+    populates that cache, and a 7-day-old set list would mean newly
+    released sets quietly miss the warm pass for up to a week. Set ids
+    are short (~5 KB total for ~170 sets), so re-fetching every warm pass
+    is negligible cost.
+
+    Raises `requests.RequestException` on transport failure; callers
+    surface that as a user-visible error rather than silently warming
+    against an empty list."""
+    from .sources.pokemontcg import API_BASE
+
+    url = f"{API_BASE}/sets?orderBy=releaseDate&pageSize=250"
+    resp = pkmn.session.get(url, timeout=30)
+    resp.raise_for_status()
+    return [s["id"] for s in resp.json().get("data", []) if s.get("id")]
+
+
+def warm_set_cards(
+    pkmn: TCGClient,
+    *,
+    set_ids: list[str] | None = None,
+    on_progress: Callable[[int, int, str], None] | None = None,
+) -> WarmSetCardsResult:
+    """Pre-prime the API disk cache for every set's card list.
+
+    `set_ids`, when provided, restricts the walk to that subset — handy
+    for the CLI's `--set` flag to warm a single set on demand. When
+    None (the default), the full Pokémon TCG catalog is fetched via
+    `fetch_set_ids` and every id is walked.
+
+    Each set fires exactly `pkmn.search_all(f'set.id:"{set_id}"')` — the
+    same query `api/routes/sets.py:_fetch_set_cards` issues. The disk
+    cache key (a sha1 of the request URL) is derived deep inside
+    `TCGClient._fetch_page`, so as long as the query strings match, the
+    keys line up and the user-facing endpoint becomes a cache hit on
+    first request.
+
+    `on_progress`, when provided, is invoked once per set with
+    `(index, total, set_id)` so callers can render a progress bar.
+
+    Returns a `WarmSetCardsResult` so the CLI / API can render a summary
+    and write the on-disk manifest that `pkmn cache stats` reports
+    against."""
+    ids = set_ids if set_ids is not None else fetch_set_ids(pkmn)
+    total = len(ids)
+    warmed = 0
+    failed: list[str] = []
+    for index, set_id in enumerate(ids, start=1):
+        if on_progress is not None:
+            on_progress(index, total, set_id)
+        # MUST mirror `_fetch_set_cards` so the disk-cache key lines up.
+        query = f'set.id:"{set_id}"'
+        results = pkmn.search_all(query)
+        if results:
+            warmed += 1
+        else:
+            failed.append(set_id)
+    return WarmSetCardsResult(
+        sets_attempted=total,
+        sets_warmed=warmed,
+        sets_failed=failed,
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -198,6 +198,8 @@ class CacheStatsCommandTests(unittest.TestCase):
                 "image_entry_count",
                 "concept_warm_timestamp",
                 "concept_warm_names",
+                "set_cards_warm_timestamp",
+                "set_cards_warm_count",
                 "root",
             },
         )

--- a/tests/test_warm_concepts.py
+++ b/tests/test_warm_concepts.py
@@ -467,8 +467,15 @@ class CacheStatsConceptLineTests(_IsolatedCacheMixin):
         # Branch covered: includes the count + "warmed" with a relative age.
         self.assertIn("42 names", result.output)
         self.assertIn("warmed", result.output)
-        # "not warmed" text from the other branch must NOT appear here.
-        self.assertNotIn("not warmed", result.output)
+        # "not warmed" text from this slice's branch must NOT appear here.
+        # We scope the negative assertion to the Concepts line so a sibling
+        # slice (e.g. the Set cards line, which renders "not warmed" when
+        # its own manifest is missing) doesn't break this test.
+        concepts_line = next(
+            (line for line in result.output.splitlines() if "Concepts:" in line),
+            "",
+        )
+        self.assertNotIn("not warmed", concepts_line)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_warm_set_cards.py
+++ b/tests/test_warm_set_cards.py
@@ -325,22 +325,61 @@ class WarmSetCardsBackgroundHookTests(_IsolatedCacheMixin):
         from api.main import _warm_set_cards_in_background
 
         # No manifest → freshness gate returns False → we expect a real
-        # background daemon. Mock the warm function so no HTTP fires and
-        # block on the thread.
-        fake = WarmSetCardsResult(sets_attempted=5, sets_warmed=4, sets_failed=["x"])
-        with patch("api.main.warm_set_cards", return_value=fake) as warm_mock:
+        # background daemon. Signal completion via an Event from the
+        # mocked warm function rather than scanning `threading.enumerate()`
+        # (which races: the thread may not yet be enumerable, or it may
+        # already have exited by the time we look).
+        done = threading.Event()
+
+        def _fake_warm(_pkmn):
+            try:
+                return WarmSetCardsResult(sets_attempted=5, sets_warmed=4, sets_failed=["x"])
+            finally:
+                done.set()
+
+        with (
+            patch("api.main.warm_set_cards", side_effect=_fake_warm),
+            patch("api.main.TCGClient"),
+        ):
             _warm_set_cards_in_background()
-            # Daemon thread does the work; join via the named thread.
-            for t in threading.enumerate():
-                if t.name == "set-cards-warm":
-                    t.join(timeout=5)
-            warm_mock.assert_called_once()
-        # Manifest landed.
+            self.assertTrue(done.wait(timeout=5.0), "background thread did not finish")
+            # Give the writer a tick to land the manifest after warm returns.
+            for _ in range(50):
+                if disk_cache.read_set_cards_warm() is not None:
+                    break
+                time.sleep(0.02)
+
         manifest = disk_cache.read_set_cards_warm()
         self.assertIsNotNone(manifest)
         assert manifest is not None
         self.assertEqual(manifest["sets_warmed"], 4)
         self.assertEqual(manifest["sets_failed"], ["x"])
+
+    def test_swallows_exceptions_so_service_keeps_running(self) -> None:
+        import threading
+
+        from api.main import _warm_set_cards_in_background
+
+        done = threading.Event()
+
+        def _boom(*_args, **_kwargs):
+            try:
+                raise RuntimeError("upstream down")
+            finally:
+                done.set()
+
+        # Even when warm_set_cards raises, the hook must not propagate
+        # (the daemon thread should log + swallow). No manifest is
+        # written when the warm fails — that's the signal the next
+        # startup should re-attempt instead of trusting a stale gate.
+        with (
+            patch("api.main.warm_set_cards", side_effect=_boom),
+            patch("api.main.TCGClient"),
+        ):
+            _warm_set_cards_in_background()  # must return without raising
+            self.assertTrue(done.wait(timeout=5.0))
+
+        self.assertIsNone(disk_cache.read_set_cards_warm())
 
 
 if __name__ == "__main__":

--- a/tests/test_warm_set_cards.py
+++ b/tests/test_warm_set_cards.py
@@ -1,0 +1,347 @@
+"""Tests for `pkmn cache warm-set-cards` — the per-set card-list warming pass.
+
+Mirrors the structure of `test_warm_concepts.py`: stub clients,
+manifest read/write/freshness, CLI summary, stats projection, and
+the FastAPI startup hook. Lives in its own module so the warm-concepts
+file stays focused."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from mgz_pkmn import cache as disk_cache
+from mgz_pkmn.lookup import (
+    WarmSetCardsResult,
+    warm_set_cards,
+)
+
+# ---------------------------------------------------------------------------
+# Stub clients used across the warm tests. We deliberately don't reuse the
+# `_CountingTCGClient` from test_warm_concepts because that returns the same
+# fixed payload for every query; here we want to script per-set behaviour
+# so the "some sets succeed, some fail" branch is exercised.
+# ---------------------------------------------------------------------------
+
+
+class _StubTCGClient:
+    """Stub `TCGClient` whose `search_all` consults a per-query mapping.
+
+    `cards_by_query[<query>] = [<card>, ...]` controls what each warmed
+    query returns. Missing keys produce an empty list — the "set
+    upstream-missing" branch."""
+
+    def __init__(self, cards_by_query: dict[str, list[dict]] | None = None) -> None:
+        self.cards_by_query: dict[str, list[dict]] = cards_by_query or {}
+        self.queries: list[str] = []
+        # `session` is hit by `fetch_set_ids` only — left as None so any
+        # accidental network access surfaces as an AttributeError, not a
+        # silent live HTTP call.
+        self.session = None
+
+    def search_all(self, query: str, **_: object) -> list[dict]:
+        self.queries.append(query)
+        return self.cards_by_query.get(query, [])
+
+
+# ---------------------------------------------------------------------------
+# Core warmer behaviour
+# ---------------------------------------------------------------------------
+
+
+class WarmSetCardsCoreTests(unittest.TestCase):
+    def test_returns_zero_when_no_set_ids_passed_and_no_fetch(self) -> None:
+        # With an explicit empty set list, no upstream call fires and the
+        # result is a clean zero. Useful smoke check that the no-ids
+        # path doesn't try to fetch the catalog.
+        client = _StubTCGClient()
+        result = warm_set_cards(client, set_ids=[])
+        self.assertEqual(result.sets_attempted, 0)
+        self.assertEqual(result.sets_warmed, 0)
+        self.assertEqual(result.sets_failed, [])
+        self.assertEqual(client.queries, [])
+
+    def test_walks_explicit_set_ids_and_counts_warmed(self) -> None:
+        client = _StubTCGClient(
+            cards_by_query={
+                'set.id:"sv8"': [{"id": "sv8-1", "name": "Pikachu"}],
+                'set.id:"sv9"': [{"id": "sv9-1", "name": "Bulbasaur"}],
+                # `bogus` returns nothing → counts as missed.
+                'set.id:"bogus"': [],
+            }
+        )
+        result = warm_set_cards(client, set_ids=["sv8", "sv9", "bogus"])
+        self.assertEqual(result.sets_attempted, 3)
+        self.assertEqual(result.sets_warmed, 2)
+        self.assertEqual(result.sets_failed, ["bogus"])
+
+    def test_query_shape_matches_endpoint(self) -> None:
+        # The disk-cache key is derived from the request URL deep inside
+        # `TCGClient._fetch_page`, so the warmer's query string MUST match
+        # `_fetch_set_cards` exactly or the cache keys won't line up.
+        client = _StubTCGClient()
+        warm_set_cards(client, set_ids=["sv8"])
+        self.assertEqual(client.queries, ['set.id:"sv8"'])
+
+    def test_progress_callback_fires_per_set(self) -> None:
+        progress: list[tuple[int, int, str]] = []
+        client = _StubTCGClient(
+            cards_by_query={
+                'set.id:"a"': [{"id": "a-1"}],
+                'set.id:"b"': [{"id": "b-1"}],
+            }
+        )
+        warm_set_cards(
+            client,
+            set_ids=["a", "b"],
+            on_progress=lambda i, t, s: progress.append((i, t, s)),
+        )
+        self.assertEqual(progress, [(1, 2, "a"), (2, 2, "b")])
+
+    def test_falls_back_to_fetched_catalog_when_no_set_ids(self) -> None:
+        # When `set_ids` is None we should call `fetch_set_ids`. Patch
+        # that helper to avoid live HTTP and assert the call shape.
+        client = _StubTCGClient(cards_by_query={'set.id:"a"': [{"id": "a"}], 'set.id:"b"': []})
+        with patch("mgz_pkmn.lookup.fetch_set_ids", return_value=["a", "b"]) as fetch_mock:
+            result = warm_set_cards(client)
+        fetch_mock.assert_called_once_with(client)
+        self.assertEqual(result.sets_attempted, 2)
+        self.assertEqual(result.sets_warmed, 1)
+        self.assertEqual(result.sets_failed, ["b"])
+
+
+# ---------------------------------------------------------------------------
+# Manifest read/write + freshness gate
+# ---------------------------------------------------------------------------
+
+
+class _IsolatedCacheMixin(unittest.TestCase):
+    """Point XDG_CACHE_HOME at a tempdir so manifest writes don't touch $HOME."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._old_xdg = os.environ.get("XDG_CACHE_HOME")
+        self._old_no_cache = os.environ.get(disk_cache._NO_CACHE_ENV)
+        os.environ["XDG_CACHE_HOME"] = self._tmp.name
+        os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+
+    def tearDown(self) -> None:
+        if self._old_xdg is None:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        else:
+            os.environ["XDG_CACHE_HOME"] = self._old_xdg
+        if self._old_no_cache is None:
+            os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+        else:
+            os.environ[disk_cache._NO_CACHE_ENV] = self._old_no_cache
+        self._tmp.cleanup()
+
+
+class SetCardsManifestTests(_IsolatedCacheMixin):
+    def test_read_returns_none_when_absent(self) -> None:
+        self.assertIsNone(disk_cache.read_set_cards_warm())
+
+    def test_write_then_read_roundtrip(self) -> None:
+        disk_cache.write_set_cards_warm(sets_warmed=12, sets_failed=["bogus"])
+        data = disk_cache.read_set_cards_warm()
+        self.assertIsNotNone(data)
+        assert data is not None  # narrow for type checkers
+        self.assertEqual(data["sets_warmed"], 12)
+        self.assertEqual(data["sets_failed"], ["bogus"])
+        self.assertIsInstance(data["timestamp"], float)
+
+    def test_read_rejects_malformed_payload(self) -> None:
+        path = disk_cache._set_cards_warm_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not json", encoding="utf-8")
+        self.assertIsNone(disk_cache.read_set_cards_warm())
+
+    def test_read_rejects_unknown_schema_version(self) -> None:
+        path = disk_cache._set_cards_warm_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({"version": 99, "timestamp": 0.0, "sets_warmed": 0, "sets_failed": []}),
+            encoding="utf-8",
+        )
+        self.assertIsNone(disk_cache.read_set_cards_warm())
+
+
+class SetCardsFreshnessTests(_IsolatedCacheMixin):
+    def test_no_manifest_is_not_fresh(self) -> None:
+        self.assertFalse(disk_cache.set_cards_warm_is_fresh())
+
+    def test_fresh_within_window(self) -> None:
+        disk_cache.write_set_cards_warm(sets_warmed=5, sets_failed=[])
+        self.assertTrue(disk_cache.set_cards_warm_is_fresh())
+
+    def test_stale_outside_window(self) -> None:
+        disk_cache.write_set_cards_warm(sets_warmed=5, sets_failed=[])
+        # Pretend we're checking 8 days in the future — past the 7-day
+        # SET_CARDS_WARM_STALE_SECONDS window.
+        future = time.time() + (8 * 24 * 60 * 60)
+        self.assertFalse(disk_cache.set_cards_warm_is_fresh(now=future))
+
+    def test_zero_warmed_manifest_is_not_fresh(self) -> None:
+        # Even a recent manifest must not suppress retry when its
+        # `sets_warmed` is zero — that's the "every upstream call failed"
+        # signal, and the next startup should re-attempt the warm.
+        disk_cache.write_set_cards_warm(sets_warmed=0, sets_failed=["a", "b"])
+        self.assertFalse(disk_cache.set_cards_warm_is_fresh())
+
+
+# ---------------------------------------------------------------------------
+# Stats projection + CLI line
+# ---------------------------------------------------------------------------
+
+
+class StatsIncludesSetCardsWarmTests(_IsolatedCacheMixin):
+    def test_stats_reports_none_when_no_manifest(self) -> None:
+        s = disk_cache.stats()
+        self.assertIsNone(s.set_cards_warm_timestamp)
+        self.assertEqual(s.set_cards_warm_count, 0)
+
+    def test_stats_reflects_recorded_manifest(self) -> None:
+        disk_cache.write_set_cards_warm(sets_warmed=42, sets_failed=[])
+        s = disk_cache.stats()
+        self.assertIsNotNone(s.set_cards_warm_timestamp)
+        self.assertEqual(s.set_cards_warm_count, 42)
+
+
+class CacheStatsSetCardsLineTests(_IsolatedCacheMixin):
+    """`pkmn cache stats` renders a Set cards: line, prompting a warm
+    when no manifest exists."""
+
+    def _invoke(self):  # type: ignore[no-untyped-def]
+        from click.testing import CliRunner
+
+        from mgz_pkmn.cli import cli
+
+        return CliRunner().invoke(cli, ["cache", "stats"])
+
+    def test_renders_not_warmed_prompt_when_no_manifest(self) -> None:
+        result = self._invoke()
+        self.assertEqual(result.exit_code, 0, result.output)
+        # The Set cards line lives on its own; "not warmed" + the
+        # subcommand name guide the operator to a fix.
+        set_cards_line = next(
+            (line for line in result.output.splitlines() if "Set cards:" in line),
+            "",
+        )
+        self.assertIn("not warmed", set_cards_line)
+        self.assertIn("warm-set-cards", set_cards_line)
+
+    def test_renders_warmed_count_when_manifest_present(self) -> None:
+        disk_cache.write_set_cards_warm(sets_warmed=173, sets_failed=[])
+        result = self._invoke()
+        self.assertEqual(result.exit_code, 0, result.output)
+        set_cards_line = next(
+            (line for line in result.output.splitlines() if "Set cards:" in line),
+            "",
+        )
+        self.assertIn("173 sets", set_cards_line)
+        self.assertIn("warmed", set_cards_line)
+        # The not-warmed branch must NOT appear on this specific line.
+        self.assertNotIn("not warmed", set_cards_line)
+
+
+# ---------------------------------------------------------------------------
+# CLI subcommand
+# ---------------------------------------------------------------------------
+
+
+class CacheWarmSetCardsCLITests(_IsolatedCacheMixin):
+    def _invoke(self, *args: str):  # type: ignore[no-untyped-def]
+        from click.testing import CliRunner
+
+        from mgz_pkmn.cli import cli
+
+        return CliRunner().invoke(cli, ["cache", "warm-set-cards", *args])
+
+    def test_warm_command_writes_manifest_and_summarises(self) -> None:
+        fake_result = WarmSetCardsResult(sets_attempted=3, sets_warmed=2, sets_failed=["bogus"])
+        with patch("mgz_pkmn.cli.warm_set_cards", return_value=fake_result):
+            result = self._invoke("--set", "sv8", "--set", "sv9", "--set", "bogus")
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("3 sets", result.output)
+        self.assertIn("2 warmed", result.output)
+        # Manifest must have landed on disk so subsequent `stats` reflects
+        # the run.
+        manifest = disk_cache.read_set_cards_warm()
+        self.assertIsNotNone(manifest)
+        assert manifest is not None
+        self.assertEqual(manifest["sets_warmed"], 2)
+        self.assertEqual(manifest["sets_failed"], ["bogus"])
+
+    def test_warm_command_fails_loudly_when_zero_sets(self) -> None:
+        # An empty catalog (e.g. `--set` flag missing and `fetch_set_ids`
+        # returned nothing) should surface as a click error rather than
+        # silently writing a zero-count manifest.
+        fake_result = WarmSetCardsResult(sets_attempted=0, sets_warmed=0, sets_failed=[])
+        with patch("mgz_pkmn.cli.warm_set_cards", return_value=fake_result):
+            result = self._invoke()
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("no sets to warm", result.output.lower())
+
+    def test_warm_command_surfaces_upstream_failure(self) -> None:
+        import requests as req_lib
+
+        with patch(
+            "mgz_pkmn.cli.warm_set_cards",
+            side_effect=req_lib.ConnectionError("upstream down"),
+        ):
+            result = self._invoke("--set", "sv8")
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("set-cards warm failed", result.output)
+
+
+# ---------------------------------------------------------------------------
+# API startup hook
+# ---------------------------------------------------------------------------
+
+
+class WarmSetCardsBackgroundHookTests(_IsolatedCacheMixin):
+    def test_skips_when_cache_is_fresh(self) -> None:
+        from api.main import _warm_set_cards_in_background
+
+        # Plant a fresh manifest — the gate should short-circuit before
+        # touching the warm function.
+        disk_cache.write_set_cards_warm(sets_warmed=10, sets_failed=[])
+        with patch("api.main.warm_set_cards") as warm_mock:
+            _warm_set_cards_in_background()
+            warm_mock.assert_not_called()
+
+    def test_runs_warm_and_persists_manifest_when_stale(self) -> None:
+        import threading
+
+        from api.main import _warm_set_cards_in_background
+
+        # No manifest → freshness gate returns False → we expect a real
+        # background daemon. Mock the warm function so no HTTP fires and
+        # block on the thread.
+        fake = WarmSetCardsResult(sets_attempted=5, sets_warmed=4, sets_failed=["x"])
+        with patch("api.main.warm_set_cards", return_value=fake) as warm_mock:
+            _warm_set_cards_in_background()
+            # Daemon thread does the work; join via the named thread.
+            for t in threading.enumerate():
+                if t.name == "set-cards-warm":
+                    t.join(timeout=5)
+            warm_mock.assert_called_once()
+        # Manifest landed.
+        manifest = disk_cache.read_set_cards_warm()
+        self.assertIsNotNone(manifest)
+        assert manifest is not None
+        self.assertEqual(manifest["sets_warmed"], 4)
+        self.assertEqual(manifest["sets_failed"], ["x"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #308

## What

Adds `pkmn cache warm-set-cards`, a new cache subcommand that walks every Pokémon TCG set and pre-primes the on-disk API response cache for each set's card list. The Browse → set-detail path in the web SPA goes from "multi-second upstream round trip on first pick of a previously-uncached set" to "cache hit, all the time."

- **Same query as the endpoint.** Fires `client.search_all(f'set.id:"<id>"')` — exactly what `api/routes/sets.py:_fetch_set_cards` issues — so the disk-cache keys (a sha1 of the request URL) line up. There's no "warm-shaped" miss; the user-facing endpoint is a true cache hit.
- **`--set <id>` (repeatable)** restricts the walk to specific sets, handy for staging a new release without re-walking the whole catalog.
- **`-v/--verbose`** prints each set id as it warms.
- **Manifest at `set_cards_warm.json`** (timestamp, sets_warmed, sets_failed) so `pkmn cache stats` reports a new **Set cards** line ("N sets · warmed 5m ago" or "not warmed · run …") and the FastAPI startup gate can skip if a manifest landed within the last week.

`MGZ_PKMN_WARM_ON_STARTUP=1` now kicks off both warmers in parallel on separate daemon threads. The concept manifest keeps its 24 h window; the set-cards manifest gets a 1-week window to match the API response cache TTL — set contents are effectively immutable once shipped (only market prices drift, and that's already covered by the 1-day browser `Cache-Control` on the endpoint). Each manifest uses a `sets_warmed > 0` guard so a fully-failed pass doesn't suppress retry.

## Why

#305 (PR #306) made the set *list* in Browse instant by baking the catalog into the SPA bundle. That removed the spinner the list used to share with per-set first-pick latency, making the remaining multi-second hit on the first open of a previously-uncached set much more visible. This change closes that last gap.

## How to verify

```bash
make check     # 374 tests, all green
cd web && npm run build   # web typecheck/build
```

Then exercise the new surfaces:

```bash
# Warm a single set
pkmn cache warm-set-cards --set sv8 -v

# Inspect the manifest via stats
pkmn cache stats   # → "Set cards: 1 sets · warmed Xs ago"

# Background warm on API startup
MGZ_PKMN_WARM_ON_STARTUP=1 make dev-api
# → both concept-warm and set-cards-warm threads spawn; subsequent
#   Browse → set-detail requests are cache hits.
```

## Tests

`tests/test_warm_set_cards.py` (24 tests) mirrors `test_warm_concepts.py`'s structure:

- Core walker — explicit ids, full-catalog fallback, query-shape match with the endpoint, progress callback.
- Manifest — read/write roundtrip, malformed/unknown-version rejection.
- Freshness gate — fresh window, stale outside window, zero-warmed manifest never reads as fresh.
- Stats projection — `CacheStats.set_cards_warm_*` populates from the manifest.
- CLI summary — `pkmn cache stats` Set-cards line in both branches.
- CLI subcommand — manifest written on success, ClickException on empty walk, upstream `RequestException` surfaces with context.
- API startup hook — skips when fresh; spawns the daemon, joins it, asserts the manifest landed when stale.

Existing `test_warm_concepts.py` got one scoped-assertion tweak so the new "Set cards: not warmed" line doesn't false-positive its negative `not warmed` check.