### PR TITLE
feat(site): email signup + homepage reorder + compact release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ Versions follow [Semantic Versioning](https://semver.org/).
   bypassing the browser print dialog so the saved file is always the
   right shape regardless of printer driver quirks. The `@page` print
   stylesheet remains as a fallback for power users.
+- Site: **email signup section** — a new "Get the next release in your
+  inbox" section on the marketing landing page collects subscribers via
+  the [Buttondown](https://buttondown.com) public embed endpoint. Honors
+  the tropical palette in light mode and the blue/zinc palette in dark.
+  Submits inline via `fetch` with a success state ("Thanks — check your
+  inbox") when JS is enabled, falling back to Buttondown's hosted popup
+  when JS is off. No new runtime dependencies; no API key in the client.
 - API: persistence layer for run history backed by SQLite + Alembic
   (see [ADR-0013](docs/adr/0013-sqlite-persistence-for-runs-collections-wishlists.md)).
   `POST /api/v1/bulk` now writes a `runs` + `run_rows` record on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,20 @@ Versions follow [Semantic Versioning](https://semver.org/).
   stylesheet remains as a fallback for power users.
 - Site: **email signup section** — a new "Get the next release in your
   inbox" section on the marketing landing page collects subscribers via
-  the [Buttondown](https://buttondown.com) public embed endpoint. Honors
-  the tropical palette in light mode and the blue/zinc palette in dark.
-  Submits inline via `fetch` with a success state ("Thanks — check your
-  inbox") when JS is enabled, falling back to Buttondown's hosted popup
-  when JS is off. No new runtime dependencies; no API key in the client.
+  the [Buttondown](https://buttondown.com) public embed endpoint. Sits
+  right under "What you get" so visitors who've already seen the value
+  prop have an easy on-ramp. Honors the tropical palette in light mode
+  and the blue/zinc palette in dark. Submits inline via `fetch` with a
+  success state ("Thanks — check your inbox") when JS is enabled, falling
+  back to Buttondown's hosted popup when JS is off. No new runtime
+  dependencies; no API key in the client.
+- Site: **"Recently shipped" stays glanceable** — the release-notes
+  section on the landing page now caps each Added/Changed/Fixed bucket
+  to the first three bullets and clamps each bullet to two lines of
+  prose. A "+N more in the changelog →" link appears when a bucket has
+  been truncated, so the long-form notes are always one click away. Keeps
+  the section a fixed-height palate-cleanser instead of a wall of text
+  on releases that ship a dozen entries in one category.
 - API: persistence layer for run history backed by SQLite + Alembic
   (see [ADR-0013](docs/adr/0013-sqlite-persistence-for-runs-collections-wishlists.md)).
   `POST /api/v1/bulk` now writes a `runs` + `run_rows` record on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - Site: **email signup section** — a new "Get the next release in your
   inbox" section on the marketing landing page collects subscribers via
   the [Buttondown](https://buttondown.com) public embed endpoint. Sits
-  right under "What you get" so visitors who've already seen the value
-  prop have an easy on-ramp. Honors the tropical palette in light mode
+  right under "What you actually walk out with" so visitors who've already
+  seen the value prop have an easy on-ramp. Honors the tropical palette in light mode
   and the blue/zinc palette in dark. Submits inline via `fetch` with a
   success state ("Thanks — check your inbox") when JS is enabled, falling
   back to Buttondown's hosted popup when JS is off. No new runtime

--- a/site/src/components/EmailSignup.astro
+++ b/site/src/components/EmailSignup.astro
@@ -125,12 +125,13 @@ const fallbackTarget = `https://buttondown.com/${buttondownUser}`;
           // doesn't return a parseable JSON body — opaque response is fine.
           mode: "no-cors",
         });
-        // `no-cors` => response.type === "opaque" and status is always 0.
-        // We can't verify server-side success from the body, but the POST
-        // does land; surface an optimistic confirmation. Buttondown sends
-        // a confirmation email so any typo gets caught there.
+        // `no-cors` => response.type === "opaque" and status is always 0,
+        // so we can't tell a 200 from a 400 (invalid syntax that slipped
+        // past the HTML5 check, rate limit, server error, etc.) — only
+        // network-layer failures hit the catch below. Soften the copy so
+        // a silently-rejected submission isn't entirely invisible.
         setStatus(
-          "Thanks — check your inbox for a confirmation email.",
+          "Thanks — Buttondown should send a confirmation email shortly. If you don't see one in a few minutes, try again.",
           "success",
         );
         form.reset();

--- a/site/src/components/EmailSignup.astro
+++ b/site/src/components/EmailSignup.astro
@@ -1,0 +1,148 @@
+---
+// Buttondown subscriber username — change here if a different handle is used.
+// The embed endpoint is public, so this is safe to commit.
+const buttondownUser = "mgz-pkmn";
+const formAction = `https://buttondown.com/api/emails/embed-subscribe/${buttondownUser}`;
+const fallbackTarget = `https://buttondown.com/${buttondownUser}`;
+---
+
+<section
+  id="signup"
+  class="border-b border-sand-300 dark:border-zinc-900/80 px-6 py-20 sm:py-24"
+>
+  <div class="mx-auto max-w-3xl text-center">
+    <p
+      class="inline-flex items-center gap-2 rounded-full border border-sand-300 bg-sand-100 backdrop-blur px-3 py-1 text-xs font-medium text-coconut-500 dark:border-zinc-800 dark:bg-zinc-900/60 dark:text-zinc-300"
+    >
+      <span class="h-1.5 w-1.5 rounded-full bg-sun-300 dark:bg-blue-400"></span>
+      Newsletter
+    </p>
+
+    <h2
+      class="mt-6 text-3xl sm:text-4xl font-bold tracking-tight text-coconut-700 dark:text-white text-balance"
+    >
+      Get the next release in your inbox.
+    </h2>
+
+    <p
+      class="mt-4 text-lg text-coconut-500 dark:text-zinc-400 max-w-xl mx-auto text-balance"
+    >
+      Occasional, no-pressure updates when a new version ships — and
+      the odd Pokemon-TCG-meets-open-source note from
+      <a
+        href="https://matt-grant.com"
+        class="text-palm-500 hover:text-palm-400 dark:text-blue-400 dark:hover:text-blue-300 underline-offset-4 hover:underline"
+        rel="noopener noreferrer"
+        target="_blank">@mgzwarrior</a
+      >. No spam, unsubscribe anytime.
+    </p>
+
+    <form
+      id="email-signup-form"
+      action={formAction}
+      method="post"
+      target="popupwindow"
+      onsubmit={`window.open('${fallbackTarget}','popupwindow')`}
+      class="mt-8 flex flex-col sm:flex-row gap-3 max-w-md mx-auto"
+      data-buttondown-user={buttondownUser}
+    >
+      <label for="signup-email" class="sr-only">Email address</label>
+      <input
+        id="signup-email"
+        type="email"
+        name="email"
+        required
+        autocomplete="email"
+        placeholder="you@example.com"
+        class="flex-1 rounded-md border border-sand-300 bg-sand-50 px-4 py-3 text-sm text-coconut-700 placeholder:text-coconut-400 focus:outline-none focus:border-palm-400 focus:ring-2 focus:ring-palm-300/40 dark:border-zinc-800 dark:bg-zinc-900/60 dark:text-zinc-100 dark:placeholder:text-zinc-500 dark:focus:border-blue-400 dark:focus:ring-blue-500/30 transition"
+      />
+      <button
+        type="submit"
+        class="inline-flex items-center justify-center gap-2 rounded-md bg-sun-300 px-5 py-3 text-sm font-semibold text-coconut-700 shadow-md hover:bg-sun-400 dark:bg-blue-500 dark:text-white dark:shadow-lg dark:shadow-blue-500/20 dark:hover:bg-blue-400 transition disabled:opacity-60 disabled:cursor-not-allowed"
+        data-default-label="Subscribe"
+      >
+        <span data-label>Subscribe</span>
+      </button>
+    </form>
+
+    <p
+      id="email-signup-status"
+      role="status"
+      aria-live="polite"
+      class="mt-4 min-h-[1.5rem] text-sm"
+    >
+    </p>
+  </div>
+</section>
+
+<script is:inline>
+  // Progressive enhancement: when JS is available, submit the Buttondown
+  // form via fetch and surface inline success/error feedback so the visitor
+  // never leaves the page. Without JS, the form falls back to Buttondown's
+  // popup window (the `target` + `onsubmit` attributes on the <form>).
+  (function () {
+    const form = document.getElementById("email-signup-form");
+    if (!form) return;
+    const status = document.getElementById("email-signup-status");
+    const button = form.querySelector("button[type=submit]");
+    const labelEl = button && button.querySelector("[data-label]");
+    const input = form.querySelector("input[name=email]");
+
+    // Strip the no-JS fallbacks so the form posts inline.
+    form.removeAttribute("target");
+    form.removeAttribute("onsubmit");
+
+    function setStatus(text, tone) {
+      if (!status) return;
+      status.textContent = text;
+      status.dataset.tone = tone;
+      // Tone-driven color: success (palm), error (ember), neutral (coconut).
+      status.className =
+        "mt-4 min-h-[1.5rem] text-sm " +
+        (tone === "success"
+          ? "text-palm-500 dark:text-emerald-400 font-medium"
+          : tone === "error"
+            ? "text-ember-500 dark:text-rose-400 font-medium"
+            : "text-coconut-400 dark:text-zinc-400");
+    }
+
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      if (!input || !input.value) return;
+
+      button.disabled = true;
+      if (labelEl) labelEl.textContent = "Subscribing…";
+      setStatus("", "neutral");
+
+      const body = new FormData();
+      body.append("email", input.value);
+
+      try {
+        const response = await fetch(form.action, {
+          method: "POST",
+          body,
+          // Buttondown's embed endpoint sets CORS to allow this, but it
+          // doesn't return a parseable JSON body — opaque response is fine.
+          mode: "no-cors",
+        });
+        // `no-cors` => response.type === "opaque" and status is always 0.
+        // We can't verify server-side success from the body, but the POST
+        // does land; surface an optimistic confirmation. Buttondown sends
+        // a confirmation email so any typo gets caught there.
+        setStatus(
+          "Thanks — check your inbox for a confirmation email.",
+          "success",
+        );
+        form.reset();
+      } catch (err) {
+        setStatus(
+          "Couldn't submit just now. Try again, or email mattgrant33@gmail.com.",
+          "error",
+        );
+      } finally {
+        button.disabled = false;
+        if (labelEl) labelEl.textContent = button.dataset.defaultLabel;
+      }
+    });
+  })();
+</script>

--- a/site/src/components/EmailSignup.astro
+++ b/site/src/components/EmailSignup.astro
@@ -30,7 +30,7 @@ const fallbackTarget = `https://buttondown.com/${buttondownUser}`;
       Occasional, no-pressure updates when a new version ships — and
       the odd Pokemon-TCG-meets-open-source note from
       <a
-        href="https://matt-grant.com"
+        href="https://www.matt-grant.com"
         class="text-palm-500 hover:text-palm-400 dark:text-blue-400 dark:hover:text-blue-300 underline-offset-4 hover:underline"
         rel="noopener noreferrer"
         target="_blank">@mgzwarrior</a

--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -51,6 +51,13 @@ const repoUrl = "https://github.com/mgzwarrior/mgz-pkmn";
       </li>
       <li>
         <a
+          href="/#signup"
+          class="px-3 py-2 rounded-md text-palm-500 hover:text-palm-400 hover:bg-sand-100 dark:text-blue-400 dark:hover:text-blue-300 dark:hover:bg-zinc-900 transition"
+          >Subscribe</a
+        >
+      </li>
+      <li class="hidden sm:list-item">
+        <a
           href="/contribute"
           class="px-3 py-2 rounded-md text-palm-500 hover:text-palm-400 hover:bg-sand-100 dark:text-blue-400 dark:hover:text-blue-300 dark:hover:bg-zinc-900 transition"
           >Contribute</a

--- a/site/src/components/WhatsNew.astro
+++ b/site/src/components/WhatsNew.astro
@@ -8,6 +8,11 @@ const releases = await fetchReleases(3);
 const repoChangelogUrl =
   "https://github.com/mgzwarrior/mgz-pkmn/blob/main/CHANGELOG.md";
 
+// Cap bullets shown per Added/Changed/Fixed section before falling back to
+// a "+N more in the changelog →" link. Keeps the landing page glanceable
+// when a single release ships a dozen entries in one category.
+const ENTRIES_PER_SECTION = 3;
+
 // Friendly date: "2026-05-25" → "May 25, 2026". Falls back to the raw
 // string if it doesn't parse.
 function formatDate(iso: string | null): string {
@@ -73,29 +78,50 @@ const sectionAccent: Record<string, string> = {
               </div>
 
               <div class="mt-4 space-y-5">
-                {release.sections.map((section) => (
-                  <div>
-                    <span
-                      class={`inline-block rounded-full border px-2.5 py-0.5 text-xs font-medium ${
-                        sectionAccent[section.name] ??
-                        "text-coconut-400 border-sand-300 dark:text-zinc-400 dark:border-zinc-700"
-                      }`}
-                    >
-                      {section.name}
-                    </span>
-                    <ul class="mt-3 space-y-2">
-                      {section.entries.map((entry) => (
-                        <li class="flex gap-2.5 text-sm leading-relaxed text-coconut-500 dark:text-zinc-300">
-                          <span
-                            aria-hidden="true"
-                            class="mt-2 h-1 w-1 shrink-0 rounded-full bg-sand-400 dark:bg-zinc-600"
-                          />
-                          <span set:html={renderInlineMarkdown(entry)} />
-                        </li>
-                      ))}
-                    </ul>
-                  </div>
-                ))}
+                {release.sections.map((section) => {
+                  // Keep "Recently shipped" readable at a glance: show only the
+                  // first few bullets per section, with each clamped to 2 lines
+                  // of prose. Long-form release notes live in the full
+                  // CHANGELOG, linked from the section header.
+                  const visible = section.entries.slice(0, ENTRIES_PER_SECTION);
+                  const overflow = section.entries.length - visible.length;
+                  return (
+                    <div>
+                      <span
+                        class={`inline-block rounded-full border px-2.5 py-0.5 text-xs font-medium ${
+                          sectionAccent[section.name] ??
+                          "text-coconut-400 border-sand-300 dark:text-zinc-400 dark:border-zinc-700"
+                        }`}
+                      >
+                        {section.name}
+                      </span>
+                      <ul class="mt-3 space-y-2">
+                        {visible.map((entry) => (
+                          <li class="flex gap-2.5 text-sm leading-relaxed text-coconut-500 dark:text-zinc-300">
+                            <span
+                              aria-hidden="true"
+                              class="mt-2 h-1 w-1 shrink-0 rounded-full bg-sand-400 dark:bg-zinc-600"
+                            />
+                            <span
+                              class="line-clamp-2"
+                              set:html={renderInlineMarkdown(entry)}
+                            />
+                          </li>
+                        ))}
+                      </ul>
+                      {overflow > 0 && (
+                        <a
+                          href={repoChangelogUrl}
+                          class="mt-2 inline-block text-xs font-medium text-coconut-400 hover:text-palm-500 dark:text-zinc-500 dark:hover:text-blue-400 transition"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          +{overflow} more in the changelog →
+                        </a>
+                      )}
+                    </div>
+                  );
+                })}
               </div>
             </li>
           ))}

--- a/site/src/components/WhatsNew.astro
+++ b/site/src/components/WhatsNew.astro
@@ -8,8 +8,9 @@ const releases = await fetchReleases(3);
 const repoChangelogUrl =
   "https://github.com/mgzwarrior/mgz-pkmn/blob/main/CHANGELOG.md";
 
-// Cap bullets shown per Added/Changed/Fixed section before falling back to
-// a "+N more in the changelog →" link. Keeps the landing page glanceable
+// Cap bullets shown per section (every accent-mapped bucket — Added,
+// Changed, Fixed, Removed, Deprecated, Security) before falling back to a
+// "+N more in the changelog →" link. Keeps the landing page glanceable
 // when a single release ships a dozen entries in one category.
 const ENTRIES_PER_SECTION = 3;
 

--- a/site/src/lib/changelog.ts
+++ b/site/src/lib/changelog.ts
@@ -86,9 +86,12 @@ export async function fetchLatestVersion(): Promise<string | null> {
 
 /**
  * Render a CHANGELOG bullet's inline Markdown to safe HTML: `[text](url)`
- * links and `` `code` `` spans, with everything else HTML-escaped. Kept
- * deliberately minimal — the bullets only ever use those two constructs,
- * and a full Markdown dependency would be overkill for a few inline spans.
+ * links, `` `code` `` spans, and `**bold**` emphasis, with everything else
+ * HTML-escaped. Kept deliberately minimal — the bullets only ever use those
+ * three constructs, and a full Markdown dependency would be overkill for a
+ * few inline spans. Matches the web app's renderer (web/src/utils/
+ * inlineMarkdown.tsx) so the same bullet renders the same way on both
+ * surfaces.
  */
 export function renderInlineMarkdown(text: string): string {
   const escape = (s: string): string =>
@@ -98,9 +101,12 @@ export function renderInlineMarkdown(text: string): string {
       .replace(/>/g, "&gt;")
       .replace(/"/g, "&quot;");
 
-  // Tokenize on links and code spans, escaping the gaps between matches so
-  // raw user text can never inject markup.
-  const pattern = /\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)|`([^`]+)`/g;
+  // Tokenize on links, code spans, and bold runs, escaping the gaps between
+  // matches so raw user text can never inject markup. Alternation order
+  // matters: code spans before bold so a `**` inside backticks isn't
+  // re-tokenized as emphasis.
+  const pattern =
+    /\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)|`([^`]+)`|\*\*([^*]+)\*\*/g;
   let html = "";
   let lastIndex = 0;
   let match: RegExpExecArray | null;
@@ -112,6 +118,9 @@ export function renderInlineMarkdown(text: string): string {
     } else if (match[3] !== undefined) {
       // Code span: `code`.
       html += `<code class="rounded bg-zinc-800 px-1 py-0.5 text-[0.85em] text-zinc-200">${escape(match[3])}</code>`;
+    } else if (match[4] !== undefined) {
+      // Bold: **emphasis**.
+      html += `<strong class="font-semibold text-coconut-700 dark:text-zinc-100">${escape(match[4])}</strong>`;
     }
     lastIndex = pattern.lastIndex;
   }

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -18,9 +18,9 @@ import Footer from "../components/Footer.astro";
     <Hero />
     <FeaturesGrid />
     <OutputGallery />
+    <EmailSignup />
     <HowItWorks />
     <WhatsNew />
-    <EmailSignup />
     <BuiltInTheOpen />
     <RoadmapTeaser />
   </main>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -6,6 +6,7 @@ import FeaturesGrid from "../components/FeaturesGrid.astro";
 import OutputGallery from "../components/OutputGallery.astro";
 import HowItWorks from "../components/HowItWorks.astro";
 import WhatsNew from "../components/WhatsNew.astro";
+import EmailSignup from "../components/EmailSignup.astro";
 import BuiltInTheOpen from "../components/BuiltInTheOpen.astro";
 import RoadmapTeaser from "../components/RoadmapTeaser.astro";
 import Footer from "../components/Footer.astro";
@@ -19,6 +20,7 @@ import Footer from "../components/Footer.astro";
     <OutputGallery />
     <HowItWorks />
     <WhatsNew />
+    <EmailSignup />
     <BuiltInTheOpen />
     <RoadmapTeaser />
   </main>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -17,12 +17,12 @@ import Footer from "../components/Footer.astro";
   <main>
     <Hero />
     <FeaturesGrid />
+    <HowItWorks />
     <OutputGallery />
     <EmailSignup />
-    <HowItWorks />
-    <WhatsNew />
     <BuiltInTheOpen />
     <RoadmapTeaser />
+    <WhatsNew />
   </main>
   <Footer />
 </BaseLayout>


### PR DESCRIPTION
Closes #329

## What

Several landing-page changes shipped together since they all touch the homepage flow:

### 1. New email signup section (the original ask in #329)

- New `EmailSignup.astro` component that posts to Buttondown's public embed endpoint (`https://buttondown.com/api/emails/embed-subscribe/mgz-pkmn`). No API key in the client.
- Progressive enhancement: with JS, submits inline via `fetch` and shows a success message in-place. Without JS, falls back to Buttondown's hosted popup window via `target` + `onsubmit` on `<form>`.
- Honors the tropical palette (sun-300 CTA, sand-50 input, palm-400 focus ring) in light mode and the existing blue/zinc palette in dark.
- The Buttondown handle is a single top-of-file constant — easy to swap.

### 2. Homepage reorder (final order after iteration)

The value-prop chain reads start-to-finish before any supporting material:

```
Hero
Everything you need at the table        (FeaturesGrid)
Three steps from idea to show floor     (HowItWorks)
What you actually walk out with         (OutputGallery)
Get the next release in your inbox      (EmailSignup)
──
Built in the open                       (BuiltInTheOpen)
Where it's going                        (RoadmapTeaser)
Recently shipped                        (WhatsNew)
```

`EmailSignup` sits right after the deliverable gallery — visitors who've already seen the actual outputs hit the on-ramp before the contributor pitch. `WhatsNew` drops to the very end as reference material rather than mid-page noise (the compacted bullets keep it glanceable down there).

### 3. Compact "Recently shipped"

`WhatsNew` was growing into a wall of text on releases that ship a dozen entries in one bucket. Now:

- Each section (Added / Changed / Fixed / Removed / Deprecated / Security — every accent-mapped bucket) caps at the first 3 bullets
- Each bullet is line-clamped to 2 lines of prose
- A "+N more in the changelog →" link appears when a bucket is truncated, so long-form notes are still one click away

### 4. Nav: Subscribe link added; mobile cleanup

Header nav gets a Subscribe → `/#signup` anchor with the same palm/blue CTA accent as Contribute. Contribute now hides on mobile alongside How it works / Roadmap so the small-screen bar stays at logo · Features · Subscribe · GitHub · Theme.

### 5. www. fix on the signature link

`matt-grant.com` apex doesn't resolve; updated the `@mgzwarrior` link's `href` to `https://www.matt-grant.com`.

## Why

We didn't have a way to nurture interest from people who land on the site but aren't ready to install a CLI. An email list lets us push v1.2 / v2.0 announcements and pairs with the show flyer (#328 / #331) that directs in-person visitors to the demo URL where the form lives. The reorder + truncation + nav addition came up while iterating: placing signup higher catches engaged readers earlier, capping the changelog keeps it a palate cleanser, and the nav anchor makes the on-ramp reachable from any scroll position.

## How to verify

1. `make dev-site` → `/`
2. Scroll the homepage in section order — flow reads Hero → Features → How → Outputs → Subscribe → Built in the open → Roadmap → Recently shipped
3. Fill an email + Subscribe — input clears and a palm-green success line appears in-place, no popup
4. Disable JS in DevTools, reload, submit — Buttondown's hosted popup opens (no JS-only failure)
5. "Recently shipped" — each bucket shows at most 3 bullets, each bullet is at most 2 lines tall, with "+N more in the changelog →" where truncated; literal `**bold**` no longer leaks since `renderInlineMarkdown` now tokenizes emphasis
6. Header — Subscribe link routes to `#signup`, scrolls into view
7. `make build-site` clean

## Notes

- The Buttondown handle `mgz-pkmn` needs to be registered/reserved before this merges. Email `mattgrant33@gmail.com` for credentials if you don't have them yet.
- `fetch` runs in `no-cors` mode so we can't verify server-side success from the response body. Copy was softened to "If you don't see one in a few minutes, try again" so a silently rejected submission isn't entirely invisible.