### PR TITLE
fix(deploy): best-effort set-catalog warm so a flaky API can't fail the build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,14 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - Stats: `pkmn cache stats` surfaces a new **Concepts** line — "N names ·
   warmed <age>" when a warm pass has landed, "not warmed" otherwise.
 
+### Fixed
+
+- Deploy: a transient `pokemontcg.io` timeout during the Docker build's
+  `pkmn cache warm-sets` step no longer fails the whole deploy. The set
+  catalog fetch now retries transient timeouts with backoff (matching the
+  card-lookup path), and the build's warm step falls back to a cold cache
+  on a sustained outage instead of exiting non-zero.
+
 ## [1.1.1] - 2026-05-25
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,13 +45,20 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 # key), the warm step is skipped cleanly so the image still builds — it just
 # starts with a cold cache.
 #
+# The warm step is best-effort: `warm-sets` already retries transient
+# pokemontcg.io timeouts, but a sustained upstream outage would still exit
+# non-zero. A cold cache is an acceptable degraded state (see the no-key
+# branch below), so trap that exit with `|| echo` rather than letting a
+# flaky API fail the whole deploy.
+#
 # Sits before `COPY api/` and `COPY --from=web-builder` so layer caching
 # isn't invalidated by every api/ or web/ change — only by src/ or deps.
 ARG POKEMONTCG_IO_API_KEY=""
 ENV XDG_CACHE_HOME=/app/.cache
 RUN if [ -n "$POKEMONTCG_IO_API_KEY" ]; then \
         POKEMONTCG_IO_API_KEY="$POKEMONTCG_IO_API_KEY" \
-            uv run pkmn cache warm-sets; \
+            uv run pkmn cache warm-sets \
+            || echo "cache warm failed (pokemontcg.io unreachable?); image will start with a cold cache"; \
     else \
         echo "POKEMONTCG_IO_API_KEY not set at build time; skipping cache warm (image will start with a cold cache)"; \
     fi

--- a/src/mgz_pkmn/set_cards.py
+++ b/src/mgz_pkmn/set_cards.py
@@ -23,6 +23,7 @@ import datetime as _dt
 import re
 import shutil
 import sys
+import time
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -92,9 +93,21 @@ def fetch_all_sets(client: TCGClient) -> list[dict[str, Any]]:
     url = "https://api.pokemontcg.io/v2/sets?orderBy=releaseDate&pageSize=250"
     raw = disk_cache.read_api(url)
     if raw is None:
-        resp = client.session.get(url, timeout=30)
-        resp.raise_for_status()
-        raw = resp.json().get("data", [])
+        # pokemontcg.io is occasionally slow on the full-catalog response.
+        # Retry transient timeouts/connection errors with backoff (mirrors
+        # TCGClient._fetch_page) so a single slow response doesn't sink the
+        # caller — notably the Docker build's `cache warm-sets` step, where
+        # one hiccup would otherwise fail the whole deploy.
+        for attempt in range(4):
+            try:
+                resp = client.session.get(url, timeout=60)
+                resp.raise_for_status()
+                raw = resp.json().get("data", [])
+                break
+            except (requests.Timeout, requests.ConnectionError):
+                if attempt == 3:
+                    raise
+                time.sleep(1 + attempt)
         disk_cache.write_api(url, raw)
     return [
         {

--- a/tests/test_set_cards.py
+++ b/tests/test_set_cards.py
@@ -8,8 +8,9 @@ import tempfile
 import unittest
 from contextlib import redirect_stderr
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+import requests
 from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
 
@@ -137,6 +138,32 @@ class FetchAllSetsTests(_IsolatedCacheMixin):
         self.assertEqual(len(sets), 1)
         self.assertEqual(sets[0]["id"], "sv8")
         self.assertEqual(sets[0]["images"]["logo"], "https://images.pokemontcg.io/sv8/logo.png")
+
+    def test_retries_transient_timeout_then_succeeds(self) -> None:
+        client = MagicMock()
+        ok = MagicMock()
+        ok.json.return_value = {"data": [{"id": "sv8", "name": "Surging Sparks"}]}
+        ok.raise_for_status.return_value = None
+        client.session.get.side_effect = [
+            requests.Timeout("read timed out"),
+            requests.ConnectionError("conn reset"),
+            ok,
+        ]
+
+        with patch("mgz_pkmn.set_cards.time.sleep"):
+            sets = fetch_all_sets(client)
+
+        self.assertEqual([s["id"] for s in sets], ["sv8"])
+        self.assertEqual(client.session.get.call_count, 3)
+
+    def test_reraises_after_exhausting_retries(self) -> None:
+        client = MagicMock()
+        client.session.get.side_effect = requests.Timeout("read timed out")
+
+        with patch("mgz_pkmn.set_cards.time.sleep"), self.assertRaises(requests.Timeout):
+            fetch_all_sets(client)
+
+        self.assertEqual(client.session.get.call_count, 4)
 
 
 class WritePdfTests(unittest.TestCase):


### PR DESCRIPTION
Closes #326

## What

Makes the Docker build's `pkmn cache warm-sets` step resilient to a
transient `pokemontcg.io` outage, so a single slow API response no longer
fails the whole deploy.

- `fetch_all_sets` now retries transient timeouts / connection errors with
  backoff (mirrors `TCGClient._fetch_page`) and bumps the catalog-fetch
  timeout from 30s to 60s.
- The Dockerfile warm step traps a sustained-outage exit with `|| echo`,
  falling back to a cold cache — the same degraded state the no-API-key
  branch already accepts.

## Why

The build bakes a warm set-image cache by running `cache warm-sets`. Its
first call fetches the full set catalog with a hard 30s read timeout and
no retry; the CLI turns any `requests.RequestException` into a fatal
`ClickException`. When the API was transiently slow the deploy died with:

```
Error: set fetch failed: HTTPSConnectionPool(host='api.pokemontcg.io', port=443): Read timed out. (read timeout=30)
error: failed to solve: process "... uv run pkmn cache warm-sets ..." did not complete successfully: exit code: 1
```

A cold cache is already an acceptable state (the build documents it for the
no-key case), so a flaky upstream should degrade to it, not block the deploy.

## How to verify

- `make check` — full suite green, including two new `FetchAllSetsTests`
  cases covering retry-then-succeed and re-raise-after-exhaustion.
- Catalog fetch self-heals on a single transient timeout; a sustained
  outage during `docker build` now logs the cold-cache fallback and the
  image still builds.