### PR TITLE
feat(site): surface release notes from CHANGELOG via a shared API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- API: new `GET /api/v1/changelog` endpoint returns structured release
+  notes parsed from `CHANGELOG.md` — the single source of truth for
+  "what's new" surfaces, shared by the marketing site and (later) the
+  demo SPA. Supports `?limit=N` (newest first) and
+  `?include_unreleased=true`; the in-flight Unreleased section is
+  omitted by default. Parsing lives in `mgz_pkmn.changelog` so it's
+  unit-testable independent of the route.
+- Site: **"Recently shipped" release notes** — a new section on the
+  marketing landing page renders the last three releases (version,
+  date, and bullets grouped by Added / Changed / Fixed) pulled at
+  build time from `GET /api/v1/changelog`. The hero's "Now shipping
+  X.Y.Z" pill is now derived from the same source instead of being
+  hand-edited every release, so it can't drift. Both degrade
+  gracefully (section omitted, pill shows just "Now shipping") if the
+  API is unreachable at build time.
 - Site: **Hero binder grid + asciinema cast** — the marketing landing
   page now opens on a tilted 3×3 binder page of real Pokémon TCG cards
   (replacing the abstract brand-color radial glow) and an embedded

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # declares it as the package readme — hatchling validates it at build time.
 COPY src/ ./src/
 COPY README.md ./
+# CHANGELOG.md backs GET /api/v1/changelog (release notes for the web
+# surfaces). Read at runtime from the repo root, so it must ship in the image.
+COPY CHANGELOG.md ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --extra api --no-dev --frozen
 

--- a/api/main.py
+++ b/api/main.py
@@ -25,7 +25,7 @@ from mgz_pkmn import cache as disk_cache
 from mgz_pkmn.lookup import warm_concepts, warm_set_cards
 from mgz_pkmn.sources import TCGClient, TCGDexClient
 
-from .routes import export, lookup, overrides, parse, set_cards, sets
+from .routes import changelog, export, lookup, overrides, parse, set_cards, sets
 
 _log = logging.getLogger(__name__)
 
@@ -163,6 +163,7 @@ app.include_router(export.router, prefix="/api/v1", tags=["export"])
 app.include_router(sets.router, prefix="/api/v1", tags=["sets"])
 app.include_router(set_cards.router, prefix="/api/v1", tags=["set-cards"])
 app.include_router(overrides.router, prefix="/api/v1", tags=["overrides"])
+app.include_router(changelog.router, prefix="/api/v1", tags=["changelog"])
 
 
 @app.get("/health")

