### PR TITLE
feat(marketing): v1 interest survey + announcement banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
   dismissible top banner on the marketing site (above the Header) and
   the demo SPA (above the existing top bar) points visitors at a short
   Tally-hosted survey. ~6 questions covering pain points, useful
-  features, return triggers, audience self-ID, favorite Pokemon, and
+  features, return triggers, audience self-ID, favorite Pokémon, and
   optional contact email. Source of truth for the question list lives
   at `docs/marketing/surveys/v1-interest-survey.md`; bump the survey
   URL and the `survey-v1` dismissal-key suffix in both banner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- Marketing: **v1 interest survey + announcement banner** — a slim
+  dismissible top banner on the marketing site (above the Header) and
+  the demo SPA (above the existing top bar) points visitors at a short
+  Tally-hosted survey. ~6 questions covering pain points, useful
+  features, return triggers, audience self-ID, favorite Pokemon, and
+  optional contact email. Source of truth for the question list lives
+  at `docs/marketing/surveys/v1-interest-survey.md`; bump the survey
+  URL and the `survey-v1` dismissal-key suffix in both banner
+  components together when shipping a future survey.
 - Site: **print-ready show flyer** — new `/flyer` page on the marketing
   site renders a double-sided quarter-letter (4.25 × 5.5 in) handout for
   in-person card shows. Front: logo, tagline, and a high error-correction

