### PR TITLE
feat(web): tropical palette + light/dark theme toggle for the SPA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Web: **Tropical palette across the SPA + theme toggle** — the React
+  demo SPA now ships the same husk/sand/sun/palm/coconut design
+  system the marketing site uses, with a header **Light/dark toggle**
+  that mirrors the site's behavior (persists in `localStorage`,
+  follows OS `prefers-color-scheme` on first visit, no flash thanks
+  to a pre-paint script in `index.html`). Light is the default to
+  match the marketing site. Every component moves onto paired
+  light/dark tokens — including the easter-egg modal, announcement
+  banner, processing-queue stage chips, modals/drawers, results
+  table, and over-cap / error / success accents (sun / ember / palm).
+  Brand chrome uses the same tropical logo (`sand-50` wordmark) in
+  dark mode. SPA functionality is unchanged.
+- Web: **Per-stage colors moved to the design system** — the bulk
+  lookup progress chips and the `Loader2` spinner now use paired
+  light/dark tokens (`sky-500/sky-300` for `looking_up`,
+  `palm-600/palm-200` for `resolved`, `sun-600/sun-300` for `no_match`,
+  `ember-500/ember-300` for `error`, etc.) instead of single
+  Tailwind `*-400` stock colors. Each pairing clears WCAG 2.1 AA
+  contrast (≥ 4.5:1) against both surfaces; the legend layout is
+  unchanged. See [`docs/accessibility.md`](docs/accessibility.md).
 - Site: **Dark mode now on the tropical palette** — the Astro marketing
   site's dark theme no longer leans on the leftover zinc/blue Tailwind
   stock palette. Surfaces use the husk coffee-charcoal tokens, body text

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -68,25 +68,27 @@ While a bulk lookup runs, the per-line progress panel
 each line's current pipeline stage as a color-coded chip. Color is never
 the *only* signal — every chip also carries a text label and a hover
 tooltip — but the colors still clear WCAG 2.1 AA contrast (≥ 4.5:1)
-against the app background (`bg-zinc-950`, `#09090b`). All are Tailwind
-`*-400` shades:
+against both app surfaces (light `bg-sand-50`, `#FBF6E8`; dark
+`bg-husk-400`, `#15120E`). Each stage carries a paired light/dark token
+from the tropical palette:
 
-| Stage | Class | Meaning |
-|---|---|---|
-| Parsed | `text-zinc-400` | Line accepted by the parser; queued for lookup |
-| Looking up | `text-blue-400` | Querying the first source (pokemontcg.io) |
-| Fallback | `text-indigo-400` | First source missed; trying TCGdex |
-| URL hint | `text-violet-400` | URL-based scrape (PriceCharting) |
-| Pricing | `text-cyan-400` | Card resolved; building the pricing snapshot |
-| Image | `text-teal-400` | Downloading + thumbnailing the image (CLI only) |
-| Resolved | `text-green-400` | Done, matched |
-| No match | `text-amber-400` | Done, no card found |
-| Error | `text-red-400` | Hard failure (network, parse, etc.) |
+| Stage | Light | Dark | Meaning |
+|---|---|---|---|
+| Parsed | `text-coconut-400` | `text-sand-300` | Line accepted by the parser; queued for lookup |
+| Looking up | `text-sky-500` | `text-sky-300` | Querying the first source (pokemontcg.io) |
+| Fallback | `text-coconut-600` | `text-coconut-200` | First source missed; trying TCGdex |
+| URL hint | `text-sky-400` | `text-sky-400` | URL-based scrape (PriceCharting) |
+| Pricing | `text-palm-500` | `text-palm-300` | Card resolved; building the pricing snapshot |
+| Image | `text-palm-400` | `text-palm-100` | Downloading + thumbnailing the image (CLI only) |
+| Resolved | `text-palm-600` | `text-palm-200` | Done, matched |
+| No match | `text-sun-600` | `text-sun-300` | Done, no card found |
+| Error | `text-ember-500` | `text-ember-300` | Hard failure (network, parse, etc.) |
 
 The `Image` stage is part of the shared vocabulary but the web app runs
 image-free, so it never appears in the SPA. A **Legend** toggle in the
 panel header (collapsed by default) maps the colors back to their labels.