--- a/api/routes/changelog.py
+++ b/api/routes/changelog.py
@@ -1,0 +1,69 @@
+"""GET /api/v1/changelog — structured release notes parsed from CHANGELOG.md.
+
+Single source of truth for "what's new" surfaces. Both the marketing site
+(at build time) and the demo SPA (at runtime) consume this instead of
+duplicating release prose. Parsing lives in `mgz_pkmn.changelog`; this route
+locates the repo's `CHANGELOG.md`, parses it, and serializes the result.
+
+The file is read fresh per request (it's tiny — a few KB) but the response
+carries a 1-hour `Cache-Control` so the browser / build cache skips the
+round-trip; the changelog only changes on a release commit.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, Query, Response
+
+from mgz_pkmn.changelog import parse_changelog
+
+router = APIRouter()
+
+# CHANGELOG.md lives at the repo root: api/routes/changelog.py → parents[2].
+# In the Docker single-unit image the layout is preserved (WORKDIR /app,
+# api/ at /app/api/, CHANGELOG.md copied to /app/CHANGELOG.md), so the same
+# relative walk resolves in both dev and prod.
+_CHANGELOG_PATH = Path(__file__).resolve().parents[2] / "CHANGELOG.md"
+
+# Browser / build-cache TTL. The changelog only changes on a release commit,
+# so an hour is comfortably conservative.
+_BROWSER_TTL = 3600
+
+
+@router.get("/changelog")
+def get_changelog(
+    response: Response,
+    limit: int | None = Query(
+        default=None,
+        ge=1,
+        le=100,
+        description="Cap the number of releases returned (newest first).",
+    ),
+    include_unreleased: bool = Query(
+        default=False,
+        description="Include the in-flight [Unreleased] section.",
+    ),
+) -> dict:
+    """Return parsed release notes, newest first.
+
+    By default the in-flight `[Unreleased]` section is omitted (public
+    "what's new" surfaces want shipped releases); pass
+    `include_unreleased=true` for the full picture. `limit` caps the count
+    *after* the unreleased filter, so `limit=1` reliably returns the most
+    recent shipped release.
+    """
+    if not _CHANGELOG_PATH.is_file():
+        # Misconfigured deploy (CHANGELOG.md not shipped). Surface it loudly
+        # rather than returning a silently-empty list a caller might cache.
+        raise HTTPException(status_code=404, detail="changelog not available")
+
+    releases = parse_changelog(_CHANGELOG_PATH.read_text(encoding="utf-8"))
+    if not include_unreleased:
+        releases = [r for r in releases if not r.is_unreleased]
+    if limit is not None:
+        releases = releases[:limit]
+
+    response.headers["Cache-Control"] = f"public, max-age={_BROWSER_TTL}"
+    return {"releases": [asdict(r) for r in releases]}

--- a/site/README.md
+++ b/site/README.md
@@ -49,6 +49,28 @@ site/
 
 Pure static output. No SSR, no runtime, no API routes.
 
+## Build-time data
+
+Two surfaces pull live data at **build time** (baked into the static HTML,
+so the shipped site stays client-side-free). Both degrade gracefully — if
+the upstream is unreachable, the helper returns empty and the section is
+omitted rather than failing the build:
+
+- **`/contribute` OSS signals** — GitHub API via
+  [`src/lib/github.ts`](src/lib/github.ts). Set `GITHUB_TOKEN` in the build
+  env to avoid the anonymous rate limit.
+- **"Recently shipped" release notes + hero version pill** — the demo
+  API's `GET /api/v1/changelog` via
+  [`src/lib/changelog.ts`](src/lib/changelog.ts). This is the single
+  source of truth shared with the demo SPA; the endpoint parses the repo's
+  `CHANGELOG.md` (see `api/routes/changelog.py`), so release copy is never
+  hand-edited on the site. Override the API origin with `MGZ_PKMN_API_BASE`
+  (default: the public demo) — useful for building against a local API:
+
+  ```bash
+  MGZ_PKMN_API_BASE=http://localhost:8000 npm run build
+  ```
+
 ## Deploying to Cloudflare Pages
 
 The site builds and deploys automatically once the Cloudflare Pages

--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -1,6 +1,13 @@
 ---
+import { fetchLatestVersion } from "../lib/changelog.ts";
+
 const demoUrl = "https://mgz-pkmn.onrender.com";
 const repoUrl = "https://github.com/mgzwarrior/mgz-pkmn";
+
+// Latest shipped version, pulled at build time from the changelog API so
+// the "Now shipping" pill never drifts. Falls back to hiding the version
+// number (just "Now shipping") if the API is unreachable at build time.
+const latestVersion = await fetchLatestVersion();
 
 // Nine real Pokémon TCG cards arranged as a tilted 3×3 binder page.
 // Same public image sources the CLI consumes; copies live in
@@ -49,7 +56,7 @@ const binderCards = [
       class="inline-flex items-center gap-2 rounded-full border border-zinc-800 bg-zinc-900/60 backdrop-blur px-3 py-1 text-xs font-medium text-zinc-300"
     >
       <span class="h-1.5 w-1.5 rounded-full bg-brand-400"></span>
-      Now shipping 1.1.1
+      {latestVersion ? `Now shipping ${latestVersion}` : "Now shipping"}
     </p>
 
     <h1

--- a/site/src/components/WhatsNew.astro
+++ b/site/src/components/WhatsNew.astro
@@ -1,0 +1,106 @@
+---
+import { fetchReleases, renderInlineMarkdown } from "../lib/changelog.ts";
+
+// Pulled at build time from the API's /api/v1/changelog endpoint (the same
+// source the demo SPA reads). Returns [] if the API is unreachable, in
+// which case the whole section is skipped below.
+const releases = await fetchReleases(3);
+const repoChangelogUrl =
+  "https://github.com/mgzwarrior/mgz-pkmn/blob/main/CHANGELOG.md";
+
+// Friendly date: "2026-05-25" → "May 25, 2026". Falls back to the raw
+// string if it doesn't parse.
+function formatDate(iso: string | null): string {
+  if (!iso) return "";
+  const d = new Date(`${iso}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+const sectionAccent: Record<string, string> = {
+  Added: "text-emerald-400 border-emerald-400/30",
+  Changed: "text-sky-400 border-sky-400/30",
+  Fixed: "text-amber-400 border-amber-400/30",
+  Removed: "text-rose-400 border-rose-400/30",
+  Deprecated: "text-orange-400 border-orange-400/30",
+  Security: "text-violet-400 border-violet-400/30",
+};
+---
+
+{
+  releases.length > 0 && (
+    <section
+      id="whats-new"
+      class="border-b border-zinc-900/80 px-6 py-20 sm:py-24"
+    >
+      <div class="mx-auto max-w-4xl">
+        <div class="flex flex-wrap items-end justify-between gap-4">
+          <div class="max-w-2xl">
+            <h2 class="text-3xl sm:text-4xl font-bold tracking-tight text-white">
+              Recently shipped.
+            </h2>
+            <p class="mt-4 text-lg text-zinc-400">
+              The last few releases at a glance — straight from the changelog.
+            </p>
+          </div>
+          <a
+            href={repoChangelogUrl}
+            class="text-sm font-semibold text-brand-400 hover:text-brand-300 transition"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Full changelog →
+          </a>
+        </div>
+
+        <ol class="mt-12 space-y-10">
+          {releases.map((release) => (
+            <li class="relative border-l border-zinc-800 pl-6">
+              <div class="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                <h3 class="text-xl font-semibold text-white">
+                  v{release.version}
+                </h3>
+                {release.date && (
+                  <time class="text-sm text-zinc-500">
+                    {formatDate(release.date)}
+                  </time>
+                )}
+              </div>
+
+              <div class="mt-4 space-y-5">
+                {release.sections.map((section) => (
+                  <div>
+                    <span
+                      class={`inline-block rounded-full border px-2.5 py-0.5 text-xs font-medium ${
+                        sectionAccent[section.name] ??
+                        "text-zinc-400 border-zinc-700"
+                      }`}
+                    >
+                      {section.name}
+                    </span>
+                    <ul class="mt-3 space-y-2">
+                      {section.entries.map((entry) => (
+                        <li class="flex gap-2.5 text-sm leading-relaxed text-zinc-300">
+                          <span
+                            aria-hidden="true"
+                            class="mt-2 h-1 w-1 shrink-0 rounded-full bg-zinc-600"
+                          />
+                          <span set:html={renderInlineMarkdown(entry)} />
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  )
+}

--- a/site/src/lib/changelog.ts
+++ b/site/src/lib/changelog.ts
@@ -1,0 +1,120 @@
+/**
+ * Build-time release-notes helper for the marketing site.
+ *
+ * Fetches structured release notes from the API's `GET /api/v1/changelog`
+ * endpoint — the single source of truth shared with the demo SPA — and
+ * bakes them into the static HTML at build time, so the site stays
+ * client-side-free.
+ *
+ * The endpoint parses the repo's `CHANGELOG.md`; see
+ * `api/routes/changelog.py`. We deliberately consume the API rather than
+ * re-parsing the Markdown here so there's exactly one parser.
+ *
+ * Failure handling mirrors `github.ts`: if the API is unreachable (the
+ * demo runs on Render's free tier, which cold-starts), the helper returns
+ * `[]` and the caller renders nothing for the "What's new" surface. The
+ * build still succeeds.
+ *
+ * Configuration: `MGZ_PKMN_API_BASE` overrides the API origin (default is
+ * the public demo). Useful for building against a local API during
+ * development.
+ */
+const API_BASE =
+  process.env.MGZ_PKMN_API_BASE?.replace(/\/$/, "") ||
+  "https://mgz-pkmn.onrender.com";
+
+// Render free-tier cold starts can take the better part of a minute; give
+// the build-time fetch room rather than dropping the section on a slow spin-up.
+const FETCH_TIMEOUT_MS = 60_000;
+
+export interface ChangelogSection {
+  name: string;
+  entries: string[];
+}
+
+export interface ChangelogRelease {
+  version: string;
+  /** ISO date (YYYY-MM-DD), or null for the in-flight Unreleased section. */
+  date: string | null;
+  sections: ChangelogSection[];
+}
+
+interface ChangelogResponse {
+  releases: ChangelogRelease[];
+}
+
+/**
+ * Fetch the most recent `limit` shipped releases (newest first). The
+ * in-flight Unreleased section is excluded by the endpoint default.
+ * Returns `[]` on any failure so the build never breaks on a cold or
+ * unreachable API.
+ */
+export async function fetchReleases(limit = 3): Promise<ChangelogRelease[]> {
+  const url = `${API_BASE}/api/v1/changelog?limit=${limit}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      headers: { Accept: "application/json" },
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      console.warn(
+        `[changelog] ${url} -> ${res.status} ${res.statusText} (skipping)`,
+      );
+      return [];
+    }
+    const data = (await res.json()) as ChangelogResponse;
+    return data.releases ?? [];
+  } catch (err) {
+    console.warn(`[changelog] ${url} threw ${(err as Error).message} (skipping)`);
+    return [];
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * Convenience: the latest shipped version string (e.g. "1.1.1"), or null
+ * if the changelog couldn't be fetched. Used to drive the hero's
+ * "Now shipping" pill so it's never hard-coded.
+ */
+export async function fetchLatestVersion(): Promise<string | null> {
+  const releases = await fetchReleases(1);
+  return releases[0]?.version ?? null;
+}
+
+/**
+ * Render a CHANGELOG bullet's inline Markdown to safe HTML: `[text](url)`
+ * links and `` `code` `` spans, with everything else HTML-escaped. Kept
+ * deliberately minimal — the bullets only ever use those two constructs,
+ * and a full Markdown dependency would be overkill for a few inline spans.
+ */
+export function renderInlineMarkdown(text: string): string {
+  const escape = (s: string): string =>
+    s
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+
+  // Tokenize on links and code spans, escaping the gaps between matches so
+  // raw user text can never inject markup.
+  const pattern = /\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)|`([^`]+)`/g;
+  let html = "";
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(text)) !== null) {
+    html += escape(text.slice(lastIndex, match.index));
+    if (match[1] !== undefined && match[2] !== undefined) {
+      // Link: [text](url). Only http(s) URLs match the pattern.
+      html += `<a href="${escape(match[2])}" class="underline decoration-zinc-600 hover:decoration-zinc-300" target="_blank" rel="noopener noreferrer">${escape(match[1])}</a>`;
+    } else if (match[3] !== undefined) {
+      // Code span: `code`.
+      html += `<code class="rounded bg-zinc-800 px-1 py-0.5 text-[0.85em] text-zinc-200">${escape(match[3])}</code>`;
+    }
+    lastIndex = pattern.lastIndex;
+  }
+  html += escape(text.slice(lastIndex));
+  return html;
+}

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -5,6 +5,7 @@ import Hero from "../components/Hero.astro";
 import FeaturesGrid from "../components/FeaturesGrid.astro";
 import OutputGallery from "../components/OutputGallery.astro";
 import HowItWorks from "../components/HowItWorks.astro";
+import WhatsNew from "../components/WhatsNew.astro";
 import BuiltInTheOpen from "../components/BuiltInTheOpen.astro";
 import RoadmapTeaser from "../components/RoadmapTeaser.astro";
 import Footer from "../components/Footer.astro";
@@ -17,6 +18,7 @@ import Footer from "../components/Footer.astro";
     <FeaturesGrid />
     <OutputGallery />
     <HowItWorks />
+    <WhatsNew />
     <BuiltInTheOpen />
     <RoadmapTeaser />
   </main>

--- a/src/mgz_pkmn/changelog.py
+++ b/src/mgz_pkmn/changelog.py
@@ -1,0 +1,146 @@
+"""Parse the project CHANGELOG (Keep a Changelog format) into structured data.
+
+The marketing site and the demo SPA both want to surface "what's new" from
+the same source of truth — `CHANGELOG.md` — rather than duplicating release
+prose by hand. This module is that single parser; the API exposes it at
+`GET /api/v1/changelog` (see `api/routes/changelog.py`) and both web surfaces
+consume the endpoint.
+
+The parser is intentionally tolerant: it understands the subset of
+[Keep a Changelog](https://keepachangelog.com/) the project actually uses
+(`## [version] - date` release headers, `### Section` groups, `- ` bullets
+with wrapped continuation lines) and quietly ignores anything else — free
+prose between a release header and its first section, `#### subsection`
+headers in older releases, blank lines. Bullet text is returned as raw
+Markdown so the rendering layer can decide how much to format.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+# `## [1.1.0] - 2026-05-25` or `## [Unreleased]`. The date is optional so the
+# in-flight Unreleased section parses with `date=None`.
+_RELEASE_RE = re.compile(r"^##\s+\[(?P<version>[^\]]+)\](?:\s+-\s+(?P<date>.+))?\s*$")
+# `### Added`, `### Changed`, `### Fixed`, …
+_SECTION_RE = re.compile(r"^###\s+(?P<name>.+?)\s*$")
+# A top-level bullet: `- some text`. Continuation lines are indented and
+# don't start with `- `, so they're matched separately.
+_BULLET_RE = re.compile(r"^-\s+(?P<text>.*)$")
+
+
+@dataclass(frozen=True)
+class Section:
+    """One `### Group` within a release — e.g. Added / Changed / Fixed."""
+
+    name: str
+    entries: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class Release:
+    """One `## [version]` block.
+
+    `date` is None for the in-flight `[Unreleased]` section (and any release
+    header that omits the trailing date). `is_unreleased` is a convenience
+    for callers that want to filter the in-flight section out of a public
+    "what's new" view."""
+
+    version: str
+    date: str | None
+    sections: list[Section] = field(default_factory=list)
+
+    @property
+    def is_unreleased(self) -> bool:
+        return self.version.strip().lower() == "unreleased"
+
+
+def parse_changelog(text: str) -> list[Release]:
+    """Parse Keep-a-Changelog Markdown into an ordered list of releases.
+
+    Releases are returned in document order (newest first, matching the
+    file's convention). Within each release, sections preserve their
+    document order; within each section, bullets preserve order with
+    wrapped continuation lines joined into a single space-separated string.
+
+    Releases with no bullet content (e.g. a header followed only by prose)
+    still appear, with an empty `sections` list — callers decide whether to
+    skip them."""
+    releases: list[Release] = []
+    current_release: dict | None = None
+    current_section: Section | None = None
+    # The bullet currently being accumulated, so wrapped continuation lines
+    # fold back into one entry.
+    pending_bullet: list[str] = []
+
+    def flush_bullet() -> None:
+        nonlocal pending_bullet
+        if pending_bullet and current_section is not None:
+            joined = " ".join(part.strip() for part in pending_bullet).strip()
+            if joined:
+                current_section.entries.append(joined)
+        pending_bullet = []
+
+    def flush_section() -> None:
+        nonlocal current_section
+        flush_bullet()
+        if current_section is not None and current_release is not None:
+            current_release["sections"].append(current_section)
+        current_section = None
+
+    def flush_release() -> None:
+        nonlocal current_release
+        flush_section()
+        if current_release is not None:
+            releases.append(
+                Release(
+                    version=current_release["version"],
+                    date=current_release["date"],
+                    sections=current_release["sections"],
+                )
+            )
+        current_release = None
+
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+
+        release_match = _RELEASE_RE.match(line)
+        if release_match:
+            flush_release()
+            date = release_match.group("date")
+            current_release = {
+                "version": release_match.group("version").strip(),
+                "date": date.strip() if date else None,
+                "sections": [],
+            }
+            continue
+
+        # Ignore anything before the first release header (the file preamble).
+        if current_release is None:
+            continue
+
+        section_match = _SECTION_RE.match(line)
+        if section_match:
+            flush_section()
+            current_section = Section(name=section_match.group("name").strip())
+            continue
+
+        bullet_match = _BULLET_RE.match(raw_line)
+        if bullet_match and current_section is not None:
+            flush_bullet()
+            pending_bullet = [bullet_match.group("text")]
+            continue
+
+        # Continuation line: indented, non-empty, while a bullet is open.
+        if pending_bullet and raw_line.strip() and raw_line[:1] in (" ", "\t"):
+            pending_bullet.append(raw_line)
+            continue
+
+        # Blank line or `#### subsection` header inside a section ends the
+        # current bullet but keeps the section open so following bullets
+        # still land under it.
+        flush_bullet()
+
+    flush_release()
+    return releases

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -534,5 +534,58 @@ class OverridesRouteTests(unittest.TestCase):
         self.assertTrue(any(url in v for v in overrides.values()))
 
 
+# ---------------------------------------------------------------------------
+# /changelog
+# ---------------------------------------------------------------------------
+
+
+class ChangelogRouteTests(unittest.TestCase):
+    def test_returns_releases_newest_first(self) -> None:
+        resp = client.get("/api/v1/changelog")
+        self.assertEqual(resp.status_code, 200)
+        releases = resp.json()["releases"]
+        self.assertGreater(len(releases), 0)
+        # First shipped release carries a date and a version.
+        self.assertIsNotNone(releases[0]["version"])
+        self.assertIsNotNone(releases[0]["date"])
+
+    def test_excludes_unreleased_by_default(self) -> None:
+        versions = [r["version"] for r in client.get("/api/v1/changelog").json()["releases"]]
+        self.assertNotIn("Unreleased", versions)
+
+    def test_include_unreleased_flag(self) -> None:
+        versions = [
+            r["version"]
+            for r in client.get("/api/v1/changelog?include_unreleased=true").json()["releases"]
+        ]
+        self.assertIn("Unreleased", versions)
+
+    def test_limit_caps_release_count(self) -> None:
+        resp = client.get("/api/v1/changelog?limit=1")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.json()["releases"]), 1)
+
+    def test_limit_applies_after_unreleased_filter(self) -> None:
+        # limit=1 without unreleased should return the most recent *shipped*
+        # release, never the in-flight Unreleased section.
+        release = client.get("/api/v1/changelog?limit=1").json()["releases"][0]
+        self.assertNotEqual(release["version"], "Unreleased")
+
+    def test_invalid_limit_rejected(self) -> None:
+        self.assertEqual(client.get("/api/v1/changelog?limit=0").status_code, 422)
+        self.assertEqual(client.get("/api/v1/changelog?limit=999").status_code, 422)
+
+    def test_cache_control_header(self) -> None:
+        resp = client.get("/api/v1/changelog")
+        self.assertIn("max-age", resp.headers.get("cache-control", ""))
+
+    def test_release_section_shape(self) -> None:
+        release = client.get("/api/v1/changelog?limit=1").json()["releases"][0]
+        self.assertIn("sections", release)
+        for section in release["sections"]:
+            self.assertIn("name", section)
+            self.assertIsInstance(section["entries"], list)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,0 +1,130 @@
+"""Tests for the Keep-a-Changelog parser (`mgz_pkmn.changelog`)."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from mgz_pkmn.changelog import Release, Section, parse_changelog
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class ParseChangelogTests(unittest.TestCase):
+    def test_empty_input_yields_no_releases(self) -> None:
+        self.assertEqual(parse_changelog(""), [])
+
+    def test_preamble_before_first_release_is_ignored(self) -> None:
+        text = (
+            "# Changelog\n\nAll notable changes...\n\n"
+            "## [1.0.0] - 2026-01-01\n\n### Added\n\n- First thing\n"
+        )
+        releases = parse_changelog(text)
+        self.assertEqual(len(releases), 1)
+        self.assertEqual(releases[0].version, "1.0.0")
+        self.assertEqual(releases[0].date, "2026-01-01")
+
+    def test_release_order_preserved(self) -> None:
+        text = (
+            "## [Unreleased]\n\n### Added\n\n- WIP\n\n"
+            "## [1.1.0] - 2026-02-01\n\n### Added\n\n- Newer\n\n"
+            "## [1.0.0] - 2026-01-01\n\n### Added\n\n- Older\n"
+        )
+        versions = [r.version for r in parse_changelog(text)]
+        self.assertEqual(versions, ["Unreleased", "1.1.0", "1.0.0"])
+
+    def test_unreleased_has_no_date_and_flag_set(self) -> None:
+        releases = parse_changelog("## [Unreleased]\n\n### Added\n\n- WIP\n")
+        self.assertIsNone(releases[0].date)
+        self.assertTrue(releases[0].is_unreleased)
+
+    def test_dated_release_is_not_unreleased(self) -> None:
+        releases = parse_changelog("## [2.0.0] - 2026-03-03\n\n### Fixed\n\n- Bug\n")
+        self.assertFalse(releases[0].is_unreleased)
+        self.assertEqual(releases[0].date, "2026-03-03")
+
+    def test_multiple_sections_preserve_order(self) -> None:
+        text = (
+            "## [1.0.0] - 2026-01-01\n\n"
+            "### Added\n\n- A\n\n"
+            "### Changed\n\n- C\n\n"
+            "### Fixed\n\n- F\n"
+        )
+        names = [s.name for s in parse_changelog(text)[0].sections]
+        self.assertEqual(names, ["Added", "Changed", "Fixed"])
+
+    def test_wrapped_bullet_lines_are_joined(self) -> None:
+        text = (
+            "## [1.0.0] - 2026-01-01\n\n### Added\n\n"
+            "- A bullet that wraps\n"
+            "  across two lines into one entry.\n"
+        )
+        entries = parse_changelog(text)[0].sections[0].entries
+        self.assertEqual(entries, ["A bullet that wraps across two lines into one entry."])
+
+    def test_blank_line_separates_bullets(self) -> None:
+        text = "## [1.0.0] - 2026-01-01\n\n### Added\n\n- First bullet\n\n- Second bullet\n"
+        entries = parse_changelog(text)[0].sections[0].entries
+        self.assertEqual(entries, ["First bullet", "Second bullet"])
+
+    def test_markdown_in_bullets_is_preserved_raw(self) -> None:
+        text = (
+            "## [1.0.0] - 2026-01-01\n\n### Added\n\n"
+            "- A `code` span and a [link](https://example.com).\n"
+        )
+        entry = parse_changelog(text)[0].sections[0].entries[0]
+        self.assertIn("`code`", entry)
+        self.assertIn("[link](https://example.com)", entry)
+
+    def test_subsection_headers_do_not_break_section(self) -> None:
+        # Older releases use `#### CLI`-style subsections. They shouldn't
+        # start a new section or drop the bullets under them.
+        text = (
+            "## [0.1.0] - 2026-01-01\n\n### Added\n\n"
+            "#### CLI\n- cli thing\n\n#### Web\n- web thing\n"
+        )
+        sections = parse_changelog(text)[0].sections
+        self.assertEqual(len(sections), 1)
+        self.assertEqual(sections[0].name, "Added")
+        self.assertEqual(sections[0].entries, ["cli thing", "web thing"])
+
+    def test_release_with_only_prose_has_empty_sections(self) -> None:
+        text = "## [0.1.0] - 2026-01-01\n\nFoundation release. No bullets here.\n"
+        releases = parse_changelog(text)
+        self.assertEqual(releases[0].sections, [])
+
+    def test_returns_dataclasses(self) -> None:
+        releases = parse_changelog("## [1.0.0] - 2026-01-01\n\n### Added\n\n- A\n")
+        self.assertIsInstance(releases[0], Release)
+        self.assertIsInstance(releases[0].sections[0], Section)
+
+
+class RealChangelogTests(unittest.TestCase):
+    """Parse the project's actual CHANGELOG.md as a regression guard."""
+
+    def setUp(self) -> None:
+        self.releases = parse_changelog((REPO_ROOT / "CHANGELOG.md").read_text(encoding="utf-8"))
+
+    def test_first_release_is_unreleased(self) -> None:
+        self.assertTrue(self.releases[0].is_unreleased)
+
+    def test_every_dated_release_has_iso_date(self) -> None:
+        for release in self.releases:
+            if release.is_unreleased:
+                continue
+            # Loose shape check: YYYY-MM-DD.
+            self.assertRegex(release.date or "", r"^\d{4}-\d{2}-\d{2}$")
+
+    def test_shipped_releases_have_at_least_one_entry(self) -> None:
+        for release in self.releases:
+            if release.is_unreleased:
+                continue
+            total = sum(len(s.entries) for s in release.sections)
+            self.assertGreater(total, 0, f"{release.version} parsed with no entries")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #315

