### PR TITLE
feat(web): "What's new" panel in the SPA, sourced from /api/v1/changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Web: **"What's new" panel** — a new header button (with an unobtrusive
+  dot when a release newer than you've seen has shipped) opens a panel of
+  recent release notes, pulled at runtime from `GET /api/v1/changelog` —
+  the same source the marketing site reads. Opening the panel marks the
+  latest version seen, clearing the dot; a first-time visitor is caught
+  up silently so it never competes with the Help button's first-visit
+  hint. Bullets render inline Markdown (links, `code`, **bold**). The
+  last-seen version persists via the existing Zustand store.
 - API: new `GET /api/v1/changelog` endpoint returns structured release
   notes parsed from `CHANGELOG.md` — the single source of truth for
   "what's new" surfaces, shared by the marketing site and (later) the

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -37,6 +37,8 @@ vi.mock('./api/client', () => ({
   setLogoUrl: vi.fn(() => ''),
   dedupeRows: vi.fn((rows: unknown[]) => rows),
   addOverride: vi.fn(),
+  // Referenced by the WhatsNewModal mounted in the header.
+  fetchChangelog: vi.fn(() => Promise.resolve([])),
 }))
 
 function makeEvent(index: number, total: number, matched = true): BulkEvent {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,6 +22,7 @@ import { ExportBar } from './components/ExportBar'
 import { ProcessingQueue } from './components/ProcessingQueue'
 import { SettingsDrawer } from './components/SettingsDrawer'
 import { HelpModal } from './components/HelpModal'
+import { WhatsNewModal } from './components/WhatsNewModal'
 import { Tour } from './components/Tour'
 import { useAppStore } from './store'
 import type { BulkEvent } from './types'
@@ -201,6 +202,7 @@ function App() {
             <div data-tour="exports">
               <ExportBar />
             </div>
+            <WhatsNewModal />
             <HelpModal onStartTour={() => setTourOpen(true)} />
             <div data-tour="settings">
               <SettingsDrawer />

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { dedupeRows } from './client'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { dedupeRows, fetchChangelog } from './client'
 import type { Row } from '../types'
 
 function makeRow(over: Partial<Row> = {}): Row {
@@ -44,5 +44,28 @@ describe('dedupeRows', () => {
       makeRow({ card: { id: 'c' } }),
     ]
     expect(dedupeRows(rows)).toHaveLength(3)
+  })
+})
+
+describe('fetchChangelog', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('requests the changelog endpoint with the limit and returns releases', async () => {
+    const releases = [{ version: '1.1.1', date: '2026-05-25', sections: [] }]
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify({ releases }), { status: 200 }),
+      )
+    const result = await fetchChangelog(3)
+    expect(fetchSpy).toHaveBeenCalledWith('/api/v1/changelog?limit=3')
+    expect(result).toEqual(releases)
+  })
+
+  it('throws on a non-ok response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 500 }))
+    await expect(fetchChangelog()).rejects.toThrow(/changelog failed: 500/)
   })
 })

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -9,6 +9,7 @@
 import type {
   BulkEvent,
   CardQuery,
+  ChangelogRelease,
   ExportFormat,
   Row,
   SetCard,
@@ -301,4 +302,22 @@ export async function addOverride(name: string, set: string | null, url: string)
     body: JSON.stringify({ name, set, url }),
   })
   if (!res.ok) throw new Error(`override failed: ${res.status}`)
+}
+
+// ---------------------------------------------------------------------------
+// changelog
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch parsed release notes (newest first) from the shared
+ * `GET /api/v1/changelog` endpoint — the same source the marketing site
+ * reads. The in-flight Unreleased section is omitted by the backend, so
+ * every release returned is shipped. Response is browser-cacheable for an
+ * hour via the backend's `Cache-Control`.
+ */
+export async function fetchChangelog(limit = 5): Promise<ChangelogRelease[]> {
+  const res = await fetch(`${BASE}/changelog?limit=${limit}`)
+  if (!res.ok) throw new Error(`changelog failed: ${res.status}`)
+  const data = await res.json()
+  return data.releases as ChangelogRelease[]
 }

