### PR TITLE
fix(site): use www.matt-grant.com on the flyer contact line

### DIFF
--- a/site/src/pages/flyer.astro
+++ b/site/src/pages/flyer.astro
@@ -400,7 +400,7 @@
           <img class="mark" src="/favicon-tropical.svg" alt="" aria-hidden="true" />
           <div class="lines">
             <span class="name">Matt Grant</span>
-            <a href="https://matt-grant.com">matt-grant.com</a> ·
+            <a href="https://www.matt-grant.com">www.matt-grant.com</a> ·
             <a href="https://github.com/mgzwarrior">@mgzwarrior</a><br />
             <a href="mailto:mattgrant33@gmail.com">mattgrant33@gmail.com</a>
           </div>


### PR DESCRIPTION
Closes #334

## What

One-line fix: `site/src/pages/flyer.astro` now points the contact link at `https://www.matt-grant.com` instead of the apex.

## Why

The personal site only serves on the `www` subdomain — the apex 404s. Visitors who scan the QR or hand-type the URL from the printed flyer were landing on a dead page from the contact line. Reported by the maintainer after the original flyer went out.

## How to verify

- `make dev-site` → `/flyer`, click the contact link — resolves to the personal site
- Visible label also flips to `www.matt-grant.com` so the printed version matches the working URL