## What

Wires up `CHANGELOG.md` as the single source of truth for "what's new" on the marketing site, via a new shared API endpoint. Two layers:

### API — the shared parser (source of truth)

- **`mgz_pkmn.changelog.parse_changelog()`** — a tolerant Keep-a-Changelog parser: `## [version] - date` release headers, `### Section` groups, `- ` bullets with wrapped continuation lines joined, `#### subsection` headers folded, file preamble ignored. Pure function, unit-tested independent of the route.
- **`GET /api/v1/changelog`** ([api/routes/changelog.py](api/routes/changelog.py)) serializes it. `?limit=N` (newest first) and `?include_unreleased=true`; the in-flight `[Unreleased]` section is **omitted by default** so public surfaces only show shipped releases. 1-hour `Cache-Control`.
- **Dockerfile** now `COPY`s `CHANGELOG.md` into the image — the endpoint reads it at runtime from the repo root, so it must ship in the single-unit deploy. (Without this the prod endpoint would 404.)

This is the endpoint the demo SPA will also consume in #316 — one parser, two surfaces.

### Marketing site — the consumer

- **[site/src/lib/changelog.ts](site/src/lib/changelog.ts)** fetches the endpoint at **build time** (baked into static HTML, mirroring the existing `github.ts` pattern). Graceful fallback to `[]` on any failure so the build never breaks on a cold/unreachable Render API. API origin configurable via `MGZ_PKMN_API_BASE`.
- **[site/src/components/WhatsNew.astro](site/src/components/WhatsNew.astro)** — a "Recently shipped" section (last 3 releases; bullets grouped by Added / Changed / Fixed with color-coded badges). Inline Markdown (links + `code` spans) rendered via a minimal escaping transform — no Markdown dependency, no XSS surface.
- **Hero version pill** is now derived from the latest shipped version via the same endpoint, replacing the hand-edited `Now shipping 1.1.1`. Falls back to plain "Now shipping" if the API is unreachable at build time.