--- a/web/src/components/WhatsNewModal.test.tsx
+++ b/web/src/components/WhatsNewModal.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { WhatsNewModal } from './WhatsNewModal'
+import { renderInlineMarkdown } from '../utils/inlineMarkdown'
+import { useAppStore } from '../store'
+import { fetchChangelog } from '../api/client'
+import type { ChangelogRelease } from '../types'
+
+vi.mock('../api/client', () => ({
+  fetchChangelog: vi.fn(),
+}))
+
+const mockFetchChangelog = vi.mocked(fetchChangelog)
+
+const RELEASES: ChangelogRelease[] = [
+  {
+    version: '1.1.1',
+    date: '2026-05-25',
+    sections: [
+      {
+        name: 'Fixed',
+        entries: ['README logo renders on the [PyPI tab](https://pypi.org/project/mgz-pkmn/).'],
+      },
+    ],
+  },
+  {
+    version: '1.1.0',
+    date: '2026-05-25',
+    sections: [
+      { name: 'Added', entries: ['`pkmn cache clear` subcommand.'] },
+      { name: 'Changed', entries: ['Export controls render as one dropdown.'] },
+    ],
+  },
+]
+
+describe('renderInlineMarkdown', () => {
+  it('renders plain text unchanged', () => {
+    const nodes = renderInlineMarkdown('just text')
+    render(<span>{nodes}</span>)
+    expect(screen.getByText('just text')).toBeInTheDocument()
+  })
+
+  it('renders a markdown link as an anchor with the href', () => {
+    const nodes = renderInlineMarkdown('see [the docs](https://example.com) now')
+    render(<span>{nodes}</span>)
+    const link = screen.getByRole('link', { name: 'the docs' })
+    expect(link).toHaveAttribute('href', 'https://example.com')
+  })
+
+  it('renders a code span as a <code> element', () => {
+    const { container } = render(<span>{renderInlineMarkdown('run `pkmn lookup` now')}</span>)
+    const code = container.querySelector('code')
+    expect(code).not.toBeNull()
+    expect(code?.textContent).toBe('pkmn lookup')
+  })
+
+  it('renders bold as a <strong> element', () => {
+    const { container } = render(
+      <span>{renderInlineMarkdown('the **Browse** button')}</span>,
+    )
+    const strong = container.querySelector('strong')
+    expect(strong).not.toBeNull()
+    expect(strong?.textContent).toBe('Browse')
+  })
+
+  it('does not emit raw HTML from the bullet text', () => {
+    const { container } = render(
+      <span>{renderInlineMarkdown('<script>alert(1)</script>')}</span>,
+    )
+    // The angle brackets are rendered as text, not a real script element.
+    expect(container.querySelector('script')).toBeNull()
+    expect(container.textContent).toContain('<script>alert(1)</script>')
+  })
+})
+
+describe('WhatsNewModal', () => {
+  beforeEach(() => {
+    useAppStore.setState({ lastSeenChangelogVersion: null })
+    mockFetchChangelog.mockReset()
+    mockFetchChangelog.mockResolvedValue(RELEASES)
+  })
+
+  it('renders the trigger button', async () => {
+    render(<WhatsNewModal />)
+    expect(await screen.findByRole('button', { name: /what's new/i })).toBeInTheDocument()
+  })
+
+  it('first-time visitor (null lastSeen) gets no dot and is caught up silently', async () => {
+    render(<WhatsNewModal />)
+    await waitFor(() =>
+      expect(useAppStore.getState().lastSeenChangelogVersion).toBe('1.1.1'),
+    )
+    // No "new release available" affordance on the button.
+    expect(
+      screen.queryByRole('button', { name: /new release available/i }),
+    ).toBeNull()
+  })
+
+  it('shows the unseen dot when a newer release shipped since last seen', async () => {
+    useAppStore.setState({ lastSeenChangelogVersion: '1.1.0' })
+    render(<WhatsNewModal />)
+    expect(
+      await screen.findByRole('button', { name: /new release available/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('does not show the dot when last seen equals the latest', async () => {
+    useAppStore.setState({ lastSeenChangelogVersion: '1.1.1' })
+    render(<WhatsNewModal />)
+    await waitFor(() => expect(mockFetchChangelog).toHaveBeenCalled())
+    expect(
+      screen.queryByRole('button', { name: /new release available/i }),
+    ).toBeNull()
+  })
+
+  it('opening the panel marks the latest version seen, clearing the dot', async () => {
+    useAppStore.setState({ lastSeenChangelogVersion: '1.1.0' })
+    render(<WhatsNewModal />)
+    const btn = await screen.findByRole('button', { name: /new release available/i })
+    fireEvent.click(btn)
+    await waitFor(() =>
+      expect(useAppStore.getState().lastSeenChangelogVersion).toBe('1.1.1'),
+    )
+  })
+
+  it('renders release versions, dates, sections, and bullets when open', async () => {
+    useAppStore.setState({ lastSeenChangelogVersion: '1.1.1' })
+    render(<WhatsNewModal />)
+    fireEvent.click(await screen.findByRole('button', { name: /what's new/i }))
+    expect(await screen.findByText('v1.1.1')).toBeInTheDocument()
+    expect(screen.getByText('v1.1.0')).toBeInTheDocument()
+    expect(screen.getByText('Fixed')).toBeInTheDocument()
+    expect(screen.getByText('Added')).toBeInTheDocument()
+    expect(screen.getByText('Changed')).toBeInTheDocument()
+    // Inline markdown link inside a bullet rendered as an anchor.
+    expect(screen.getByRole('link', { name: 'PyPI tab' })).toBeInTheDocument()
+  })
+
+  it('shows a fallback when the changelog fetch fails', async () => {
+    mockFetchChangelog.mockRejectedValue(new Error('boom'))
+    render(<WhatsNewModal />)
+    fireEvent.click(await screen.findByRole('button', { name: /what's new/i }))
+    expect(await screen.findByText(/couldn't be loaded/i)).toBeInTheDocument()
+  })
+})

--- a/web/src/components/WhatsNewModal.tsx
+++ b/web/src/components/WhatsNewModal.tsx
@@ -1,0 +1,209 @@
+/**
+ * WhatsNewModal — a header-triggered release-notes panel.
+ *
+ * Surfaces shipped changes inside the app so returning users discover
+ * features that landed since their last visit. Release data comes from the
+ * shared `GET /api/v1/changelog` endpoint (the same source the marketing
+ * site reads), so there's one parser and the copy never drifts.
+ *
+ * Discovery without nagging: the trigger button shows a small dot when a
+ * release newer than the user's last-seen version has shipped. Opening the
+ * panel marks the latest version seen, clearing the dot. A first-time
+ * visitor (no stored version) is silently caught up to the current latest
+ * — no dot — so the panel never competes with the Help button's
+ * first-visit hint.
+ */
+import * as Dialog from '@radix-ui/react-dialog'
+import { Sparkles, X } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { fetchChangelog } from '../api/client'
+import { useAppStore } from '../store'
+import type { ChangelogRelease } from '../types'
+import { renderInlineMarkdown } from '../utils/inlineMarkdown'
+
+const REPO_CHANGELOG_URL =
+  'https://github.com/mgzwarrior/mgz-pkmn/blob/main/CHANGELOG.md'
+
+// Section-name → badge accent. Unknown names fall back to a neutral chip.
+const SECTION_ACCENT: Record<string, string> = {
+  Added: 'text-emerald-400 border-emerald-400/30',
+  Changed: 'text-sky-400 border-sky-400/30',
+  Fixed: 'text-amber-400 border-amber-400/30',
+  Removed: 'text-rose-400 border-rose-400/30',
+  Deprecated: 'text-orange-400 border-orange-400/30',
+  Security: 'text-violet-400 border-violet-400/30',
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return ''
+  const d = new Date(`${iso}T00:00:00Z`)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+
+export function WhatsNewModal() {
+  const [open, setOpen] = useState(false)
+  const [releases, setReleases] = useState<ChangelogRelease[] | null>(null)
+  const [error, setError] = useState(false)
+
+  const lastSeen = useAppStore((s) => s.lastSeenChangelogVersion)
+  const setLastSeen = useAppStore((s) => s.setLastSeenChangelogVersion)
+
+  const latest = releases?.[0]?.version ?? null
+
+  // Fetch once on mount. A failure leaves `releases` null + `error` true;
+  // the button still renders (no dot) and the panel shows a fallback.
+  useEffect(() => {
+    let cancelled = false
+    fetchChangelog(5)
+      .then((data) => {
+        if (!cancelled) setReleases(data)
+      })
+      .catch(() => {
+        if (!cancelled) setError(true)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Silent first-time catch-up: a visitor with no stored version is pinned
+  // to the current latest so the dot never shows on a first visit.
+  useEffect(() => {
+    if (latest && lastSeen === null) setLastSeen(latest)
+  }, [latest, lastSeen, setLastSeen])
+
+  const hasUnseen = !!latest && lastSeen !== null && latest !== lastSeen
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next)
+    // Mark the latest version seen the moment the panel opens.
+    if (next && latest) setLastSeen(latest)
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={handleOpenChange}>
+      <Dialog.Trigger asChild>
+        <button
+          className="relative flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-800 px-2.5 py-1.5 text-sm text-zinc-200 hover:bg-zinc-700 transition-colors sm:px-3"
+          title="What's new"
+          aria-label={hasUnseen ? "What's new (new release available)" : "What's new"}
+        >
+          <Sparkles size={15} />
+          <span className="hidden sm:inline">What's new</span>
+          {hasUnseen && (
+            <span
+              aria-hidden="true"
+              className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full bg-blue-500 ring-2 ring-zinc-950"
+            />
+          )}
+        </button>
+      </Dialog.Trigger>
+
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm" />
+        <Dialog.Content
+          aria-describedby={undefined}
+          className="fixed left-1/2 top-1/2 z-50 flex max-h-[90vh] w-[min(640px,92vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-zinc-700 bg-zinc-900 shadow-2xl"
+        >
+          <div className="flex items-center justify-between border-b border-zinc-700 px-5 py-4">
+            <Dialog.Title className="text-base font-semibold text-zinc-100">
+              What's new
+            </Dialog.Title>
+            <Dialog.Close asChild>
+              <button
+                className="rounded p-1 text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700 transition-colors"
+                aria-label="Close"
+              >
+                <X size={16} />
+              </button>
+            </Dialog.Close>
+          </div>
+
+          <div
+            tabIndex={0}
+            className="flex-1 overflow-y-auto px-5 py-4 text-sm text-zinc-300 focus:outline-none focus:ring-1 focus:ring-blue-500"
+          >
+            {error || (releases && releases.length === 0) ? (
+              <p className="text-zinc-400">
+                Release notes couldn't be loaded right now. See the{' '}
+                <a
+                  href={REPO_CHANGELOG_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-400 underline hover:text-blue-300"
+                >
+                  full changelog
+                </a>
+                .
+              </p>
+            ) : releases === null ? (
+              <p className="text-zinc-500">Loading release notes…</p>
+            ) : (
+              <ol className="space-y-8">
+                {releases.map((release) => (
+                  <li
+                    key={release.version}
+                    className="border-l border-zinc-800 pl-4"
+                  >
+                    <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                      <h3 className="text-base font-semibold text-zinc-100">
+                        v{release.version}
+                      </h3>
+                      {release.date && (
+                        <time className="text-xs text-zinc-500">
+                          {formatDate(release.date)}
+                        </time>
+                      )}
+                    </div>
+                    <div className="mt-3 space-y-4">
+                      {release.sections.map((section) => (
+                        <div key={section.name}>
+                          <span
+                            className={`inline-block rounded-full border px-2 py-0.5 text-xs font-medium ${
+                              SECTION_ACCENT[section.name] ??
+                              'text-zinc-400 border-zinc-700'
+                            }`}
+                          >
+                            {section.name}
+                          </span>
+                          <ul className="mt-2 space-y-1.5">
+                            {section.entries.map((entry, i) => (
+                              <li key={i} className="flex gap-2 leading-relaxed">
+                                <span
+                                  aria-hidden="true"
+                                  className="mt-2 h-1 w-1 shrink-0 rounded-full bg-zinc-600"
+                                />
+                                <span>{renderInlineMarkdown(entry)}</span>
+                              </li>
+                            ))}
+                          </ul>
+                        </div>
+                      ))}
+                    </div>
+                  </li>
+                ))}
+              </ol>
+            )}
+          </div>
+
+          <div className="flex items-center justify-end border-t border-zinc-700 px-5 py-3">
+            <a
+              href={REPO_CHANGELOG_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs font-medium text-blue-400 hover:text-blue-300 transition-colors"
+            >
+              Full changelog →
+            </a>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/web/src/store/index.test.ts
+++ b/web/src/store/index.test.ts
@@ -218,3 +218,16 @@ describe('store: settings.showTimer', () => {
     expect(useAppStore.getState().settings.showTimer).toBe(false)
   })
 })
+
+describe('store: lastSeenChangelogVersion', () => {
+  beforeEach(() => useAppStore.setState({ lastSeenChangelogVersion: null }))
+
+  it('defaults to null', () => {
+    expect(useAppStore.getState().lastSeenChangelogVersion).toBeNull()
+  })
+
+  it('setLastSeenChangelogVersion records the version', () => {
+    useAppStore.getState().setLastSeenChangelogVersion('1.1.1')
+    expect(useAppStore.getState().lastSeenChangelogVersion).toBe('1.1.1')
+  })
+})

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -92,6 +92,16 @@ interface AppState {
   pushRecentRun: (lines: string[]) => void
   removeRecentRun: (id: string) => void
   clearRecentRuns: () => void
+
+  /**
+   * Latest changelog version the user has seen in the "What's new" panel.
+   * `null` until the panel first resolves a version. Persisted so the
+   * "unseen release" dot only shows when a newer release has shipped
+   * since the user last opened the panel. A first-time visitor (null) is
+   * initialised silently to the current latest — no dot, no nag.
+   */
+  lastSeenChangelogVersion: string | null
+  setLastSeenChangelogVersion: (version: string) => void
 }
 
 export const useAppStore = create<AppState>()(
@@ -185,6 +195,10 @@ export const useAppStore = create<AppState>()(
           recentRuns: state.recentRuns.filter((r) => r.id !== id),
         })),
       clearRecentRuns: () => set({ recentRuns: [] }),
+
+      lastSeenChangelogVersion: null,
+      setLastSeenChangelogVersion: (version) =>
+        set({ lastSeenChangelogVersion: version }),
     }),
     {
       name: 'mgz-pkmn-settings',
@@ -194,6 +208,7 @@ export const useAppStore = create<AppState>()(
         settings: state.settings,
         selectedSetIds: state.selectedSetIds,
         recentRuns: state.recentRuns,
+        lastSeenChangelogVersion: state.lastSeenChangelogVersion,
       }),
       // Merge persisted state with defaults so new settings fields (e.g.
       // `sort`, added later) fall back to the initial value rather than

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -128,6 +128,27 @@ export interface SetCard {
 }
 
 /**
+ * One section within a release (Added / Changed / Fixed / …) as returned
+ * by `GET /api/v1/changelog`. Bullet `entries` are raw Markdown — the
+ * renderer formats inline links and code spans.
+ */
+export interface ChangelogSection {
+  name: string
+  entries: string[]
+}
+
+/**
+ * One release block from `GET /api/v1/changelog`. The endpoint omits the
+ * in-flight Unreleased section by default, so every release here is
+ * shipped and carries a `date`.
+ */
+export interface ChangelogRelease {
+  version: string
+  date: string | null
+  sections: ChangelogSection[]
+}
+
+/**
  * One entry in the recent-searches history. Captured the moment the
  * user clicks **Look up** so the panel reflects what was actually
  * submitted (even if the run later errored or was stopped).

--- a/web/src/utils/inlineMarkdown.tsx
+++ b/web/src/utils/inlineMarkdown.tsx
@@ -1,0 +1,58 @@
+import { Fragment, type ReactNode } from 'react'
+
+/**
+ * Render a CHANGELOG bullet's inline Markdown to React nodes: `[text](url)`
+ * links, `` `code` `` spans, and `**bold**` emphasis — everything else as
+ * plain text. Returns React elements (not HTML strings), so there's no
+ * dangerouslySetInnerHTML and no escaping to get wrong. Kept minimal — the
+ * bullets only use those three constructs.
+ */
+export function renderInlineMarkdown(text: string): ReactNode[] {
+  // Alternation order matters: bold `**…**` must be tried before a bare
+  // run so the double-asterisks are consumed as a unit.
+  const pattern =
+    /\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)|`([^`]+)`|\*\*([^*]+)\*\*/g
+  const nodes: ReactNode[] = []
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = pattern.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      nodes.push(
+        <Fragment key={nodes.length}>{text.slice(lastIndex, match.index)}</Fragment>,
+      )
+    }
+    if (match[1] !== undefined && match[2] !== undefined) {
+      nodes.push(
+        <a
+          key={nodes.length}
+          href={match[2]}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline decoration-zinc-600 hover:decoration-zinc-300"
+        >
+          {match[1]}
+        </a>,
+      )
+    } else if (match[3] !== undefined) {
+      nodes.push(
+        <code
+          key={nodes.length}
+          className="rounded bg-zinc-800 px-1 py-0.5 text-[0.85em] text-zinc-200"
+        >
+          {match[3]}
+        </code>,
+      )
+    } else if (match[4] !== undefined) {
+      nodes.push(
+        <strong key={nodes.length} className="font-semibold text-zinc-100">
+          {match[4]}
+        </strong>,
+      )
+    }
+    lastIndex = pattern.lastIndex
+  }
+  if (lastIndex < text.length) {
+    nodes.push(<Fragment key={nodes.length}>{text.slice(lastIndex)}</Fragment>)
+  }
+  return nodes
+}


### PR DESCRIPTION
Closes #316

## What

An in-app **"What's new"** panel so returning users discover features that shipped since their last visit. It consumes the shared `GET /api/v1/changelog` endpoint (added in #318) **at runtime** — the same source the marketing site reads — so there's one parser and the copy never drifts.

- **`fetchChangelog(limit)`** + `ChangelogRelease` / `ChangelogSection` types in the API client.
- **`WhatsNewModal.tsx`** — a header button (Sparkles icon) opening a Radix dialog of recent releases: version + date headers, `Added` / `Changed` / `Fixed` badges, and bullets rendered with a small inline-Markdown→React-node helper.
- **Unseen-release dot** — shows when the latest release is newer than the user's stored last-seen version. Opening the panel marks it seen and clears the dot. A first-time visitor (`null` last-seen) is caught up **silently** so the panel never competes with the Help button's first-visit hint. The last-seen version persists via the existing Zustand store (added to `partialize` alongside `recentRuns`).
- **`inlineMarkdown.tsx`** — the renderer lives in its own file so the component module only exports a component (Fast Refresh stays happy) and the helper is independently unit-testable. Handles `[links](url)`, `` `code` ``, and `**bold**` as React elements — no `dangerouslySetInnerHTML`.

## Why

New features (Browse, recent searches, lookup timer, card detail modal) shipped silently — a user who learned the app three features ago never discovered the rest. This closes that gap using the source of truth from #315/#318 rather than duplicating release prose.

## How to verify

```bash
make dev-api          # serves /api/v1/changelog
make dev-web          # Vite proxies /api/v1 → :8000
# open the SPA → "What's new" button in the header
```

- **First visit** — no dot (silently caught up to the latest version).
- **Returning user behind a release** — to simulate, set an older version in localStorage and reload:
  ```js
  localStorage.setItem('mgz-pkmn-settings', JSON.stringify({ state: { lastSeenChangelogVersion: '1.0.0' }, version: 0 }))
  ```
  → blue dot on the button. Open the panel → dot clears, and stays cleared across reloads.
- **Panel** renders recent releases with badges, `code`/**bold**/link formatting, and a "Full changelog →" link.

## Tests

- **WhatsNewModal** — trigger render, dot logic (first-visit / behind / caught-up), silent first-time catch-up, mark-seen-on-open, fetch-failure fallback, and release rendering (versions, dates, sections, inline link).
- **inlineMarkdown** — links, code spans, bold, and a guard that raw HTML in bullet text is rendered as text (no injected elements).
- **store** — `lastSeenChangelogVersion` default + setter.
- **client** — `fetchChangelog` requests the right URL and throws on non-OK.

`make check` + full web vitest (180 tests) + `npm run build` all green. Browser-verified the button, dot, and panel against a local API.

## Dependencies / sequencing

- Runtime-depends on `GET /api/v1/changelog`, merged via #318.
- The endpoint only serves once the Render image ships `CHANGELOG.md` — see **#319** (`.dockerignore` fix), which must merge + deploy for the live demo's panel to populate. Until then the panel shows its graceful "couldn't be loaded" fallback.

## Follow-up (noted, not in scope)

The marketing site's `renderInlineMarkdown` (from #315) handles links + code but **not** `**bold**`, so the site's "Recently shipped" shows literal `**`. Worth a small parity fix.