### PR TITLE
web: color-coded per-line search progress with finer-grained SSE stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Web: **color-coded search progress** — while a bulk lookup runs, each
+  input line's chip in the progress panel now reflects the exact pipeline
+  stage it's in (parsed → looking up → fallback / URL hint → pricing →
+  resolved / no match / error) instead of a single blue spinner. The
+  `/api/v1/bulk` SSE stream carries a `stage` on every frame, including
+  intermediate progress-only frames streamed live as a line moves through
+  the sources. Hovering a chip shows how long the line has spent in its
+  current stage, and a **Legend** toggle in the panel header maps the
+  colors to their meanings. All stage colors clear WCAG AA contrast —
+  see [docs/accessibility.md](docs/accessibility.md#color-coded-progress-stages).
 - Web: **"What's new" panel** — a new header button (with an unobtrusive
   dot when a release newer than you've seen has shipped) opens a panel of
   recent release notes, pulled at runtime from `GET /api/v1/changelog` —

--- a/api/routes/lookup.py
+++ b/api/routes/lookup.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
+from collections.abc import Callable
 from typing import Any
 
 import requests as req_lib
@@ -80,15 +82,30 @@ def _pricing_to_dict(p: Pricing) -> dict[str, Any]:
     }
 
 
+def _terminal_stage(matched: bool, reason: str) -> str:
+    """Map a resolved row's (matched, reason) onto a terminal pipeline stage.
+
+    Mirrors the `LOOKUP_STAGES` vocabulary so the SPA can render the final
+    chip from the same field it uses for intermediate progress: a hard
+    failure (network / unparseable) is `error`, a match is `resolved`, and
+    every "looked but found nothing" reason (`no_candidates`, `set_mismatch`,
+    `no_results`, `price_mismatch`) is `no_match`."""
+    if reason in ("error", "unparseable"):
+        return "error"
+    return "resolved" if matched else "no_match"
+
+
 def _row_to_dict(row: Row, reason: str) -> dict[str, Any]:
     card = row.card or {}
+    matched = row.card is not None
     return {
         "query": _query_to_dict(row.query),
         "card": card if card else None,
         "pricing": _pricing_to_dict(row.pricing),
         "tag": row.tag,
-        "matched": row.card is not None,
+        "matched": matched,
         "reason": reason,
+        "stage": _terminal_stage(matched, reason),
     }
 
 
@@ -98,19 +115,27 @@ def _do_lookup(
     pc: PriceChartingClient,
     q: CardQuery,
     settings: Settings,
+    on_stage: Callable[[str], None] | None = None,
 ) -> list[tuple[Row, str]]:
     """Run a blocking card lookup and return (Row, reason) pairs.
 
     `reason` mirrors `MatchResult.reason` for single lookups
     ("matched" | "no_candidates" | "set_mismatch") and uses synthetic values
     for bulk / error paths ("matched" | "no_results" | "error").
+
+    `on_stage`, when provided, is forwarded into the lookup coordinator so the
+    caller can stream finer-grained per-line progress (see `LOOKUP_STAGES`).
+    It runs synchronously on this worker thread; the SSE route hops each call
+    back onto the event loop.
     """
     out: list[tuple[Row, str]] = []
 
     if q.bulk_top or q.bulk_all:
         try:
             effective_limit = None if q.bulk_all else q.bulk_top
-            top = find_top_cards(pkmn, q, limit=effective_limit, max_price=settings.max_price)
+            top = find_top_cards(
+                pkmn, q, limit=effective_limit, max_price=settings.max_price, on_stage=on_stage
+            )
             err = False
         except req_lib.RequestException:
             top = []
@@ -123,12 +148,14 @@ def _do_lookup(
             out.append((Row(query=q, card=None, pricing=Pricing(), tag=settings.tag), reason))
     else:
         try:
-            result = find_card(pkmn, tcgdex, pc, q, default_lang=settings.lang)
+            result = find_card(pkmn, tcgdex, pc, q, default_lang=settings.lang, on_stage=on_stage)
         except req_lib.RequestException:
             from mgz_pkmn.sources.base import MatchResult
 
             result = MatchResult(None, "error")
         if result.card:
+            if on_stage is not None:
+                on_stage("pricing")
             pricing = extract_pricing(result.card, q.variant_hint)
             out.append(
                 (
@@ -185,17 +212,37 @@ async def lookup(req: LookupRequest) -> dict:
     return {"rows": [_row_to_dict(r, reason) for r, reason in pairs]}
 
 
+def _stage_frame(index: int, total: int, stage: str) -> str:
+    """Serialize a progress-only SSE frame (no row payload).
+
+    Distinguishable from a resolved-row frame by the absence of `matched` /
+    `query` — the SPA branches on that to update a line's current stage
+    without appending a result row."""
+    return f"data: {json.dumps({'index': index, 'total': total, 'stage': stage})}\n\n"
+
+
+# Sentinel pushed onto a line's stage queue once its threadpool lookup
+# resolves, so the async drain loop knows to stop waiting for more stages.
+_STAGE_DONE = object()
+
+
 @router.post("/bulk")
 async def bulk(req: BulkRequest) -> StreamingResponse:
     """Stream row-by-row results for a multi-line lookup via Server-Sent Events.
 
-    Each SSE event is a JSON object:
-      `{ index, total, query, card, pricing, tag, matched, reason }`
+    Two kinds of per-line frames are emitted, both carrying `{ index, total }`:
+
+    * **Progress** — `{ stage }` only. Fired as a line moves through the
+      pipeline (`parsed` → `looking_up` → `fallback`/`url_hint` → `pricing`).
+    * **Resolved row** — the full `{ query, card, pricing, tag, matched,
+      reason, stage }` object, where `stage` is the terminal state
+      (`resolved` / `no_match` / `error`). A `top:N` line emits several.
 
     Blank / `#`-comment lines are silently skipped (matching CLI behavior),
     so they don't appear in the stream and don't count toward `total`. Lines
-    that fail to parse are emitted as a single unmatched event with
-    `reason: "unparseable"`, so the client never silently loses input.
+    that fail to parse are emitted as a single unmatched row event with
+    `reason: "unparseable"` (terminal stage `error`), so the client never
+    silently loses input.
 
     A final `{ done: true, total }` event is emitted when all lines are done.
     """
@@ -209,6 +256,7 @@ async def bulk(req: BulkRequest) -> StreamingResponse:
     pkmn, tcgdex, pc = _make_clients(req.settings)
 
     async def event_stream():
+        loop = asyncio.get_running_loop()
         for stream_idx, (_orig_idx, line) in enumerate(indexed):
             q = parse_line(line)
             if q is None:
@@ -221,8 +269,31 @@ async def bulk(req: BulkRequest) -> StreamingResponse:
                 yield f"data: {json.dumps(payload)}\n\n"
                 continue
 
-            pairs = await run_in_threadpool(_do_lookup, pkmn, tcgdex, pc, q, req.settings)
-            for row, reason in pairs:
+            # The line is in the pipeline before any upstream call goes out.
+            yield _stage_frame(stream_idx, total, "parsed")
+
+            # Bridge the synchronous `on_stage` callback (invoked on the
+            # threadpool worker) to this async generator. The worker pushes
+            # stage names via `call_soon_threadsafe`; a done-callback pushes a
+            # sentinel once the lookup returns. We drain in between, so stage
+            # frames interleave with the blocking lookup in real time.
+            stage_queue: asyncio.Queue = asyncio.Queue()
+
+            def on_stage(name: str, _q: asyncio.Queue = stage_queue) -> None:
+                loop.call_soon_threadsafe(_q.put_nowait, name)
+
+            task = asyncio.ensure_future(
+                run_in_threadpool(_do_lookup, pkmn, tcgdex, pc, q, req.settings, on_stage)
+            )
+            task.add_done_callback(lambda _t, _q=stage_queue: _q.put_nowait(_STAGE_DONE))
+
+            while True:
+                item = await stage_queue.get()
+                if item is _STAGE_DONE:
+                    break
+                yield _stage_frame(stream_idx, total, item)
+
+            for row, reason in task.result():
                 payload = {
                     "index": stream_idx,
                     "total": total,

--- a/api/routes/lookup.py
+++ b/api/routes/lookup.py
@@ -87,10 +87,11 @@ def _terminal_stage(matched: bool, reason: str) -> str:
 
     Mirrors the `LOOKUP_STAGES` vocabulary so the SPA can render the final
     chip from the same field it uses for intermediate progress: a hard
-    failure (network / unparseable) is `error`, a match is `resolved`, and
-    every "looked but found nothing" reason (`no_candidates`, `set_mismatch`,
-    `no_results`, `price_mismatch`) is `no_match`."""
-    if reason in ("error", "unparseable"):
+    failure (network / scrape / unparseable) is `error`, a match is
+    `resolved`, and every "looked but found nothing" reason
+    (`no_candidates`, `set_mismatch`, `no_results`, `price_mismatch`) is
+    `no_match`."""
+    if reason in ("error", "scrape_failed", "unparseable"):
         return "error"
     return "resolved" if matched else "no_match"
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -61,6 +61,34 @@ document.head.appendChild(s)
 [issue-62]: https://github.com/mgzwarrior/mgz-pkmn/issues/62
 [pr-220]: https://github.com/mgzwarrior/mgz-pkmn/pull/220
 
+## Color-coded progress stages
+
+While a bulk lookup runs, the per-line progress panel
+([`ProcessingQueue`](../web/src/components/ProcessingQueue.tsx)) renders
+each line's current pipeline stage as a color-coded chip. Color is never
+the *only* signal — every chip also carries a text label and a hover
+tooltip — but the colors still clear WCAG 2.1 AA contrast (≥ 4.5:1)
+against the app background (`bg-zinc-950`, `#09090b`). All are Tailwind
+`*-400` shades:
+
+| Stage | Class | Meaning |
+|---|---|---|
+| Parsed | `text-zinc-400` | Line accepted by the parser; queued for lookup |
+| Looking up | `text-blue-400` | Querying the first source (pokemontcg.io) |
+| Fallback | `text-indigo-400` | First source missed; trying TCGdex |
+| URL hint | `text-violet-400` | URL-based scrape (PriceCharting) |
+| Pricing | `text-cyan-400` | Card resolved; building the pricing snapshot |
+| Image | `text-teal-400` | Downloading + thumbnailing the image (CLI only) |
+| Resolved | `text-green-400` | Done, matched |
+| No match | `text-amber-400` | Done, no card found |
+| Error | `text-red-400` | Hard failure (network, parse, etc.) |
+
+The `Image` stage is part of the shared vocabulary but the web app runs
+image-free, so it never appears in the SPA. A **Legend** toggle in the
+panel header (collapsed by default) maps the colors back to their labels.
+When adding or recoloring a stage, keep it a `*-400`-or-lighter shade and
+re-run the live-browser contrast scan below.
+
 ## Keyboard reference
 
 | Where | Key | Effect |

--- a/src/mgz_pkmn/lookup.py
+++ b/src/mgz_pkmn/lookup.py
@@ -25,6 +25,32 @@ from .sources.base import MatchResult, name_clause
 # full set in help text without re-declaring it.
 WARM_SOURCES = ("pokemontcg", "tcgdex", "all")
 
+# Pipeline stages surfaced to the web UI via the bulk SSE stream. The lookup
+# coordinator emits the intermediate stages (`looking_up` / `fallback` /
+# `url_hint` / `pricing`) through the optional `on_stage` callback below; the
+# API route brackets a run with `parsed` and resolves it into one of the
+# terminal stages (`resolved` / `no_match` / `error`). `image` is part of the
+# vocabulary the CLI uses when it downloads thumbnails, but the web flow runs
+# image-free, so it never fires there. Kept here as the single source of truth
+# so the API, the SPA, and the tests all agree on the spelling.
+LOOKUP_STAGES = (
+    "parsed",
+    "url_hint",
+    "looking_up",
+    "fallback",
+    "pricing",
+    "image",
+    "resolved",
+    "no_match",
+    "error",
+)
+
+# Type alias for the per-stage progress callback threaded through the lookup
+# coordinator. Invoked with the stage name as the lookup advances through its
+# sources; `None` (the default) disables emission entirely for callers — like
+# the CLI and the single-line `/lookup` endpoint — that don't stream progress.
+StageCallback = Callable[[str], None]
+
 # Bulk subjects that aren't Pokemon names but card subtypes. When the user
 # writes `top 4 tag team` they want cards whose subtype is "TAG TEAM" (cards
 # featuring 2+ Pokemon), not cards literally named "tag team". Keys are
@@ -165,6 +191,7 @@ def find_card(
     pc: PriceChartingClient,
     q: CardQuery,
     default_lang: str | None = None,
+    on_stage: StageCallback | None = None,
 ) -> MatchResult:
     """Coordinate lookups across pokemontcg.io, TCGdex (multilingual), and an
     optional explicit URL hint (currently PriceCharting). The first source
@@ -177,7 +204,17 @@ def find_card(
     `default_lang` is consulted only as a fallback when the line itself didn't
     name a language. It's used by the CLI/API global ``--lang`` knob — set it
     to ``"ja"`` to make every untagged line fall through to TCGdex Japanese
-    after pokemontcg.io misses."""
+    after pokemontcg.io misses.
+
+    `on_stage`, when provided, is called with the name of each pipeline stage
+    as the lookup advances (`url_hint` / `looking_up` / `fallback`) so the web
+    UI can show finer-grained per-line progress. It's a pure passthrough of
+    state that already drives control flow here — see `LOOKUP_STAGES`."""
+
+    def _stage(name: str) -> None:
+        if on_stage is not None:
+            on_stage(name)
+
     # 1. Explicit URL hint takes precedence — the user already found the card.
     #    A scrape failure (404 / 500 / connection error) propagates as
     #    `scrape_failed` so the CLI can name the URL instead of pretending
@@ -185,6 +222,7 @@ def find_card(
     #    URL the user pastes once doesn't get pinned as a sticky override
     #    that quietly fails on every subsequent run.
     if q.url_hint and _is_pricecharting_url(q.url_hint):
+        _stage("url_hint")
         result = pc.fetch(q.url_hint)
         if result.card:
             disk_cache.record_url_override(q.name, q.set_hint, q.url_hint)
@@ -199,11 +237,13 @@ def find_card(
     #    failing the lookup — the user didn't paste it this run.
     override = disk_cache.find_url_override(q.name, q.set_hint)
     if override and _is_pricecharting_url(override):
+        _stage("url_hint")
         override_result = pc.fetch(override)
         if override_result.card:
             return _apply_price_bounds(override_result, q)
 
     # 3. pokemontcg.io — best for English / international English releases.
+    _stage("looking_up")
     primary = search_pokemontcg(pkmn, q)
     if primary.card:
         return _apply_price_bounds(primary, q)
@@ -219,6 +259,7 @@ def find_card(
         langs.append("en")
 
     saw_set_mismatch = primary.reason == "set_mismatch"
+    _stage("fallback")
     for lang in langs:
         result = search_tcgdex(tcgdex, q, lang)
         if result.card:
@@ -334,6 +375,7 @@ def find_top_cards(
     q: CardQuery,
     limit: int | None = 5,
     max_price: float | None = None,
+    on_stage: StageCallback | None = None,
 ) -> list[dict[str, Any]]:
     """Return up to `limit` chase cards for a name, ranked by market price.
 
@@ -356,7 +398,14 @@ def find_top_cards(
     results when there are enough cheap variants in the pool. The per-query
     bounds (`q.price_min` / `q.price_max`) are AND-combined with `max_price`,
     so an inline `>= $20` on the line excludes cheap fillers and inline
-    `<= $50` further tightens the global cap."""
+    `<= $50` further tightens the global cap.
+
+    `on_stage`, when provided, is called with `looking_up` before the upstream
+    searches and `pricing` before the pool is ranked, so the web UI can show
+    per-line progress for bulk (`top:N` / `All <set>`) queries."""
+    if on_stage is not None:
+        on_stage("looking_up")
+
     cleaned = strip_noise(q.name) or q.name
     seen_ids: set[str] = set()
     pool: list[dict[str, Any]] = []
@@ -523,6 +572,9 @@ def find_top_cards(
             effective_max_exclusive = True
     effective_min = q.price_min
     effective_min_exclusive = q.price_min_exclusive
+
+    if on_stage is not None:
+        on_stage("pricing")
 
     enriched: list[tuple[float, dict[str, Any]]] = []
     for card in pool:

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -130,6 +130,87 @@ class LookupRouteTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# /bulk (SSE) — stage streaming
+# ---------------------------------------------------------------------------
+
+
+def _parse_sse(text: str) -> list[dict]:
+    """Parse a collected SSE body into a list of decoded JSON frames."""
+    frames = []
+    for chunk in text.strip().split("\n\n"):
+        chunk = chunk.strip()
+        if chunk.startswith("data: "):
+            frames.append(json.loads(chunk[len("data: ") :]))
+    return frames
+
+
+class TerminalStageTests(unittest.TestCase):
+    """`_terminal_stage` collapses a resolved row's (matched, reason) onto
+    one of the three terminal pipeline stages."""
+
+    def test_mapping(self) -> None:
+        from api.routes.lookup import _terminal_stage
+
+        self.assertEqual(_terminal_stage(True, "matched"), "resolved")
+        self.assertEqual(_terminal_stage(False, "no_candidates"), "no_match")
+        self.assertEqual(_terminal_stage(False, "set_mismatch"), "no_match")
+        self.assertEqual(_terminal_stage(False, "no_results"), "no_match")
+        self.assertEqual(_terminal_stage(False, "price_mismatch"), "no_match")
+        self.assertEqual(_terminal_stage(False, "error"), "error")
+        self.assertEqual(_terminal_stage(False, "unparseable"), "error")
+
+
+class BulkStageStreamTests(unittest.TestCase):
+    """The /bulk SSE stream interleaves progress-only stage frames with the
+    terminal resolved-row frame for each line."""
+
+    def test_streams_parsed_then_pipeline_stages_then_resolved_row(self) -> None:
+        from mgz_pkmn.pricing import Pricing
+        from mgz_pkmn.spreadsheet import Row
+
+        def fake(pkmn, tcgdex, pc, q, settings, on_stage=None):
+            if on_stage is not None:
+                on_stage("looking_up")
+                on_stage("fallback")
+            card = {"id": "base1-4", "name": "Charizard"}
+            return [(Row(query=q, card=card, pricing=Pricing(market=100.0), tag=""), "matched")]
+
+        with patch("api.routes.lookup._do_lookup", side_effect=fake):
+            resp = client.post("/api/v1/bulk", json={"lines": ["Charizard"]})
+
+        self.assertEqual(resp.status_code, 200)
+        frames = _parse_sse(resp.text)
+
+        progress = [f["stage"] for f in frames if "matched" not in f and not f.get("done")]
+        self.assertEqual(progress, ["parsed", "looking_up", "fallback"])
+
+        rows = [f for f in frames if "matched" in f]
+        self.assertEqual(len(rows), 1)
+        self.assertTrue(rows[0]["matched"])
+        self.assertEqual(rows[0]["stage"], "resolved")
+
+        self.assertTrue(frames[-1].get("done"))
+
+    def test_unmatched_row_carries_no_match_terminal_stage(self) -> None:
+        from mgz_pkmn.pricing import Pricing
+        from mgz_pkmn.spreadsheet import Row
+
+        def fake(pkmn, tcgdex, pc, q, settings, on_stage=None):
+            if on_stage is not None:
+                on_stage("looking_up")
+            return [(Row(query=q, card=None, pricing=Pricing(), tag=""), "no_candidates")]
+
+        with patch("api.routes.lookup._do_lookup", side_effect=fake):
+            resp = client.post("/api/v1/bulk", json={"lines": ["Nonsense"]})
+
+        frames = _parse_sse(resp.text)
+        rows = [f for f in frames if "matched" in f]
+        self.assertEqual(len(rows), 1)
+        self.assertFalse(rows[0]["matched"])
+        self.assertEqual(rows[0]["stage"], "no_match")
+
+
+# ---------------------------------------------------------------------------
 # /sets
 # ---------------------------------------------------------------------------
 

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -157,6 +157,7 @@ class TerminalStageTests(unittest.TestCase):
         self.assertEqual(_terminal_stage(False, "no_results"), "no_match")
         self.assertEqual(_terminal_stage(False, "price_mismatch"), "no_match")
         self.assertEqual(_terminal_stage(False, "error"), "error")
+        self.assertEqual(_terminal_stage(False, "scrape_failed"), "error")
         self.assertEqual(_terminal_stage(False, "unparseable"), "error")
 
 

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -560,5 +560,97 @@ class FindCardUrlHintOverrideTests(unittest.TestCase):
         self.assertEqual(cache.find_url_override("Charizard", None), self.URL)
 
 
+class StageCallbackTests(unittest.TestCase):
+    """The lookup coordinator surfaces pipeline stages through `on_stage`
+    so the web UI can render finer-grained per-line progress."""
+
+    def setUp(self) -> None:
+        # Isolate the disk cache so the URL-hint test's sticky override
+        # can't leak into the DB-source tests (which would otherwise see a
+        # phantom `url_hint` stage from a recorded override).
+        self._tmp = tempfile.TemporaryDirectory()
+        self._old_xdg = os.environ.get("XDG_CACHE_HOME")
+        self._old_no_cache = os.environ.get(cache._NO_CACHE_ENV)
+        os.environ["XDG_CACHE_HOME"] = self._tmp.name
+        os.environ.pop(cache._NO_CACHE_ENV, None)
+
+    def tearDown(self) -> None:
+        if self._old_xdg is None:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        else:
+            os.environ["XDG_CACHE_HOME"] = self._old_xdg
+        if self._old_no_cache is None:
+            os.environ.pop(cache._NO_CACHE_ENV, None)
+        else:
+            os.environ[cache._NO_CACHE_ENV] = self._old_no_cache
+        self._tmp.cleanup()
+
+    def _charizard(self, market: float = 100.0) -> dict:
+        return {
+            "id": "base1-4",
+            "name": "Charizard",
+            "number": "4",
+            "set": {"name": "Base Set", "series": "Base"},
+            "tcgplayer": {"prices": {"holofoil": {"market": market}}},
+        }
+
+    def test_find_card_emits_looking_up_on_pokemontcg_hit(self) -> None:
+        client = _StubTCGClient({"name:Charizard": [self._charizard()]})
+        q = CardQuery(raw="Charizard", name="Charizard")
+        stages: list[str] = []
+        find_card(
+            client,
+            _NullTCGDexClient(),
+            _StubPCClient(MatchResult(None, "no_candidates")),
+            q,
+            on_stage=stages.append,
+        )
+        # pokemontcg.io hits first, so the TCGdex fallback never fires.
+        self.assertEqual(stages, ["looking_up"])
+
+    def test_find_card_emits_fallback_when_pokemontcg_misses(self) -> None:
+        class _EmptyTCGDex:
+            def search(self, *_: object, **__: object) -> list[dict]:
+                return []
+
+        client = _StubTCGClient()  # empty map → no pokemontcg.io match
+        q = CardQuery(raw="Charizard", name="Charizard")
+        stages: list[str] = []
+        find_card(
+            client,
+            _EmptyTCGDex(),
+            _StubPCClient(MatchResult(None, "no_candidates")),
+            q,
+            on_stage=stages.append,
+        )
+        self.assertEqual(stages, ["looking_up", "fallback"])
+
+    def test_find_card_emits_url_hint_on_pricecharting_url(self) -> None:
+        url = "https://www.pricecharting.com/game/pokemon-base-set/charizard-4"
+        pc = _StubPCClient(MatchResult(self._charizard(), "matched"))
+        q = CardQuery(raw=f"Charizard | {url}", name="Charizard", url_hint=url)
+        stages: list[str] = []
+        find_card(_StubTCGClient(), _NullTCGDexClient(), pc, q, on_stage=stages.append)
+        # A successful URL hint short-circuits the DB sources entirely.
+        self.assertEqual(stages, ["url_hint"])
+
+    def test_find_top_cards_emits_looking_up_then_pricing(self) -> None:
+        client = _StubTCGClient({"name:Charizard": [_card("base1-4", "Charizard", 100.0)]})
+        q = CardQuery(raw="top:5 Charizard", name="Charizard", bulk_top=5)
+        stages: list[str] = []
+        find_top_cards(client, q, limit=5, on_stage=stages.append)
+        self.assertEqual(stages, ["looking_up", "pricing"])
+
+    def test_on_stage_none_is_a_silent_no_op(self) -> None:
+        # The default (no callback) must not raise — the CLI and the
+        # single-line endpoint rely on it.
+        client = _StubTCGClient({"name:Charizard": [self._charizard()]})
+        q = CardQuery(raw="Charizard", name="Charizard")
+        result = find_card(
+            client, _NullTCGDexClient(), _StubPCClient(MatchResult(None, "no_candidates")), q
+        )
+        self.assertIsNotNone(result.card)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -47,6 +47,7 @@ function makeEvent(index: number, total: number, matched = true): BulkEvent {
     total,
     matched,
     reason: matched ? '' : 'no match',
+    stage: matched ? 'resolved' : 'no_match',
     tag: '',
     query: {
       raw: `q${index}`,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -39,6 +39,7 @@ function App() {
     setProgress,
     setProcessingLines,
     markLineStatus,
+    updateLineStage,
     setRunStartedAt,
     setRunEndedAt,
     pushRecentRun,
@@ -90,13 +91,21 @@ function App() {
     let firstEventSeen = false
 
     function onEvent(event: BulkEvent) {
-      if (event.done) return
+      if ('done' in event && event.done) return
       if (!firstEventSeen) {
         firstEventSeen = true
         setRunStartedAt(Date.now())
       }
 
-      // First event for this input line transitions it out of "pending".
+      // Record the latest stage for the line either way — both progress
+      // frames and the terminal row frame carry one.
+      updateLineStage(event.index, event.stage)
+
+      // Progress-only frame (no row payload): the line advanced a stage but
+      // hasn't resolved yet, so don't append a result or flip its status.
+      if (!('matched' in event)) return
+
+      // First row event for this input line transitions it out of "pending".
       // Subsequent events (top:N expansions) leave the status alone.
       markLineStatus(event.index, event.matched ? 'resolved' : 'error')
 
@@ -148,6 +157,7 @@ function App() {
     setProgress,
     setProcessingLines,
     markLineStatus,
+    updateLineStage,
     setRunStartedAt,
     setRunEndedAt,
     pushRecentRun,

--- a/web/src/components/ProcessingQueue.test.tsx
+++ b/web/src/components/ProcessingQueue.test.tsx
@@ -1,6 +1,16 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { ProcessingQueue } from './ProcessingQueue'
+
+const baseSettings = {
+  apiKey: '',
+  maxPrice: null,
+  noImages: true,
+  tag: '',
+  dedupe: false,
+  sort: 'number' as const,
+  showTimer: false,
+}
 
 const { mockState } = vi.hoisted(() => ({
   mockState: {
@@ -8,7 +18,7 @@ const { mockState } = vi.hoisted(() => ({
       { line: 'Charizard | Base Set | 4', status: 'resolved' as const, endedAt: 1500 },
       { line: 'Pikachu | Jungle', status: 'error' as const, endedAt: 1800 },
       { line: 'top:5 Mew ex', status: 'pending' as const },
-    ],
+    ] as Array<Record<string, unknown>>,
     isRunning: true,
     runStartedAt: 1000,
     settings: {
@@ -62,5 +72,60 @@ describe('ProcessingQueue', () => {
     expect(screen.getByLabelText('Finished in 500 milliseconds')).toBeInTheDocument()
     expect(screen.getByLabelText('Finished in 800 milliseconds')).toBeInTheDocument()
     expect(screen.queryByLabelText(/Resolved in/)).not.toBeInTheDocument()
+  })
+})
+
+describe('ProcessingQueue stage chips', () => {
+  beforeEach(() => {
+    mockState.settings = { ...baseSettings }
+    mockState.processingLines = [
+      { line: 'Charizard | Base Set | 4', status: 'pending', stage: 'looking_up', stageStartedAt: 1000 },
+      { line: 'Mew', status: 'pending', stage: 'fallback', stageStartedAt: 1000 },
+      { line: 'Lugia', status: 'resolved', stage: 'resolved', stageStartedAt: 1400, endedAt: 1500 },
+      { line: 'Ditto', status: 'error', stage: 'no_match', stageStartedAt: 1700, endedAt: 1800 },
+    ]
+  })
+
+  it('renders the stage label for each line', () => {
+    render(<ProcessingQueue />)
+    expect(screen.getAllByText('Looking up').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Fallback').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Resolved').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('No match').length).toBeGreaterThan(0)
+  })
+
+  it('applies the matching color class to the stage label', () => {
+    render(<ProcessingQueue />)
+    // The looking_up line's label is rendered in blue (the chip uses the
+    // stage color class on its own <span>, not the legend swatch).
+    const lookingUp = screen
+      .getAllByText('Looking up')
+      .find((el) => el.tagName === 'SPAN' && el.className.includes('text-blue-400'))
+    expect(lookingUp).toBeDefined()
+    const noMatch = screen
+      .getAllByText('No match')
+      .find((el) => el.className.includes('text-amber-400'))
+    expect(noMatch).toBeDefined()
+  })
+
+  it('exposes per-stage elapsed time via the row tooltip for finished lines', () => {
+    render(<ProcessingQueue />)
+    // Lugia spent 1500 - 1400 = 100ms in the resolved stage.
+    expect(screen.getByTitle('Resolved · 100ms')).toBeInTheDocument()
+    // Ditto spent 1800 - 1700 = 100ms in the no_match stage.
+    expect(screen.getByTitle('No match · 100ms')).toBeInTheDocument()
+  })
+
+  it('legend is collapsed by default and toggles open from the header', () => {
+    render(<ProcessingQueue />)
+    const toggle = screen.getByRole('button', { name: /legend/i })
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    // Collapsed: the unique terminal labels (URL hint) aren't shown twice.
+    expect(screen.queryByText('URL hint')).not.toBeInTheDocument()
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    // Open: the legend lists every stage, including ones no line is in.
+    expect(screen.getByText('URL hint')).toBeInTheDocument()
+    expect(screen.getByText('Pricing')).toBeInTheDocument()
   })
 })

--- a/web/src/components/ProcessingQueue.tsx
+++ b/web/src/components/ProcessingQueue.tsx
@@ -1,16 +1,75 @@
 /**
  * ProcessingQueue — per-line status panel shown while a bulk lookup is
- * in flight. Each input line transitions pending → resolved / error as
- * its first SSE event arrives. The panel unmounts as soon as the run
- * finishes (whether by completion, Stop, or error) so abandoned
- * pending entries don't spin indefinitely.
+ * in flight. Each input line moves through the lookup pipeline one stage
+ * at a time (parsed → looking up → fallback / URL hint → pricing →
+ * resolved / no match / error), driven by the `stage` field on the SSE
+ * stream. The chip's color and label reflect the latest stage; a hover
+ * tooltip reports how long the line has spent in it. The panel unmounts
+ * as soon as the run finishes (whether by completion, Stop, or error) so
+ * abandoned pending entries don't spin indefinitely.
  */
-import { CheckCircle2, AlertTriangle, Loader2 } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import {
+  CheckCircle2,
+  AlertTriangle,
+  XCircle,
+  Loader2,
+  ChevronDown,
+} from 'lucide-react'
 import { useAppStore } from '../store'
-import type { ProcessingLine } from '../types'
+import type { ProcessingLine, Stage } from '../types'
+
+/**
+ * Per-stage presentation. Colors are Tailwind `*-400` shades, all of which
+ * clear WCAG 2.1 AA contrast (≥ 4.5:1) against the app background
+ * (`bg-zinc-950`) — see docs/accessibility.md. `terminal` marks the three
+ * end states (which get a static icon); the rest are in-flight and spin.
+ */
+const STAGE_CONFIG: Record<Stage, { label: string; color: string; terminal: boolean }> = {
+  parsed: { label: 'Parsed', color: 'text-zinc-400', terminal: false },
+  looking_up: { label: 'Looking up', color: 'text-blue-400', terminal: false },
+  fallback: { label: 'Fallback', color: 'text-indigo-400', terminal: false },
+  url_hint: { label: 'URL hint', color: 'text-violet-400', terminal: false },
+  pricing: { label: 'Pricing', color: 'text-cyan-400', terminal: false },
+  image: { label: 'Image', color: 'text-teal-400', terminal: false },
+  resolved: { label: 'Resolved', color: 'text-green-400', terminal: true },
+  no_match: { label: 'No match', color: 'text-amber-400', terminal: true },
+  error: { label: 'Error', color: 'text-red-400', terminal: true },
+}
+
+/** Display order for the legend — pipeline order, terminal states last. */
+const STAGE_ORDER: Stage[] = [
+  'parsed',
+  'looking_up',
+  'fallback',
+  'url_hint',
+  'pricing',
+  'image',
+  'resolved',
+  'no_match',
+  'error',
+]
+
+/**
+ * A wall-clock value that advances ~4×/sec, so the per-stage elapsed time
+ * in chip tooltips keeps ticking for lines still in flight. Reading
+ * `Date.now()` straight in render is impure (and flagged by lint); this
+ * keeps the time in state and updates it on an interval instead.
+ */
+function useNow(active: boolean): number {
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    if (!active) return
+    const id = setInterval(() => setNow(Date.now()), 250)
+    return () => clearInterval(id)
+  }, [active])
+  return now
+}
 
 export function ProcessingQueue() {
   const { processingLines, isRunning, runStartedAt, settings } = useAppStore()
+  const [legendOpen, setLegendOpen] = useState(false)
+  const now = useNow(isRunning)
 
   if (processingLines.length === 0) return null
   // Hide as soon as the run finishes — covers both the success case
@@ -23,14 +82,27 @@ export function ProcessingQueue() {
 
   return (
     <div className="rounded-md border border-zinc-800 bg-zinc-900/60 px-4 py-3">
-      <div className="mb-2 flex items-center justify-between">
-        <span className="text-xs font-medium text-zinc-400">
-          Looking up cards…
-        </span>
-        <span className="text-xs tabular-nums text-zinc-400">
-          {done} of {total} done
-        </span>
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <span className="text-xs font-medium text-zinc-400">Looking up cards…</span>
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => setLegendOpen((v) => !v)}
+            aria-expanded={legendOpen}
+            className="flex items-center gap-1 rounded text-xs text-zinc-400 hover:text-zinc-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+          >
+            Legend
+            <ChevronDown
+              size={12}
+              className={`transition-transform ${legendOpen ? 'rotate-180' : ''}`}
+            />
+          </button>
+          <span className="text-xs tabular-nums text-zinc-400">
+            {done} of {total} done
+          </span>
+        </div>
       </div>
+      {legendOpen && <StageLegend />}
       <ul className="grid grid-cols-1 gap-1 sm:grid-cols-2 md:grid-cols-3">
         {processingLines.map((pl, i) => (
           <LineStatus
@@ -38,6 +110,7 @@ export function ProcessingQueue() {
             line={pl}
             runStartedAt={runStartedAt}
             showTimer={settings.showTimer}
+            now={now}
           />
         ))}
       </ul>
@@ -45,23 +118,57 @@ export function ProcessingQueue() {
   )
 }
 
+/** Color key explaining what each chip color means. Collapsed by default. */
+function StageLegend() {
+  return (
+    <ul className="mb-2 flex flex-wrap gap-x-3 gap-y-1 rounded bg-zinc-900/80 px-2 py-1.5">
+      {STAGE_ORDER.map((stage) => {
+        const cfg = STAGE_CONFIG[stage]
+        return (
+          <li key={stage} className="flex items-center gap-1 text-[10px]">
+            <span
+              aria-hidden
+              className={`h-2 w-2 rounded-full bg-current ${cfg.color}`}
+            />
+            <span className="text-zinc-400">{cfg.label}</span>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+function stageIcon(line: ProcessingLine) {
+  // Before the first stage frame arrives, fall back to the generic
+  // in-flight spinner (matches the historical pending appearance).
+  if (!line.stage) {
+    return <Loader2 size={12} className="flex-shrink-0 animate-spin text-blue-400" />
+  }
+  const cfg = STAGE_CONFIG[line.stage]
+  if (!cfg.terminal) {
+    return <Loader2 size={12} className={`flex-shrink-0 animate-spin ${cfg.color}`} />
+  }
+  if (line.stage === 'resolved') {
+    return <CheckCircle2 size={12} className={`flex-shrink-0 ${cfg.color}`} />
+  }
+  if (line.stage === 'no_match') {
+    return <AlertTriangle size={12} className={`flex-shrink-0 ${cfg.color}`} />
+  }
+  return <XCircle size={12} className={`flex-shrink-0 ${cfg.color}`} />
+}
+
 function LineStatus({
   line,
   runStartedAt,
   showTimer,
+  now,
 }: {
   line: ProcessingLine
   runStartedAt: number | null
   showTimer: boolean
+  now: number
 }) {
-  const icon =
-    line.status === 'pending' ? (
-      <Loader2 size={12} className="flex-shrink-0 animate-spin text-blue-400" />
-    ) : line.status === 'resolved' ? (
-      <CheckCircle2 size={12} className="flex-shrink-0 text-green-400" />
-    ) : (
-      <AlertTriangle size={12} className="flex-shrink-0 text-amber-400" />
-    )
+  const cfg = line.stage ? STAGE_CONFIG[line.stage] : null
 
   // Per-line elapsed badge: wall-clock from the run start to the moment
   // this line transitioned out of pending. Gated by the same setting as
@@ -71,13 +178,33 @@ function LineStatus({
       ? Math.max(0, line.endedAt - runStartedAt)
       : null
 
+  // Time spent in the current stage, for the hover tooltip. Uses the
+  // line's end time once it's resolved, else the ticking wall clock.
+  const inStageMs =
+    line.stageStartedAt != null
+      ? Math.max(0, (line.endedAt ?? now) - line.stageStartedAt)
+      : null
+  const tooltip =
+    cfg != null
+      ? inStageMs != null
+        ? `${cfg.label} · ${inStageMs}ms`
+        : cfg.label
+      : undefined
+
   return (
-    <li className="flex items-center gap-1.5 text-xs text-zinc-400">
-      {icon}
+    <li
+      className="flex items-center gap-1.5 text-xs text-zinc-400"
+      title={tooltip}
+      aria-label={tooltip ? `${line.line} — ${tooltip}` : undefined}
+    >
+      {stageIcon(line)}
       <span className="truncate">{line.line}</span>
+      {cfg && (
+        <span className={`ml-auto flex-shrink-0 text-[10px] ${cfg.color}`}>{cfg.label}</span>
+      )}
       {elapsedMs != null && (
         <span
-          className="ml-auto flex-shrink-0 rounded bg-zinc-800 px-1 py-0.5 font-mono text-[10px] tabular-nums text-zinc-400"
+          className="flex-shrink-0 rounded bg-zinc-800 px-1 py-0.5 font-mono text-[10px] tabular-nums text-zinc-400"
           aria-label={`Finished in ${elapsedMs} milliseconds`}
         >
           {elapsedMs}ms

--- a/web/src/store/index.test.ts
+++ b/web/src/store/index.test.ts
@@ -44,6 +44,50 @@ describe('store: processingLines', () => {
       vi.useRealTimers()
     }
   })
+
+  it('updateLineStage records the stage and stamps stageStartedAt', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(1_700_000_000_000)
+      useAppStore.setState({
+        processingLines: [{ line: 'Charizard', status: 'pending' }],
+      })
+      useAppStore.getState().updateLineStage(0, 'looking_up')
+      const line = useAppStore.getState().processingLines[0]
+      expect(line.stage).toBe('looking_up')
+      expect(line.stageStartedAt).toBe(1_700_000_000_000)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('updateLineStage resets stageStartedAt only when the stage changes', () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(1000)
+      useAppStore.setState({
+        processingLines: [{ line: 'a', status: 'pending' }],
+      })
+      useAppStore.getState().updateLineStage(0, 'looking_up')
+      vi.setSystemTime(2000)
+      // Same stage again → timestamp must not move.
+      useAppStore.getState().updateLineStage(0, 'looking_up')
+      expect(useAppStore.getState().processingLines[0].stageStartedAt).toBe(1000)
+      // New stage → timestamp advances.
+      useAppStore.getState().updateLineStage(0, 'fallback')
+      expect(useAppStore.getState().processingLines[0].stageStartedAt).toBe(2000)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('updateLineStage ignores out-of-range indices', () => {
+    useAppStore.setState({
+      processingLines: [{ line: 'a', status: 'pending' }],
+    })
+    useAppStore.getState().updateLineStage(99, 'looking_up')
+    expect(useAppStore.getState().processingLines[0].stage).toBeUndefined()
+  })
 })
 
 describe('store: run timestamps', () => {

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -64,6 +64,12 @@ interface AppState {
   processingLines: ProcessingLine[]
   setProcessingLines: (lines: ProcessingLine[]) => void
   markLineStatus: (index: number, status: ProcessingLine['status']) => void
+  /**
+   * Record the latest pipeline stage for a line. Resets `stageStartedAt`
+   * only when the stage actually changes, so the chip tooltip measures
+   * time spent in the *current* stage rather than since the run began.
+   */
+  updateLineStage: (index: number, stage: NonNullable<ProcessingLine['stage']>) => void
 
   /** Persistent settings (survives page reload). */
   settings: Settings
@@ -153,6 +159,14 @@ export const useAppStore = create<AppState>()(
           if (!current || current.status !== 'pending') return state
           const next = state.processingLines.slice()
           next[index] = { ...current, status, endedAt: Date.now() }
+          return { processingLines: next }
+        }),
+      updateLineStage: (index, stage) =>
+        set((state) => {
+          const current = state.processingLines[index]
+          if (!current || current.stage === stage) return state
+          const next = state.processingLines.slice()
+          next[index] = { ...current, stage, stageStartedAt: Date.now() }
           return { processingLines: next }
         }),
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -55,12 +55,52 @@ export interface Row {
   reason: string
 }
 
-/** SSE event payload emitted by POST /api/v1/bulk. */
-export interface BulkEvent extends Row {
+/**
+ * One stage in the per-line lookup pipeline, surfaced by the bulk SSE
+ * stream. Mirrors `mgz_pkmn.lookup.LOOKUP_STAGES`. The first five are
+ * intermediate (the line is still in flight); the last three are terminal.
+ * `image` is part of the shared vocabulary (the CLI downloads thumbnails)
+ * but the web app runs image-free, so it never arrives over the wire here.
+ */
+export type Stage =
+  | 'parsed'
+  | 'url_hint'
+  | 'looking_up'
+  | 'fallback'
+  | 'pricing'
+  | 'image'
+  | 'resolved'
+  | 'no_match'
+  | 'error'
+
+/**
+ * A progress-only SSE frame: the line moved to a new stage but hasn't
+ * resolved yet. Distinguished from a row event by the absence of `query` /
+ * `matched`.
+ */
+export interface StageEvent {
   index: number
   total: number
-  done?: boolean
+  stage: Stage
 }
+
+/** A resolved-row SSE frame — a full {@link Row} plus its terminal stage. */
+export interface RowEvent extends Row {
+  index: number
+  total: number
+  stage: Stage
+  done?: false
+}
+
+/** The single terminating SSE frame emitted once all lines are done. */
+export interface DoneEvent {
+  index?: undefined
+  total: number
+  done: true
+}
+
+/** Any frame emitted by POST /api/v1/bulk. */
+export type BulkEvent = StageEvent | RowEvent | DoneEvent
 
 /** Sort modes accepted by the API (must mirror mgz_pkmn.sorting.SORT_MODES). */
 export type SortMode =
@@ -90,11 +130,23 @@ export interface ProcessingLine {
   line: string
   status: 'pending' | 'resolved' | 'error'
   /**
+   * The most recent pipeline stage reported for this line. Drives the
+   * color-coded chip. `undefined` until the first stage frame arrives
+   * (briefly, before the `parsed` frame).
+   */
+  stage?: Stage
+  /**
+   * Wall-clock ms (Date.now()) when the line entered its current
+   * `stage`. Used to render the per-stage elapsed time in the chip
+   * tooltip.
+   */
+  stageStartedAt?: number
+  /**
    * Wall-clock ms (Date.now()) when the line transitioned out of
-   * `pending` — i.e. when its first SSE event arrived. The status at
-   * that point is either `resolved` or `error`; either way the elapsed
-   * badge represents the time between the run starting and the line
-   * leaving the queue.
+   * `pending` — i.e. when its first terminal (row) event arrived. The
+   * status at that point is either `resolved` or `error`; either way the
+   * elapsed badge represents the time between the run starting and the
+   * line leaving the queue.
    */
   endedAt?: number
 }


### PR DESCRIPTION
Closes #260

## What

Each input line in the bulk-lookup progress panel now reflects the exact stage of the lookup pipeline it's in — color-coded, labelled, and updated live — instead of a single blue "pending" spinner that sits there until the line resolves.

**Backend**
- `mgz_pkmn.lookup`: an optional `on_stage` callback is threaded through `find_card` / `find_top_cards`, emitting `url_hint` / `looking_up` / `fallback` / `pricing` as control flow advances. It defaults to a no-op, so the CLI and the single-line `/lookup` endpoint are untouched. `LOOKUP_STAGES` is the single shared vocabulary.
- `api/routes/lookup.py`: `/bulk` bridges the synchronous `on_stage` callback (invoked on the threadpool worker) to the async SSE generator via an `asyncio.Queue` + sentinel, so progress-only `{stage}` frames stream **live** while the blocking lookup runs. Every resolved-row frame now also carries a terminal `stage` (`resolved` / `no_match` / `error`).

**Frontend**
- The latest stage per line is stored in Zustand (`updateLineStage`). `ProcessingQueue` renders a color-coded chip + label, a hover tooltip showing per-stage elapsed time, and a collapsible **Legend** in the panel header (collapsed by default).
- `BulkEvent` is now a discriminated union (stage-only / resolved-row / done); `App.tsx` branches on it.

**Docs**
- `docs/accessibility.md` documents every stage color (all Tailwind `*-400`, clearing WCAG 2.1 AA contrast against `bg-zinc-950`).

The `image` stage is part of the shared vocabulary (the CLI downloads thumbnails) but the web app runs image-free, so it never streams in the SPA — documented as such.

## Why

On a long list (`top:N`, `All <set>`, 50-line lists) there were long stretches where every line looked identically "pending" with no signal as to what the backend was doing. This exposes the pipeline state that already drives control flow.

## How to verify

Automated:
- `make check` (406 Python tests) and `cd web && npm run build && npx vitest run` (187 web tests) — all green.
- New backend tests cover `on_stage` emission (`tests/test_lookup.py::StageCallbackTests`), the terminal-stage mapping, and the `/bulk` SSE stream interleaving stage frames with the resolved row (`tests/test_api_routes.py`).
- New frontend tests cover the store action and the stage→chip/color/tooltip/legend mapping.

Manual (done): ran the API + web dev servers and submitted a multi-line list including `top:N` queries. Verified live in the browser — chips transition green **Resolved** / blue **Looking up** (spinning) / pending, the **Legend** toggle expands the full color key, the done-count advances, and there are no console errors.