## Why

The site never told a returning visitor what changed, and the hero version pill drifted because it was edited by hand every release. CHANGELOG.md is already high-quality and maintained — the site (and soon the SPA) should render from it rather than duplicating release prose.

Per the discussion on #315/#316, the parser is exposed as an **API endpoint** rather than re-implemented per surface, so there's exactly one parser to maintain.

## How to verify

```bash
# Endpoint
make dev-api
curl -s "http://localhost:8000/api/v1/changelog?limit=2" | jq '.releases[].version'
curl -sI "http://localhost:8000/api/v1/changelog" | grep -i cache-control

# Site against the local API
MGZ_PKMN_API_BASE=http://localhost:8000 make dev-site   # or: cd site && MGZ_PKMN_API_BASE=... npm run build
# open http://localhost:4321 → "Recently shipped" section + dynamic hero pill

# Graceful degradation (the cold-Render scenario)
cd site && MGZ_PKMN_API_BASE=http://localhost:59999 npm run build   # exits 0, omits the section
```

## Tests

- **Parser** ([tests/test_changelog.py](tests/test_changelog.py)) — empty input, preamble, release ordering, unreleased/date handling, multi-section order, wrapped-bullet joining, blank-line separation, raw-Markdown preservation, subsection folding, prose-only releases. Plus a regression guard that parses the real `CHANGELOG.md`.
- **Endpoint** ([tests/test_api_routes.py](tests/test_api_routes.py)) — newest-first ordering, unreleased excluded by default + opt-in flag, `limit` cap (and that it applies after the unreleased filter), invalid-limit rejection (422), `Cache-Control` header, section shape.
- `make check` green (parser + endpoint tests included); site builds against both a live and a dead API.

## Verification artifacts

Browser-verified locally:
- "Recently shipped" section renders v1.1.1 / v1.1.0 / v1.0.1 with dated headers, color-coded Added/Changed/Fixed badges, and working inline links + code spans.
- Hero pill reads "Now shipping 1.1.1", sourced from the endpoint (not hard-coded).

## Follow-up

- #316 (demo SPA "What's new") consumes this same endpoint at runtime — coordinate so the parser isn't duplicated.