### PR TITLE
docs(marketing): 3-email welcome sequence draft

### DIFF
--- a/docs/marketing/emails/README.md
+++ b/docs/marketing/emails/README.md
@@ -1,0 +1,37 @@
+# Marketing emails
+
+Source of truth for the project's Buttondown email copy. Each file is a
+self-contained markdown draft — subject line, preheader, body — ready to
+paste into Buttondown's composer (or a future automation that drives
+the welcome sequence by tag).
+
+## Files
+
+| # | File | Trigger | Audience |
+|---|---|---|---|
+| 1 | [`welcome-1-show-prep-problem.md`](welcome-1-show-prep-problem.md) | Send immediately on confirm | New subscriber |
+| 2 | [`welcome-2-what-you-can-do-today.md`](welcome-2-what-you-can-do-today.md) | Send 2 days after #1 | New subscriber |
+| 3 | [`welcome-3-built-in-the-open.md`](welcome-3-built-in-the-open.md) | Send 5 days after #2 | New subscriber |
+
+## Sending convention
+
+- Buttondown subscriber list is at <https://buttondown.com/mgz-pkmn>
+  (see [ADR-0014](../../adr/0014-buttondown-for-email-subscriptions.md)).
+- These three are tag-driven `welcome` automations, not broadcasts:
+  whoever subscribes from the marketing-site `/EmailSignup.astro` form
+  gets all three on the cadence above, regardless of when they signed
+  up. Existing subscribers are not re-enrolled.
+- Subject lines are committed in the front-matter of each file so
+  changes are reviewable in PR.
+- Each email opens with the inline project logo (same convention as
+  every GitHub Discussion post — see the maintainer's memory on this).
+- All copy is markdown; Buttondown's editor renders it directly.
+
+## When this changes
+
+Edit the markdown in-repo first, then mirror into Buttondown. The
+repo is the canonical source — Buttondown is the rendering surface.
+
+When the welcome sequence ships its first batch of confirmed
+subscribers, post a short Discussion update with the open rate so
+future-us has a baseline to A/B against.

--- a/docs/marketing/emails/welcome-1-show-prep-problem.md
+++ b/docs/marketing/emails/welcome-1-show-prep-problem.md
@@ -1,0 +1,61 @@
+---
+sequence: welcome-1
+when: immediately on subscriber confirm
+audience: new newsletter subscriber
+subject: "Welcome — and the want-list-on-a-napkin problem"
+preheader: "What you signed up for, and the thing mgz-pkmn was built to fix."
+---
+
+![mgz-pkmn](https://raw.githubusercontent.com/mgzwarrior/mgz-pkmn/main/assets/logo.svg)
+
+Hi —
+
+Thanks for subscribing. I'm Matt, and **mgz-pkmn** is the side
+project I built because every card show I've ever walked into,
+I've done the same dumb thing:
+
+> Print a list on the way out the door. Realize at the table that
+> half the cards have multiple printings. Pull out my phone.
+> Convention-center Wi-Fi is hot garbage. Pay too much for a
+> Holo when an Unlimited was three feet away.
+
+If that scenario has happened to you exactly once, you're already
+ahead of me. If it's happened a dozen times, you're my target
+audience.
+
+The thing the tool tries to fix isn't "find a price" — there are a
+dozen apps that do that. It's the **prep step before** the show:
+turn the list of cards you actually want into a printable binder
+with thumbnails, market prices across three open data sources, a
+negotiation floor (80% / 85% / 90% / 95%), and a tag that tells
+you which binder page each card lives on.
+
+You walk in informed. The Wi-Fi can be on fire and it doesn't
+matter.
+
+That's the pitch.
+
+## What's in this welcome sequence
+
+Three short emails over the next week:
+
+1. **(this one)** The problem and what the tool is.
+2. **In ~2 days** — what you can actually do with it today
+   (features tour + the demo link).
+3. **In ~7 days** — how it's built in the open, in case you'd
+   rather contribute than just use it.
+
+After that, expect maybe one email per shipped release. No drip,
+no upsell, no "10 secrets the TCG community doesn't want you to
+know." I will not waste your inbox.
+
+Reply to this email if you want to tell me what your worst card
+show was. I read everything.
+
+— Matt
+
+---
+
+*You're getting this because you subscribed at
+[mgz-pkmn.com](https://mgz-pkmn.com). If this isn't for you, the
+unsubscribe link is right below — no hard feelings.*

--- a/docs/marketing/emails/welcome-2-what-you-can-do-today.md
+++ b/docs/marketing/emails/welcome-2-what-you-can-do-today.md
@@ -1,0 +1,73 @@
+---
+sequence: welcome-2
+when: 2 days after welcome-1
+audience: new newsletter subscriber
+subject: "What mgz-pkmn actually does (90-second tour)"
+preheader: "Paste a list, get a binder. Here's the demo link and what to try first."
+---
+
+![mgz-pkmn](https://raw.githubusercontent.com/mgzwarrior/mgz-pkmn/main/assets/logo.svg)
+
+Hi again —
+
+Quick 90-second tour, then a demo link and the one thing I'd try
+first.
+
+## The loop
+
+1. **You paste a list.** One card per line. Anything from a precise
+   `Charizard | Base Set | 4/102` to a fuzzy `Mew ex`, or a bulk
+   request like `top:5 Charizard cards`.
+2. **It looks them up.** Three open data sources stacked in priority
+   order (pokemontcg.io → TCGdex → TCGPlayer comps). Results stream
+   in as each line resolves.
+3. **You walk away with a binder.** A printable PDF with
+   thumbnails, market prices, negotiation floors (80% / 85% / 90% /
+   95%), and a tag column that tells you which binder page each
+   card lives on. Also `.xlsx` if you'd rather pivot it later, and
+   a quarter-letter `checklist.pdf` for the floor.
+
+## Try this first
+
+Open the live demo: **<https://mgz-pkmn.onrender.com>**
+
+(Free Render tier — first request takes ~30 seconds to wake the
+server. After that it's snappy.)
+
+Paste this:
+
+```
+Charizard | Base Set | 4/102
+Pikachu | Jungle
+top:5 Charizard cards
+Mew ex | Scarlet & Violet
+```
+
+Hit **Look up**. Watch the progress chips light up by stage
+(parsed → looking up → resolved). Then click **Export** → **PDF
+binder** to see the actual artifact you'd walk into a show with.
+
+## The thing I'm proud of
+
+The **Browse** button (the icon top-left). Pick any Pokémon TCG
+set, see every card with its market price, click to add to your
+list. Useful for the "which Charizards from Surging Sparks are
+under $20" question. The set-card data is pre-warmed on the server
+so even niche sets respond instantly.
+
+## What's coming
+
+A persistence layer is landing in v1.2 — saved runs you can pull
+up later without re-fetching, and the start of collection +
+wishlist tracking. The roadmap lives at
+<https://github.com/mgzwarrior/mgz-pkmn/blob/main/docs/roadmap.md>
+if you want the full picture.
+
+Reply with what works (or doesn't) — that's how this gets better.
+
+— Matt
+
+---
+
+*Subscribe link: [mgz-pkmn.com](https://mgz-pkmn.com).
+Unsubscribe is below.*

--- a/docs/marketing/emails/welcome-3-built-in-the-open.md
+++ b/docs/marketing/emails/welcome-3-built-in-the-open.md
@@ -1,0 +1,75 @@
+---
+sequence: welcome-3
+when: 5 days after welcome-2 (so ~1 week after subscribing)
+audience: new newsletter subscriber
+subject: "Built in the open — and how to jump in if you're so inclined"
+preheader: "Source is on GitHub, the roadmap is public, and there's a good-first-issues lane if you want to ship."
+---
+
+![mgz-pkmn](https://raw.githubusercontent.com/mgzwarrior/mgz-pkmn/main/assets/logo.svg)
+
+Hi —
+
+Last one in the welcome run, then I'll go quiet until the next
+release.
+
+**mgz-pkmn is open source.** Not "open core, but the real product
+is a SaaS" — actually open source. MIT-licensed Python CLI, MIT
+React SPA, MIT Astro marketing site. Every line of code that
+runs on the demo is in the repo:
+
+→ <https://github.com/mgzwarrior/mgz-pkmn>
+
+If you want to use the tool, ignore the rest of this email. The
+rest of this email is for the chunk of subscribers who'd actually
+rather *contribute* than just consume.
+
+## The lay of the land
+
+- **`src/mgz_pkmn/`** — the Python CLI. Click-based. The lookup
+  pipeline, cache, output writers (xlsx / binder.pdf / checklist),
+  and the CLI subcommands.
+- **`api/`** — FastAPI service that wraps the CLI's lookup pipeline
+  in HTTP / SSE so the web app can stream results.
+- **`web/`** — React + Vite + Tailwind 4 SPA. The demo at
+  mgz-pkmn.onrender.com.
+- **`site/`** — Astro marketing site, the one you came in from.
+- **`docs/adr/`** — Architecture Decision Records. Read these
+  first if you want to understand *why* anything is the way it
+  is.
+
+## If you want to ship something
+
+- **Good first issues** filtered on GitHub:
+  <https://github.com/mgzwarrior/mgz-pkmn/labels/good%20first%20issue>
+  Scoped, well-defined, mostly in the 1–3 hour range.
+- **Discussions** for "is this a thing you'd accept a PR for"
+  before you start: <https://github.com/mgzwarrior/mgz-pkmn/discussions>
+- **Contributor guide** (DCO sign-off, branch naming, the local
+  CI gate):
+  <https://github.com/mgzwarrior/mgz-pkmn/blob/main/docs/contributing.md>
+
+First-time contributors get celebrated in the project's
+Discussions thread when their PR merges — small thing, but it's
+genuinely the most fun part of running an open-source project.
+
+## What I'm focused on
+
+The v1.x line is about *real persistence + polish*. v2.0 is going
+to be the harder architectural lift — multi-user collections,
+binder organization, the front-of-house workflows that make this
+tool useful **between** shows, not just on the morning of.
+
+If that arc sounds interesting, the
+[`docs/roadmap.md`](https://github.com/mgzwarrior/mgz-pkmn/blob/main/docs/roadmap.md)
+is the source of truth for what's next.
+
+Thanks for being here. I'll see you at the next release.
+
+— Matt
+
+---
+
+*If you'd rather just hear when stuff ships, you're already
+opted in. If you'd prefer to leave, unsubscribe is below — no
+hard feelings.*


### PR DESCRIPTION
Closes #330

## What

Three new markdown drafts under [`docs/marketing/emails/`](docs/marketing/emails/):

- [`welcome-1-show-prep-problem.md`](docs/marketing/emails/welcome-1-show-prep-problem.md) — the "want-list-on-a-napkin" hook for hobbyist collectors, sets expectations for the sequence cadence.
- [`welcome-2-what-you-can-do-today.md`](docs/marketing/emails/welcome-2-what-you-can-do-today.md) — 90-second features tour, demo link, copy-pasteable input to try the live app.
- [`welcome-3-built-in-the-open.md`](docs/marketing/emails/welcome-3-built-in-the-open.md) — secondary hook for OSS contributors, points at good-first-issues + Discussions + contributor guide.

Plus a [README](docs/marketing/emails/README.md) documenting cadence, sending convention, and the "repo is canonical, Buttondown is the rendering surface" rule (mirrors the Tally survey doc pattern).

## Why

When the Buttondown welcome automation gets wired up (next iteration), the copy should already exist. Writing this *after* signups start is how lists go cold.

Each email follows the project's voice + the maintainer's conventions:

- Opens with the inline project logo (consistent with every GitHub Discussion post).
- Subject + preheader committed in front-matter so changes are reviewable in PR.
- Buttondown is the rendering surface; this folder is the source of truth — same pattern as [`docs/marketing/surveys/`](docs/marketing/surveys/) (see ADR-0015).

## How to verify

- [ ] Three new email markdown files + a README in `docs/marketing/emails/`.
- [ ] Each email has front-matter (`sequence`, `when`, `audience`, `subject`, `preheader`), opens with the inline logo, and ends with a footer mentioning subscribe / unsubscribe.
- [ ] No code / CI changes (`make check` skipped — docs-only).

## Out of scope

- Wiring the Buttondown automation itself (separate ticket once the list is live).
- A/B variants (one canonical draft per email; iteration after the first batch ships).
- Tracking / open-rate analysis (Buttondown reports cover this).