-When adding or recoloring a stage, keep it a `*-400`-or-lighter shade and
+When adding or recoloring a stage, pair a light/dark token from the same
+palette family, keep the contrast ratio ≥ 4.5:1 against both surfaces, and
 re-run the live-browser contrast scan below.
 
 ## Keyboard reference

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,25 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>web</title>
+    <title>mgz-pkmn — card lookup</title>
+    <script>
+      // Resolve the theme before first paint to avoid a flash. A saved
+      // choice wins; otherwise follow OS preference, defaulting to light
+      // so the SPA matches the marketing site's first-visit experience.
+      (function () {
+        try {
+          var stored = localStorage.getItem("theme");
+          var theme = stored
+            ? stored
+            : window.matchMedia("(prefers-color-scheme: dark)").matches
+              ? "dark"
+              : "light";
+          if (theme === "dark") {
+            document.documentElement.classList.add("dark");
+          }
+        } catch (e) {}
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -24,10 +24,12 @@ import { ProcessingQueue } from './components/ProcessingQueue'
 import { SettingsDrawer } from './components/SettingsDrawer'
 import { HelpModal } from './components/HelpModal'
 import { WhatsNewModal } from './components/WhatsNewModal'
+import { ThemeToggle } from './components/ThemeToggle'
 import { Tour } from './components/Tour'
 import { useAppStore } from './store'
 import type { BulkEvent } from './types'
-import logoUrl from './assets/logo.svg'
+import logoLightUrl from './assets/logo-tropical.svg'
+import logoDarkUrl from './assets/logo-tropical-dark.svg'
 
 function App() {
   const {
@@ -184,26 +186,27 @@ function App() {
   )
 
   return (
-    <div className="min-h-screen bg-zinc-950 text-zinc-100">
+    <div className="min-h-screen bg-sand-50 text-coconut-700 dark:bg-husk-400 dark:text-sand-50">
       <AnnouncementBanner />
       {/* Header */}
-      <header className="sticky top-0 z-30 border-b border-zinc-800 bg-zinc-950/90 backdrop-blur">
+      <header className="sticky top-0 z-30 border-b border-sand-300 bg-sand-50/80 dark:border-husk-200/80 dark:bg-husk-400/80 backdrop-blur">
         <h1 className="sr-only">mgz-pkmn — Pokemon card lookup</h1>
         <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3">
           <button
             type="button"
             onClick={handleBrandClick}
-            className="flex items-center gap-3 cursor-pointer rounded focus:outline-none focus:ring-2 focus:ring-zinc-700"
+            className="flex items-center gap-3 cursor-pointer rounded focus:outline-none focus:ring-2 focus:ring-palm-400 dark:focus:ring-sun-300"
             aria-label="mgz-pkmn"
           >
-            <img src={logoUrl} alt="mgz-pkmn" className="h-8 w-auto" />
-            <span className="text-xs text-zinc-500 hidden sm:inline">card lookup</span>
+            <img src={logoLightUrl} alt="mgz-pkmn" className="h-8 w-auto dark:hidden" />
+            <img src={logoDarkUrl} alt="" aria-hidden="true" className="hidden h-8 w-auto dark:block" />
+            <span className="text-xs text-coconut-400 dark:text-sand-400 hidden sm:inline">card lookup</span>
           </button>
           <div className="flex items-center gap-2">
             <button
               type="button"
               onClick={() => setBrowseOpen(true)}
-              className="flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-800 px-2.5 py-1.5 text-sm text-zinc-200 hover:bg-zinc-700 transition-colors sm:px-3"
+              className="flex items-center gap-1.5 rounded-md border border-sand-300 bg-sand-100 px-2.5 py-1.5 text-sm text-coconut-700 hover:bg-sand-200 hover:border-sand-400 dark:border-husk-50 dark:bg-husk-200 dark:text-sand-50 dark:hover:bg-husk-100 dark:hover:border-coconut-400 transition-colors sm:px-3"
               title="Browse sets"
               aria-label="Browse sets"
               data-tour="browse"
@@ -219,6 +222,7 @@ function App() {
             <div data-tour="settings">
               <SettingsDrawer />
             </div>
+            <ThemeToggle />
           </div>
         </div>
       </header>
@@ -226,7 +230,7 @@ function App() {
       {/* Main content */}
       <main className="mx-auto max-w-7xl px-4 py-6 space-y-6">
         <section data-tour="input">
-          <h2 className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-400">
+          <h2 className="mb-2 text-xs font-semibold uppercase tracking-wider text-coconut-400 dark:text-sand-300">
             Card list
           </h2>
           <InputEditor onRun={handleRun} onStop={handleStop} />
@@ -236,7 +240,7 @@ function App() {
         </section>
 
         <section data-tour="results">
-          <h2 className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-400">
+          <h2 className="mb-2 text-xs font-semibold uppercase tracking-wider text-coconut-400 dark:text-sand-300">
             Results
           </h2>
           <div className="flex flex-col gap-3">
@@ -255,31 +259,31 @@ function App() {
       {/* Easter egg overlay — see handleBrandClick. */}
       {showEgg && (
         <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-coconut-700/60 dark:bg-husk-500/80 backdrop-blur-sm"
           onClick={() => setShowEgg(false)}
           role="dialog"
           aria-label="easter egg"
         >
           <div
-            className="max-w-md rounded-lg border border-green-700 bg-zinc-900 p-8 text-center shadow-2xl"
+            className="max-w-md rounded-lg border border-palm-300 bg-sand-50 dark:border-palm-500 dark:bg-husk-200 p-8 text-center shadow-2xl shadow-coconut-700/30"
             onClick={(e) => e.stopPropagation()}
           >
             <div className="mb-4 text-6xl" role="img" aria-label="palm tree">
               🌴
             </div>
-            <h2 className="mb-2 text-xl font-bold text-green-400">
+            <h2 className="mb-2 text-xl font-bold text-palm-500 dark:text-palm-200">
               You found Exeggutor!
             </h2>
-            <p className="mb-4 text-sm text-zinc-400">
+            <p className="mb-4 text-sm text-coconut-500 dark:text-sand-300">
               The maintainer&apos;s all-time favorite Pokemon, here since v.0.1!
             </p>
-            <p className="mb-4 text-sm text-zinc-300">
+            <p className="mb-4 text-sm text-coconut-700 dark:text-sand-200">
               Claim code:{' '}
-              <code className="rounded bg-zinc-800 px-2 py-1 font-mono text-yellow-300">
+              <code className="rounded bg-sand-200 px-2 py-1 font-mono text-coconut-700 dark:bg-husk-100 dark:text-sun-300">
                 EGG-EXEGGCUTE
               </code>
             </p>
-            <p className="mb-6 text-xs text-zinc-500">
+            <p className="mb-6 text-xs text-sand-500 dark:text-sand-400">
               The Wall of Eggs is hidden somewhere in the repo. Find it
               to claim what you&apos;ve collected.
             </p>
@@ -288,14 +292,14 @@ function App() {
                 href="https://github.com/mgzwarrior/mgz-pkmn"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="rounded-md border border-green-700 bg-green-900/30 px-4 py-1.5 text-sm text-green-300 hover:bg-green-900/50"
+                className="rounded-md border border-palm-300 bg-palm-50 px-4 py-1.5 text-sm text-palm-600 hover:bg-palm-100 dark:border-palm-500 dark:bg-palm-500/15 dark:text-palm-200 dark:hover:bg-palm-500/25 transition-colors"
               >
                 View the repo →
               </a>
               <button
                 type="button"
                 onClick={() => setShowEgg(false)}
-                className="rounded-md border border-zinc-700 bg-zinc-800 px-4 py-1.5 text-sm text-zinc-200 hover:bg-zinc-700"
+                className="rounded-md border border-sand-300 bg-sand-100 px-4 py-1.5 text-sm text-coconut-700 hover:bg-sand-200 dark:border-husk-50 dark:bg-husk-100 dark:text-sand-50 dark:hover:bg-husk-50 transition-colors"
               >
                 Close
               </button>
@@ -304,13 +308,13 @@ function App() {
         </div>
       )}
 
-      <footer className="border-t border-zinc-800 py-4 text-center text-xs text-zinc-400">
+      <footer className="border-t border-sand-300 dark:border-husk-200 py-4 text-center text-xs text-coconut-400 dark:text-sand-400">
         mgz-pkmn · a personal card-show prep tool ·{' '}
         <a
           href="https://github.com/mgzwarrior/mgz-pkmn"
           target="_blank"
           rel="noopener noreferrer"
-          className="hover:text-zinc-200"
+          className="text-palm-500 hover:text-palm-400 dark:text-sun-300 dark:hover:text-sun-200 transition-colors"
         >
           GitHub
         </a>

--- a/web/src/assets/logo-tropical-dark.svg
+++ b/web/src/assets/logo-tropical-dark.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 88" width="360" height="88" role="img" aria-label="mgz-pkmn">
+  <title>mgz-pkmn</title>
+  <defs>
+    <linearGradient id="card-front" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#F5C94B"></stop>
+      <stop offset="1" stop-color="#E8B028"></stop>
+    </linearGradient>
+    <linearGradient id="trunk" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#80623F"></stop>
+      <stop offset="1" stop-color="#4D341F"></stop>
+    </linearGradient>
+  </defs>
+
+  <g transform="translate(8, 8)">
+    <rect x="0" y="0" width="56" height="72" rx="8" ry="8" fill="url(#card-front)" stroke="#6B4A2F" stroke-width="2"></rect>
+    <rect x="5" y="5" width="46" height="9" rx="3" ry="3" fill="#2D5A28"></rect>
+    <rect x="5" y="17" width="46" height="34" rx="4" ry="4" fill="#FBF6E8" stroke="#6B4A2F" stroke-width="1"></rect>
+
+    <g transform="translate(28, 47)">
+      <rect x="-1.5" y="-14" width="3" height="14" rx="1" fill="url(#trunk)"></rect>
+      <g fill="#4A8B3B" stroke="#2D5A28" stroke-width="0.6" stroke-linejoin="round">
+        <path d="M0,-14 C-8,-18 -12,-14 -13,-10 C-9,-12 -4,-13 0,-12 Z"></path>
+        <path d="M0,-14 C 8,-18 12,-14 13,-10 C 9,-12 4,-13 0,-12 Z"></path>
+        <path d="M0,-14 C-6,-22 -2,-26 0,-26 C 2,-26 6,-22 0,-14 Z"></path>
+        <path d="M0,-14 C-10,-15 -14,-12 -15,-9 C-13,-13 -8,-15 0,-15 Z" opacity="0.85"></path>
+        <path d="M0,-14 C 10,-15 14,-12 15,-9 C 13,-13 8,-15 0,-15 Z" opacity="0.85"></path>
+      </g>
+      <circle cx="-3" cy="-13" r="1.6" fill="#4D341F"></circle>
+      <circle cx="3" cy="-13" r="1.6" fill="#4D341F"></circle>
+    </g>
+
+    <rect x="7" y="56" width="32" height="3" rx="1" fill="#6B4A2F"></rect>
+    <rect x="7" y="62" width="20" height="3" rx="1" fill="#80623F"></rect>
+  </g>
+
+  <text x="80" y="54" font-family="'Bricolage Grotesque', ui-sans-serif, system-ui, sans-serif" font-size="34" font-weight="700" letter-spacing="-0.02em" fill="#FBF6E8">mgz-pkmn</text>
+</svg>

--- a/web/src/assets/logo-tropical.svg
+++ b/web/src/assets/logo-tropical.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 88" width="360" height="88" role="img" aria-label="mgz-pkmn">
+  <title>mgz-pkmn</title>
+  <defs>
+    <linearGradient id="card-front" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#F5C94B"></stop>
+      <stop offset="1" stop-color="#E8B028"></stop>
+    </linearGradient>
+    <linearGradient id="trunk" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#80623F"></stop>
+      <stop offset="1" stop-color="#4D341F"></stop>
+    </linearGradient>
+  </defs>
+
+  
+  <g transform="translate(8, 8)">
+    
+    <rect x="0" y="0" width="56" height="72" rx="8" ry="8" fill="url(#card-front)" stroke="#6B4A2F" stroke-width="2"></rect>
+    
+    <rect x="5" y="5" width="46" height="9" rx="3" ry="3" fill="#2D5A28"></rect>
+    
+    <rect x="5" y="17" width="46" height="34" rx="4" ry="4" fill="#FBF6E8" stroke="#6B4A2F" stroke-width="1"></rect>
+
+    
+    <g transform="translate(28, 47)">
+      
+      <rect x="-1.5" y="-14" width="3" height="14" rx="1" fill="url(#trunk)"></rect>
+      
+      <g fill="#4A8B3B" stroke="#2D5A28" stroke-width="0.6" stroke-linejoin="round">
+        <path d="M0,-14 C-8,-18 -12,-14 -13,-10 C-9,-12 -4,-13 0,-12 Z"></path>
+        <path d="M0,-14 C 8,-18 12,-14 13,-10 C 9,-12 4,-13 0,-12 Z"></path>
+        <path d="M0,-14 C-6,-22 -2,-26 0,-26 C 2,-26 6,-22 0,-14 Z"></path>
+        <path d="M0,-14 C-10,-15 -14,-12 -15,-9 C-13,-13 -8,-15 0,-15 Z" opacity="0.85"></path>
+        <path d="M0,-14 C 10,-15 14,-12 15,-9 C 13,-13 8,-15 0,-15 Z" opacity="0.85"></path>
+      </g>
+      
+      <circle cx="-3" cy="-13" r="1.6" fill="#4D341F"></circle>
+      <circle cx="3" cy="-13" r="1.6" fill="#4D341F"></circle>
+    </g>
+
+    
+    <rect x="7" y="56" width="32" height="3" rx="1" fill="#6B4A2F"></rect>
+    <rect x="7" y="62" width="20" height="3" rx="1" fill="#80623F"></rect>
+  </g>
+
+  
+  <text x="80" y="54" font-family="&#39;Bricolage Grotesque&#39;, ui-sans-serif, system-ui, sans-serif" font-size="34" font-weight="700" letter-spacing="-0.02em" fill="#1F1B16">mgz-pkmn</text>
+</svg>

--- a/web/src/components/AnnouncementBanner.tsx
+++ b/web/src/components/AnnouncementBanner.tsx
@@ -49,7 +49,7 @@ export function AnnouncementBanner() {
     <div
       role="region"
       aria-label="Site announcement"
-      className="border-b border-blue-500/40 bg-blue-500/15 text-blue-50"
+      className="border-b border-sun-400/40 bg-sun-300 text-coconut-700 dark:border-sun-400/40 dark:bg-sun-400/15 dark:text-sun-100"
     >
       <div className="mx-auto flex max-w-7xl items-center gap-3 px-4 py-2 text-sm">
         <span aria-hidden="true" className="text-base">
@@ -71,7 +71,7 @@ export function AnnouncementBanner() {
           type="button"
           onClick={dismiss}
           aria-label="Dismiss announcement"
-          className="rounded-md p-1 text-blue-100 transition-colors hover:bg-blue-500/30 hover:text-white"
+          className="rounded-md p-1 text-coconut-500 hover:bg-sun-400/40 hover:text-coconut-700 dark:text-sun-100 dark:hover:bg-sun-400/30 dark:hover:text-sand-50 transition-colors"
         >
           <X size={16} strokeWidth={2.5} aria-hidden="true" />
         </button>

--- a/web/src/components/BrowseModal.tsx
+++ b/web/src/components/BrowseModal.tsx
@@ -302,29 +302,29 @@ export function BrowseModal({ open, onOpenChange }: Props) {
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm" />
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-coconut-700/50 dark:bg-husk-500/70 backdrop-blur-sm" />
         <Dialog.Content
           aria-describedby="browse-description"
-          className="fixed left-1/2 top-1/2 z-50 flex max-h-[90vh] w-[min(1100px,95vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-zinc-700 bg-zinc-900 shadow-2xl"
+          className="fixed left-1/2 top-1/2 z-50 flex max-h-[90vh] w-[min(1100px,95vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-sand-300 dark:border-husk-50 bg-sand-50 dark:bg-husk-200 shadow-2xl"
         >
-          <header className="flex items-center justify-between gap-3 border-b border-zinc-800 px-5 py-4">
+          <header className="flex items-center justify-between gap-3 border-b border-sand-200 dark:border-husk-100 px-5 py-4">
             <div className="flex items-center gap-2">
               {activeSet && (
                 <button
                   type="button"
                   onClick={() => setActiveSet(null)}
                   aria-label="Back to set list"
-                  className="rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+                  className="rounded p-1 text-coconut-400 dark:text-sand-300 hover:bg-sand-200 dark:hover:bg-husk-100 hover:text-coconut-700 dark:hover:text-sand-50"
                 >
                   <ArrowLeft size={16} />
                 </button>
               )}
-              <Library size={18} className="text-zinc-300" />
-              <Dialog.Title className="text-lg font-semibold text-zinc-100">
+              <Library size={18} className="text-coconut-600 dark:text-sand-200" />
+              <Dialog.Title className="text-lg font-semibold text-coconut-700 dark:text-sand-50">
                 {activeSet ? activeSet.name : 'Browse sets'}
               </Dialog.Title>
               {activeSet && (
-                <span className="text-xs text-zinc-500">
+                <span className="text-xs text-coconut-400 dark:text-sand-400">
                   {activeSet.series}
                   {releaseYear(activeSet.releaseDate)
                     ? ` · ${releaseYear(activeSet.releaseDate)}`
@@ -335,7 +335,7 @@ export function BrowseModal({ open, onOpenChange }: Props) {
             <Dialog.Close asChild>
               <button
                 aria-label="Close"
-                className="rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+                className="rounded p-1 text-coconut-400 dark:text-sand-300 hover:bg-sand-200 dark:hover:bg-husk-100 hover:text-coconut-700 dark:hover:text-sand-50"
               >
                 <X size={18} />
               </button>
@@ -344,7 +344,7 @@ export function BrowseModal({ open, onOpenChange }: Props) {
 
           <Dialog.Description
             id="browse-description"
-            className="px-5 pt-3 text-sm text-zinc-400"
+            className="px-5 pt-3 text-sm text-coconut-400 dark:text-sand-300"
           >
             {activeSet
               ? 'Click a card to add it to your input list, or use the bulk actions below.'
@@ -410,9 +410,9 @@ function SetListView({ groups, onPick }: SetListProps) {
       <ul className="space-y-4">
         {groups.map((group) => (
           <li key={group.series}>
-            <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-300">
+            <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-coconut-600 dark:text-sand-200">
               {group.series}
-              <span className="ml-1 font-normal normal-case tracking-normal text-zinc-500">
+              <span className="ml-1 font-normal normal-case tracking-normal text-coconut-400 dark:text-sand-400">
                 ({group.sets.length})
                 </span>
               </div>
@@ -436,11 +436,11 @@ function SetTile({ set, onPick }: { set: SetInfo; onPick: () => void }) {
       <button
         type="button"
         onClick={onPick}
-        className="flex w-full items-center gap-3 rounded-md border border-zinc-800 bg-zinc-950/40 px-3 py-2 text-left hover:border-zinc-700 hover:bg-zinc-900 focus:outline-none focus:ring-2 focus:ring-zinc-700"
+        className="flex w-full items-center gap-3 rounded-md border border-sand-200 dark:border-husk-100 bg-sand-50 dark:bg-husk-400/40 px-3 py-2 text-left hover:border-sand-300 dark:hover:border-husk-50 hover:bg-sand-50 dark:hover:bg-husk-200 focus:outline-none focus:ring-2 focus:ring-sand-300 dark:ring-husk-50"
       >
-        <div className="flex h-10 w-14 flex-none items-center justify-center rounded bg-zinc-950">
+        <div className="flex h-10 w-14 flex-none items-center justify-center rounded bg-sand-50 dark:bg-husk-400">
           {logoFailed ? (
-            <ImageOff size={16} className="text-zinc-600" aria-hidden />
+            <ImageOff size={16} className="text-coconut-300 dark:text-sand-500" aria-hidden />
           ) : (
             <img
               src={setLogoUrl(set.id)}
@@ -452,10 +452,10 @@ function SetTile({ set, onPick }: { set: SetInfo; onPick: () => void }) {
           )}
         </div>
         <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-medium text-zinc-100">
+          <div className="truncate text-sm font-medium text-coconut-700 dark:text-sand-50">
             {set.name}
           </div>
-          <div className="truncate text-xs text-zinc-500">
+          <div className="truncate text-xs text-coconut-400 dark:text-sand-400">
             {year || '—'} · {set.total ? `${set.total} cards` : 'count unknown'}
           </div>
         </div>
@@ -519,11 +519,11 @@ function SetDetailView({
   return (
     <>
       {/* Toolbar */}
-      <div className="flex flex-wrap items-center gap-2 border-b border-zinc-800 px-5 py-3">
+      <div className="flex flex-wrap items-center gap-2 border-b border-sand-200 dark:border-husk-100 px-5 py-3">
         <label className="relative flex-1 min-w-[180px]">
           <Search
             size={14}
-            className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-zinc-500"
+            className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-coconut-400 dark:text-sand-400"
             aria-hidden
           />
           <input
@@ -531,7 +531,7 @@ function SetDetailView({
             placeholder="Search this set…"
             value={search}
             onChange={(e) => onSearch(e.target.value)}
-            className="w-full rounded-md border border-zinc-700 bg-zinc-950 py-1.5 pl-8 pr-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:border-zinc-500 focus:outline-none"
+            className="w-full rounded-md border border-sand-300 dark:border-husk-50 bg-sand-50 dark:bg-husk-400 py-1.5 pl-8 pr-2 text-sm text-coconut-700 dark:text-sand-50 placeholder:text-coconut-400 dark:text-sand-400 focus:border-sand-400 dark:border-coconut-400 focus:outline-none"
             aria-label="Search cards in this set"
           />
         </label>
@@ -542,12 +542,12 @@ function SetDetailView({
             </Chip>
           ))}
         </div>
-        <label className="flex items-center gap-1 text-xs text-zinc-400">
+        <label className="flex items-center gap-1 text-xs text-coconut-400 dark:text-sand-300">
           Sort
           <select
             value={sort}
             onChange={(e) => onSort(e.target.value as CardSort)}
-            className="rounded-md border border-zinc-700 bg-zinc-950 px-2 py-1 text-sm text-zinc-100 focus:border-zinc-500 focus:outline-none"
+            className="rounded-md border border-sand-300 dark:border-husk-50 bg-sand-50 dark:bg-husk-400 px-2 py-1 text-sm text-coconut-700 dark:text-sand-50 focus:border-sand-400 dark:border-coconut-400 focus:outline-none"
             aria-label="Sort cards"
           >
             {SORT_OPTIONS.map((s) => (
@@ -560,16 +560,16 @@ function SetDetailView({
       </div>
 
       {/* Bulk-action toolbar */}
-      <div className="flex flex-wrap items-center gap-2 border-b border-zinc-800 px-5 py-2 text-xs text-zinc-400">
+      <div className="flex flex-wrap items-center gap-2 border-b border-sand-200 dark:border-husk-100 px-5 py-2 text-xs text-coconut-400 dark:text-sand-300">
         <span>
           {cards.length} of {total} card{total === 1 ? '' : 's'}
         </span>
-        <span className="text-zinc-600">·</span>
+        <span className="text-coconut-300 dark:text-sand-500">·</span>
         <BulkButton onClick={onAddAll}>Add all visible</BulkButton>
         <BulkButton onClick={onAddHolos}>Add holos</BulkButton>
         <BulkButton onClick={onAddRares}>Add rares</BulkButton>
         {addedCount != null && (
-          <span className="ml-auto text-emerald-400" role="status">
+          <span className="ml-auto text-palm-500 dark:text-palm-200" role="status">
             Added {addedCount} line{addedCount === 1 ? '' : 's'} to your list
           </span>
         )}
@@ -578,18 +578,18 @@ function SetDetailView({
       {/* Grid */}
       <div className="flex-1 overflow-y-auto px-5 py-3">
         {error && (
-          <p className="rounded border border-red-900/50 bg-red-950/30 px-3 py-2 text-sm text-red-300">
+          <p className="rounded border border-ember-500/40 dark:border-ember-500/40/50 bg-ember-500/10 dark:bg-ember-500/15/30 px-3 py-2 text-sm text-ember-400 dark:text-ember-300">
             Couldn’t load cards: {error}
           </p>
         )}
         {loading && !error && (
-          <p className="flex items-center gap-2 text-sm text-zinc-400">
+          <p className="flex items-center gap-2 text-sm text-coconut-400 dark:text-sand-300">
             <Loader2 size={14} className="animate-spin" />
             Loading cards…
           </p>
         )}
         {!loading && !error && cards.length === 0 && (
-          <p className="text-sm text-zinc-500">No cards match your filters.</p>
+          <p className="text-sm text-coconut-400 dark:text-sand-400">No cards match your filters.</p>
         )}
         {!loading && !error && cards.length > 0 && (
           <ul className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
@@ -606,8 +606,8 @@ function SetDetailView({
 function CardTile({ card, onAdd }: { card: SetCard; onAdd: () => void }) {
   const [thumbFailed, setThumbFailed] = useState(false)
   return (
-    <li className="group flex flex-col rounded-md border border-zinc-800 bg-zinc-950/40 p-2 text-left hover:border-zinc-700 hover:bg-zinc-900">
-      <div className="relative aspect-[245/342] w-full overflow-hidden rounded bg-zinc-950">
+    <li className="group flex flex-col rounded-md border border-sand-200 dark:border-husk-100 bg-sand-50 dark:bg-husk-400/40 p-2 text-left hover:border-sand-300 dark:hover:border-husk-50 hover:bg-sand-50 dark:hover:bg-husk-200">
+      <div className="relative aspect-[245/342] w-full overflow-hidden rounded bg-sand-50 dark:bg-husk-400">
         {card.thumb && !thumbFailed ? (
           <img
             src={card.thumb}
@@ -617,29 +617,29 @@ function CardTile({ card, onAdd }: { card: SetCard; onAdd: () => void }) {
             onError={() => setThumbFailed(true)}
           />
         ) : (
-          <div className="flex h-full w-full items-center justify-center text-zinc-700">
+          <div className="flex h-full w-full items-center justify-center text-coconut-700 dark:text-sand-200">
             <ImageOff size={28} aria-hidden />
           </div>
         )}
       </div>
       <div className="mt-2 min-w-0 flex-1">
-        <div className="truncate text-sm font-medium text-zinc-100" title={card.name}>
+        <div className="truncate text-sm font-medium text-coconut-700 dark:text-sand-50" title={card.name}>
           {card.name}
         </div>
-        <div className="flex items-center justify-between text-xs text-zinc-500">
+        <div className="flex items-center justify-between text-xs text-coconut-400 dark:text-sand-400">
           <span>#{card.number}</span>
           {card.market != null && (
-            <span className="text-emerald-400">${card.market.toFixed(2)}</span>
+            <span className="text-palm-500 dark:text-palm-200">${card.market.toFixed(2)}</span>
           )}
         </div>
         {card.rarity && (
-          <div className="truncate text-[11px] text-zinc-500">{card.rarity}</div>
+          <div className="truncate text-[11px] text-coconut-400 dark:text-sand-400">{card.rarity}</div>
         )}
       </div>
       <button
         type="button"
         onClick={onAdd}
-        className="mt-2 flex items-center justify-center gap-1 rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-zinc-200 hover:border-emerald-700 hover:bg-emerald-900/30 hover:text-emerald-300"
+        className="mt-2 flex items-center justify-center gap-1 rounded-md border border-sand-300 dark:border-husk-50 bg-sand-200 dark:bg-husk-100 px-2 py-1 text-xs text-coconut-600 dark:text-sand-200 hover:border-palm-400 dark:hover:border-palm-500 hover:bg-palm-100 dark:hover:bg-palm-500/20/30 hover:text-palm-400 dark:hover:text-palm-100"
         aria-label={`Add ${card.name} to list`}
       >
         <Plus size={12} />
@@ -669,8 +669,8 @@ function Chip({
       aria-pressed={active}
       className={`rounded-md border px-2 py-1 text-xs transition-colors ${
         active
-          ? 'border-blue-700 bg-blue-900/40 text-blue-200'
-          : 'border-zinc-700 bg-zinc-800 text-zinc-300 hover:bg-zinc-700'
+          ? 'border-palm-400 dark:border-sun-400 bg-sun-400/15 dark:bg-sun-400/15/40 text-palm-700 dark:text-sun-100'
+          : 'border-sand-300 dark:border-husk-50 bg-sand-200 dark:bg-husk-100 text-coconut-600 dark:text-sand-200 hover:bg-sand-200 dark:hover:bg-husk-100'
       }`}
     >
       {children}
@@ -689,7 +689,7 @@ function BulkButton({
     <button
       type="button"
       onClick={onClick}
-      className="rounded-md border border-zinc-700 bg-zinc-800 px-2 py-1 text-xs text-zinc-200 hover:bg-zinc-700"
+      className="rounded-md border border-sand-300 dark:border-husk-50 bg-sand-200 dark:bg-husk-100 px-2 py-1 text-xs text-coconut-600 dark:text-sand-200 hover:bg-sand-200 dark:hover:bg-husk-100"
     >
       {children}
     </button>

--- a/web/src/components/BrowseModal.tsx
+++ b/web/src/components/BrowseModal.tsx
@@ -531,7 +531,7 @@ function SetDetailView({
             placeholder="Search this set…"
             value={search}
             onChange={(e) => onSearch(e.target.value)}
-            className="w-full rounded-md border border-sand-300 dark:border-husk-50 bg-sand-50 dark:bg-husk-400 py-1.5 pl-8 pr-2 text-sm text-coconut-700 dark:text-sand-50 placeholder:text-coconut-400 dark:text-sand-400 focus:border-sand-400 dark:border-coconut-400 focus:outline-none"
+            className="w-full rounded-md border border-sand-300 dark:border-husk-50 bg-sand-50 dark:bg-husk-400 py-1.5 pl-8 pr-2 text-sm text-coconut-700 dark:text-sand-50 placeholder:text-coconut-400 dark:placeholder:text-sand-400 focus:border-sand-400 dark:focus:border-coconut-400 focus:outline-none"
             aria-label="Search cards in this set"
           />
         </label>
@@ -547,7 +547,7 @@ function SetDetailView({
           <select
             value={sort}
             onChange={(e) => onSort(e.target.value as CardSort)}
-            className="rounded-md border border-sand-300 dark:border-husk-50 bg-sand-50 dark:bg-husk-400 px-2 py-1 text-sm text-coconut-700 dark:text-sand-50 focus:border-sand-400 dark:border-coconut-400 focus:outline-none"
+            className="rounded-md border border-sand-300 dark:border-husk-50 bg-sand-50 dark:bg-husk-400 px-2 py-1 text-sm text-coconut-700 dark:text-sand-50 focus:border-sand-400 dark:focus:border-coconut-400 focus:outline-none"
             aria-label="Sort cards"
           >
             {SORT_OPTIONS.map((s) => (
@@ -578,7 +578,7 @@ function SetDetailView({
       {/* Grid */}
       <div className="flex-1 overflow-y-auto px-5 py-3">
         {error && (
-          <p className="rounded border border-ember-500/40 dark:border-ember-500/40/50 bg-ember-500/10 dark:bg-ember-500/15/30 px-3 py-2 text-sm text-ember-400 dark:text-ember-300">
+          <p className="rounded border border-ember-500/40 dark:border-ember-500/50 bg-ember-500/10 dark:bg-ember-500/30 px-3 py-2 text-sm text-ember-400 dark:text-ember-300">
             Couldn’t load cards: {error}
           </p>
         )}
@@ -639,7 +639,7 @@ function CardTile({ card, onAdd }: { card: SetCard; onAdd: () => void }) {
       <button
         type="button"
         onClick={onAdd}
-        className="mt-2 flex items-center justify-center gap-1 rounded-md border border-sand-300 dark:border-husk-50 bg-sand-200 dark:bg-husk-100 px-2 py-1 text-xs text-coconut-600 dark:text-sand-200 hover:border-palm-400 dark:hover:border-palm-500 hover:bg-palm-100 dark:hover:bg-palm-500/20/30 hover:text-palm-400 dark:hover:text-palm-100"
+        className="mt-2 flex items-center justify-center gap-1 rounded-md border border-sand-300 dark:border-husk-50 bg-sand-200 dark:bg-husk-100 px-2 py-1 text-xs text-coconut-600 dark:text-sand-200 hover:border-palm-400 dark:hover:border-palm-500 hover:bg-palm-100 dark:hover:bg-palm-500/30 hover:text-palm-400 dark:hover:text-palm-100"
         aria-label={`Add ${card.name} to list`}
       >
         <Plus size={12} />
@@ -669,7 +669,7 @@ function Chip({
       aria-pressed={active}
       className={`rounded-md border px-2 py-1 text-xs transition-colors ${
         active
-          ? 'border-palm-400 dark:border-sun-400 bg-sun-400/15 dark:bg-sun-400/15/40 text-palm-700 dark:text-sun-100'
+          ? 'border-palm-400 dark:border-sun-400 bg-sun-400/15 dark:bg-sun-400/40 text-palm-700 dark:text-sun-100'
           : 'border-sand-300 dark:border-husk-50 bg-sand-200 dark:bg-husk-100 text-coconut-600 dark:text-sand-200 hover:bg-sand-200 dark:hover:bg-husk-100'
       }`}
     >

--- a/web/src/components/CardDetailModal.tsx
+++ b/web/src/components/CardDetailModal.tsx
@@ -74,7 +74,7 @@ export function CardDetailModal({ rows, index, onChangeIndex }: Props) {
         <Dialog.Overlay className="fixed inset-0 z-40 bg-black/70 backdrop-blur-sm" />
         <Dialog.Content
           aria-describedby={undefined}
-          className="fixed left-1/2 top-1/2 z-50 flex max-h-[92vh] w-[min(960px,94vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-zinc-700 bg-zinc-900 shadow-2xl"
+          className="fixed left-1/2 top-1/2 z-50 flex max-h-[92vh] w-[min(960px,94vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-sand-300 dark:border-husk-50 bg-sand-50 dark:bg-husk-200 shadow-2xl"
         >
           {row ? (
             <CardDetailBody
@@ -131,12 +131,12 @@ function CardDetailBody({
   return (
     <>
       {/* Header */}
-      <div className="flex items-center justify-between border-b border-zinc-700 px-5 py-3">
+      <div className="flex items-center justify-between border-b border-sand-300 dark:border-husk-50 px-5 py-3">
         <div className="flex items-center gap-2">
-          <Dialog.Title className="text-base font-semibold text-zinc-100">
+          <Dialog.Title className="text-base font-semibold text-coconut-700 dark:text-sand-50">
             {(card?.name as string | undefined) ?? row.query.name}
           </Dialog.Title>
-          <span className="text-xs text-zinc-500 font-mono tabular-nums">
+          <span className="text-xs text-coconut-400 dark:text-sand-400 font-mono tabular-nums">
             {index + 1} / {total}
           </span>
         </div>
@@ -153,7 +153,7 @@ function CardDetailBody({
           </NavButton>
           <Dialog.Close asChild>
             <button
-              className="rounded p-1 text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700 transition-colors"
+              className="rounded p-1 text-coconut-400 dark:text-sand-300 hover:text-coconut-700 dark:hover:text-sand-50 hover:bg-sand-200 dark:hover:bg-husk-100 transition-colors"
               aria-label="Close"
             >
               <X size={16} />
@@ -165,7 +165,7 @@ function CardDetailBody({
       {/* Body — scrollable */}
       <div
         tabIndex={0}
-        className="flex-1 overflow-y-auto px-5 py-4 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        className="flex-1 overflow-y-auto px-5 py-4 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:ring-sun-300"
       >
         <div className="grid gap-6 md:grid-cols-[260px_1fr]">
           {/* Image column */}
@@ -174,11 +174,11 @@ function CardDetailBody({
               <img
                 src={imgUrl}
                 alt={(card?.name as string | undefined) ?? row.query.name}
-                className="rounded-md shadow-lg max-h-[420px] w-auto object-contain bg-zinc-800"
+                className="rounded-md shadow-lg max-h-[420px] w-auto object-contain bg-sand-200 dark:bg-husk-100"
                 loading="lazy"
               />
             ) : (
-              <div className="flex h-[360px] w-[260px] items-center justify-center rounded-md border border-zinc-700 bg-zinc-800 text-sm text-zinc-500">
+              <div className="flex h-[360px] w-[260px] items-center justify-center rounded-md border border-sand-300 dark:border-husk-50 bg-sand-200 dark:bg-husk-100 text-sm text-coconut-400 dark:text-sand-400">
                 No image available
               </div>
             )}
@@ -198,10 +198,10 @@ function CardDetailBody({
                 ]}
               />
               <div>
-                <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-400 mb-2">
+                <h3 className="text-xs font-semibold uppercase tracking-wider text-coconut-400 dark:text-sand-300 mb-2">
                   Pricing
                 </h3>
-                <div className="rounded-md border border-zinc-700 bg-zinc-950 p-3 space-y-1">
+                <div className="rounded-md border border-sand-300 dark:border-husk-50 bg-sand-50 dark:bg-husk-400 p-3 space-y-1">
                   <PriceLine
                     label="Market"
                     value={formatMoney(pricing.market, pricing.currency)}
@@ -226,8 +226,8 @@ function CardDetailBody({
                   />
                 </div>
                 {pricing.source && (
-                  <p className="mt-2 text-xs text-zinc-400">
-                    Source: <span className="text-zinc-300">{pricing.source}</span>
+                  <p className="mt-2 text-xs text-coconut-400 dark:text-sand-300">
+                    Source: <span className="text-coconut-600 dark:text-sand-200">{pricing.source}</span>
                   </p>
                 )}
                 {source && (
@@ -235,7 +235,7 @@ function CardDetailBody({
                     href={source.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-blue-400 hover:text-blue-300"
+                    className="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-palm-500 dark:text-sun-300 hover:text-palm-400 dark:hover:text-sun-200"
                   >
                     View on {source.label} <ExternalLink size={11} />
                   </a>
@@ -292,7 +292,7 @@ function CardMetadataBlock({ card }: { card: CardData | null }) {
 
   if (!hasAnyField) {
     return (
-      <p className="text-xs text-zinc-500">
+      <p className="text-xs text-coconut-400 dark:text-sand-400">
         No additional card data was returned by the source.
       </p>
     )
@@ -300,10 +300,10 @@ function CardMetadataBlock({ card }: { card: CardData | null }) {
 
   return (
     <div>
-      <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-400 mb-2">
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-coconut-400 dark:text-sand-300 mb-2">
         Card data
       </h3>
-      <div className="rounded-md border border-zinc-700 bg-zinc-950 p-4 space-y-3 text-sm">
+      <div className="rounded-md border border-sand-300 dark:border-husk-50 bg-sand-50 dark:bg-husk-400 p-4 space-y-3 text-sm">
         {(supertype || subtypes.length > 0) && (
           <Row label="Type">
             {[supertype, subtypes.join(' · ')].filter(Boolean).join(' — ')}
@@ -315,28 +315,28 @@ function CardMetadataBlock({ card }: { card: CardData | null }) {
 
         {attacks.length > 0 && (
           <div>
-            <div className="text-xs uppercase tracking-wider text-zinc-500 mb-1">
+            <div className="text-xs uppercase tracking-wider text-coconut-400 dark:text-sand-400 mb-1">
               Attacks
             </div>
             <ul className="space-y-2">
               {attacks.map((a, i) => (
                 <li
                   key={i}
-                  className="rounded border border-zinc-800 bg-zinc-900 p-2"
+                  className="rounded border border-sand-200 dark:border-husk-100 bg-sand-50 dark:bg-husk-200 p-2"
                 >
                   <div className="flex items-baseline justify-between gap-3">
-                    <span className="font-medium text-zinc-100">{a.name}</span>
+                    <span className="font-medium text-coconut-700 dark:text-sand-50">{a.name}</span>
                     {a.damage && (
-                      <span className="font-mono text-zinc-300">{a.damage}</span>
+                      <span className="font-mono text-coconut-600 dark:text-sand-200">{a.damage}</span>
                     )}
                   </div>
                   {a.cost && a.cost.length > 0 && (
-                    <div className="text-xs text-zinc-400 mt-0.5">
+                    <div className="text-xs text-coconut-400 dark:text-sand-300 mt-0.5">
                       Cost: {a.cost.join(' · ')}
                     </div>
                   )}
                   {a.text && (
-                    <p className="text-xs text-zinc-400 mt-1 leading-snug">
+                    <p className="text-xs text-coconut-400 dark:text-sand-300 mt-1 leading-snug">
                       {a.text}
                     </p>
                   )}
@@ -366,7 +366,7 @@ function CardMetadataBlock({ card }: { card: CardData | null }) {
         )}
         {flavorText && (
           <Row label="Flavor">
-            <span className="italic text-zinc-300">{flavorText}</span>
+            <span className="italic text-coconut-600 dark:text-sand-200">{flavorText}</span>
           </Row>
         )}
       </div>
@@ -407,7 +407,7 @@ function NavButton({
       disabled={disabled}
       aria-label={label}
       title={label}
-      className="rounded p-1 text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700 transition-colors disabled:opacity-30 disabled:hover:bg-transparent"
+      className="rounded p-1 text-coconut-400 dark:text-sand-300 hover:text-coconut-700 dark:hover:text-sand-50 hover:bg-sand-200 dark:hover:bg-husk-100 transition-colors disabled:opacity-30 disabled:hover:bg-transparent"
     >
       {children}
     </button>
@@ -417,7 +417,7 @@ function NavButton({
 function DefinitionList({ rows }: { rows: [string, string | null][] }) {
   return (
     <div>
-      <h3 className="text-xs font-semibold uppercase tracking-wider text-zinc-400 mb-2">
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-coconut-400 dark:text-sand-300 mb-2">
         Identity
       </h3>
       <dl className="space-y-1.5 text-sm">
@@ -425,8 +425,8 @@ function DefinitionList({ rows }: { rows: [string, string | null][] }) {
           .filter(([, value]) => value != null && value !== '')
           .map(([label, value]) => (
             <div key={label} className="flex gap-2">
-              <dt className="text-zinc-500 min-w-[64px]">{label}</dt>
-              <dd className="text-zinc-200">{value}</dd>
+              <dt className="text-coconut-400 dark:text-sand-400 min-w-[64px]">{label}</dt>
+              <dd className="text-coconut-600 dark:text-sand-200">{value}</dd>
             </div>
           ))}
       </dl>
@@ -437,10 +437,10 @@ function DefinitionList({ rows }: { rows: [string, string | null][] }) {
 function Row({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="flex gap-3">
-      <span className="text-xs uppercase tracking-wider text-zinc-500 min-w-[80px] mt-0.5">
+      <span className="text-xs uppercase tracking-wider text-coconut-400 dark:text-sand-400 min-w-[80px] mt-0.5">
         {label}
       </span>
-      <span className="flex-1 text-zinc-200">{children}</span>
+      <span className="flex-1 text-coconut-600 dark:text-sand-200">{children}</span>
     </div>
   )
 }
@@ -458,10 +458,10 @@ function PriceLine({
 }) {
   return (
     <div className="flex items-baseline justify-between">
-      <span className="text-xs text-zinc-400">{label}</span>
+      <span className="text-xs text-coconut-400 dark:text-sand-300">{label}</span>
       <span
         className={`font-mono tabular-nums ${bold ? 'font-bold text-base' : 'text-sm'} ${
-          highlight ? 'text-green-400' : 'text-zinc-200'
+          highlight ? 'text-palm-500 dark:text-palm-200' : 'text-coconut-600 dark:text-sand-200'
         }`}
       >
         {value}

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -37,24 +37,24 @@ export class ErrorBoundary extends Component<Props, State> {
       return (
         <div
           role="alert"
-          className="min-h-screen flex items-center justify-center bg-zinc-950 px-4 text-zinc-100"
+          className="min-h-screen flex items-center justify-center bg-sand-50 dark:bg-husk-400 px-4 text-coconut-700 dark:text-sand-50"
         >
-          <div className="max-w-lg w-full rounded-lg border border-red-800 bg-zinc-900 p-6 shadow-2xl">
-            <h1 className="mb-2 text-lg font-semibold text-red-400">
+          <div className="max-w-lg w-full rounded-lg border border-ember-500/30 dark:border-ember-500/30 bg-sand-50 dark:bg-husk-200 p-6 shadow-2xl">
+            <h1 className="mb-2 text-lg font-semibold text-ember-500 dark:text-ember-300">
               Something went wrong.
             </h1>
-            <p className="mb-4 text-sm text-zinc-300">
+            <p className="mb-4 text-sm text-coconut-600 dark:text-sand-200">
               The page hit an unexpected error. Reloading often clears it. If it
               keeps happening, please report it so we can fix it.
             </p>
-            <pre className="mb-4 max-h-40 overflow-auto rounded-md border border-zinc-800 bg-zinc-950 p-3 text-xs text-zinc-400 whitespace-pre-wrap break-words">
+            <pre className="mb-4 max-h-40 overflow-auto rounded-md border border-sand-200 dark:border-husk-100 bg-sand-50 dark:bg-husk-400 p-3 text-xs text-coconut-400 dark:text-sand-300 whitespace-pre-wrap break-words">
               {this.state.error.message || String(this.state.error)}
             </pre>
             <div className="flex flex-wrap items-center gap-2">
               <button
                 type="button"
                 onClick={this.handleReload}
-                className="rounded-md border border-zinc-700 bg-zinc-800 px-4 py-1.5 text-sm text-zinc-100 hover:bg-zinc-700 transition-colors"
+                className="rounded-md border border-sand-300 dark:border-husk-50 bg-sand-200 dark:bg-husk-100 px-4 py-1.5 text-sm text-coconut-700 dark:text-sand-50 hover:bg-sand-200 dark:hover:bg-husk-100 transition-colors"
               >
                 Reload page
               </button>
@@ -62,7 +62,7 @@ export class ErrorBoundary extends Component<Props, State> {
                 href={ISSUES_URL}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="rounded-md border border-red-800 bg-red-900/30 px-4 py-1.5 text-sm text-red-200 hover:bg-red-900/50 transition-colors"
+                className="rounded-md border border-ember-500/40 bg-ember-500/15 px-4 py-1.5 text-sm text-ember-600 hover:bg-ember-500/25 dark:border-ember-500/40 dark:bg-ember-500/15 dark:text-ember-300 dark:hover:bg-ember-500/25 transition-colors"
               >
                 Report on GitHub →
               </a>

--- a/web/src/components/ExportBar.tsx
+++ b/web/src/components/ExportBar.tsx
@@ -74,7 +74,7 @@ export function ExportBar() {
       <DropdownMenu.Root>
         <DropdownMenu.Trigger asChild>
           <button
-            className="flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-200 hover:bg-zinc-700 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            className="flex items-center gap-1.5 rounded-md border border-sand-300 bg-sand-100 px-3 py-1.5 text-sm text-coconut-700 hover:bg-sand-200 hover:border-sand-400 dark:border-husk-50 dark:bg-husk-200 dark:text-sand-50 dark:hover:bg-husk-100 dark:hover:border-coconut-400 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
             disabled={anyLoading}
             aria-label="Export"
           >
@@ -87,31 +87,31 @@ export function ExportBar() {
           <DropdownMenu.Content
             align="end"
             sideOffset={6}
-            className="z-50 min-w-[200px] rounded-md border border-zinc-700 bg-zinc-900 p-1 shadow-xl"
+            className="z-50 min-w-[200px] rounded-md border border-sand-300 bg-sand-50 dark:border-husk-50 dark:bg-husk-200 p-1 shadow-xl shadow-coconut-700/15"
           >
             {BUTTONS.map((b) => (
               <DropdownMenu.Item
                 key={b.format}
                 disabled={disabled}
                 onSelect={() => handleExport(b.format)}
-                className="flex items-center gap-2 rounded px-2.5 py-2 text-sm text-zinc-200 outline-none data-[highlighted]:bg-zinc-800 data-[disabled]:opacity-40 data-[disabled]:cursor-not-allowed"
+                className="flex items-center gap-2 rounded px-2.5 py-2 text-sm text-coconut-700 dark:text-sand-50 outline-none data-[highlighted]:bg-sand-200 dark:data-[highlighted]:bg-husk-100 data-[disabled]:opacity-40 data-[disabled]:cursor-not-allowed"
               >
                 {b.icon}
                 {b.label}
               </DropdownMenu.Item>
             ))}
-            <DropdownMenu.Separator className="my-1 h-px bg-zinc-800" />
+            <DropdownMenu.Separator className="my-1 h-px bg-sand-200 dark:bg-husk-100" />
             <DropdownMenu.Item
               onSelect={() => setPickerOpen(true)}
-              className="flex items-center gap-2 rounded px-2.5 py-2 text-sm text-zinc-200 outline-none data-[highlighted]:bg-zinc-800"
+              className="flex items-center gap-2 rounded px-2.5 py-2 text-sm text-coconut-700 dark:text-sand-50 outline-none data-[highlighted]:bg-sand-200 dark:data-[highlighted]:bg-husk-100"
             >
               <Tags size={14} />
               Set ID cards…
             </DropdownMenu.Item>
             {matchedRows.length > 0 && (
               <>
-                <DropdownMenu.Separator className="my-1 h-px bg-zinc-800" />
-                <DropdownMenu.Label className="px-2.5 py-1.5 text-xs text-zinc-400">
+                <DropdownMenu.Separator className="my-1 h-px bg-sand-200 dark:bg-husk-100" />
+                <DropdownMenu.Label className="px-2.5 py-1.5 text-xs text-coconut-400 dark:text-sand-300">
                   {matchedRows.length} row{matchedRows.length !== 1 ? 's' : ''}
                 </DropdownMenu.Label>
               </>
@@ -121,7 +121,7 @@ export function ExportBar() {
       </DropdownMenu.Root>
       {/* Errors live outside the dropdown so they stay visible after the
           user picks a format and the menu closes. */}
-      {error && <span className="text-xs text-red-400">{error}</span>}
+      {error && <span className="text-xs text-ember-500 dark:text-ember-300">{error}</span>}
       <SetPickerModal open={pickerOpen} onOpenChange={setPickerOpen} />
     </div>
   )

--- a/web/src/components/HelpModal.tsx
+++ b/web/src/components/HelpModal.tsx
@@ -55,8 +55,8 @@ export function HelpModal({ onStartTour }: Props) {
     <Dialog.Root open={open} onOpenChange={handleOpenChange}>
       <Dialog.Trigger asChild>
         <button
-          className={`relative flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-800 px-2.5 py-1.5 text-sm text-zinc-200 hover:bg-zinc-700 transition-colors sm:px-3 ${
-            hint ? 'ring-2 ring-blue-500 animate-pulse' : ''
+          className={`relative flex items-center gap-1.5 rounded-md border border-sand-300 dark:border-husk-50 bg-sand-200 dark:bg-husk-100 px-2.5 py-1.5 text-sm text-coconut-600 dark:text-sand-200 hover:bg-sand-200 dark:hover:bg-husk-100 transition-colors sm:px-3 ${
+            hint ? 'ring-2 ring-palm-400 dark:ring-sun-300 animate-pulse' : ''
           }`}
           title="Help"
           aria-label="Help"
@@ -67,19 +67,19 @@ export function HelpModal({ onStartTour }: Props) {
       </Dialog.Trigger>
 
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm" />
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-coconut-700/50 dark:bg-husk-500/70 backdrop-blur-sm" />
         <Dialog.Content
           aria-describedby={undefined}
-          className="fixed left-1/2 top-1/2 z-50 flex max-h-[90vh] w-[min(640px,92vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-zinc-700 bg-zinc-900 shadow-2xl"
+          className="fixed left-1/2 top-1/2 z-50 flex max-h-[90vh] w-[min(640px,92vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-sand-300 dark:border-husk-50 bg-sand-50 dark:bg-husk-200 shadow-2xl"
         >
           {/* Header */}
-          <div className="flex items-center justify-between border-b border-zinc-700 px-5 py-4">
-            <Dialog.Title className="text-base font-semibold text-zinc-100">
+          <div className="flex items-center justify-between border-b border-sand-300 dark:border-husk-50 px-5 py-4">
+            <Dialog.Title className="text-base font-semibold text-coconut-700 dark:text-sand-50">
               How to use mgz-pkmn
             </Dialog.Title>
             <Dialog.Close asChild>
               <button
-                className="rounded p-1 text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700 transition-colors"
+                className="rounded p-1 text-coconut-400 dark:text-sand-300 hover:text-coconut-700 dark:hover:text-sand-50 hover:bg-sand-200 dark:hover:bg-husk-100 transition-colors"
                 aria-label="Close"
               >
                 <X size={16} />
@@ -90,7 +90,7 @@ export function HelpModal({ onStartTour }: Props) {
           {/* Body */}
           <div
             tabIndex={0}
-            className="flex-1 overflow-y-auto px-5 py-4 space-y-6 text-sm text-zinc-300 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="flex-1 overflow-y-auto px-5 py-4 space-y-6 text-sm text-coconut-600 dark:text-sand-200 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:ring-sun-300"
           >
             <Section title="What this does">
               <p>
@@ -102,7 +102,7 @@ export function HelpModal({ onStartTour }: Props) {
             </Section>
 
             <Section title="Writing queries">
-              <p className="mb-2 text-zinc-400">
+              <p className="mb-2 text-coconut-400 dark:text-sand-300">
                 One card per line. Blank lines and <code>#</code> comments are
                 skipped. Common formats:
               </p>
@@ -156,13 +156,13 @@ export function HelpModal({ onStartTour }: Props) {
           </div>
 
           {/* Footer */}
-          <div className="flex items-center justify-between border-t border-zinc-700 px-5 py-4">
-            <span className="text-xs text-zinc-400">
+          <div className="flex items-center justify-between border-t border-sand-300 dark:border-husk-50 px-5 py-4">
+            <span className="text-xs text-coconut-400 dark:text-sand-300">
               New here? Take the interactive tour.
             </span>
             <button
               onClick={handleTakeTour}
-              className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-500 transition-colors"
+              className="rounded-md bg-sun-300 px-3 py-1.5 text-sm font-medium text-coconut-700 hover:bg-sun-400 dark:bg-sun-300 dark:text-husk-500 dark:hover:bg-sun-200 transition-colors"
             >
               Take the tour
             </button>
@@ -176,7 +176,7 @@ export function HelpModal({ onStartTour }: Props) {
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <section>
-      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-zinc-400">
+      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-coconut-400 dark:text-sand-300">
         {title}
       </h3>
       {children}
@@ -186,7 +186,7 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 
 function Kbd({ children }: { children: React.ReactNode }) {
   return (
-    <kbd className="rounded border border-zinc-700 bg-zinc-800 px-1.5 py-0.5 font-mono text-xs text-zinc-200">
+    <kbd className="rounded border border-sand-300 dark:border-husk-50 bg-sand-200 dark:bg-husk-100 px-1.5 py-0.5 font-mono text-xs text-coconut-600 dark:text-sand-200">
       {children}
     </kbd>
   )
@@ -197,10 +197,10 @@ function Examples({ rows }: { rows: [string, string][] }) {
     <ul className="space-y-1.5">
       {rows.map(([query, desc]) => (
         <li key={query} className="flex flex-col gap-0.5 sm:flex-row sm:items-baseline sm:gap-3">
-          <code className="rounded bg-zinc-800 px-2 py-0.5 font-mono text-xs text-zinc-100">
+          <code className="rounded bg-sand-200 dark:bg-husk-100 px-2 py-0.5 font-mono text-xs text-coconut-700 dark:text-sand-50">
             {query}
           </code>
-          <span className="text-xs text-zinc-400">{desc}</span>
+          <span className="text-xs text-coconut-400 dark:text-sand-300">{desc}</span>
         </li>
       ))}
     </ul>
@@ -212,8 +212,8 @@ function Definitions({ rows }: { rows: [React.ReactNode, string][] }) {
     <dl className="space-y-2">
       {rows.map(([term, desc], i) => (
         <div key={i} className="flex flex-col gap-0.5 sm:flex-row sm:gap-3">
-          <dt className="font-medium text-zinc-200 sm:min-w-[140px]">{term}</dt>
-          <dd className="text-xs text-zinc-400 sm:flex-1 sm:text-sm">{desc}</dd>
+          <dt className="font-medium text-coconut-600 dark:text-sand-200 sm:min-w-[140px]">{term}</dt>
+          <dd className="text-xs text-coconut-400 dark:text-sand-300 sm:flex-1 sm:text-sm">{desc}</dd>
         </div>
       ))}
     </dl>

--- a/web/src/components/InputEditor.tsx
+++ b/web/src/components/InputEditor.tsx
@@ -101,7 +101,7 @@ export function InputEditor({ onRun, onStop }: Props) {
     <div className="flex flex-col gap-2">
       {/* Toolbar */}
       <div className="flex items-center justify-between">
-        <span className="text-xs text-zinc-400">
+        <span className="text-xs text-coconut-400 dark:text-sand-300">
           {lineCount > 0 ? `${lineCount} card line${lineCount !== 1 ? 's' : ''}` : 'Enter card lines below'}
         </span>
         <div className="flex items-center gap-2">
@@ -110,7 +110,7 @@ export function InputEditor({ onRun, onStop }: Props) {
               clearRows()
               setInputText('')
             }}
-            className="flex items-center gap-1 rounded px-2 py-1 text-xs text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700 transition-colors"
+            className="flex items-center gap-1 rounded px-2 py-1 text-xs text-coconut-400 hover:text-coconut-700 hover:bg-sand-200 dark:text-sand-300 dark:hover:text-sand-50 dark:hover:bg-husk-100 transition-colors"
             title="Clear input and results"
           >
             <RotateCcw size={12} />
@@ -119,7 +119,7 @@ export function InputEditor({ onRun, onStop }: Props) {
           {isRunning ? (
             <button
               onClick={onStop}
-              className="flex items-center gap-1.5 rounded-md bg-red-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-600 transition-colors"
+              className="flex items-center gap-1.5 rounded-md bg-ember-500 px-3 py-1.5 text-sm font-medium text-sand-50 hover:bg-ember-400 dark:bg-ember-500 dark:hover:bg-ember-400 transition-colors"
             >
               <Square size={13} fill="currentColor" />
               Stop
@@ -129,11 +129,11 @@ export function InputEditor({ onRun, onStop }: Props) {
               onClick={() => onRun()}
               disabled={lineCount === 0}
               data-tour="run"
-              className="flex items-center gap-1.5 rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+              className="flex items-center gap-1.5 rounded-md bg-sun-300 px-3 py-1.5 text-sm font-medium text-coconut-700 shadow-sm hover:bg-sun-400 dark:bg-sun-300 dark:text-husk-500 dark:hover:bg-sun-200 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
             >
               <Play size={13} fill="currentColor" />
               Look up&nbsp;
-              <span className="text-xs text-white">(⌘↵)</span>
+              <span className="text-xs opacity-80">(⌘↵)</span>
             </button>
           )}
         </div>
@@ -157,19 +157,19 @@ export function InputEditor({ onRun, onStop }: Props) {
         spellCheck={false}
         rows={12}
         placeholder={`One card per line, e.g.:\nCharizard | Base Set | 4/102\nPikachu | Jungle\ntop:5 Charizard cards\nMew ex | Scarlet & Violet`}
-        className="w-full resize-y rounded-md border border-zinc-700 bg-zinc-900 px-3 py-2.5 font-mono text-sm text-zinc-100 placeholder:text-zinc-600 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        className="w-full resize-y rounded-md border border-sand-300 bg-sand-50 px-3 py-2.5 font-mono text-sm text-coconut-700 placeholder:text-coconut-300 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:border-husk-50 dark:bg-husk-200 dark:text-sand-50 dark:placeholder:text-sand-500 dark:focus:ring-sun-300"
       />
 
       {/* Example query chips — guided empty-state */}
       {isEmpty && !isRunning && (
-        <div className="flex flex-col gap-2 rounded-md border border-zinc-700 bg-zinc-800/40 px-3 py-3">
-          <span className="text-xs text-zinc-400">Try one of these</span>
+        <div className="flex flex-col gap-2 rounded-md border border-sand-300 bg-sand-100 dark:border-husk-50 dark:bg-husk-200/40 px-3 py-3">
+          <span className="text-xs text-coconut-400 dark:text-sand-300">Try one of these</span>
           <div className="flex flex-wrap gap-1.5">
             {EXAMPLE_QUERIES.map((example) => (
               <button
                 key={example}
                 onClick={() => handleChipClick(example)}
-                className="rounded-full border border-zinc-700 bg-zinc-900 px-2.5 py-1 font-mono text-xs text-zinc-300 hover:border-blue-500 hover:bg-zinc-800 hover:text-zinc-100 transition-colors"
+                className="rounded-full border border-sand-300 bg-sand-50 px-2.5 py-1 font-mono text-xs text-coconut-600 hover:border-palm-400 hover:bg-sand-200 hover:text-coconut-700 dark:border-husk-50 dark:bg-husk-300 dark:text-sand-200 dark:hover:border-sun-300 dark:hover:bg-husk-100 dark:hover:text-sand-50 transition-colors"
               >
                 {example}
               </button>
@@ -180,22 +180,22 @@ export function InputEditor({ onRun, onStop }: Props) {
 
       {/* Parse preview for the active line */}
       {parsedPreview && (
-        <div className="rounded-md border border-zinc-700 bg-zinc-800/60 px-3 py-2 text-xs text-zinc-400">
-          <span className="text-zinc-500">Parsed: </span>
-          <span className="text-zinc-200 font-medium">{parsedPreview.name}</span>
+        <div className="rounded-md border border-sand-300 bg-sand-100 dark:border-husk-50 dark:bg-husk-200/60 px-3 py-2 text-xs text-coconut-400 dark:text-sand-300">
+          <span className="text-coconut-400 dark:text-sand-400">Parsed: </span>
+          <span className="text-coconut-700 dark:text-sand-50 font-medium">{parsedPreview.name}</span>
           {parsedPreview.set_hint && (
-            <span className="text-zinc-400"> · {parsedPreview.set_hint}</span>
+            <span className="text-coconut-400 dark:text-sand-300"> · {parsedPreview.set_hint}</span>
           )}
           {parsedPreview.number && (
-            <span className="text-zinc-500"> #{parsedPreview.number}</span>
+            <span className="text-coconut-400 dark:text-sand-400"> #{parsedPreview.number}</span>
           )}
           {parsedPreview.bulk_all ? (
-            <span className="text-blue-400"> (all)</span>
+            <span className="text-palm-500 dark:text-sun-300"> (all)</span>
           ) : parsedPreview.bulk_top ? (
-            <span className="text-blue-400"> (top {parsedPreview.bulk_top})</span>
+            <span className="text-palm-500 dark:text-sun-300"> (top {parsedPreview.bulk_top})</span>
           ) : null}
           {parsedPreview.variant_hint && (
-            <span className="text-amber-400"> [{parsedPreview.variant_hint}]</span>
+            <span className="text-sun-600 dark:text-sun-300"> [{parsedPreview.variant_hint}]</span>
           )}
         </div>
       )}

--- a/web/src/components/LookupTimer.tsx
+++ b/web/src/components/LookupTimer.tsx
@@ -42,9 +42,9 @@ export function LookupTimer() {
         role="status"
         aria-live="polite"
         aria-label="Lookup timer"
-        className="flex items-center gap-1.5 text-xs tabular-nums text-zinc-400"
+        className="flex items-center gap-1.5 text-xs tabular-nums text-coconut-400 dark:text-sand-300"
       >
-        <Timer size={12} className="text-blue-400" />
+        <Timer size={12} className="text-palm-500 dark:text-sun-300" />
         <span>{formatElapsed(elapsedMs)}</span>
       </div>
     )
@@ -56,7 +56,7 @@ export function LookupTimer() {
   const count = rows.length
   if (count === 0) {
     return (
-      <div className="flex items-center gap-1.5 text-xs tabular-nums text-zinc-400">
+      <div className="flex items-center gap-1.5 text-xs tabular-nums text-coconut-400 dark:text-sand-300">
         <Timer size={12} />
         <span>{formatElapsed(elapsedMs)}</span>
       </div>
@@ -65,7 +65,7 @@ export function LookupTimer() {
   const perCard = Math.round(elapsedMs / count)
   const cardWord = count === 1 ? 'card' : 'cards'
   return (
-    <div className="flex items-center gap-1.5 text-xs tabular-nums text-zinc-400">
+    <div className="flex items-center gap-1.5 text-xs tabular-nums text-coconut-400 dark:text-sand-300">
       <Timer size={12} />
       <span>
         {formatElapsed(elapsedMs)} · {count} {cardWord} · {perCard} ms/card

--- a/web/src/components/ProcessingQueue.test.tsx
+++ b/web/src/components/ProcessingQueue.test.tsx
@@ -96,15 +96,17 @@ describe('ProcessingQueue stage chips', () => {
 
   it('applies the matching color class to the stage label', () => {
     render(<ProcessingQueue />)
-    // The looking_up line's label is rendered in blue (the chip uses the
-    // stage color class on its own <span>, not the legend swatch).
+    // The looking_up label uses the sky-* palette in both themes (the
+    // chip's own <span> carries the stage color class, not the legend
+    // swatch). We assert the light-mode token; the `dark:` counterpart
+    // ships in the same className.
     const lookingUp = screen
       .getAllByText('Looking up')
-      .find((el) => el.tagName === 'SPAN' && el.className.includes('text-blue-400'))
+      .find((el) => el.tagName === 'SPAN' && el.className.includes('text-sky-500'))
     expect(lookingUp).toBeDefined()
     const noMatch = screen
       .getAllByText('No match')
-      .find((el) => el.className.includes('text-amber-400'))
+      .find((el) => el.className.includes('text-sun-600'))
     expect(noMatch).toBeDefined()
   })
 

--- a/web/src/components/ProcessingQueue.tsx
+++ b/web/src/components/ProcessingQueue.tsx
@@ -20,21 +20,25 @@ import { useAppStore } from '../store'
 import type { ProcessingLine, Stage } from '../types'
 
 /**
- * Per-stage presentation. Colors are Tailwind `*-400` shades, all of which
- * clear WCAG 2.1 AA contrast (≥ 4.5:1) against the app background
- * (`bg-zinc-950`) — see docs/accessibility.md. `terminal` marks the three
- * end states (which get a static icon); the rest are in-flight and spin.
+ * Per-stage presentation. Colors are paired light/dark variants from
+ * the tropical palette — `coconut`/`sand` for muted, `sky` for the
+ * initial lookup, `palm` for pricing/resolved, `sun` for the warn
+ * terminal, `ember` for error. All combinations clear WCAG 2.1 AA
+ * contrast (≥ 4.5:1) against both surfaces (`bg-sand-50` light,
+ * `bg-husk-400` dark) — see docs/accessibility.md.
+ * `terminal` marks the three end states (which get a static icon);
+ * the rest are in-flight and spin.
  */
 const STAGE_CONFIG: Record<Stage, { label: string; color: string; terminal: boolean }> = {
-  parsed: { label: 'Parsed', color: 'text-zinc-400', terminal: false },
-  looking_up: { label: 'Looking up', color: 'text-blue-400', terminal: false },
-  fallback: { label: 'Fallback', color: 'text-indigo-400', terminal: false },
-  url_hint: { label: 'URL hint', color: 'text-violet-400', terminal: false },
-  pricing: { label: 'Pricing', color: 'text-cyan-400', terminal: false },
-  image: { label: 'Image', color: 'text-teal-400', terminal: false },
-  resolved: { label: 'Resolved', color: 'text-green-400', terminal: true },
-  no_match: { label: 'No match', color: 'text-amber-400', terminal: true },
-  error: { label: 'Error', color: 'text-red-400', terminal: true },
+  parsed: { label: 'Parsed', color: 'text-coconut-400 dark:text-sand-300', terminal: false },
+  looking_up: { label: 'Looking up', color: 'text-sky-500 dark:text-sky-300', terminal: false },
+  fallback: { label: 'Fallback', color: 'text-coconut-600 dark:text-coconut-200', terminal: false },
+  url_hint: { label: 'URL hint', color: 'text-sky-400 dark:text-sky-400', terminal: false },
+  pricing: { label: 'Pricing', color: 'text-palm-500 dark:text-palm-300', terminal: false },
+  image: { label: 'Image', color: 'text-palm-400 dark:text-palm-100', terminal: false },
+  resolved: { label: 'Resolved', color: 'text-palm-600 dark:text-palm-200', terminal: true },
+  no_match: { label: 'No match', color: 'text-sun-600 dark:text-sun-300', terminal: true },
+  error: { label: 'Error', color: 'text-ember-500 dark:text-ember-300', terminal: true },
 }
 
 /** Display order for the legend — pipeline order, terminal states last. */
@@ -81,15 +85,15 @@ export function ProcessingQueue() {
   const total = processingLines.length
 
   return (
-    <div className="rounded-md border border-zinc-800 bg-zinc-900/60 px-4 py-3">
+    <div className="rounded-md border border-sand-300 bg-sand-100 dark:border-husk-50 dark:bg-husk-200/60 px-4 py-3">
       <div className="mb-2 flex items-center justify-between gap-2">
-        <span className="text-xs font-medium text-zinc-400">Looking up cards…</span>
+        <span className="text-xs font-medium text-coconut-500 dark:text-sand-300">Looking up cards…</span>
         <div className="flex items-center gap-3">
           <button
             type="button"
             onClick={() => setLegendOpen((v) => !v)}
             aria-expanded={legendOpen}
-            className="flex items-center gap-1 rounded text-xs text-zinc-400 hover:text-zinc-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+            className="flex items-center gap-1 rounded text-xs text-coconut-400 hover:text-coconut-700 dark:text-sand-300 dark:hover:text-sand-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-palm-400 dark:focus-visible:ring-sun-300"
           >
             Legend
             <ChevronDown
@@ -97,7 +101,7 @@ export function ProcessingQueue() {
               className={`transition-transform ${legendOpen ? 'rotate-180' : ''}`}
             />
           </button>
-          <span className="text-xs tabular-nums text-zinc-400">
+          <span className="text-xs tabular-nums text-coconut-400 dark:text-sand-300">
             {done} of {total} done
           </span>
         </div>
@@ -121,7 +125,7 @@ export function ProcessingQueue() {
 /** Color key explaining what each chip color means. Collapsed by default. */
 function StageLegend() {
   return (
-    <ul className="mb-2 flex flex-wrap gap-x-3 gap-y-1 rounded bg-zinc-900/80 px-2 py-1.5">
+    <ul className="mb-2 flex flex-wrap gap-x-3 gap-y-1 rounded bg-sand-50 dark:bg-husk-300/80 px-2 py-1.5">
       {STAGE_ORDER.map((stage) => {
         const cfg = STAGE_CONFIG[stage]
         return (
@@ -130,7 +134,7 @@ function StageLegend() {
               aria-hidden
               className={`h-2 w-2 rounded-full bg-current ${cfg.color}`}
             />
-            <span className="text-zinc-400">{cfg.label}</span>
+            <span className="text-coconut-500 dark:text-sand-300">{cfg.label}</span>
           </li>
         )
       })}
@@ -142,7 +146,7 @@ function stageIcon(line: ProcessingLine) {
   // Before the first stage frame arrives, fall back to the generic
   // in-flight spinner (matches the historical pending appearance).
   if (!line.stage) {
-    return <Loader2 size={12} className="flex-shrink-0 animate-spin text-blue-400" />
+    return <Loader2 size={12} className="flex-shrink-0 animate-spin text-sky-500 dark:text-sky-300" />
   }
   const cfg = STAGE_CONFIG[line.stage]
   if (!cfg.terminal) {
@@ -193,7 +197,7 @@ function LineStatus({
 
   return (
     <li
-      className="flex items-center gap-1.5 text-xs text-zinc-400"
+      className="flex items-center gap-1.5 text-xs text-coconut-500 dark:text-sand-300"
       title={tooltip}
       aria-label={tooltip ? `${line.line} — ${tooltip}` : undefined}
     >
@@ -204,7 +208,7 @@ function LineStatus({
       )}
       {elapsedMs != null && (
         <span
-          className="flex-shrink-0 rounded bg-zinc-800 px-1 py-0.5 font-mono text-[10px] tabular-nums text-zinc-400"
+          className="flex-shrink-0 rounded bg-sand-200 dark:bg-husk-100 px-1 py-0.5 font-mono text-[10px] tabular-nums text-coconut-500 dark:text-sand-300"
           aria-label={`Finished in ${elapsedMs} milliseconds`}
         >
           {elapsedMs}ms

--- a/web/src/components/RecentRuns.tsx
+++ b/web/src/components/RecentRuns.tsx
@@ -38,25 +38,25 @@ export function RecentRuns({ onRun }: Props) {
   return (
     <section
       aria-label="Recent searches"
-      className="flex flex-col gap-2 rounded-md border border-zinc-800 bg-zinc-900/40 px-3 py-2"
+      className="flex flex-col gap-2 rounded-md border border-sand-200 dark:border-husk-100 bg-sand-50 dark:bg-husk-200/40 px-3 py-2"
     >
       <header className="flex items-center justify-between">
         <button
           type="button"
           onClick={() => setCollapsed((c) => !c)}
           aria-expanded={!collapsed}
-          className="flex items-center gap-1.5 rounded text-xs font-medium text-zinc-400 hover:text-zinc-200"
+          className="flex items-center gap-1.5 rounded text-xs font-medium text-coconut-400 dark:text-sand-300 hover:text-coconut-600 dark:hover:text-sand-200"
         >
           <History size={12} />
           Recent searches
-          <span className="text-zinc-500">({recentRuns.length})</span>
+          <span className="text-coconut-400 dark:text-sand-400">({recentRuns.length})</span>
           {collapsed ? <ChevronDown size={12} /> : <ChevronUp size={12} />}
         </button>
         {!collapsed && (
           <button
             type="button"
             onClick={clearRecentRuns}
-            className="rounded px-1.5 py-0.5 text-xs text-zinc-500 hover:text-zinc-200 hover:bg-zinc-800 transition-colors"
+            className="rounded px-1.5 py-0.5 text-xs text-coconut-400 dark:text-sand-400 hover:text-coconut-600 dark:hover:text-sand-200 hover:bg-sand-200 dark:hover:bg-husk-100 transition-colors"
           >
             Clear all
           </button>
@@ -96,7 +96,7 @@ function RecentRunRow({
   const lineWord = run.lines.length === 1 ? 'line' : 'lines'
 
   return (
-    <li className="group flex items-center gap-2 rounded border border-transparent hover:border-zinc-700 hover:bg-zinc-800/60 transition-colors">
+    <li className="group flex items-center gap-2 rounded border border-transparent hover:border-sand-300 dark:hover:border-husk-50 hover:bg-sand-200 dark:hover:bg-husk-100/60 transition-colors">
       <button
         type="button"
         onClick={onRerun}
@@ -104,19 +104,19 @@ function RecentRunRow({
         aria-label={`Rerun search from ${formatRelativeTime(run.savedAt)}: ${summary}`}
         className="flex-1 min-w-0 flex items-center gap-2 px-2 py-1 text-left text-xs disabled:cursor-not-allowed disabled:opacity-50"
       >
-        <span className="flex-shrink-0 tabular-nums text-zinc-500">
+        <span className="flex-shrink-0 tabular-nums text-coconut-400 dark:text-sand-400">
           {formatRelativeTime(run.savedAt)}
         </span>
-        <span className="flex-shrink-0 rounded bg-zinc-800 px-1.5 py-0.5 font-mono text-[10px] tabular-nums text-zinc-400">
+        <span className="flex-shrink-0 rounded bg-sand-200 dark:bg-husk-100 px-1.5 py-0.5 font-mono text-[10px] tabular-nums text-coconut-400 dark:text-sand-300">
           {run.lines.length} {lineWord}
         </span>
-        <span className="truncate font-mono text-zinc-300">{summary}</span>
+        <span className="truncate font-mono text-coconut-600 dark:text-sand-200">{summary}</span>
       </button>
       <button
         type="button"
         onClick={onDelete}
         aria-label={`Delete recent search: ${summary}`}
-        className="flex-shrink-0 rounded p-1 text-zinc-500 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 focus-visible:opacity-100 hover:text-zinc-200 hover:bg-zinc-700 transition-opacity"
+        className="flex-shrink-0 rounded p-1 text-coconut-400 dark:text-sand-400 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 focus-visible:opacity-100 hover:text-coconut-600 dark:hover:text-sand-200 hover:bg-sand-200 dark:hover:bg-husk-100 transition-opacity"
       >
         <X size={12} />
       </button>

--- a/web/src/components/ResultsTable.tsx
+++ b/web/src/components/ResultsTable.tsx
@@ -72,7 +72,7 @@ export function ResultsTable({ onRerunLine }: Props) {
 
   if (rows.length === 0 && !isRunning) {
     return (
-      <div className="flex items-center justify-center rounded-md border border-zinc-700 bg-zinc-900 py-16 text-zinc-400 text-sm">
+      <div className="flex items-center justify-center rounded-md border border-sand-300 dark:border-husk-50 bg-sand-50 dark:bg-husk-200 py-16 text-coconut-400 dark:text-sand-300 text-sm">
         Results will appear here after you run a lookup.
       </div>
     )
@@ -85,14 +85,14 @@ export function ResultsTable({ onRerunLine }: Props) {
       {/* Progress bar */}
       {(isRunning || (progress && progress.done < progress.total)) && (
         <div className="flex items-center gap-3">
-          <div className="flex-1 h-1.5 rounded-full bg-zinc-700 overflow-hidden">
+          <div className="flex-1 h-1.5 rounded-full bg-sand-200 dark:bg-husk-100 overflow-hidden">
             <div
-              className="h-full rounded-full bg-blue-500 transition-all duration-200"
+              className="h-full rounded-full bg-palm-400 dark:bg-sun-300 transition-all duration-200"
               style={{ width: `${pct}%` }}
             />
           </div>
           {progress && (
-            <span className="text-xs text-zinc-400 tabular-nums whitespace-nowrap">
+            <span className="text-xs text-coconut-400 dark:text-sand-300 tabular-nums whitespace-nowrap">
               {progress.done} / {progress.total}
             </span>
           )}
@@ -107,8 +107,8 @@ export function ResultsTable({ onRerunLine }: Props) {
           aria-pressed={showFilters}
           className={`flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs transition-colors ${
             showFilters
-              ? 'border-blue-700 bg-blue-900/30 text-blue-300'
-              : 'border-zinc-700 bg-zinc-800 text-zinc-400 hover:text-zinc-200 hover:bg-zinc-700'
+              ? 'border-palm-400 bg-palm-50 text-palm-700 dark:border-sun-300/60 dark:bg-sun-400/15 dark:text-sun-300'
+              : 'border-sand-300 dark:border-husk-50 bg-sand-100 dark:bg-husk-200 text-coconut-400 dark:text-sand-300 hover:text-coconut-700 dark:hover:text-sand-50 hover:bg-sand-200 dark:hover:bg-husk-100'
           }`}
         >
           <Filter size={12} />
@@ -122,7 +122,7 @@ export function ResultsTable({ onRerunLine }: Props) {
               setSortDir(null)
               setFilters(EMPTY_FILTERS)
             }}
-            className="text-xs text-zinc-400 hover:text-zinc-300"
+            className="text-xs text-coconut-400 dark:text-sand-300 hover:text-coconut-600 dark:text-sand-200"
           >
             Clear sort &amp; filters
           </button>
@@ -130,12 +130,12 @@ export function ResultsTable({ onRerunLine }: Props) {
       </div>
 
       {/* Table */}
-      <div className="overflow-x-auto rounded-md border border-zinc-700">
+      <div className="overflow-x-auto rounded-md border border-sand-300 dark:border-husk-50">
         <table className="w-full text-sm border-collapse">
           <thead>
-            <tr className="border-b border-zinc-700 bg-zinc-800 text-left">
+            <tr className="border-b border-sand-300 dark:border-husk-50 bg-sand-100 dark:bg-husk-200 text-left">
               {!settings.noImages && (
-                <th className="px-3 py-2 text-xs font-medium text-zinc-400 w-16">Img</th>
+                <th className="px-3 py-2 text-xs font-medium text-coconut-400 dark:text-sand-300 w-16">Img</th>
               )}
               <SortableHeader
                 label="Name"
@@ -168,10 +168,10 @@ export function ResultsTable({ onRerunLine }: Props) {
                 onClick={cycleSort}
                 align="right"
               />
-              <th className="px-3 py-2 text-xs font-medium text-zinc-400 text-right hidden xl:table-cell">80%</th>
-              <th className="px-3 py-2 text-xs font-medium text-zinc-400 text-right hidden xl:table-cell">85%</th>
-              <th className="px-3 py-2 text-xs font-medium text-zinc-400 text-right hidden xl:table-cell">90%</th>
-              <th className="px-3 py-2 text-xs font-medium text-zinc-400 text-right hidden xl:table-cell">95%</th>
+              <th className="px-3 py-2 text-xs font-medium text-coconut-400 dark:text-sand-300 text-right hidden xl:table-cell">80%</th>
+              <th className="px-3 py-2 text-xs font-medium text-coconut-400 dark:text-sand-300 text-right hidden xl:table-cell">85%</th>
+              <th className="px-3 py-2 text-xs font-medium text-coconut-400 dark:text-sand-300 text-right hidden xl:table-cell">90%</th>
+              <th className="px-3 py-2 text-xs font-medium text-coconut-400 dark:text-sand-300 text-right hidden xl:table-cell">95%</th>
               <SortableHeader
                 label="Source"
                 column="source"
@@ -180,12 +180,12 @@ export function ResultsTable({ onRerunLine }: Props) {
                 onClick={cycleSort}
                 className="hidden sm:table-cell"
               />
-              <th className="px-3 py-2 text-xs font-medium text-zinc-400 w-8">
+              <th className="px-3 py-2 text-xs font-medium text-coconut-400 dark:text-sand-300 w-8">
                 <span className="sr-only">Actions</span>
               </th>
             </tr>
             {showFilters && (
-              <tr className="border-b border-zinc-700 bg-zinc-900">
+              <tr className="border-b border-sand-300 dark:border-husk-50 bg-sand-50 dark:bg-husk-200">
                 {!settings.noImages && (
                   <th>
                     <span className="sr-only">Image (no filter)</span>
@@ -274,7 +274,7 @@ export function ResultsTable({ onRerunLine }: Props) {
             {isRunning && (
               <tr>
                 <td colSpan={12} className="py-2 px-3">
-                  <div className="h-1 w-24 rounded animate-pulse bg-zinc-700" />
+                  <div className="h-1 w-24 rounded animate-pulse bg-sand-200 dark:bg-husk-100" />
                 </td>
               </tr>
             )}
@@ -282,12 +282,12 @@ export function ResultsTable({ onRerunLine }: Props) {
         </table>
       </div>
 
-      <p className="text-xs text-zinc-400 text-right">
+      <p className="text-xs text-coconut-400 dark:text-sand-300 text-right">
         {displayedRows.filter((r) => r.matched).length} matched ·{' '}
         {displayedRows.filter((r) => !r.matched).length} unmatched ·{' '}
         {displayedRows.length} shown
         {displayedRows.length !== rows.length && (
-          <span className="text-zinc-400"> (of {rows.length})</span>
+          <span className="text-coconut-400 dark:text-sand-300"> (of {rows.length})</span>
         )}
       </p>
 
@@ -331,7 +331,7 @@ function SortableHeader({
         type="button"
         onClick={() => onClick(column)}
         className={`inline-flex items-center gap-1 ${
-          isActive ? 'text-zinc-100' : 'text-zinc-400 hover:text-zinc-200'
+          isActive ? 'text-coconut-700 dark:text-sand-50' : 'text-coconut-400 dark:text-sand-300 hover:text-coconut-700 dark:hover:text-sand-50'
         }`}
         aria-label={`Sort by ${label}`}
       >
@@ -372,7 +372,7 @@ function FilterInput({
       placeholder={placeholder}
       aria-label={ariaLabel}
       onChange={(e) => onChange(e.target.value)}
-      className="w-full rounded border border-zinc-700 bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-200 placeholder:text-zinc-600 focus:outline-none focus:ring-1 focus:ring-blue-500"
+      className="w-full rounded border border-sand-300 dark:border-husk-50 bg-sand-100 dark:bg-husk-200 px-1.5 py-0.5 text-xs text-coconut-600 dark:text-sand-200 placeholder:text-coconut-300 dark:placeholder:text-sand-500 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:focus:ring-sun-300"
     />
   )
 }
@@ -447,9 +447,9 @@ function ResultRow({
   return (
     <>
       <tr
-        className={`border-b border-zinc-800 hover:bg-zinc-800/50 transition-colors motion-safe:animate-[fadeInRow_220ms_ease-out] ${
+        className={`border-b border-sand-200 dark:border-husk-100 hover:bg-sand-100 dark:bg-husk-200/50 transition-colors motion-safe:animate-[fadeInRow_220ms_ease-out] ${
           !row.matched ? 'opacity-60' : ''
-        } ${isOverCap ? 'bg-amber-950/30' : ''} ${canOpenDetail ? 'cursor-pointer' : ''}`}
+        } ${isOverCap ? 'bg-sun-100 dark:bg-sun-400/15' : ''} ${canOpenDetail ? 'cursor-pointer' : ''}`}
         onClick={canOpenDetail ? handleRowClick : undefined}
         onKeyDown={canOpenDetail ? handleRowKey : undefined}
         tabIndex={canOpenDetail ? 0 : undefined}
@@ -470,8 +470,8 @@ function ResultRow({
                 loading="lazy"
               />
             ) : (
-              <div className="w-10 h-14 rounded bg-zinc-800 flex items-center justify-center">
-                <span className="text-zinc-400 text-xs">?</span>
+              <div className="w-10 h-14 rounded bg-sand-100 dark:bg-husk-200 flex items-center justify-center">
+                <span className="text-coconut-400 dark:text-sand-300 text-xs">?</span>
               </div>
             )}
           </td>
@@ -481,18 +481,18 @@ function ResultRow({
         <td className="px-3 py-2 max-w-[200px]">
           {row.matched ? (
             <div>
-              <div className="font-medium text-zinc-100 truncate">{card?.name as string}</div>
-              <div className="text-xs text-zinc-400 truncate">{row.query.raw}</div>
+              <div className="font-medium text-coconut-700 dark:text-sand-50 truncate">{card?.name as string}</div>
+              <div className="text-xs text-coconut-400 dark:text-sand-300 truncate">{row.query.raw}</div>
             </div>
           ) : (
             <div>
-              <div className="flex items-center gap-1 text-zinc-400">
-                <AlertCircle size={13} className="text-amber-400 flex-shrink-0" />
+              <div className="flex items-center gap-1 text-coconut-400 dark:text-sand-300">
+                <AlertCircle size={13} className="text-sun-600 dark:text-sun-300 flex-shrink-0" />
                 <span className="truncate">{row.query.raw}</span>
               </div>
               <button
                 onClick={() => setShowOverrideForm((v) => !v)}
-                className="mt-0.5 text-xs text-blue-400 hover:text-blue-300 hover:underline"
+                className="mt-0.5 text-xs text-palm-500 hover:text-palm-400 dark:text-sun-300 dark:hover:text-sun-200 hover:underline"
               >
                 + Add PriceCharting URL
               </button>
@@ -501,43 +501,43 @@ function ResultRow({
         </td>
 
         {/* Set */}
-        <td className="px-3 py-2 text-zinc-400 text-xs hidden md:table-cell max-w-[160px]">
+        <td className="px-3 py-2 text-coconut-400 dark:text-sand-300 text-xs hidden md:table-cell max-w-[160px]">
           <div className="truncate">{setName ?? '—'}</div>
           {card?.number && (
-            <div className="text-zinc-400">#{card.number as string}</div>
+            <div className="text-coconut-400 dark:text-sand-300">#{card.number as string}</div>
           )}
         </td>
 
         {/* Rarity */}
-        <td className="px-3 py-2 text-xs text-zinc-400 hidden lg:table-cell max-w-[120px] truncate">
+        <td className="px-3 py-2 text-xs text-coconut-400 dark:text-sand-300 hidden lg:table-cell max-w-[120px] truncate">
           {(card?.rarity as string | undefined) ?? '—'}
         </td>
 
         {/* Market */}
         <td
           className={`px-3 py-2 text-right font-mono tabular-nums ${
-            isOverCap ? 'text-amber-400 font-bold' : p.market ? 'text-green-400' : 'text-zinc-400'
+            isOverCap ? 'text-sun-600 dark:text-sun-300 font-bold' : p.market ? 'text-palm-500 dark:text-palm-200' : 'text-coconut-400 dark:text-sand-300'
           }`}
         >
           {formatMoney(p.market, p.currency)}
         </td>
 
         {/* Comp tiers */}
-        <td className="px-3 py-2 text-right font-mono tabular-nums text-zinc-400 text-xs hidden xl:table-cell">
+        <td className="px-3 py-2 text-right font-mono tabular-nums text-coconut-400 dark:text-sand-300 text-xs hidden xl:table-cell">
           {formatComp(p.market, 80, p.currency)}
         </td>
-        <td className="px-3 py-2 text-right font-mono tabular-nums text-zinc-400 text-xs hidden xl:table-cell">
+        <td className="px-3 py-2 text-right font-mono tabular-nums text-coconut-400 dark:text-sand-300 text-xs hidden xl:table-cell">
           {formatComp(p.market, 85, p.currency)}
         </td>
-        <td className="px-3 py-2 text-right font-mono tabular-nums text-zinc-400 text-xs hidden xl:table-cell">
+        <td className="px-3 py-2 text-right font-mono tabular-nums text-coconut-400 dark:text-sand-300 text-xs hidden xl:table-cell">
           {formatComp(p.market, 90, p.currency)}
         </td>
-        <td className="px-3 py-2 text-right font-mono tabular-nums text-zinc-400 text-xs hidden xl:table-cell">
+        <td className="px-3 py-2 text-right font-mono tabular-nums text-coconut-400 dark:text-sand-300 text-xs hidden xl:table-cell">
           {formatComp(p.market, 95, p.currency)}
         </td>
 
         {/* Price source */}
-        <td className="px-3 py-2 text-xs text-zinc-400 hidden sm:table-cell">
+        <td className="px-3 py-2 text-xs text-coconut-400 dark:text-sand-300 hidden sm:table-cell">
           {p.source ?? '—'}
         </td>
 
@@ -548,7 +548,7 @@ function ResultRow({
               href={p.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-zinc-400 hover:text-blue-400 transition-colors"
+              className="text-coconut-400 hover:text-palm-500 dark:text-sand-300 dark:hover:text-sun-300 transition-colors"
               title="Open listing"
             >
               <ExternalLink size={13} />
@@ -559,7 +559,7 @@ function ResultRow({
 
       {/* Override URL form (inline, expands below row) */}
       {showOverrideForm && (
-        <tr className="border-b border-zinc-800 bg-zinc-800/60">
+        <tr className="border-b border-sand-200 dark:border-husk-100 bg-sand-100 dark:bg-husk-200/60">
           <td colSpan={12} className="px-3 py-2">
             <div className="flex items-center gap-2">
               <input
@@ -567,19 +567,19 @@ function ResultRow({
                 value={overrideUrl}
                 onChange={(e) => setOverrideUrl(e.target.value)}
                 placeholder="https://www.pricecharting.com/game/pokemon-…"
-                className="flex-1 rounded border border-zinc-600 bg-zinc-900 px-2 py-1 text-xs text-zinc-100 placeholder:text-zinc-600 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                className="flex-1 rounded border border-sand-300 dark:border-coconut-500 bg-sand-50 dark:bg-husk-200 px-2 py-1 text-xs text-coconut-700 dark:text-sand-50 placeholder:text-coconut-300 dark:placeholder:text-sand-500 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:focus:ring-sun-300"
                 onKeyDown={(e) => e.key === 'Enter' && handleSaveOverride()}
               />
               <button
                 onClick={handleSaveOverride}
                 disabled={overrideSaving || !overrideUrl.trim()}
-                className="rounded bg-blue-700 px-2 py-1 text-xs text-white hover:bg-blue-600 disabled:opacity-50"
+                className="rounded bg-sun-300 px-2 py-1 text-xs font-medium text-coconut-700 hover:bg-sun-400 dark:bg-sun-300 dark:text-husk-500 dark:hover:bg-sun-200 disabled:opacity-50 transition-colors"
               >
                 {overrideSaving ? 'Saving…' : 'Save & re-run'}
               </button>
               <button
                 onClick={() => setShowOverrideForm(false)}
-                className="text-zinc-400 hover:text-zinc-300 text-xs"
+                className="text-coconut-400 dark:text-sand-300 hover:text-coconut-600 dark:text-sand-200 text-xs"
               >
                 Cancel
               </button>

--- a/web/src/components/ResultsTable.tsx
+++ b/web/src/components/ResultsTable.tsx
@@ -122,7 +122,7 @@ export function ResultsTable({ onRerunLine }: Props) {
               setSortDir(null)
               setFilters(EMPTY_FILTERS)
             }}
-            className="text-xs text-coconut-400 dark:text-sand-300 hover:text-coconut-600 dark:text-sand-200"
+            className="text-xs text-coconut-400 dark:text-sand-300 hover:text-coconut-600 dark:hover:text-sand-200"
           >
             Clear sort &amp; filters
           </button>
@@ -447,7 +447,7 @@ function ResultRow({
   return (
     <>
       <tr
-        className={`border-b border-sand-200 dark:border-husk-100 hover:bg-sand-100 dark:bg-husk-200/50 transition-colors motion-safe:animate-[fadeInRow_220ms_ease-out] ${
+        className={`border-b border-sand-200 dark:border-husk-100 hover:bg-sand-100 dark:hover:bg-husk-200/50 transition-colors motion-safe:animate-[fadeInRow_220ms_ease-out] ${
           !row.matched ? 'opacity-60' : ''
         } ${isOverCap ? 'bg-sun-100 dark:bg-sun-400/15' : ''} ${canOpenDetail ? 'cursor-pointer' : ''}`}
         onClick={canOpenDetail ? handleRowClick : undefined}
@@ -579,7 +579,7 @@ function ResultRow({
               </button>
               <button
                 onClick={() => setShowOverrideForm(false)}
-                className="text-coconut-400 dark:text-sand-300 hover:text-coconut-600 dark:text-sand-200 text-xs"
+                className="text-coconut-400 dark:text-sand-300 hover:text-coconut-600 dark:hover:text-sand-200 text-xs"
               >
                 Cancel
               </button>

--- a/web/src/components/SetPickerModal.tsx
+++ b/web/src/components/SetPickerModal.tsx
@@ -352,7 +352,7 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
             <button
               onClick={handleSubmit}
               disabled={submitting || draft.size === 0}
-              className="flex items-center gap-1.5 rounded-md border border-palm-400 dark:border-sun-400 bg-sun-400 dark:bg-sun-400 px-3 py-1.5 text-sm font-medium text-white hover:bg-sun-300 dark:hover:bg-sun-300 disabled:opacity-40 disabled:cursor-not-allowed"
+              className="flex items-center gap-1.5 rounded-md border border-palm-400 dark:border-sun-400 bg-sun-400 dark:bg-sun-400 px-3 py-1.5 text-sm font-medium text-coconut-700 dark:text-husk-500 hover:bg-sun-300 dark:hover:bg-sun-300 disabled:opacity-40 disabled:cursor-not-allowed"
             >
               {submitting ? (
                 <Loader2 size={14} className="animate-spin" />

--- a/web/src/components/SetPickerModal.tsx
+++ b/web/src/components/SetPickerModal.tsx
@@ -231,22 +231,22 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm" />
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-coconut-700/50 dark:bg-husk-500/70 backdrop-blur-sm" />
         <Dialog.Content
-          className="fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-[min(720px,92vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-zinc-700 bg-zinc-900 shadow-2xl"
+          className="fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-[min(720px,92vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-sand-300 dark:border-husk-50 bg-sand-50 dark:bg-husk-200 shadow-2xl"
           aria-describedby="set-picker-description"
         >
-          <header className="flex items-center justify-between gap-3 border-b border-zinc-800 px-5 py-4">
+          <header className="flex items-center justify-between gap-3 border-b border-sand-200 dark:border-husk-100 px-5 py-4">
             <div className="flex items-center gap-2">
-              <Tags size={18} className="text-zinc-300" />
-              <Dialog.Title className="text-lg font-semibold text-zinc-100">
+              <Tags size={18} className="text-coconut-600 dark:text-sand-200" />
+              <Dialog.Title className="text-lg font-semibold text-coconut-700 dark:text-sand-50">
                 Choose sets
               </Dialog.Title>
             </div>
             <Dialog.Close asChild>
               <button
                 aria-label="Close"
-                className="rounded p-1 text-zinc-400 hover:bg-zinc-800 hover:text-zinc-100"
+                className="rounded p-1 text-coconut-400 dark:text-sand-300 hover:bg-sand-200 dark:hover:bg-husk-100 hover:text-coconut-700 dark:hover:text-sand-50"
               >
                 <X size={18} />
               </button>
@@ -255,7 +255,7 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
 
           <Dialog.Description
             id="set-picker-description"
-            className="px-5 pt-3 text-sm text-zinc-400"
+            className="px-5 pt-3 text-sm text-coconut-400 dark:text-sand-300"
           >
             Pick which Pokémon TCG sets the printable ID cards PDF should
             include. {`${selectedCount} of ${allCount} selected.`}
@@ -292,15 +292,15 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
                           aria-expanded={!collapsed}
                           aria-controls={headerId}
                           onClick={() => toggleSeriesCollapsed(group.series)}
-                          className="flex items-center gap-1.5 rounded text-left text-xs font-semibold uppercase tracking-wider text-zinc-300 hover:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-zinc-700"
+                          className="flex items-center gap-1.5 rounded text-left text-xs font-semibold uppercase tracking-wider text-coconut-600 dark:text-sand-200 hover:text-coconut-700 dark:hover:text-sand-50 focus:outline-none focus:ring-2 focus:ring-sand-300 dark:ring-husk-50"
                         >
                           {collapsed ? (
-                            <ChevronRight size={14} aria-hidden className="text-zinc-500" />
+                            <ChevronRight size={14} aria-hidden className="text-coconut-400 dark:text-sand-400" />
                           ) : (
-                            <ChevronDown size={14} aria-hidden className="text-zinc-500" />
+                            <ChevronDown size={14} aria-hidden className="text-coconut-400 dark:text-sand-400" />
                           )}
                           {group.series}{' '}
-                          <span className="font-normal normal-case tracking-normal text-zinc-500">
+                          <span className="font-normal normal-case tracking-normal text-coconut-400 dark:text-sand-400">
                             {selectedInSeries > 0
                               ? `(${selectedInSeries}/${group.sets.length})`
                               : `(${group.sets.length})`}
@@ -309,7 +309,7 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
                         <button
                           type="button"
                           onClick={() => selectSeries(group.series)}
-                          className="text-xs text-zinc-400 underline-offset-2 hover:text-zinc-200 hover:underline"
+                          className="text-xs text-coconut-400 dark:text-sand-300 underline-offset-2 hover:text-coconut-600 dark:hover:text-sand-200 hover:underline"
                         >
                           Select series
                         </button>
@@ -335,9 +335,9 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
             </ul>
           </div>
 
-          <footer className="flex items-center justify-between gap-3 border-t border-zinc-800 px-5 py-4">
-            <div className="flex-1 text-xs text-zinc-400">
-              {submitError && <span className="text-red-400">{submitError}</span>}
+          <footer className="flex items-center justify-between gap-3 border-t border-sand-200 dark:border-husk-100 px-5 py-4">
+            <div className="flex-1 text-xs text-coconut-400 dark:text-sand-300">
+              {submitError && <span className="text-ember-500 dark:text-ember-300">{submitError}</span>}
               {!submitError && (
                 <span>
                   {selectedCount} set{selectedCount === 1 ? '' : 's'} selected
@@ -345,14 +345,14 @@ export function SetPickerModal({ open, onOpenChange }: Props) {
               )}
             </div>
             <Dialog.Close asChild>
-              <button className="rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-200 hover:bg-zinc-700">
+              <button className="rounded-md border border-sand-300 dark:border-husk-50 bg-sand-200 dark:bg-husk-100 px-3 py-1.5 text-sm text-coconut-600 dark:text-sand-200 hover:bg-sand-200 dark:hover:bg-husk-100">
                 Cancel
               </button>
             </Dialog.Close>
             <button
               onClick={handleSubmit}
               disabled={submitting || draft.size === 0}
-              className="flex items-center gap-1.5 rounded-md border border-blue-700 bg-blue-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-600 disabled:opacity-40 disabled:cursor-not-allowed"
+              className="flex items-center gap-1.5 rounded-md border border-palm-400 dark:border-sun-400 bg-sun-400 dark:bg-sun-400 px-3 py-1.5 text-sm font-medium text-white hover:bg-sun-300 dark:hover:bg-sun-300 disabled:opacity-40 disabled:cursor-not-allowed"
             >
               {submitting ? (
                 <Loader2 size={14} className="animate-spin" />
@@ -379,7 +379,7 @@ function BulkButton({
     <button
       type="button"
       onClick={onClick}
-      className="rounded-md border border-zinc-700 bg-zinc-800 px-2.5 py-1 text-xs text-zinc-200 hover:bg-zinc-700"
+      className="rounded-md border border-sand-300 dark:border-husk-50 bg-sand-200 dark:bg-husk-100 px-2.5 py-1 text-xs text-coconut-600 dark:text-sand-200 hover:bg-sand-200 dark:hover:bg-husk-100"
     >
       {children}
     </button>
@@ -399,19 +399,19 @@ function SetRow({ set, checked, onToggle }: RowProps) {
     <li>
       <label
         className={`flex items-center gap-3 rounded-md px-2 py-1.5 cursor-pointer transition-colors ${
-          checked ? 'bg-blue-950/40 ring-1 ring-blue-700/40' : 'hover:bg-zinc-800/60'
+          checked ? 'bg-palm-50 ring-1 ring-palm-500 dark:bg-sun-400/15 dark:ring-sun-400/40' : 'hover:bg-sand-200 dark:hover:bg-husk-100/60'
         }`}
       >
         <input
           type="checkbox"
           checked={checked}
           onChange={onToggle}
-          className="accent-blue-500"
+          className="accent-palm-500 dark:accent-sun-300"
           aria-label={`Include ${set.name}`}
         />
-        <div className="flex h-8 w-12 flex-none items-center justify-center rounded bg-zinc-950/60">
+        <div className="flex h-8 w-12 flex-none items-center justify-center rounded bg-sand-50 dark:bg-husk-400/60">
           {logoFailed ? (
-            <ImageOff size={14} className="text-zinc-600" aria-hidden />
+            <ImageOff size={14} className="text-coconut-300 dark:text-sand-500" aria-hidden />
           ) : (
             // Cached logo from /api/v1/sets/{id}/logo. The endpoint 404s for
             // un-warmed sets; onError hides the broken image so the row
@@ -426,8 +426,8 @@ function SetRow({ set, checked, onToggle }: RowProps) {
           )}
         </div>
         <div className="min-w-0 flex-1">
-          <div className="truncate text-sm text-zinc-100">{set.name}</div>
-          <div className="truncate text-xs text-zinc-500">
+          <div className="truncate text-sm text-coconut-700 dark:text-sand-50">{set.name}</div>
+          <div className="truncate text-xs text-coconut-400 dark:text-sand-400">
             {year || '—'} · {set.total ? `${set.total} cards` : 'count unknown'}
           </div>
         </div>

--- a/web/src/components/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer.tsx
@@ -24,7 +24,7 @@ export function SettingsDrawer() {
     <Dialog.Root>
       <Dialog.Trigger asChild>
         <button
-          className="flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-800 px-2.5 py-1.5 text-sm text-zinc-200 hover:bg-zinc-700 transition-colors sm:px-3"
+          className="flex items-center gap-1.5 rounded-md border border-sand-300 dark:border-husk-50 bg-sand-200 dark:bg-husk-100 px-2.5 py-1.5 text-sm text-coconut-600 dark:text-sand-200 hover:bg-sand-200 dark:hover:bg-husk-100 transition-colors sm:px-3"
           title="Settings"
           aria-label="Settings"
         >
@@ -34,20 +34,20 @@ export function SettingsDrawer() {
       </Dialog.Trigger>
 
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm" />
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-coconut-700/50 dark:bg-husk-500/70 backdrop-blur-sm" />
         <Dialog.Content
           aria-describedby={undefined}
-          className="fixed right-0 top-0 z-50 h-full w-full sm:w-80 bg-zinc-900 border-l border-zinc-700 shadow-2xl flex flex-col"
+          className="fixed right-0 top-0 z-50 h-full w-full sm:w-80 bg-sand-50 dark:bg-husk-200 border-l border-sand-300 dark:border-husk-50 shadow-2xl flex flex-col"
         >
           {/* Header */}
-          <div className="flex items-center justify-between border-b border-zinc-700 px-5 py-4">
-            <Dialog.Title className="text-base font-semibold text-zinc-100">
+          <div className="flex items-center justify-between border-b border-sand-300 dark:border-husk-50 px-5 py-4">
+            <Dialog.Title className="text-base font-semibold text-coconut-700 dark:text-sand-50">
               Settings
             </Dialog.Title>
             <Dialog.Close asChild>
               <button
                 aria-label="Close settings"
-                className="rounded p-1 text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700 transition-colors"
+                className="rounded p-1 text-coconut-400 dark:text-sand-300 hover:text-coconut-700 dark:hover:text-sand-50 hover:bg-sand-200 dark:hover:bg-husk-100 transition-colors"
               >
                 <X size={16} />
               </button>
@@ -64,7 +64,7 @@ export function SettingsDrawer() {
                 value={settings.apiKey}
                 onChange={(e) => updateSettings({ apiKey: e.target.value })}
                 placeholder="Optional — raises rate limit"
-                className="w-full rounded-md border border-zinc-600 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 placeholder:text-zinc-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                className="w-full rounded-md border border-sand-300 dark:border-coconut-500 bg-sand-200 dark:bg-husk-100 px-3 py-1.5 text-sm text-coconut-700 dark:text-sand-50 placeholder:text-coconut-400 dark:text-sand-400 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:ring-sun-300"
               />
             </Field>
 
@@ -76,7 +76,7 @@ export function SettingsDrawer() {
                 value={settings.tag}
                 onChange={(e) => updateSettings({ tag: e.target.value })}
                 placeholder="Labels rows in the export"
-                className="w-full rounded-md border border-zinc-600 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 placeholder:text-zinc-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                className="w-full rounded-md border border-sand-300 dark:border-coconut-500 bg-sand-200 dark:bg-husk-100 px-3 py-1.5 text-sm text-coconut-700 dark:text-sand-50 placeholder:text-coconut-400 dark:text-sand-400 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:ring-sun-300"
               />
             </Field>
 
@@ -86,7 +86,7 @@ export function SettingsDrawer() {
                 id="sort"
                 value={settings.sort}
                 onChange={(e) => updateSettings({ sort: e.target.value as SortMode })}
-                className="w-full rounded-md border border-zinc-600 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                className="w-full rounded-md border border-sand-300 dark:border-coconut-500 bg-sand-200 dark:bg-husk-100 px-3 py-1.5 text-sm text-coconut-700 dark:text-sand-50 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:ring-sun-300"
               >
                 {SORT_OPTIONS.map((opt) => (
                   <option key={opt.value} value={opt.value}>
@@ -94,7 +94,7 @@ export function SettingsDrawer() {
                   </option>
                 ))}
               </select>
-              <p className="mt-1 text-xs text-zinc-400">
+              <p className="mt-1 text-xs text-coconut-400 dark:text-sand-300">
                 Applied to every export (xlsx, PDF binder, condensed PDF, checklist). Tag stays the
                 outermost group; this only changes order within each tag.
               </p>
@@ -114,9 +114,9 @@ export function SettingsDrawer() {
                   })
                 }
                 placeholder="No cap"
-                className="w-full rounded-md border border-zinc-600 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 placeholder:text-zinc-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                className="w-full rounded-md border border-sand-300 dark:border-coconut-500 bg-sand-200 dark:bg-husk-100 px-3 py-1.5 text-sm text-coconut-700 dark:text-sand-50 placeholder:text-coconut-400 dark:text-sand-400 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:ring-sun-300"
               />
-              <p className="mt-1 text-xs text-zinc-400">
+              <p className="mt-1 text-xs text-coconut-400 dark:text-sand-300">
                 Bulk top-N results above this price are excluded. Single-card lookups are always
                 shown (flagged amber in the export).
               </p>
@@ -149,10 +149,10 @@ export function SettingsDrawer() {
           </div>
 
           {/* Footer */}
-          <div className="border-t border-zinc-700 px-5 py-4">
+          <div className="border-t border-sand-300 dark:border-husk-50 px-5 py-4">
             <button
               onClick={resetSettings}
-              className="w-full rounded-md border border-zinc-700 bg-zinc-800 px-3 py-1.5 text-sm text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700 transition-colors"
+              className="w-full rounded-md border border-sand-300 dark:border-husk-50 bg-sand-200 dark:bg-husk-100 px-3 py-1.5 text-sm text-coconut-400 dark:text-sand-300 hover:text-coconut-700 dark:hover:text-sand-50 hover:bg-sand-200 dark:hover:bg-husk-100 transition-colors"
             >
               Restore defaults
             </button>
@@ -178,7 +178,7 @@ function Field({
 }) {
   return (
     <div>
-      <label htmlFor={htmlFor} className="block mb-1.5 text-sm font-medium text-zinc-300">
+      <label htmlFor={htmlFor} className="block mb-1.5 text-sm font-medium text-coconut-600 dark:text-sand-200">
         {label}
       </label>
       {children}
@@ -210,15 +210,15 @@ function Toggle({
           className="sr-only"
         />
         <div
-          className={`w-9 h-5 rounded-full transition-colors ${checked ? 'bg-blue-600' : 'bg-zinc-600'}`}
+          className={`w-9 h-5 rounded-full transition-colors ${checked ? 'bg-sun-300 dark:bg-sun-300' : 'bg-sand-300 dark:bg-husk-50'}`}
         />
         <div
           className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow transition-transform ${checked ? 'translate-x-4' : ''}`}
         />
       </div>
       <div>
-        <p className="text-sm text-zinc-200 group-hover:text-zinc-100">{label}</p>
-        <p className="text-xs text-zinc-400">{description}</p>
+        <p className="text-sm text-coconut-600 dark:text-sand-200 group-hover:text-coconut-700 dark:hover:text-sand-50">{label}</p>
+        <p className="text-xs text-coconut-400 dark:text-sand-300">{description}</p>
       </div>
     </label>
   )

--- a/web/src/components/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer.tsx
@@ -64,7 +64,7 @@ export function SettingsDrawer() {
                 value={settings.apiKey}
                 onChange={(e) => updateSettings({ apiKey: e.target.value })}
                 placeholder="Optional — raises rate limit"
-                className="w-full rounded-md border border-sand-300 dark:border-coconut-500 bg-sand-200 dark:bg-husk-100 px-3 py-1.5 text-sm text-coconut-700 dark:text-sand-50 placeholder:text-coconut-400 dark:text-sand-400 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:ring-sun-300"
+                className="w-full rounded-md border border-sand-300 dark:border-coconut-500 bg-sand-200 dark:bg-husk-100 px-3 py-1.5 text-sm text-coconut-700 dark:text-sand-50 placeholder:text-coconut-400 dark:placeholder:text-sand-400 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:ring-sun-300"
               />
             </Field>
 
@@ -76,7 +76,7 @@ export function SettingsDrawer() {
                 value={settings.tag}
                 onChange={(e) => updateSettings({ tag: e.target.value })}
                 placeholder="Labels rows in the export"
-                className="w-full rounded-md border border-sand-300 dark:border-coconut-500 bg-sand-200 dark:bg-husk-100 px-3 py-1.5 text-sm text-coconut-700 dark:text-sand-50 placeholder:text-coconut-400 dark:text-sand-400 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:ring-sun-300"
+                className="w-full rounded-md border border-sand-300 dark:border-coconut-500 bg-sand-200 dark:bg-husk-100 px-3 py-1.5 text-sm text-coconut-700 dark:text-sand-50 placeholder:text-coconut-400 dark:placeholder:text-sand-400 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:ring-sun-300"
               />
             </Field>
 
@@ -114,7 +114,7 @@ export function SettingsDrawer() {
                   })
                 }
                 placeholder="No cap"
-                className="w-full rounded-md border border-sand-300 dark:border-coconut-500 bg-sand-200 dark:bg-husk-100 px-3 py-1.5 text-sm text-coconut-700 dark:text-sand-50 placeholder:text-coconut-400 dark:text-sand-400 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:ring-sun-300"
+                className="w-full rounded-md border border-sand-300 dark:border-coconut-500 bg-sand-200 dark:bg-husk-100 px-3 py-1.5 text-sm text-coconut-700 dark:text-sand-50 placeholder:text-coconut-400 dark:placeholder:text-sand-400 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:ring-sun-300"
               />
               <p className="mt-1 text-xs text-coconut-400 dark:text-sand-300">
                 Bulk top-N results above this price are excluded. Single-card lookups are always

--- a/web/src/components/ThemeToggle.tsx
+++ b/web/src/components/ThemeToggle.tsx
@@ -1,0 +1,71 @@
+/**
+ * ThemeToggle — light/dark toggle for the demo SPA.
+ *
+ * Mirrors the marketing site's `site/src/components/ThemeToggle.astro`:
+ * flips `.dark` on `<html>` and persists in `localStorage` under the
+ * same `theme` key, so the choice survives reloads and roundtrips
+ * between the SPA and the marketing site (if they ever share an
+ * origin) without re-prompting. The pre-paint script in `index.html`
+ * is the source of truth for the *initial* class — this component is
+ * only the user-facing toggle.
+ *
+ * Icons follow lucide-react (Sun/Moon) so they match the rest of the
+ * SPA's icon system. The shown icon is the theme you'd switch *to*.
+ */
+import { useCallback, useEffect, useState } from 'react'
+import { Moon, Sun } from 'lucide-react'
+
+export function ThemeToggle() {
+  // Mirror the actual <html> class on first mount instead of guessing —
+  // the pre-paint script already resolved it before React loaded.
+  const [isDark, setIsDark] = useState<boolean>(() => {
+    if (typeof document === 'undefined') return false
+    return document.documentElement.classList.contains('dark')
+  })
+
+  // Sync if the OS theme changes mid-session and the user hasn't pinned
+  // a choice. Symmetric with how the pre-paint script resolves on load.
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return
+    let cancelled = false
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    function onChange(event: MediaQueryListEvent) {
+      if (cancelled) return
+      try {
+        if (localStorage.getItem('theme')) return // user-pinned, ignore
+      } catch {
+        // localStorage unavailable; fall through and follow the OS.
+      }
+      document.documentElement.classList.toggle('dark', event.matches)
+      setIsDark(event.matches)
+    }
+    mq.addEventListener('change', onChange)
+    return () => {
+      cancelled = true
+      mq.removeEventListener('change', onChange)
+    }
+  }, [])
+
+  const toggle = useCallback(() => {
+    const next = !document.documentElement.classList.contains('dark')
+    document.documentElement.classList.toggle('dark', next)
+    try {
+      localStorage.setItem('theme', next ? 'dark' : 'light')
+    } catch {
+      // Best-effort persistence; the toggle still works for the session.
+    }
+    setIsDark(next)
+  }, [])
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label="Toggle color theme"
+      title="Toggle color theme"
+      className="inline-flex h-9 w-9 items-center justify-center rounded-md text-coconut-500 hover:text-coconut-700 hover:bg-sand-100 dark:text-sand-200 dark:hover:text-sand-50 dark:hover:bg-husk-100 transition"
+    >
+      {isDark ? <Sun size={18} /> : <Moon size={18} />}
+    </button>
+  )
+}

--- a/web/src/components/Tour.tsx
+++ b/web/src/components/Tour.tsx
@@ -192,7 +192,7 @@ export function Tour({ onClose, onRun, onStop }: Props) {
         </button>
         <button
           onClick={next}
-          className="flex items-center gap-1 rounded-md bg-sun-300 dark:bg-sun-300 px-3 py-1 text-xs font-medium text-white hover:bg-sun-300 dark:hover:bg-sun-300 transition-colors"
+          className="flex items-center gap-1 rounded-md bg-sun-300 dark:bg-sun-300 px-3 py-1 text-xs font-medium text-coconut-700 dark:text-husk-500 hover:bg-sun-400 dark:hover:bg-sun-200 transition-colors"
         >
           {isLast ? 'Done' : 'Next'}
           {!isLast && <ChevronRight size={14} />}

--- a/web/src/components/Tour.tsx
+++ b/web/src/components/Tour.tsx
@@ -154,45 +154,45 @@ export function Tour({ onClose, onRun, onStop }: Props) {
 
   return (
     <div
-      className="fixed inset-x-0 bottom-4 z-50 mx-auto w-[min(560px,92vw)] rounded-lg border border-blue-500/60 bg-zinc-900 shadow-2xl"
+      className="fixed inset-x-0 bottom-4 z-50 mx-auto w-[min(560px,92vw)] rounded-lg border border-palm-400/60 dark:border-sun-300/60 bg-sand-50 dark:bg-husk-200 shadow-2xl shadow-coconut-700/30"
       role="dialog"
       aria-label={`Tour: ${step.title}`}
     >
-      <div className="flex items-center justify-between border-b border-zinc-700 px-4 py-2.5">
+      <div className="flex items-center justify-between border-b border-sand-300 dark:border-husk-50 px-4 py-2.5">
         <div className="flex items-center gap-2">
-          <span className="text-xs font-semibold text-blue-400">
+          <span className="text-xs font-semibold text-palm-500 dark:text-sun-300">
             Step {stepIndex + 1} of {STEPS.length}
           </span>
-          <span className="text-sm font-semibold text-zinc-100">{step.title}</span>
+          <span className="text-sm font-semibold text-coconut-700 dark:text-sand-50">{step.title}</span>
         </div>
         <button
           onClick={onClose}
-          className="rounded p-1 text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700 transition-colors"
+          className="rounded p-1 text-coconut-400 dark:text-sand-300 hover:text-coconut-700 dark:hover:text-sand-50 hover:bg-sand-200 dark:hover:bg-husk-100 transition-colors"
           aria-label="Skip tour"
           title="Skip tour"
         >
           <X size={16} />
         </button>
       </div>
-      <div className="px-4 py-3 text-sm text-zinc-300">{step.body}</div>
-      <div className="flex items-center justify-between border-t border-zinc-700 px-4 py-2.5">
+      <div className="px-4 py-3 text-sm text-coconut-600 dark:text-sand-200">{step.body}</div>
+      <div className="flex items-center justify-between border-t border-sand-300 dark:border-husk-50 px-4 py-2.5">
         <button
           onClick={prev}
           disabled={isFirst}
-          className="flex items-center gap-1 rounded px-2 py-1 text-xs text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+          className="flex items-center gap-1 rounded px-2 py-1 text-xs text-coconut-400 dark:text-sand-300 hover:text-coconut-700 dark:hover:text-sand-50 hover:bg-sand-200 dark:hover:bg-husk-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
         >
           <ChevronLeft size={14} />
           Back
         </button>
         <button
           onClick={onClose}
-          className="rounded px-2 py-1 text-xs text-zinc-500 hover:text-zinc-200 transition-colors"
+          className="rounded px-2 py-1 text-xs text-coconut-400 dark:text-sand-400 hover:text-coconut-600 dark:hover:text-sand-200 transition-colors"
         >
           Skip
         </button>
         <button
           onClick={next}
-          className="flex items-center gap-1 rounded-md bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-500 transition-colors"
+          className="flex items-center gap-1 rounded-md bg-sun-300 dark:bg-sun-300 px-3 py-1 text-xs font-medium text-white hover:bg-sun-300 dark:hover:bg-sun-300 transition-colors"
         >
           {isLast ? 'Done' : 'Next'}
           {!isLast && <ChevronRight size={14} />}

--- a/web/src/components/WhatsNewModal.tsx
+++ b/web/src/components/WhatsNewModal.tsx
@@ -26,12 +26,12 @@ const REPO_CHANGELOG_URL =
 
 // Section-name → badge accent. Unknown names fall back to a neutral chip.
 const SECTION_ACCENT: Record<string, string> = {
-  Added: 'text-emerald-400 border-emerald-400/30',
-  Changed: 'text-sky-400 border-sky-400/30',
-  Fixed: 'text-amber-400 border-amber-400/30',
-  Removed: 'text-rose-400 border-rose-400/30',
-  Deprecated: 'text-orange-400 border-orange-400/30',
-  Security: 'text-violet-400 border-violet-400/30',
+  Added: 'text-palm-600 border-palm-500/30 dark:text-palm-200 dark:border-palm-300/30',
+  Changed: 'text-sky-500 border-sky-400/30 dark:text-sky-300 dark:border-sky-400/30',
+  Fixed: 'text-sun-600 border-sun-400/30 dark:text-sun-300 dark:border-sun-400/30',
+  Removed: 'text-ember-500 border-ember-400/30 dark:text-ember-300 dark:border-ember-400/30',
+  Deprecated: 'text-sun-700 border-sun-500/30 dark:text-sun-400 dark:border-sun-500/30',
+  Security: 'text-ember-600 border-ember-500/30 dark:text-ember-300 dark:border-ember-500/30',
 }
 
 function formatDate(iso: string | null): string {
@@ -90,7 +90,7 @@ export function WhatsNewModal() {
     <Dialog.Root open={open} onOpenChange={handleOpenChange}>
       <Dialog.Trigger asChild>
         <button
-          className="relative flex items-center gap-1.5 rounded-md border border-zinc-700 bg-zinc-800 px-2.5 py-1.5 text-sm text-zinc-200 hover:bg-zinc-700 transition-colors sm:px-3"
+          className="relative flex items-center gap-1.5 rounded-md border border-sand-300 bg-sand-100 px-2.5 py-1.5 text-sm text-coconut-700 hover:bg-sand-200 hover:border-sand-400 dark:border-husk-50 dark:bg-husk-200 dark:text-sand-50 dark:hover:bg-husk-100 dark:hover:border-coconut-400 transition-colors sm:px-3"
           title="What's new"
           aria-label={hasUnseen ? "What's new (new release available)" : "What's new"}
         >
@@ -99,25 +99,25 @@ export function WhatsNewModal() {
           {hasUnseen && (
             <span
               aria-hidden="true"
-              className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full bg-blue-500 ring-2 ring-zinc-950"
+              className="absolute -right-1 -top-1 h-2.5 w-2.5 rounded-full bg-palm-400 dark:bg-sun-300 ring-2 ring-sand-50 dark:ring-husk-400"
             />
           )}
         </button>
       </Dialog.Trigger>
 
       <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm" />
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-coconut-700/50 dark:bg-husk-500/70 backdrop-blur-sm" />
         <Dialog.Content
           aria-describedby={undefined}
-          className="fixed left-1/2 top-1/2 z-50 flex max-h-[90vh] w-[min(640px,92vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-zinc-700 bg-zinc-900 shadow-2xl"
+          className="fixed left-1/2 top-1/2 z-50 flex max-h-[90vh] w-[min(640px,92vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-sand-300 dark:border-husk-50 bg-sand-50 dark:bg-husk-200 shadow-2xl"
         >
-          <div className="flex items-center justify-between border-b border-zinc-700 px-5 py-4">
-            <Dialog.Title className="text-base font-semibold text-zinc-100">
+          <div className="flex items-center justify-between border-b border-sand-300 dark:border-husk-50 px-5 py-4">
+            <Dialog.Title className="text-base font-semibold text-coconut-700 dark:text-sand-50">
               What's new
             </Dialog.Title>
             <Dialog.Close asChild>
               <button
-                className="rounded p-1 text-zinc-400 hover:text-zinc-100 hover:bg-zinc-700 transition-colors"
+                className="rounded p-1 text-coconut-400 dark:text-sand-300 hover:text-coconut-700 dark:hover:text-sand-50 hover:bg-sand-200 dark:hover:bg-husk-100 transition-colors"
                 aria-label="Close"
               >
                 <X size={16} />
@@ -127,36 +127,36 @@ export function WhatsNewModal() {
 
           <div
             tabIndex={0}
-            className="flex-1 overflow-y-auto px-5 py-4 text-sm text-zinc-300 focus:outline-none focus:ring-1 focus:ring-blue-500"
+            className="flex-1 overflow-y-auto px-5 py-4 text-sm text-coconut-600 dark:text-sand-200 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:ring-sun-300"
           >
             {error || (releases && releases.length === 0) ? (
-              <p className="text-zinc-400">
+              <p className="text-coconut-400 dark:text-sand-300">
                 Release notes couldn't be loaded right now. See the{' '}
                 <a
                   href={REPO_CHANGELOG_URL}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-blue-400 underline hover:text-blue-300"
+                  className="text-palm-500 dark:text-sun-300 underline hover:text-palm-400 dark:hover:text-sun-200"
                 >
                   full changelog
                 </a>
                 .
               </p>
             ) : releases === null ? (
-              <p className="text-zinc-500">Loading release notes…</p>
+              <p className="text-coconut-400 dark:text-sand-400">Loading release notes…</p>
             ) : (
               <ol className="space-y-8">
                 {releases.map((release) => (
                   <li
                     key={release.version}
-                    className="border-l border-zinc-800 pl-4"
+                    className="border-l border-sand-200 dark:border-husk-100 pl-4"
                   >
                     <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-                      <h3 className="text-base font-semibold text-zinc-100">
+                      <h3 className="text-base font-semibold text-coconut-700 dark:text-sand-50">
                         v{release.version}
                       </h3>
                       {release.date && (
-                        <time className="text-xs text-zinc-500">
+                        <time className="text-xs text-coconut-400 dark:text-sand-400">
                           {formatDate(release.date)}
                         </time>
                       )}
@@ -167,7 +167,7 @@ export function WhatsNewModal() {
                           <span
                             className={`inline-block rounded-full border px-2 py-0.5 text-xs font-medium ${
                               SECTION_ACCENT[section.name] ??
-                              'text-zinc-400 border-zinc-700'
+                              'text-coconut-400 dark:text-sand-300 border-sand-300 dark:border-husk-50'
                             }`}
                           >
                             {section.name}
@@ -177,7 +177,7 @@ export function WhatsNewModal() {
                               <li key={i} className="flex gap-2 leading-relaxed">
                                 <span
                                   aria-hidden="true"
-                                  className="mt-2 h-1 w-1 shrink-0 rounded-full bg-zinc-600"
+                                  className="mt-2 h-1 w-1 shrink-0 rounded-full bg-sand-300 dark:bg-husk-50"
                                 />
                                 <span>{renderInlineMarkdown(entry)}</span>
                               </li>
@@ -192,12 +192,12 @@ export function WhatsNewModal() {
             )}
           </div>
 
-          <div className="flex items-center justify-end border-t border-zinc-700 px-5 py-3">
+          <div className="flex items-center justify-end border-t border-sand-300 dark:border-husk-50 px-5 py-3">
             <a
               href={REPO_CHANGELOG_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-xs font-medium text-blue-400 hover:text-blue-300 transition-colors"
+              className="text-xs font-medium text-palm-500 dark:text-sun-300 hover:text-palm-400 dark:hover:text-sun-200 transition-colors"
             >
               Full changelog →
             </a>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,5 +1,152 @@
+/* ============================================================
+ * web/src/index.css — Tailwind v4 @theme for the React SPA.
+ *
+ * Mirrors site/src/styles/global.css so the marketing site and
+ * the demo SPA render identically: same tropical palette
+ * (sun / palm / coconut / sand / husk / sky / ember), same
+ * type stack (Bricolage / DM Sans / JetBrains Mono), same warm
+ * coconut-alpha shadows.
+ *
+ * Light is the default. Dark opts in via `.dark` on <html>,
+ * driven by the pre-paint script in index.html so the choice
+ * persists and follows OS preference without flashing.
+ * ============================================================ */
 @import "tailwindcss";
 
+@import url("https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,600;12..96,700;12..96,800&family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=JetBrains+Mono:wght@400;500;700&display=swap");
+
+@custom-variant dark (&:where(.dark, .dark *));
+
+@theme {
+  /* Sun — primary yellow (Exeggutor's heads / ripe coconut). */
+  --color-sun-50: #fdf6d9;
+  --color-sun-100: #fbeba8;
+  --color-sun-200: #f8dd78;
+  --color-sun-300: #f5c94b;
+  --color-sun-400: #e8b028;
+  --color-sun-500: #c8901a;
+  --color-sun-600: #946812;
+  --color-sun-700: #5e420b;
+
+  /* Palm — secondary green (Exeggutor's crown / success / links). */
+  --color-palm-50: #eaf3e2;
+  --color-palm-100: #c9e0b5;
+  --color-palm-200: #97c57e;
+  --color-palm-300: #6bac55;
+  --color-palm-400: #4a8b3b;
+  --color-palm-500: #386c2c;
+  --color-palm-600: #2d5a28;
+  --color-palm-700: #1c3a19;
+
+  /* Coconut — tertiary brown (trunk / body text on cream). */
+  --color-coconut-50: #f4ecdd;
+  --color-coconut-100: #e4d2b0;
+  --color-coconut-200: #c8ac7e;
+  --color-coconut-300: #a6845a;
+  --color-coconut-400: #80623f;
+  --color-coconut-500: #6b4a2f;
+  --color-coconut-600: #4d341f;
+  --color-coconut-700: #2e1f11;
+
+  /* Sand — neutral cream surfaces. */
+  --color-sand-50: #fbf6e8;
+  --color-sand-100: #f4ecd3;
+  --color-sand-200: #e8ddbc;
+  --color-sand-300: #d6c99f;
+  --color-sand-400: #b4a77c;
+  --color-sand-500: #8c8261;
+  --color-sand-600: #5f583f;
+  --color-sand-700: #3a361f;
+
+  /* Husk — coffee-charcoal for dark-mode surfaces. */
+  --color-husk-50: #4a453b;
+  --color-husk-100: #353128;
+  --color-husk-200: #2a2620;
+  --color-husk-300: #1f1b16;
+  --color-husk-400: #15120e;
+  --color-husk-500: #0d0b07;
+
+  /* Sky — sparing info accent over warm surfaces. */
+  --color-sky-300: #8fc3dd;
+  --color-sky-400: #6fb1d9;
+  --color-sky-500: #4a8fb8;
+
+  /* Ember — clay-red for destructive / danger. */
+  --color-ember-300: #e8a088;
+  --color-ember-400: #d26b4d;
+  --color-ember-500: #a84a2f;
+  --color-ember-600: #7d331e;
+
+  /* Type. */
+  --font-display:
+    "Bricolage Grotesque", ui-sans-serif, system-ui, -apple-system, "Segoe UI",
+    Roboto, sans-serif;
+  --font-sans:
+    "DM Sans", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+    sans-serif;
+  --font-mono:
+    "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    monospace;
+
+  /* Radii. */
+  --radius-xs: 4px;
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 14px;
+  --radius-xl: 20px;
+  --radius-2xl: 28px;
+
+  /* Shadows — warm coconut alpha. */
+  --shadow-xs: 0 1px 0 0 rgba(77, 52, 31, 0.06);
+  --shadow-sm:
+    0 1px 2px 0 rgba(77, 52, 31, 0.08), 0 1px 1px -1px rgba(77, 52, 31, 0.04);
+  --shadow-md:
+    0 4px 10px -2px rgba(77, 52, 31, 0.12),
+    0 2px 4px -2px rgba(77, 52, 31, 0.06);
+  --shadow-lg:
+    0 12px 28px -8px rgba(77, 52, 31, 0.18),
+    0 4px 10px -6px rgba(77, 52, 31, 0.08);
+  --shadow-xl:
+    0 24px 52px -12px rgba(77, 52, 31, 0.22),
+    0 8px 20px -10px rgba(77, 52, 31, 0.1);
+}
+
+/* ---------- Base body styles ----------
+   Light is the default to match the marketing site after #343.
+   The pre-paint script in index.html flips to `.dark` before the
+   first paint when the persisted choice or OS preference says so,
+   so the html background here is the cream sand-50. */
+html {
+  scroll-behavior: smooth;
+  background-color: var(--color-sand-50);
+  color-scheme: light;
+}
+
+html.dark {
+  background-color: var(--color-husk-400);
+  color-scheme: dark;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-feature-settings: "cv11", "ss01";
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+@layer base {
+  h1,
+  h2,
+  h3,
+  h4 {
+    font-family: var(--font-display);
+    letter-spacing: -0.02em;
+    text-wrap: balance;
+  }
+}
+
+/* Streaming-results row enter animation — unchanged from before
+   the palette move. */
 @keyframes fadeInRow {
   from {
     opacity: 0;
@@ -11,9 +158,14 @@
   }
 }
 
+/* Tour highlight ring — kept ember-red on purpose; the tour wants
+   an *attention-grab* color that pops in both themes, not the brand
+   palette. */
 .tour-highlight {
   position: relative;
-  box-shadow: 0 0 0 3px #ef4444, 0 0 24px 6px rgba(239, 68, 68, 0.4);
+  box-shadow:
+    0 0 0 3px var(--color-ember-400),
+    0 0 24px 6px rgba(210, 107, 77, 0.4);
   border-radius: 6px;
   transition: box-shadow 200ms ease-in-out;
 }

--- a/web/src/utils/inlineMarkdown.tsx
+++ b/web/src/utils/inlineMarkdown.tsx
@@ -28,7 +28,7 @@ export function renderInlineMarkdown(text: string): ReactNode[] {
           href={match[2]}
           target="_blank"
           rel="noopener noreferrer"
-          className="underline decoration-zinc-600 hover:decoration-zinc-300"
+          className="underline decoration-coconut-300 hover:decoration-palm-500 dark:decoration-sand-400 dark:hover:decoration-sun-300"
         >
           {match[1]}
         </a>,
@@ -37,14 +37,14 @@ export function renderInlineMarkdown(text: string): ReactNode[] {
       nodes.push(
         <code
           key={nodes.length}
-          className="rounded bg-zinc-800 px-1 py-0.5 text-[0.85em] text-zinc-200"
+          className="rounded bg-sand-200 dark:bg-husk-100 px-1 py-0.5 text-[0.85em] text-coconut-600 dark:text-sand-200"
         >
           {match[3]}
         </code>,
       )
     } else if (match[4] !== undefined) {
       nodes.push(
-        <strong key={nodes.length} className="font-semibold text-zinc-100">
+        <strong key={nodes.length} className="font-semibold text-coconut-700 dark:text-sand-50">
           {match[4]}
         </strong>,
       )


### PR DESCRIPTION
Closes #344

## What

Mirrors the marketing-site sweep from [#343](https://github.com/mgzwarrior/mgz-pkmn/pull/343) onto the React SPA so the
two surfaces look like the same product:

- [`web/src/index.css`](web/src/index.css) adopts the same `@theme`
  block as the marketing site (sun / palm / coconut / sand / husk /
  sky / ember palettes, Bricolage + DM Sans + JetBrains Mono fonts,
  warm coconut-alpha shadows, `@custom-variant dark`). The
  `tour-highlight` keyframe ring moves from a hardcoded `#ef4444`
  to `--color-ember-400`.
- [`web/index.html`](web/index.html) gains the same pre-paint
  resolution script the marketing site uses — saved-choice → OS
  preference → light default — so first paint never flashes the
  wrong surface.
- New [`ThemeToggle`](web/src/components/ThemeToggle.tsx) React
  component (lucide `Sun`/`Moon` icons, matching the SPA aesthetic)
  flips `.dark` on `<html>` and persists in `localStorage` under the
  same `theme` key as the marketing site. Mid-session OS changes
  follow through when the user hasn't pinned a choice.
- App shell, every modal/drawer (`Browse`, `CardDetail`, `Help`,
  `WhatsNew`, `SetPicker`, `Settings`), `ProcessingQueue` (stage
  chips + legend + spinner), `ResultsTable` (progress bar, over-cap
  amber, market green, error red), `InputEditor` (example chips,
  parse preview, Stop button), `ExportBar` dropdown, `RecentRuns`,
  `Tour`, and the easter-egg modal all move onto paired light/dark
  tokens.
- Stage colors in [`ProcessingQueue`](web/src/components/ProcessingQueue.tsx)
  get a paired-token mapping (`sky-500/sky-300` for `looking_up`,
  `palm-600/palm-200` for `resolved`, `sun-600/sun-300` for
  `no_match`, `ember-500/ember-300` for `error`, etc.) so the legend
  reads on both surfaces. The accessibility doc is updated.
- [`AnnouncementBanner`](web/src/components/AnnouncementBanner.tsx),
  [`inlineMarkdown`](web/src/utils/inlineMarkdown.tsx) (linkified
  release notes), and the [`ErrorBoundary`](web/src/components/ErrorBoundary.tsx)
  fallback also swept off the leftover zinc/blue stock palette.

Light is the default to match the marketing site's first-visit
experience after [#343](https://github.com/mgzwarrior/mgz-pkmn/pull/343).
Behavior is unchanged; only colors and the new theme toggle ship.

## Why

[#344](https://github.com/mgzwarrior/mgz-pkmn/issues/344) — the SPA was the last surface still rendering on the stock
zinc/blue Tailwind palette after [#300](https://github.com/mgzwarrior/mgz-pkmn/issues/300) (light theme) and [#342](https://github.com/mgzwarrior/mgz-pkmn/issues/342) (site
dark mode) landed. Visually unrelated surfaces are the kind of
papercut that makes a small project look like it's wearing two hats.

## How to verify

- [x] Open the SPA in light mode: cream `sand-50` background,
      sun-yellow Look up button (`text-coconut-700` on `bg-sun-300`),
      palm-green prices, sun-yellow announcement banner.
- [x] Toggle to dark via the new header Sun/Moon icon →
      coffee/husk surfaces, sun-yellow CTAs, tropical-dark logo
      (sand-50 wordmark), palm/sun chips.
- [x] Refresh — chosen theme persists (`localStorage[theme]`); no
      flash of the wrong surface.
- [x] OS toggle to dark / light mid-session (clear localStorage
      first) → SPA follows the OS preference.
- [x] Run a lookup → progress chips render distinct colors in both
      themes (sky for looking up, palm for resolved, sun for
      no_match, ember for error).
- [x] Open Help / What's new / Browse / Settings → modal chrome,
      release-note chips, and form controls all render on the
      palette.
- [x] Easter-egg (click the brand 5×) → palm-green border, sun-yellow
      claim code chip, cream surface in light / husk in dark.
- [x] `make check` and `cd web && npm run build` green (verified
      locally; one updated test in `ProcessingQueue.test.tsx`).

## Screenshots

<img width="1147" height="631" alt="image" src="https://github.com/user-attachments/assets/2e5d29b4-67d7-41eb-abf1-1390b4e02037" />
<img width="1147" height="627" alt="image" src="https://github.com/user-attachments/assets/0d3d3a71-c171-4c26-b592-a325de8cde49" />

## Out of scope

- Self-hosted webfonts.
- Component layout / copy changes.
- API / backend changes.

## Copilot review fixes (4c5f123)

- Scoped `dark:text-sand-400` to placeholders in Settings inputs and Browse search.
- Scoped Browse select/search dark focus border to `dark:focus:border-coconut-400`.
- Fixed invalid doubled-opacity Tailwind fragments (`/40/50`, `/15/30`, `/20/30`, `/15/40`) on Browse error callout, add-card hover, and active rarity chip.
- Scoped ResultsTable hover-only utilities to `dark:hover:*` so the rest state keeps its color.
- Tour + SetPicker primary CTAs now use `text-coconut-700 dark:text-husk-500` on the sun-yellow fill to clear WCAG contrast (was `text-white`).