### PR TITLE
docs: add ADRs for v1.2 deliverables (0014–0017)

### DIFF
--- a/docs/adr/0014-buttondown-for-email-subscriptions.md
+++ b/docs/adr/0014-buttondown-for-email-subscriptions.md
@@ -44,8 +44,10 @@ POST https://buttondown.com/api/emails/embed-subscribe/<username>
 The username (`mgz-pkmn`) is committed; no API key is in the
 client. The component uses progressive enhancement: when JS is
 available, the form submits inline via `fetch` and shows a success
-state in place; when JS is off, the browser posts the form
-normally and lands on Buttondown's hosted confirmation page.
+state in place; when JS is off, the `<form>` falls back to
+`target="popupwindow"` + an `onsubmit` that calls
+`window.open(...)` so the submission opens Buttondown's hosted
+form in a popup rather than navigating away from the page.
 Buttondown sets CORS on the embed endpoint so the inline path
 works without a proxy.
 

--- a/docs/adr/0014-buttondown-for-email-subscriptions.md
+++ b/docs/adr/0014-buttondown-for-email-subscriptions.md
@@ -1,0 +1,91 @@
+# ADR 0014: Buttondown for newsletter / email subscriptions
+
+- **Status:** Accepted
+- **Date:** 2026-05-31
+- **Tags:** marketing, site, infra
+
+## Context
+
+Visitors who land on the marketing site but aren't ready to install
+the CLI today need a low-friction way to be notified when a future
+release ships something they care about. Without a capture surface
+the project loses every one of those visitors: there's no
+re-engagement path, no audience to ship survey #2 or release #1.2.0
+to, and no way to validate which features actually pull people
+back.
+
+Constraints that shape the option space:
+
+- Solo maintainer. The capture surface can't add a second deploy
+  pipeline, a database to back up, or a recurring monthly fee.
+- The site is a pure static Astro build deployed to Cloudflare
+  Pages ([ADR-0011](0011-marketing-site-stack.md)) — there is no
+  server-side runtime to receive a `POST /subscribe` request.
+- No subscriber PII in the repo, ever. The capture surface must
+  not require an API key in the client, since the client is just
+  static HTML.
+- Subscribers must own their address: a confirmation email + an
+  obvious unsubscribe link, no surprise enrollment.
+- Future iterations may want to send the v1 interest survey
+  ([ADR-0015](0015-tally-for-surveys.md)) directly to subscribers,
+  so the chosen tool should not be hostile to that path.
+
+## Decision
+
+Use **[Buttondown](https://buttondown.com)** as the email
+subscription provider, embedded into
+[`site/src/components/EmailSignup.astro`](../../site/src/components/EmailSignup.astro)
+via Buttondown's public **embed-subscribe endpoint**:
+
+```
+POST https://buttondown.com/api/emails/embed-subscribe/<username>
+```
+
+The username (`mgz-pkmn`) is committed; no API key is in the
+client. The component uses progressive enhancement: when JS is
+available, the form submits inline via `fetch` and shows a success
+state in place; when JS is off, the browser posts the form
+normally and lands on Buttondown's hosted confirmation page.
+Buttondown sets CORS on the embed endpoint so the inline path
+works without a proxy.
+
+## Consequences
+
+- Zero new infrastructure. No serverless function, no Worker, no
+  Cloudflare Pages Function. The site stays a pure static build.
+- Buttondown's free tier (currently up to 100 subscribers) covers
+  the project comfortably through the v1.x line; paid tiers start
+  at $9/mo when we cross it.
+- Confirmation email + standard unsubscribe footer are handled by
+  Buttondown — no PII or compliance surface in this repo.
+- Subscriber list lives in Buttondown's dashboard, not in the
+  repo. Exporting to CSV is a one-click operation should we ever
+  need to migrate providers.
+- Migration cost if Buttondown raises prices or shuts down: swap
+  the form action in one Astro component and re-import the CSV
+  into the new provider. The component contract (one `<form>`
+  posting an email) is portable.
+
+## Alternatives considered
+
+- **Mailchimp.** Industry default but heavyweight: complex embed
+  forms, mandatory branding on free tier, account UX optimized
+  for marketing teams rather than solo maintainers. Overkill for
+  a "drop me a note when X.Y.Z ships" newsletter.
+- **Substack.** Excellent author-facing UX but its core abstraction
+  is *posts*, not transactional release notifications. Forces a
+  blogging cadence we don't have, and the embed UI puts Substack's
+  branding on our page above the fold.
+- **ConvertKit / Beehiiv.** Similar to Mailchimp's tradeoff —
+  feature-rich for creators selling courses, but the embed form
+  is a heavier component and the free tier caps tighter than
+  Buttondown's.
+- **Self-host (Listmonk + Postgres + an SMTP relay).** Cheap at
+  scale, but adds a database to back up, a service to monitor, and
+  a deliverability problem (warming a new IP). The exact opposite
+  of "no operational overhead."
+- **Roll our own** (Cloudflare Worker + KV + Mailgun). Smallest
+  possible footprint but still adds a Worker to maintain,
+  unsubscribe handling to implement, and a CAN-SPAM compliance
+  surface to own. Not worth the engineering for ~hundreds of
+  subscribers.

--- a/docs/adr/0015-tally-for-surveys.md
+++ b/docs/adr/0015-tally-for-surveys.md
@@ -1,0 +1,88 @@
+# ADR 0015: Tally for marketing surveys (with a Buttondown migration clause)
+
+- **Status:** Accepted
+- **Date:** 2026-05-31
+- **Tags:** marketing, site
+
+## Context
+
+The v1 interest survey
+([`docs/marketing/surveys/v1-interest-survey.md`](../marketing/surveys/v1-interest-survey.md))
+needs a hosting surface that can: render a ~6-question form on a
+public URL, accept free-text answers, accept an optional contact
+email, give the maintainer a readable response dashboard, and not
+cost anything on the v1.x audience scale (tens to low hundreds of
+responses).
+
+It also needs to be embeddable in the marketing-site announcement
+banner ([`AnnouncementBanner.astro`](../../site/src/components/AnnouncementBanner.astro))
+as a single click-through link — no iframe, no third-party JS on
+our page, because the site is a pure static Astro build deployed
+to Cloudflare Pages and we want it to stay that way
+([ADR-0011](0011-marketing-site-stack.md)).
+
+Constraints:
+
+- Solo maintainer. The survey tool can't add a recurring fee or
+  another service to babysit.
+- No PII in the repo, no API keys in the static client.
+- The current question list lives in repo as the source of truth;
+  the hosting tool is the rendering surface, not the spec.
+
+## Decision
+
+Use **[Tally](https://tally.so)** for the v1 interest survey, linked
+out from the announcement banner. Specifically:
+
+- Tally form ID lives in two places: the survey doc
+  ([`docs/marketing/surveys/v1-interest-survey.md`](../marketing/surveys/v1-interest-survey.md))
+  and `AnnouncementBanner.astro`'s `SURVEY_URL`. Bump both, plus
+  the `survey-v1` dismissal-key suffix, when shipping a future
+  survey.
+- One question per Tally screen (Tally's default); responses go
+  to Tally's dashboard.
+- The question list in `docs/marketing/surveys/` is the source of
+  truth — Tally is the rendering surface. To revise, edit the
+  doc, then mirror into Tally's editor.
+
+**Migration clause:** When the Buttondown subscriber list
+([ADR-0014](0014-buttondown-for-email-subscriptions.md)) becomes
+the primary audience for the survey (rather than cold marketing-site
+visitors), revisit whether Buttondown's built-in survey feature is
+the better fit. The migration cost is one Astro component edit and
+a one-time CSV import; we're not building a moat around Tally.
+
+## Consequences
+
+- Zero infrastructure. No iframe on our page, no JS on our page —
+  just an `<a href>` in the banner that opens the Tally form.
+- Tally's free tier covers unlimited forms with unlimited
+  responses; the project pays nothing.
+- Response data lives in Tally's dashboard, off-repo, with optional
+  CSV export. Acceptable for a marketing survey; would be wrong for
+  anything we needed to query programmatically.
+- Two surfaces (announcement banner + survey doc) must stay in
+  sync on the Tally URL. The CHANGELOG note for the survey-banner
+  feature spells this out so future-us doesn't forget.
+- No subscriber funnel built in: a Tally respondent isn't
+  automatically subscribed to Buttondown. We accept that tradeoff
+  for v1 — the survey has an optional email field whose answers we
+  can manually port into Buttondown if/when we choose.
+
+## Alternatives considered
+
+- **Google Forms.** Free, ubiquitous, fine UX for respondents. Loses
+  on the embed/branding axis (forces a Google-branded chrome) and
+  has a clunkier response-export path. Tally's free tier covers the
+  same use case with better in-product polish.
+- **Typeform.** Best-in-class form UX, but free tier caps at 10
+  responses per form per month. Disqualifying for a "go wide on
+  social" survey push.
+- **Buttondown's built-in survey feature.** The "what do you want
+  next?" question is a natural fit to ask the subscriber list,
+  but in v1 the survey is aimed at *cold* marketing-site visitors
+  who haven't subscribed yet, so this is the wrong tool for now.
+  Captured as the migration clause above.
+- **Self-host a form (Formspree, Static Forms, our own Cloudflare
+  Worker).** Adds either a recurring fee or a service to maintain,
+  with no respondent-side UX advantage over Tally's free tier.

--- a/docs/adr/0015-tally-for-surveys.md
+++ b/docs/adr/0015-tally-for-surveys.md
@@ -34,11 +34,14 @@ Constraints:
 Use **[Tally](https://tally.so)** for the v1 interest survey, linked
 out from the announcement banner. Specifically:
 
-- Tally form ID lives in two places: the survey doc
-  ([`docs/marketing/surveys/v1-interest-survey.md`](../marketing/surveys/v1-interest-survey.md))
-  and `AnnouncementBanner.astro`'s `SURVEY_URL`. Bump both, plus
-  the `survey-v1` dismissal-key suffix, when shipping a future
-  survey.
+- Tally form ID lives in three places: the survey doc
+  ([`docs/marketing/surveys/v1-interest-survey.md`](../marketing/surveys/v1-interest-survey.md)),
+  the marketing-site banner
+  ([`site/src/components/AnnouncementBanner.astro`](../../site/src/components/AnnouncementBanner.astro)'s
+  `SURVEY_URL`), and the demo SPA banner
+  ([`web/src/components/AnnouncementBanner.tsx`](../../web/src/components/AnnouncementBanner.tsx)'s
+  `SURVEY_URL`). Bump all three, plus the `survey-v1`
+  dismissal-key suffix, when shipping a future survey.
 - One question per Tally screen (Tally's default); responses go
   to Tally's dashboard.
 - The question list in `docs/marketing/surveys/` is the source of
@@ -61,9 +64,10 @@ a one-time CSV import; we're not building a moat around Tally.
 - Response data lives in Tally's dashboard, off-repo, with optional
   CSV export. Acceptable for a marketing survey; would be wrong for
   anything we needed to query programmatically.
-- Two surfaces (announcement banner + survey doc) must stay in
-  sync on the Tally URL. The CHANGELOG note for the survey-banner
-  feature spells this out so future-us doesn't forget.
+- Three surfaces (survey doc + marketing-site banner + demo SPA
+  banner) must stay in sync on the Tally URL. The CHANGELOG note
+  for the survey-banner feature spells this out so future-us
+  doesn't forget.
 - No subscriber funnel built in: a Tally respondent isn't
   automatically subscribed to Buttondown. We accept that tradeoff
   for v1 — the survey has an optional email field whose answers we

--- a/docs/adr/0016-deployment-topology.md
+++ b/docs/adr/0016-deployment-topology.md
@@ -50,20 +50,26 @@ them, with a single registrar in front:
   [ADR-0011](0011-marketing-site-stack.md).
 - **Demo app (`api/` + `web/`):** **Render** as a Docker web
   service, blueprinted from [`render.yaml`](../../render.yaml) at
-  the repo root, auto-deploy on push to `main`. The app starts on
-  the free Hobby plan and is currently on **Starter** (512 MB RAM,
-  0.5 CPU) to cover the binder-PDF and persistence-layer memory
-  ceilings. Forced rebuilds happen via the existing manual *Deploy*
-  GitHub Action (see [`docs/deployment.md`](../deployment.md)).
+  the repo root, auto-deploy on push to `main`. The blueprint pins
+  the **free Hobby plan** so a fresh `Blueprint → New` from this
+  repo always starts cheap; the running service's tier is an
+  operational dashboard setting that can be raised as demand
+  warrants (e.g., Starter — 512 MB RAM, 0.5 CPU — covers the
+  binder-PDF and persistence-layer memory ceilings without touching
+  the blueprint). Forced rebuilds happen via the existing manual
+  *Deploy* GitHub Action (see
+  [`docs/deployment.md`](../deployment.md)).
 - **Domain registrar:** **Cloudflare Registrar** for both
   `mgz-pkmn.com` and the maintainer's `matt-grant.com`. At-cost
   pricing, no markup on renewals, and the registrar/Pages/DNS
   control plane is one tool.
 
 Tier upgrades follow demand, not feature scope: if Render's free
-spin-down (~30 s wake on cold start) becomes a real
-papercut on a demo link in the README/Slack, that's the moment to
-upgrade — which we've done once already (Hobby → Starter).
+Hobby spin-down (~30 s wake on cold start) becomes a real papercut
+on a demo link in the README/Slack, or the binder-PDF / persistence
+path starts brushing the 512 MB ceiling, that's the trigger to
+bump the dashboard tier (Starter at $7/mo lifts both limits).
+Bumps are reversible and don't touch the committed blueprint.
 
 ## Consequences
 

--- a/docs/adr/0016-deployment-topology.md
+++ b/docs/adr/0016-deployment-topology.md
@@ -1,0 +1,117 @@
+# ADR 0016: Production deployment topology — Cloudflare Pages + Render
+
+- **Status:** Accepted
+- **Date:** 2026-05-31
+- **Tags:** infra, deploy
+
+## Context
+
+Three surfaces ship from this repo and need a production home:
+
+1. The **marketing site** at `site/` — a pure static Astro build
+   ([ADR-0011](0011-marketing-site-stack.md)).
+2. The **demo web app** at `web/` (React SPA) + the **API** at
+   `api/` (FastAPI on uvicorn) — a single Docker image built from
+   the repo root, served at <https://mgz-pkmn.onrender.com>.
+3. The custom **domain registrar** — `mgz-pkmn.com` and
+   `matt-grant.com` (the maintainer's personal domain that also
+   hosts the project's `www.matt-grant.com/mgz-pkmn` redirect line
+   on the printed flyer).
+
+The marketing site and the demo app have very different runtime
+profiles: the site is static HTML/CSS/JS with no warm path, the
+app needs Python + reportlab + Pillow + an HTTPS upstream to
+`pokemontcg.io` and benefits from a persistent disk cache. Treating
+them as the same workload would either bloat the static surface
+with a Python runtime it doesn't need, or pay the static surface's
+edge-CDN nothing for the app's actual hot path.
+
+Constraints:
+
+- Solo maintainer. No second control plane to babysit, no fixed
+  monthly bill where a free tier covers the actual traffic.
+- Auto-deploy on push to `main` for both surfaces — the existing
+  ship cadence is "merge the PR, see it live in minutes."
+- The demo SPA has been gradually getting heavier (binder PDF
+  generation, persistence layer via [ADR-0013](0013-sqlite-persistence-for-runs-collections-wishlists.md),
+  set-card warming on startup), so the app's memory and CPU
+  ceilings need to scale without re-platforming.
+
+## Decision
+
+Split the two surfaces across the two providers that best fit
+them, with a single registrar in front:
+
+- **Marketing site (`site/`):** **Cloudflare Pages**, auto-deploy
+  on push to `main`. Unmetered bandwidth, free TLS, free custom
+  domain (`mgz-pkmn.com`). Pages config is one-time in the
+  Cloudflare dashboard; the per-build config lives in
+  [`site/README.md`](../../site/README.md). Codified in
+  [ADR-0011](0011-marketing-site-stack.md).
+- **Demo app (`api/` + `web/`):** **Render** as a Docker web
+  service, blueprinted from [`render.yaml`](../../render.yaml) at
+  the repo root, auto-deploy on push to `main`. The app starts on
+  the free Hobby plan and is currently on **Starter** (512 MB RAM,
+  0.5 CPU) to cover the binder-PDF and persistence-layer memory
+  ceilings. Forced rebuilds happen via the existing manual *Deploy*
+  GitHub Action (see [`docs/deployment.md`](../deployment.md)).
+- **Domain registrar:** **Cloudflare Registrar** for both
+  `mgz-pkmn.com` and the maintainer's `matt-grant.com`. At-cost
+  pricing, no markup on renewals, and the registrar/Pages/DNS
+  control plane is one tool.
+
+Tier upgrades follow demand, not feature scope: if Render's free
+spin-down (~30 s wake on cold start) becomes a real
+papercut on a demo link in the README/Slack, that's the moment to
+upgrade — which we've done once already (Hobby → Starter).
+
+## Consequences
+
+- The static marketing path is served entirely from Cloudflare's
+  global edge — no cold starts, no compute meter, no bill.
+- The app's autoscaling story is "scale the Render service up,"
+  not "re-architect the deploy" — the existing `render.yaml`
+  blueprint already covers env vars (`POKEMONTCG_IO_API_KEY`,
+  `MGZ_PKMN_*`), so a plan bump is a one-click action.
+- Two providers means two dashboards to log into when something
+  breaks, which is real-but-mild overhead. Both have email/Slack
+  alerting on deploy failures so the maintainer doesn't have to
+  poll.
+- Render's free tier's ~15-minute spin-down is the known
+  rough edge — fine for casual demo traffic, jarring for someone
+  clicking the README link cold. The Starter upgrade resolves this
+  for the duration of the v1.x line.
+- The repo's deploy story is reproducible from
+  [`render.yaml`](../../render.yaml) (Render) plus
+  [`site/README.md`](../../site/README.md) (Pages, one-time UI
+  setup). Both surfaces could be torn down and re-created in under
+  ten minutes from those files.
+- Custom domain DNS lives in one Cloudflare account, so cert
+  rotation and DNS edits happen in one place even though the
+  origins are split across two providers.
+
+## Alternatives considered
+
+- **Everything on Render (site + app on the same web service).**
+  Simpler in count-of-vendors terms; loses the edge CDN for the
+  marketing path, and the marketing surface starts to pay for
+  compute it doesn't use. Worse first-paint on the most-visited
+  page.
+- **Everything on Cloudflare (Pages for the site, Workers / Pages
+  Functions for the app).** Tempting for the single-vendor story,
+  but the app's runtime needs (Python + reportlab + Pillow + a
+  persistent SQLite file, see [ADR-0013](0013-sqlite-persistence-for-runs-collections-wishlists.md))
+  don't fit Workers' V8-isolate model without significant rewrite.
+  Re-evaluate when/if a Python edge runtime matures.
+- **Fly.io for the app.** Comparable feature set to Render with
+  global anycast and per-region scale; Render's GitHub-integration
+  UX and the existing `render.yaml` blueprint are why it stays.
+  Cited in [`docs/deployment.md`](../deployment.md) as the move if
+  Render ever stops working out.
+- **Vercel for the marketing site.** Excellent DX, parity with
+  Pages on the static path. Metered bandwidth on the free tier
+  where Cloudflare is unmetered, and the single-vendor story with
+  Cloudflare Registrar is cleaner.
+- **GitHub Pages for the marketing site.** Free, in-repo, fine for
+  static content. Loses Pages' integration with Cloudflare DNS and
+  the at-cost registrar story; not worth the move.

--- a/docs/adr/0016-deployment-topology.md
+++ b/docs/adr/0016-deployment-topology.md
@@ -13,10 +13,13 @@ Three surfaces ship from this repo and need a production home:
 2. The **demo web app** at `web/` (React SPA) + the **API** at
    `api/` (FastAPI on uvicorn) — a single Docker image built from
    the repo root, served at <https://mgz-pkmn.onrender.com>.
-3. The custom **domain registrar** — `mgz-pkmn.com` and
-   `matt-grant.com` (the maintainer's personal domain that also
-   hosts the project's `www.matt-grant.com/mgz-pkmn` redirect line
-   on the printed flyer).
+3. The custom **domain registrar** — `mgz-pkmn.com` is the
+   project's domain. The maintainer's personal `matt-grant.com`
+   sits on the same registrar account for operational convenience
+   (one dashboard, one billing surface) but is not a project
+   surface; it appears in repo content only for personal
+   attribution (the flyer contact block, the EmailSignup
+   `@mgzwarrior` link).
 
 The marketing site and the demo app have very different runtime
 profiles: the site is static HTML/CSS/JS with no warm path, the
@@ -59,10 +62,12 @@ them, with a single registrar in front:
   the blueprint). Forced rebuilds happen via the existing manual
   *Deploy* GitHub Action (see
   [`docs/deployment.md`](../deployment.md)).
-- **Domain registrar:** **Cloudflare Registrar** for both
-  `mgz-pkmn.com` and the maintainer's `matt-grant.com`. At-cost
-  pricing, no markup on renewals, and the registrar/Pages/DNS
-  control plane is one tool.
+- **Domain registrar:** **Cloudflare Registrar** for the project's
+  `mgz-pkmn.com`. The maintainer's personal `matt-grant.com` rides
+  the same account for operational convenience (one dashboard, one
+  billing surface) — it is not a project surface. At-cost pricing,
+  no markup on renewals, and the registrar/Pages/DNS control plane
+  is one tool.
 
 Tier upgrades follow demand, not feature scope: if Render's free
 Hobby spin-down (~30 s wake on cold start) becomes a real papercut

--- a/docs/adr/0017-tropical-design-system.md
+++ b/docs/adr/0017-tropical-design-system.md
@@ -1,0 +1,128 @@
+# ADR 0017: Tropical design system — sun + palm + coconut, paired light/dark tokens
+
+- **Status:** Accepted
+- **Date:** 2026-05-31
+- **Tags:** design, site, web
+
+## Context
+
+Through v1.0 and most of v1.1, every surface — marketing site,
+demo SPA, GitHub README — leaned on Tailwind's stock zinc/blue
+palette. It worked but it didn't say anything: the project looked
+like every other "dark-theme developer tool" shipped by everyone
+else's solo side-project, which is the opposite of the actual
+brand (a personal, warm, cards-and-collecting project where the
+mascot is, more or less, Alolan Exeggutor).
+
+By the v1.x line the project shipped enough surfaces that the
+gap was load-bearing: a visitor could land on the marketing site,
+click the demo, and feel like they'd opened a different app. The
+README, the inline logo, the favicon, and the social preview all
+told slightly different visual stories.
+
+Constraints:
+
+- Two surfaces (Astro marketing site + React SPA) with different
+  styling stacks but a shared Tailwind 4 `@theme` mental model.
+- Colors must clear WCAG AA contrast everywhere they appear (we
+  publish [`docs/accessibility.md`](../accessibility.md) and want
+  it to stay honest).
+- Dark mode must remain a first-class theme — a meaningful slice
+  of users (and the maintainer) live there.
+- Solo maintainer. Whatever convention we land on has to be cheap
+  to apply across every component without a design-tokens build
+  pipeline.
+
+## Decision
+
+Adopt a **tropical palette** as the design system across every
+surface, in two themes:
+
+- **Light** (default; first-paint after [#343](https://github.com/mgzwarrior/mgz-pkmn/pull/343)
+  and [#347](https://github.com/mgzwarrior/mgz-pkmn/pull/347)):
+  cream `sand-50` background, sun-yellow CTAs, palm-green accents
+  and prices, coconut-brown body text. Display type **Bricolage
+  Grotesque**, body **DM Sans**, monospace **JetBrains Mono**.
+  Warm coconut-alpha shadows replace flat black.
+- **Dark:** husk coffee-charcoal surfaces (`husk-100` through
+  `husk-500`), warm sand body text (`sand-50`/`sand-200`/`sand-300`),
+  the same sun-yellow CTAs that define light mode, and badge
+  accents on palm / sun / ember instead of generic emerald / blue
+  / rose.
+
+Mechanism — applied identically on both surfaces:
+
+- Palette tokens defined once per surface in an `@theme` block in
+  the surface's root CSS
+  ([`site/src/styles/global.css`](../../site/src/styles/global.css),
+  [`web/src/index.css`](../../web/src/index.css)). The token names
+  (`--color-sun-300`, `--color-palm-400`, `--color-coconut-700`,
+  …) are the contract.
+- Tailwind 4's **`@custom-variant dark`** drives the theme switch,
+  scoped to `.dark` on `<html>`. A pre-paint inline script reads
+  `localStorage[theme]` → OS `prefers-color-scheme` → light
+  default, before first paint to avoid the flash.
+- Components use **paired classes** for every theme-sensitive
+  property: `bg-sand-50 dark:bg-husk-400`,
+  `text-coconut-700 dark:text-sand-50`,
+  `border-sand-300 dark:border-husk-100`. The pairing is the
+  convention, not a tool — there is no codegen.
+- The stage-color mapping for the progress chips is documented in
+  [`docs/accessibility.md`](../accessibility.md#color-coded-progress-stages)
+  with the exact contrast ratios for both themes; that doc is the
+  authority when we add a new state color.
+
+The full design-system definition (palette swatches, type ramp,
+component anatomy) lives outside the repo at
+*~/Downloads/mgz-pkmn Design System-2/* on the maintainer's
+machine. The repo intentionally only ships the *applied* tokens
+in `@theme`, not the spec — the spec is allowed to drift ahead of
+the code, and PRs reconcile when a new component lands.
+
+## Consequences
+
+- Every surface tells the same visual story: marketing → demo →
+  README → social preview all use the same warm cream + sun-yellow
+  + palm-green + coconut-brown vocabulary.
+- The paired-class convention is verbose at the call site
+  (`bg-sand-50 dark:bg-husk-400` instead of a single semantic
+  token), but it stays readable in JSX/Astro and makes contrast
+  bugs obvious in code review: missing `dark:` half is a smell.
+  This is the lesson [#347](https://github.com/mgzwarrior/mgz-pkmn/pull/347)
+  reinforced — every fixed Copilot finding was either a missing
+  `dark:` half or an unscoped variant that overrode the rest state.
+- Dark mode no longer ships as an afterthought. Both themes are
+  load-bearing and tested in the same review pass; the contrast
+  doc is the spec.
+- Light as the default is a soft brand decision: the cream + sun
+  palette only really lands in light, and that's where the
+  warmest first-visit impression lives. Visitors who prefer dark
+  flip in one click; their choice persists.
+- Migration cost when we change a token (e.g., bump `sun-300`
+  from `#F5C94B` to a different yellow): one find-and-replace in
+  the two `@theme` blocks. Components don't reference hex codes
+  directly.
+- The design-system spec living outside the repo is a known
+  drift risk. Acceptable today because the maintainer is also the
+  designer; revisit when that stops being true.
+
+## Alternatives considered
+
+- **Keep zinc/blue, polish the existing look.** Cheapest path,
+  zero migration cost. Loses the brand-coherence win and leaves
+  the marketing site looking interchangeable with every other
+  developer-tool landing page.
+- **Tropical as a single (light-only) theme.** Half the work, but
+  forces the meaningful dark-mode userbase off the brand. Would
+  have shipped a "looks great until you're a dark-mode user"
+  product.
+- **CSS-in-JS theme provider (Stitches / vanilla-extract).**
+  Generates type-safe tokens with semantic names. More
+  ergonomic at the call site, but adds a runtime / build-time
+  dependency on both surfaces and a second mental model on top of
+  Tailwind. Tailwind 4's `@theme` + `@custom-variant dark`
+  already gives us tokens-in-CSS without the extra layer.
+- **Two separate palettes per surface (site stays zinc, SPA
+  goes tropical).** Cuts the rollout in half but reintroduces the
+  exact "feels like a different app" gap the rollout was meant to
+  close.

--- a/docs/adr/0017-tropical-design-system.md
+++ b/docs/adr/0017-tropical-design-system.md
@@ -35,22 +35,37 @@ Constraints:
 
 ## Decision
 
-Adopt a **tropical palette** as the design system across every
-surface, in two themes:
+Adopt a **tropical palette** as the design system on the user-facing
+surfaces (marketing site via [#342](https://github.com/mgzwarrior/mgz-pkmn/pull/342)
++ [#343](https://github.com/mgzwarrior/mgz-pkmn/pull/343); demo SPA
+via [#347](https://github.com/mgzwarrior/mgz-pkmn/pull/347)), in two
+themes:
 
-- **Light** (default; first-paint after [#343](https://github.com/mgzwarrior/mgz-pkmn/pull/343)
-  and [#347](https://github.com/mgzwarrior/mgz-pkmn/pull/347)):
-  cream `sand-50` background, sun-yellow CTAs, palm-green accents
-  and prices, coconut-brown body text. Display type **Bricolage
-  Grotesque**, body **DM Sans**, monospace **JetBrains Mono**.
-  Warm coconut-alpha shadows replace flat black.
+- **Light:** cream `sand-50` background, sun-yellow CTAs, palm-green
+  accents and prices, coconut-brown body text. Display type
+  **Bricolage Grotesque**, body **DM Sans**, monospace **JetBrains
+  Mono**. Warm coconut-alpha shadows replace flat black.
 - **Dark:** husk coffee-charcoal surfaces (`husk-100` through
   `husk-500`), warm sand body text (`sand-50`/`sand-200`/`sand-300`),
   the same sun-yellow CTAs that define light mode, and badge
   accents on palm / sun / ember instead of generic emerald / blue
   / rose.
 
-Mechanism — applied identically on both surfaces:
+First-paint default differs per surface (each gets the
+strongest-impression theme for its visitor pattern):
+
+- **Marketing site** defaults to **dark** —
+  [`site/src/layouts/BaseLayout.astro`](../../site/src/layouts/BaseLayout.astro)
+  renders `<html class="dark">` and the pre-paint script resolves
+  `localStorage[theme]` → OS `prefers-color-scheme: light` →
+  `dark` fallback.
+- **Demo SPA** defaults to **light** —
+  [`web/index.html`](../../web/index.html)'s pre-paint script
+  resolves saved choice → OS preference → `light` fallback, to
+  match the site's tropical-light look the SPA inherits when
+  visitors click through from a landing-page CTA.
+
+Mechanism — applied per surface, same shape on each:
 
 - Palette tokens defined once per surface in an `@theme` block in
   the surface's root CSS
@@ -59,9 +74,9 @@ Mechanism — applied identically on both surfaces:
   (`--color-sun-300`, `--color-palm-400`, `--color-coconut-700`,
   …) are the contract.
 - Tailwind 4's **`@custom-variant dark`** drives the theme switch,
-  scoped to `.dark` on `<html>`. A pre-paint inline script reads
-  `localStorage[theme]` → OS `prefers-color-scheme` → light
-  default, before first paint to avoid the flash.
+  scoped to `.dark` on `<html>`. Each surface owns its own
+  pre-paint inline script (see defaults above) so the toggle never
+  flashes.
 - Components use **paired classes** for every theme-sensitive
   property: `bg-sand-50 dark:bg-husk-400`,
   `text-coconut-700 dark:text-sand-50`,
@@ -74,7 +89,7 @@ Mechanism — applied identically on both surfaces:
 
 The full design-system definition (palette swatches, type ramp,
 component anatomy) lives outside the repo at
-*~/Downloads/mgz-pkmn Design System-2/* on the maintainer's
+`~/Downloads/mgz-pkmn Design System-2/` on the maintainer's
 machine. The repo intentionally only ships the *applied* tokens
 in `@theme`, not the spec — the spec is allowed to drift ahead of
 the code, and PRs reconcile when a new component lands.
@@ -94,10 +109,12 @@ the code, and PRs reconcile when a new component lands.
 - Dark mode no longer ships as an afterthought. Both themes are
   load-bearing and tested in the same review pass; the contrast
   doc is the spec.
-- Light as the default is a soft brand decision: the cream + sun
-  palette only really lands in light, and that's where the
-  warmest first-visit impression lives. Visitors who prefer dark
-  flip in one click; their choice persists.
+- The per-surface first-paint default (site → dark, SPA → light)
+  is a soft brand decision: a marketing-site landing has the most
+  punch on the moody dark palette, while the demo SPA looks most
+  like a real tool on the warm tropical-light surface. Visitors
+  who prefer the other half flip in one click; their choice
+  persists in `localStorage[theme]`.
 - Migration cost when we change a token (e.g., bump `sun-300`
   from `#F5C94B` to a different yellow): one find-and-replace in
   the two `@theme` blocks. Components don't reference hex codes

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,6 +24,10 @@ not just the shape.
 | [0011](0011-marketing-site-stack.md) | Marketing site under `site/` (Astro + Tailwind, Cloudflare Pages) | Accepted | 2026-05-16 |
 | [0012](0012-open-core-architecture.md) | Open-core architecture for a paid Vendor tier | Proposed | 2026-05-16 |
 | [0013](0013-sqlite-persistence-for-runs-collections-wishlists.md) | SQLite + Alembic persistent store for runs, collections, and wishlists | Proposed | 2026-05-20 |
+| [0014](0014-buttondown-for-email-subscriptions.md) | Buttondown for newsletter / email subscriptions | Accepted | 2026-05-31 |
+| [0015](0015-tally-for-surveys.md) | Tally for marketing surveys (with a Buttondown migration clause) | Accepted | 2026-05-31 |
+| [0016](0016-deployment-topology.md) | Production deployment topology — Cloudflare Pages + Render | Accepted | 2026-05-31 |
+| [0017](0017-tropical-design-system.md) | Tropical design system — sun + palm + coconut, paired light/dark tokens | Accepted | 2026-05-31 |
 
 ## Adding a new ADR
 


### PR DESCRIPTION
Closes #348

## What

Four new ADRs capturing the v1.2 architectural decisions:

- [`0014`](docs/adr/0014-buttondown-for-email-subscriptions.md) — **Buttondown** for newsletter / email subscriptions.
- [`0015`](docs/adr/0015-tally-for-surveys.md) — **Tally** for marketing surveys (with a Buttondown migration clause).
- [`0016`](docs/adr/0016-deployment-topology.md) — **Production deployment topology** (Cloudflare Pages + Render + Cloudflare Registrar).
- [`0017`](docs/adr/0017-tropical-design-system.md) — **Tropical design system** (sun + palm + coconut + husk, paired light/dark tokens).

Index updated in [`docs/adr/README.md`](docs/adr/README.md).

## Why

The v1.2 line shipped four load-bearing decisions that were not
captured in any ADR. Recording them now means a contributor six
months from now picking up `EmailSignup.astro` or `BaseLayout.astro`
or the design-token files can recover the *intent* without an
archaeology pass through PR descriptions.

Each ADR follows the existing convention:

- Context → constraints → decision → consequences → alternatives.
- ~80–120 lines each.
- Links to the relevant source files and prior ADRs (0011, 0013)
  so the chain of reasoning is one click away.

## How to verify

- [x] `make check` is green.
- [x] [`docs/adr/README.md`](docs/adr/README.md) renders the four
      new index rows in numeric order, all linked to their files.
- [x] Each ADR file's status is **Accepted** (not Proposed) since
      the decisions are already what the codebase does.
- [x] Cross-links between ADRs (0014 ↔ 0015, 0011/0013 → 0016, 0011
      → 0017) resolve.

## Out of scope

- No code changes — this PR is documentation only.
- The design-system spec (palette swatches, type ramp) intentionally
  stays out-of-repo per ADR-0017's "spec is allowed to drift ahead
  of the code" clause.

## Copilot review fixes (3b77748)

- **0014 (Buttondown):** corrected the no-JS fallback description — it's a popup-window via `target="popupwindow"` + `window.open()`, not a hosted confirmation page.
- **0015 (Tally):** updated to call out **three** places the Tally URL must stay in sync (survey doc + marketing-site banner + demo SPA banner), not two.
- **0016 (deployment topology):** matched the committed `render.yaml` (`plan: free`), framed Starter as an operational dashboard choice rather than a historical claim.
- **0017 (tropical design system):** scoped the rollout claim to the user-facing surfaces (site + SPA, not docs), called out the per-surface first-paint default explicitly (site → dark, SPA → light), removed the inaccurate "light as the default" consequence, and switched the local design-system path from emphasis to inline code.