### PR TITLE
fix(docker): allow CHANGELOG.md into the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,6 +34,9 @@ tests/
 # Local docs
 *.md
 !README.md
+# CHANGELOG.md backs GET /api/v1/changelog (release notes) — the runtime
+# reads it at /app/CHANGELOG.md, so it must survive into the build context.
+!CHANGELOG.md
 
 # Misc
 .env


### PR DESCRIPTION
## What

Adds a `!CHANGELOG.md` re-include to `.dockerignore` so the file isn't stripped from the Docker build context.

## Why

#318 added `COPY CHANGELOG.md ./` to the Dockerfile — the file backs the new `GET /api/v1/changelog` endpoint, which the runtime reads from `/app/CHANGELOG.md`. But `.dockerignore` excludes all markdown except README:

```
# Local docs
*.md
!README.md
```

So `CHANGELOG.md` never made it into the build context, and the Render deploy failed:

```
[runtime  8/12] COPY CHANGELOG.md ./
ERROR: failed to calculate checksum of ref ...: "/CHANGELOG.md": not found
error: failed to solve: ... "/CHANGELOG.md": not found
```

The fix is a one-line exception using the same mechanism as the working `!README.md` line — a `!` re-include placed *after* the `*.md` exclude (later patterns win in `.dockerignore`).

## How to verify

```bash
docker build -t mgz-pkmn .   # COPY CHANGELOG.md ./ now succeeds
```

(I couldn't run this locally — no Docker daemon in my environment — but the fix is identical in form to the proven `!README.md` exception. The Render deploy on merge is the real confirmation.)

## Notes

- This unblocks the deploy regression introduced by #318.
- It's also a prerequisite for #316 (the demo SPA "What's new" panel), which fetches `/api/v1/changelog` at runtime — the endpoint can't serve until the file ships in the image.