### PR TITLE
deploy: enable MGZ_PKMN_WARM_ON_STARTUP=1 in render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -15,3 +15,11 @@ services:
       # via `ARG`, so a single entry covers both.
       - key: POKEMONTCG_IO_API_KEY
         sync: false
+      # Warm the concept + set-cards API caches on startup so the first
+      # user after a deploy (or a free-tier spin-up) gets cache hits
+      # instead of paying the full upstream round trip. The warmers run on
+      # background daemon threads — startup and the /health check aren't
+      # blocked — and their on-disk freshness manifests (24 h concepts /
+      # 1 week set-cards) keep restarts within the window from re-walking.
+      - key: MGZ_PKMN_WARM_ON_STARTUP
+        value: "1"


### PR DESCRIPTION
Closes #312

## What

Adds `MGZ_PKMN_WARM_ON_STARTUP=1` to the deployed service's `envVars` in `render.yaml`.

## Why

The API already supports an opt-in startup hook that warms the concept and set-cards caches on background daemon threads (added in #309), but `render.yaml` never enabled it. So the deployed demo started cold on every deploy / free-tier spin-up, and the first user to hit a concept lookup or a Browse → set-detail open paid the full multi-second upstream round trip.

Turning it on converts "first user pays the slow path" into "the deploy pays it once."

## Safety

- The warmers run on **background daemon threads**, so neither startup nor the `/health` check is blocked.
- On-disk freshness manifests (24 h concepts / 1 week set-cards) keep restarts within the window from re-walking.
- The `POKEMONTCG_IO_API_KEY` already set here gives the warm pass the 20k/day rate limit — comfortably above the ~700 requests a full cold-start warm makes.

## Caveat (tracked separately)

Render's free-tier filesystem is ephemeral, so each redeploy wipes the cache and the warm re-runs from scratch. That's expected and still a net win; the persistent-disk question is [#313](https://github.com/mgzwarrior/mgz-pkmn/issues/313).

## How to verify

After this merges and Render redeploys:
- Render logs show `concept warm complete: …` and `set-cards warm complete: …` info lines on boot.
- The first Browse → set-detail request after the deploy is a cache hit (curl-time `GET /api/v1/sets/{id}/cards`, or check `/api/v1/cache/stats` once #311 lands).

## Notes

- Validated `render.yaml` still parses as valid YAML with the new entry.
- Deploy-config only — no app code touched, so no CHANGELOG entry (the warm-on-startup feature itself was changelogged in #309).