--- a/docs/marketing/surveys/v1-interest-survey.md
+++ b/docs/marketing/surveys/v1-interest-survey.md
@@ -2,7 +2,7 @@
 sequence: 1
 when: v1.x — top-banner CTA on the marketing site & demo SPA
 host: Tally (https://tally.so)
-form_url: https://tally.so/r/REPLACE_ME
+form_url: https://tally.so/r/gDvZOM
 length: ~2 minutes / 6 questions
 audience: anyone hitting mgz-pkmn.com or the live demo
 ---

--- a/docs/marketing/surveys/v1-interest-survey.md
+++ b/docs/marketing/surveys/v1-interest-survey.md
@@ -58,7 +58,7 @@ list without logging into a third-party tool.
   - Open-source contributor
   - Just curious
 
-### 5. Favorite Pokemon? (just for fun — feel free to skip)
+### 5. Favorite Pokémon? (just for fun — feel free to skip)
 
 - **Type:** short text
 - **Required:** no

--- a/docs/marketing/surveys/v1-interest-survey.md
+++ b/docs/marketing/surveys/v1-interest-survey.md
@@ -1,0 +1,86 @@
+---
+sequence: 1
+when: v1.x — top-banner CTA on the marketing site & demo SPA
+host: Tally (https://tally.so)
+form_url: https://tally.so/r/REPLACE_ME
+length: ~2 minutes / 6 questions
+audience: anyone hitting mgz-pkmn.com or the live demo
+---
+
+# v1 Interest Survey
+
+The first signal-gathering pass. Anonymous by default; respondents can
+opt into a contact email if they want a reply. Source of truth for the
+questions — paste these into Tally when creating/updating the form, and
+keep this file in lockstep so future maintainers can read the canonical
+list without logging into a third-party tool.
+
+## Intro copy (Tally welcome screen)
+
+> Quick favor: a 2-minute survey to help shape what mgz-pkmn ships
+> next. No wrong answers, all questions optional, fully anonymous unless
+> you choose to drop an email at the end. Thanks for trying the tool.
+
+## Questions
+
+### 1. What's the single biggest pain point in your card-show prep today?
+
+- **Type:** long text
+- **Required:** no
+
+### 2. Which mgz-pkmn features have been most useful so far?
+
+- **Type:** multi-select (checkboxes)
+- **Required:** no
+- **Options:**
+  - Want-list lookup (CLI / web)
+  - Printable PDF binder
+  - Set-completion checklist
+  - Xlsx export
+  - Browse-by-set modal
+  - Recently shipped / changelog
+  - Haven't actually used it yet
+  - Other (free text)
+
+### 3. What's the one thing that would make you come back and use this tool again next show?
+
+- **Type:** long text
+- **Required:** no
+
+### 4. Which describes you best?
+
+- **Type:** single-select (radio)
+- **Required:** no
+- **Options:**
+  - Hobbyist collector — show up with want-lists
+  - Vendor / reseller — work booths
+  - LGS owner / staff
+  - Open-source contributor
+  - Just curious
+
+### 5. Favorite Pokemon? (just for fun — feel free to skip)
+
+- **Type:** short text
+- **Required:** no
+
+### 6. Optional: email if you'd like a reply
+
+- **Type:** email
+- **Required:** no
+- **Help text:** Won't be added to the newsletter unless you ask.
+
+## Outro copy (Tally thank-you screen)
+
+> Thanks — every answer here directly shapes the v1.2 / v2.0 roadmap.
+> If you want occasional release-shipped emails, the newsletter signup
+> on the site is the better fit.
+
+## Operational notes
+
+- Tally renders one question per screen by default. Keep it that way —
+  long-form layouts have lower completion rates for first-time visitors.
+- When the form URL changes (e.g. for a v2 survey), bump the constant
+  in `site/src/components/AnnouncementBanner.astro` and
+  `web/src/components/AnnouncementBanner.tsx` together, and change the
+  localStorage dismissal key suffix from `survey-v1` to `survey-v2` so
+  prior dismissers see the new banner.

--- a/site/src/components/AnnouncementBanner.astro
+++ b/site/src/components/AnnouncementBanner.astro
@@ -6,7 +6,7 @@
 //
 // Source of truth for the questions: docs/marketing/surveys/v1-interest-survey.md
 // Update both this URL and the localStorage key suffix when shipping a new survey.
-const SURVEY_URL = "https://tally.so/r/REPLACE_ME";
+const SURVEY_URL = "https://tally.so/r/gDvZOM";
 const DISMISS_KEY = "mgz-pkmn-announce-survey-v1";
 ---
 

--- a/site/src/components/AnnouncementBanner.astro
+++ b/site/src/components/AnnouncementBanner.astro
@@ -10,6 +10,33 @@ const SURVEY_URL = "https://tally.so/r/gDvZOM";
 const DISMISS_KEY = "mgz-pkmn-announce-survey-v1";
 ---
 
+<noscript>
+  <!-- JS-disabled fallback: render the banner unconditionally so the
+       survey CTA stays reachable. No dismiss button (nothing to write
+       the dismissal to without JS); visitors can ignore it. -->
+  <div
+    class="border-b border-sun-400/40 bg-sun-300 text-coconut-700 dark:border-blue-500/40 dark:bg-blue-500/15 dark:text-blue-50"
+    role="region"
+    aria-label="Site announcement"
+  >
+    <div class="mx-auto flex max-w-6xl items-center gap-3 px-6 py-2 text-sm">
+      <span aria-hidden="true" class="text-base">📣</span>
+      <p class="flex-1 leading-snug">
+        <span class="font-semibold">We're listening.</span>
+        Help shape what mgz-pkmn ships next —
+        <a
+          href={SURVEY_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="font-semibold underline underline-offset-2 hover:no-underline"
+        >
+          take the 2-min survey →
+        </a>
+      </p>
+    </div>
+  </div>
+</noscript>
+
 <div
   id="announcement-banner"
   data-dismiss-key={DISMISS_KEY}

--- a/site/src/components/AnnouncementBanner.astro
+++ b/site/src/components/AnnouncementBanner.astro
@@ -1,0 +1,85 @@
+---
+// Slim, dismissible top banner pointing at the v1 interest survey on
+// Tally. Render above the Header in BaseLayout so it appears on every
+// page that uses the layout (the print-only /flyer page bypasses the
+// layout intentionally).
+//
+// Source of truth for the questions: docs/marketing/surveys/v1-interest-survey.md
+// Update both this URL and the localStorage key suffix when shipping a new survey.
+const SURVEY_URL = "https://tally.so/r/REPLACE_ME";
+const DISMISS_KEY = "mgz-pkmn-announce-survey-v1";
+---
+
+<div
+  id="announcement-banner"
+  data-dismiss-key={DISMISS_KEY}
+  class="hidden border-b border-sun-400/40 bg-sun-300 text-coconut-700 dark:border-blue-500/40 dark:bg-blue-500/15 dark:text-blue-50"
+  role="region"
+  aria-label="Site announcement"
+>
+  <div class="mx-auto flex max-w-6xl items-center gap-3 px-6 py-2 text-sm">
+    <span aria-hidden="true" class="text-base">📣</span>
+    <p class="flex-1 leading-snug">
+      <span class="font-semibold">We're listening.</span>
+      Help shape what mgz-pkmn ships next —
+      <a
+        href={SURVEY_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="font-semibold underline underline-offset-2 hover:no-underline"
+      >
+        take the 2-min survey →
+      </a>
+    </p>
+    <button
+      type="button"
+      id="announcement-dismiss"
+      class="rounded-md p-1 text-coconut-500 hover:bg-sun-400/40 hover:text-coconut-700 dark:text-blue-100 dark:hover:bg-blue-500/30 dark:hover:text-white transition"
+      aria-label="Dismiss announcement"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M18 6 6 18" /><path d="m6 6 12 12" />
+      </svg>
+    </button>
+  </div>
+</div>
+
+<script is:inline>
+  // Inline + pre-paint: read the dismiss flag and either show or hide
+  // the banner before the page renders, so there's no flash of an
+  // already-dismissed banner on reload.
+  (function () {
+    var el = document.getElementById("announcement-banner");
+    if (!el) return;
+    var key = el.dataset.dismissKey;
+    try {
+      if (key && localStorage.getItem(key) === "1") return;
+    } catch (e) {
+      // Storage unavailable (private mode, blocked) — fall through and show.
+    }
+    el.classList.remove("hidden");
+
+    var btn = document.getElementById("announcement-dismiss");
+    if (!btn) return;
+    btn.addEventListener("click", function () {
+      el.classList.add("hidden");
+      try {
+        if (key) localStorage.setItem(key, "1");
+      } catch (e) {
+        // Best-effort — the banner is dismissed for this session even if
+        // the choice can't be persisted.
+      }
+    });
+  })();
+</script>

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -1,5 +1,6 @@
 ---
 import "../styles/global.css";
+import AnnouncementBanner from "../components/AnnouncementBanner.astro";
 
 interface Props {
   title?: string;
@@ -55,6 +56,7 @@ const ogImage = new URL("/social-preview-tropical.png", Astro.site).toString();
     <meta name="twitter:image" content={ogImage} />
   </head>
   <body class="bg-sand-50 text-coconut-700 dark:bg-zinc-950 dark:text-zinc-100">
+    <AnnouncementBanner />
     <slot />
   </body>
 </html>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,6 +14,7 @@
 import { useCallback, useRef, useState } from 'react'
 import { Library } from 'lucide-react'
 import { bulkLookup, lookupLine } from './api/client'
+import { AnnouncementBanner } from './components/AnnouncementBanner'
 import { BrowseModal } from './components/BrowseModal'
 import { InputEditor } from './components/InputEditor'
 import { RecentRuns } from './components/RecentRuns'
@@ -184,6 +185,7 @@ function App() {
 
   return (
     <div className="min-h-screen bg-zinc-950 text-zinc-100">
+      <AnnouncementBanner />
       {/* Header */}
       <header className="sticky top-0 z-30 border-b border-zinc-800 bg-zinc-950/90 backdrop-blur">
         <h1 className="sr-only">mgz-pkmn — Pokemon card lookup</h1>

--- a/web/src/components/AnnouncementBanner.test.tsx
+++ b/web/src/components/AnnouncementBanner.test.tsx
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { AnnouncementBanner } from './AnnouncementBanner'
+
+const DISMISS_KEY = 'mgz-pkmn-announce-survey-v1'
+
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+})
+
+describe('AnnouncementBanner', () => {
+  it('renders the survey CTA when localStorage has no dismiss flag', () => {
+    render(<AnnouncementBanner />)
+    expect(screen.getByRole('region', { name: 'Site announcement' })).toBeTruthy()
+    const cta = screen.getByRole('link', { name: /take the 2-min survey/i })
+    expect(cta.getAttribute('href')).toMatch(/^https:\/\/tally\.so\//)
+    expect(cta.getAttribute('target')).toBe('_blank')
+  })
+
+  it('does not render when localStorage already carries the dismiss flag', () => {
+    localStorage.setItem(DISMISS_KEY, '1')
+    const { container } = render(<AnnouncementBanner />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('hides itself and persists the choice when the dismiss button is clicked', () => {
+    render(<AnnouncementBanner />)
+    const dismiss = screen.getByRole('button', { name: 'Dismiss announcement' })
+    fireEvent.click(dismiss)
+    expect(screen.queryByRole('region', { name: 'Site announcement' })).toBeNull()
+    expect(localStorage.getItem(DISMISS_KEY)).toBe('1')
+  })
+
+  it('stays hidden across re-renders once localStorage is set', () => {
+    const { unmount } = render(<AnnouncementBanner />)
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss announcement' }))
+    unmount()
+
+    const { container } = render(<AnnouncementBanner />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/web/src/components/AnnouncementBanner.tsx
+++ b/web/src/components/AnnouncementBanner.tsx
@@ -11,7 +11,7 @@
 import { useState } from 'react'
 import { X } from 'lucide-react'
 
-const SURVEY_URL = 'https://tally.so/r/REPLACE_ME'
+const SURVEY_URL = 'https://tally.so/r/gDvZOM'
 const DISMISS_KEY = 'mgz-pkmn-announce-survey-v1'
 
 /**

--- a/web/src/components/AnnouncementBanner.tsx
+++ b/web/src/components/AnnouncementBanner.tsx
@@ -1,0 +1,81 @@
+/**
+ * AnnouncementBanner — slim, dismissible top banner pointing at the v1
+ * interest survey on Tally. Mirrors site/src/components/
+ * AnnouncementBanner.astro on the marketing site; same survey URL, same
+ * dismissal-key suffix, separate localStorage origin (per-host).
+ *
+ * Source of truth for the questions: docs/marketing/surveys/v1-interest-survey.md.
+ * When shipping a new survey, bump the URL + `DISMISS_KEY` suffix in both
+ * components together so prior dismissers see the new banner.
+ */
+import { useState } from 'react'
+import { X } from 'lucide-react'
+
+const SURVEY_URL = 'https://tally.so/r/REPLACE_ME'
+const DISMISS_KEY = 'mgz-pkmn-announce-survey-v1'
+
+/**
+ * Read the dismiss flag synchronously so initial render already knows
+ * whether to show the banner — avoids both a flash of an already-
+ * dismissed banner and the eslint-flagged cascading-render pattern of
+ * setting state from an effect. Safe because this SPA is client-only;
+ * if we ever introduce SSR, gate this on `typeof window !== 'undefined'`.
+ */
+function readInitialVisible(): boolean {
+  try {
+    return localStorage.getItem(DISMISS_KEY) !== '1'
+  } catch {
+    // Storage unavailable (private mode, blocked) — show by default.
+    return true
+  }
+}
+
+export function AnnouncementBanner() {
+  const [visible, setVisible] = useState(readInitialVisible)
+
+  const dismiss = () => {
+    setVisible(false)
+    try {
+      localStorage.setItem(DISMISS_KEY, '1')
+    } catch {
+      // Best-effort — banner is hidden for this session even if the
+      // choice can't be persisted.
+    }
+  }
+
+  if (!visible) return null
+
+  return (
+    <div
+      role="region"
+      aria-label="Site announcement"
+      className="border-b border-blue-500/40 bg-blue-500/15 text-blue-50"
+    >
+      <div className="mx-auto flex max-w-7xl items-center gap-3 px-4 py-2 text-sm">
+        <span aria-hidden="true" className="text-base">
+          📣
+        </span>
+        <p className="flex-1 leading-snug">
+          <span className="font-semibold">We&apos;re listening.</span>{' '}
+          Help shape what mgz-pkmn ships next —{' '}
+          <a
+            href={SURVEY_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-semibold underline underline-offset-2 hover:no-underline"
+          >
+            take the 2-min survey →
+          </a>
+        </p>
+        <button
+          type="button"
+          onClick={dismiss}
+          aria-label="Dismiss announcement"
+          className="rounded-md p-1 text-blue-100 transition-colors hover:bg-blue-500/30 hover:text-white"
+        >
+          <X size={16} strokeWidth={2.5} aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #336

## What

Slim dismissible top banner pointing at a short Tally-hosted interest survey, shown on both the marketing site and the demo SPA.

- `site/src/components/AnnouncementBanner.astro` — mounted in `BaseLayout.astro` so it sits above the Header on every layout page (the print-only `/flyer` deliberately bypasses the layout so it stays clean)
- `web/src/components/AnnouncementBanner.tsx` — mounted in `App.tsx` above the existing top bar
- `docs/marketing/surveys/v1-interest-survey.md` — canonical source of truth for the six questions (single biggest pain point / most useful feature / what would bring you back / audience self-ID / favorite Pokemon / optional email)

## Why

We have product-hypothesis questions (what's the next feature?) and no signal beyond GitHub stars. A short, anonymous survey at the top of every visit is the cheapest way to start collecting that signal — and pairs naturally with the email signup (#329) for follow-up.

## How to verify

1. `make dev-site` → `/` — sun-yellow banner above the header, link goes to the Tally URL, X dismisses, choice persists across reload via localStorage
2. Reload after dismissing — no flash of the banner (Astro variant uses an inline pre-paint script; React variant uses a useState lazy initializer)
3. `make dev-web` → `/` — same banner in blue, same dismissal behavior, separate per-origin storage
4. `make build-site` + `make build-web` clean; ESLint + TypeScript pass

## Notes

~~- Survey URL is currently `https://tally.so/r/REPLACE_ME` — drop in the real Tally form URL before merging. The questions/intro/outro copy lives in the markdown file; paste them into Tally to keep the two in sync.~~
- When shipping a v2 survey later, bump both `SURVEY_URL` and the `survey-v1` dismissal-key suffix in both banner components together so prior dismissers see the new banner.