### PR TITLE
feat(api): expose GET /api/v1/cache/stats for deployed cache introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- API: **`GET /api/v1/cache/stats`** returns the same JSON shape as
+  `pkmn cache stats --json` so operators can introspect a deployed
+  instance's cache state without shelling onto the host
+  ([#311](https://github.com/mgzwarrior/mgz-pkmn/issues/311)). Answers
+  the "did `MGZ_PKMN_WARM_ON_STARTUP` actually land?" question on demand
+  rather than from log-grep, with no auth required (entry counts and
+  timestamps aren't sensitive) and `Cache-Control: no-store` so the
+  reading reflects current on-disk state. Wired into
+  [`docs/deployment.md`](docs/deployment.md#inspecting-deployed-cache-state)
+  as the canonical inspection surface.
+
 ### Fixed
 
 - Web: **results table counts now live above the table** — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,19 @@ Versions follow [Semantic Versioning](https://semver.org/).
   the "did `MGZ_PKMN_WARM_ON_STARTUP` actually land?" question on demand
   rather than from log-grep, with no auth required (entry counts and
   timestamps aren't sensitive) and `Cache-Control: no-store` so the
-  reading reflects current on-disk state. Wired into
+  reading reflects current on-disk state. Falls back to a zeroed
+  snapshot on `OSError` (read-only / misconfigured filesystem) so the
+  diagnostics endpoint never 500s on the surface meant to diagnose
+  failures. Wired into
   [`docs/deployment.md`](docs/deployment.md#inspecting-deployed-cache-state)
   as the canonical inspection surface.
+- Web: **Cache-stats panel in the Settings drawer** — surfaces the
+  same `/api/v1/cache/stats` snapshot inline in the SPA so contributors
+  and operators can see the deployed instance's API / image / override
+  counts and warm-pass freshness without leaving the app. Reads on
+  drawer open with a refresh button for re-reads, and renders "not
+  warmed" in amber for the concept and set-cards slices when the
+  manifests are missing.
 
 ### Fixed
 

--- a/api/main.py
+++ b/api/main.py
@@ -35,7 +35,16 @@ from .db.session import get_engine
 from .routes import (
     cache as cache_route,
 )
-from .routes import changelog, export, lookup, overrides, parse, runs, set_cards, sets
+from .routes import (
+    changelog,
+    export,
+    lookup,
+    overrides,
+    parse,
+    runs,
+    set_cards,
+    sets,
+)
 
 _log = logging.getLogger(__name__)
 

--- a/api/main.py
+++ b/api/main.py
@@ -32,6 +32,9 @@ from mgz_pkmn.sources import TCGClient, TCGDexClient
 # have the lifespan see the patched values.
 from .db import migrate
 from .db.session import get_engine
+from .routes import (
+    cache as cache_route,
+)
 from .routes import changelog, export, lookup, overrides, parse, runs, set_cards, sets
 
 _log = logging.getLogger(__name__)
@@ -193,6 +196,7 @@ app.include_router(set_cards.router, prefix="/api/v1", tags=["set-cards"])
 app.include_router(overrides.router, prefix="/api/v1", tags=["overrides"])
 app.include_router(changelog.router, prefix="/api/v1", tags=["changelog"])
 app.include_router(runs.router, prefix="/api/v1", tags=["runs"])
+app.include_router(cache_route.router, prefix="/api/v1", tags=["cache"])
 
 
 @app.get("/health")

--- a/api/routes/cache.py
+++ b/api/routes/cache.py
@@ -25,14 +25,45 @@ from mgz_pkmn import cache as disk_cache
 router = APIRouter()
 
 
+def _zeroed_snapshot() -> disk_cache.CacheStats:
+    """Best-effort fallback when `disk_cache.stats()` can't read the cache.
+
+    `cache_root()` does an `mkdir`, which raises `OSError` on read-only or
+    misconfigured filesystems. A diagnostics endpoint shouldn't 500 just
+    because nothing is cacheable; return the same schema with everything
+    zeroed (and `root` resolved without the mkdir side effect) so the
+    operator gets the "nothing to see" answer instead of an opaque error.
+    """
+    return disk_cache.CacheStats(
+        root=disk_cache._cache_root_path(),
+        api_entry_count=0,
+        api_bytes=0,
+        api_oldest_mtime=None,
+        override_count=0,
+        override_bytes=0,
+        image_entry_count=0,
+        image_bytes=0,
+        concept_warm_timestamp=None,
+        concept_warm_names=0,
+        set_cards_warm_timestamp=None,
+        set_cards_warm_count=0,
+    )
+
+
 @router.get("/cache/stats")
 def get_cache_stats(response: Response) -> dict:
     """Return on-disk cache stats in the same shape as `pkmn cache stats --json`.
 
     `root` is stringified (the dataclass holds a `Path`) so the response
-    serializes cleanly; every other field is already a primitive.
+    serializes cleanly; every other field is already a primitive. Swallows
+    `OSError` from the underlying filesystem reads — see `_zeroed_snapshot`
+    for the rationale.
     """
-    payload = asdict(disk_cache.stats())
+    try:
+        snapshot = disk_cache.stats()
+    except OSError:
+        snapshot = _zeroed_snapshot()
+    payload = asdict(snapshot)
     payload["root"] = str(payload["root"])
     response.headers["Cache-Control"] = "no-store"
     return payload

--- a/api/routes/cache.py
+++ b/api/routes/cache.py
@@ -1,0 +1,38 @@
+"""GET /api/v1/cache/stats — inspect on-disk cache state of a deployed instance.
+
+Mirrors the shape of `pkmn cache stats --json` so users can pipe between
+the CLI and the API without translating field names. Answers operational
+questions the CLI tool can't on a remote deploy: did the warm-on-startup
+pass actually land, how many entries are cached, when was the last warm
+pass.
+
+The payload is operational, not sensitive — entry counts and timestamps
+don't expose anything an attacker could exploit — so the route is public
+read with no auth. The response carries `Cache-Control: no-store` because
+the underlying state changes whenever the warm passes or a cache write
+runs; a stale value would defeat the "is the deploy warmed *right now*?"
+question this endpoint exists to answer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+
+from fastapi import APIRouter, Response
+
+from mgz_pkmn import cache as disk_cache
+
+router = APIRouter()
+
+
+@router.get("/cache/stats")
+def get_cache_stats(response: Response) -> dict:
+    """Return on-disk cache stats in the same shape as `pkmn cache stats --json`.
+
+    `root` is stringified (the dataclass holds a `Path`) so the response
+    serializes cleanly; every other field is already a primitive.
+    """
+    payload = asdict(disk_cache.stats())
+    payload["root"] = str(payload["root"])
+    response.headers["Cache-Control"] = "no-store"
+    return payload

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -133,3 +133,21 @@ hook and Render starts a fresh build from `main`.
 > ~15 min of idle traffic; the next request takes ~30s to wake it.
 > Fine for hobby use. Upgrade to *Starter* (or move to Fly.io) if cold
 > starts hurt.
+
+## Inspecting deployed cache state
+
+`pkmn cache stats` reads `~/.cache/mgz-pkmn` on the local filesystem, so
+it can't see what's warmed on a remote deploy. The API surfaces the same
+snapshot at `GET /api/v1/cache/stats`:
+
+```bash
+curl -s https://mgz-pkmn.onrender.com/api/v1/cache/stats | jq
+```
+
+Same field names as `pkmn cache stats --json`, so the two surfaces are
+pipe-compatible. Use it to confirm `MGZ_PKMN_WARM_ON_STARTUP` actually
+landed (`concept_warm_timestamp` / `set_cards_warm_timestamp` are
+non-null after a successful warm pass) and to spot drift between the
+entry counts you expected and what's actually on disk. The response is
+served with `Cache-Control: no-store` because the underlying state
+changes on every warm pass and cache write.

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -734,6 +734,20 @@ class CacheStatsRouteTests(unittest.TestCase):
         resp = client.get("/api/v1/cache/stats")
         self.assertEqual(resp.headers.get("cache-control"), "no-store")
 
+    def test_oserror_from_stats_falls_back_to_zero_snapshot(self) -> None:
+        """A read-only / misconfigured filesystem shouldn't 500 a diagnostics endpoint."""
+        with patch.object(cache, "stats", side_effect=OSError("read-only fs")):
+            resp = client.get("/api/v1/cache/stats")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        # Same schema, just zeros + nulls.
+        self.assertEqual(data["api_entry_count"], 0)
+        self.assertEqual(data["api_bytes"], 0)
+        self.assertIsNone(data["api_oldest_mtime"])
+        self.assertIsNone(data["concept_warm_timestamp"])
+        self.assertIsNone(data["set_cards_warm_timestamp"])
+        self.assertIsInstance(data["root"], str)
+
     def test_field_names_match_cli_json_shape(self) -> None:
         """Acceptance check: same field names as `pkmn cache stats --json`.
 

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -669,5 +669,84 @@ class ChangelogRouteTests(unittest.TestCase):
             self.assertIsInstance(section["entries"], list)
 
 
+# ---------------------------------------------------------------------------
+# /cache/stats
+# ---------------------------------------------------------------------------
+
+
+class CacheStatsRouteTests(unittest.TestCase):
+    """Pinning the JSON shape so it stays interchangeable with `pkmn cache stats --json`.
+
+    Both setUp/tearDown follow the OverridesRouteTests pattern: redirect
+    XDG_CACHE_HOME at a tempdir and clear MGZ_PKMN_NO_CACHE so writes
+    actually land. Tests that don't write any cache entries get the
+    "fresh install" shape; the warmed test seeds the two warm manifests
+    directly via `cache.write_*_warm` so we don't need a real upstream.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._old_xdg = os.environ.get("XDG_CACHE_HOME")
+        self._old_no_cache = os.environ.get(cache._NO_CACHE_ENV)
+        os.environ["XDG_CACHE_HOME"] = self._tmp.name
+        os.environ.pop(cache._NO_CACHE_ENV, None)
+
+    def tearDown(self) -> None:
+        if self._old_xdg is None:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        else:
+            os.environ["XDG_CACHE_HOME"] = self._old_xdg
+        if self._old_no_cache is None:
+            os.environ.pop(cache._NO_CACHE_ENV, None)
+        else:
+            os.environ[cache._NO_CACHE_ENV] = self._old_no_cache
+        self._tmp.cleanup()
+
+    def test_empty_cache_returns_zeroed_shape(self) -> None:
+        resp = client.get("/api/v1/cache/stats")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+
+        self.assertTrue(data["root"].startswith(self._tmp.name))
+        self.assertEqual(data["api_entry_count"], 0)
+        self.assertEqual(data["api_bytes"], 0)
+        self.assertIsNone(data["api_oldest_mtime"])
+        self.assertEqual(data["override_count"], 0)
+        self.assertEqual(data["override_bytes"], 0)
+        self.assertEqual(data["image_entry_count"], 0)
+        self.assertEqual(data["image_bytes"], 0)
+        self.assertIsNone(data["concept_warm_timestamp"])
+        self.assertEqual(data["concept_warm_names"], 0)
+        self.assertIsNone(data["set_cards_warm_timestamp"])
+        self.assertEqual(data["set_cards_warm_count"], 0)
+
+    def test_warmed_cache_surfaces_manifest_counts(self) -> None:
+        cache.write_concept_warm(names_warmed=47, names_failed=[], source="test")
+        cache.write_set_cards_warm(sets_warmed=12, sets_failed=[])
+
+        data = client.get("/api/v1/cache/stats").json()
+        self.assertEqual(data["concept_warm_names"], 47)
+        self.assertIsInstance(data["concept_warm_timestamp"], float)
+        self.assertEqual(data["set_cards_warm_count"], 12)
+        self.assertIsInstance(data["set_cards_warm_timestamp"], float)
+
+    def test_response_is_not_browser_cached(self) -> None:
+        resp = client.get("/api/v1/cache/stats")
+        self.assertEqual(resp.headers.get("cache-control"), "no-store")
+
+    def test_field_names_match_cli_json_shape(self) -> None:
+        """Acceptance check: same field names as `pkmn cache stats --json`.
+
+        Drift here would silently break operators piping between the two
+        surfaces. Compares against `asdict(CacheStats)` directly rather than
+        spelling the field set out twice.
+        """
+        from dataclasses import fields
+
+        api_keys = set(client.get("/api/v1/cache/stats").json().keys())
+        cli_keys = {f.name for f in fields(cache.CacheStats)}
+        self.assertEqual(api_keys, cli_keys)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -8,6 +8,7 @@
 
 import type {
   BulkEvent,
+  CacheStats,
   CardQuery,
   ChangelogRelease,
   ExportFormat,
@@ -320,4 +321,21 @@ export async function fetchChangelog(limit = 5): Promise<ChangelogRelease[]> {
   if (!res.ok) throw new Error(`changelog failed: ${res.status}`)
   const data = await res.json()
   return data.releases as ChangelogRelease[]
+}
+
+// ---------------------------------------------------------------------------
+// cache
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch on-disk cache stats from `GET /api/v1/cache/stats`. Used by the
+ * Settings drawer to surface whether the instance is warmed and how many
+ * entries are cached. Backend serves the response with
+ * `Cache-Control: no-store` so consumers don't need to bust the cache
+ * themselves.
+ */
+export async function fetchCacheStats(): Promise<CacheStats> {
+  const res = await fetch(`${BASE}/cache/stats`)
+  if (!res.ok) throw new Error(`cache stats failed: ${res.status}`)
+  return (await res.json()) as CacheStats
 }

--- a/web/src/components/SettingsDrawer.test.tsx
+++ b/web/src/components/SettingsDrawer.test.tsx
@@ -1,6 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { SettingsDrawer } from './SettingsDrawer'
+import { fetchCacheStats } from '../api/client'
+
+vi.mock('../api/client', () => ({
+  fetchCacheStats: vi.fn(),
+}))
+const mockFetchCacheStats = vi.mocked(fetchCacheStats)
 
 const { mockResetSettings, mockUpdateSettings } = vi.hoisted(() => ({
   mockResetSettings: vi.fn(),
@@ -27,6 +33,24 @@ describe('SettingsDrawer', () => {
   beforeEach(() => {
     mockResetSettings.mockClear()
     mockUpdateSettings.mockClear()
+    mockFetchCacheStats.mockReset()
+    // Default cache-stats shape — most tests don't care, but the panel
+    // mounts as soon as the drawer opens and would otherwise hit a real
+    // fetch.
+    mockFetchCacheStats.mockResolvedValue({
+      root: '/tmp/cache',
+      api_entry_count: 0,
+      api_bytes: 0,
+      api_oldest_mtime: null,
+      override_count: 0,
+      override_bytes: 0,
+      image_entry_count: 0,
+      image_bytes: 0,
+      concept_warm_timestamp: null,
+      concept_warm_names: 0,
+      set_cards_warm_timestamp: null,
+      set_cards_warm_count: 0,
+    })
   })
 
   it('renders the settings trigger button', () => {
@@ -46,5 +70,47 @@ describe('SettingsDrawer', () => {
     fireEvent.click(screen.getByRole('button', { name: /settings/i }))
     fireEvent.click(screen.getByLabelText(/show lookup timer/i))
     expect(mockUpdateSettings).toHaveBeenCalledWith({ showTimer: true })
+  })
+
+  it('cache-stats panel renders the values returned by /cache/stats', async () => {
+    mockFetchCacheStats.mockResolvedValueOnce({
+      root: '/tmp/cache',
+      api_entry_count: 42,
+      api_bytes: 1_500_000,
+      api_oldest_mtime: null,
+      override_count: 3,
+      override_bytes: 800,
+      image_entry_count: 173,
+      image_bytes: 5_242_880,
+      concept_warm_timestamp: Date.now() / 1000 - 120, // 2 min ago
+      concept_warm_names: 47,
+      set_cards_warm_timestamp: null,
+      set_cards_warm_count: 0,
+    })
+
+    render(<SettingsDrawer />)
+    fireEvent.click(screen.getByRole('button', { name: /settings/i }))
+
+    await waitFor(() => expect(screen.getByText(/42 ·/)).toBeInTheDocument())
+    expect(screen.getByText(/173 ·/)).toBeInTheDocument()
+    expect(screen.getByText(/47 ·/)).toBeInTheDocument()
+    // The not-warmed branch renders for set cards.
+    expect(screen.getByText(/^not warmed$/)).toBeInTheDocument()
+  })
+
+  it('refresh button re-fetches /cache/stats', async () => {
+    render(<SettingsDrawer />)
+    fireEvent.click(screen.getByRole('button', { name: /settings/i }))
+    await waitFor(() => expect(mockFetchCacheStats).toHaveBeenCalledTimes(1))
+
+    fireEvent.click(screen.getByRole('button', { name: /refresh cache stats/i }))
+    await waitFor(() => expect(mockFetchCacheStats).toHaveBeenCalledTimes(2))
+  })
+
+  it('cache-stats panel surfaces fetch errors without crashing', async () => {
+    mockFetchCacheStats.mockRejectedValueOnce(new Error('boom'))
+    render(<SettingsDrawer />)
+    fireEvent.click(screen.getByRole('button', { name: /settings/i }))
+    await waitFor(() => expect(screen.getByText(/boom/i)).toBeInTheDocument())
   })
 })

--- a/web/src/components/SettingsDrawer.test.tsx
+++ b/web/src/components/SettingsDrawer.test.tsx
@@ -101,9 +101,16 @@ describe('SettingsDrawer', () => {
   it('refresh button re-fetches /cache/stats', async () => {
     render(<SettingsDrawer />)
     fireEvent.click(screen.getByRole('button', { name: /settings/i }))
-    await waitFor(() => expect(mockFetchCacheStats).toHaveBeenCalledTimes(1))
 
-    fireEvent.click(screen.getByRole('button', { name: /refresh cache stats/i }))
+    // Wait for the initial fetch to settle — the button is disabled while
+    // `loading` is true, so clicking it before the finally() clears
+    // loading would silently no-op and the call count would never reach
+    // two. Waiting on the button's enabled state is the cleanest signal.
+    const refresh = await screen.findByRole('button', { name: /refresh cache stats/i })
+    await waitFor(() => expect(refresh).not.toBeDisabled())
+    expect(mockFetchCacheStats).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(refresh)
     await waitFor(() => expect(mockFetchCacheStats).toHaveBeenCalledTimes(2))
   })
 

--- a/web/src/components/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer.tsx
@@ -3,10 +3,11 @@
  * Uses the Radix Dialog primitive styled with Tailwind.
  */
 import * as Dialog from '@radix-ui/react-dialog'
-import type { ReactNode } from 'react'
-import { Settings as SettingsIcon, X } from 'lucide-react'
+import { useEffect, useState, type ReactNode } from 'react'
+import { Database, RefreshCw, Settings as SettingsIcon, X } from 'lucide-react'
+import { fetchCacheStats } from '../api/client'
 import { useAppStore } from '../store'
-import type { SortMode } from '../types'
+import type { CacheStats, SortMode } from '../types'
 
 const SORT_OPTIONS: { value: SortMode; label: string }[] = [
   { value: 'number', label: 'Card number (group by set) — default' },
@@ -146,6 +147,8 @@ export function SettingsDrawer() {
                 onChange={(v) => updateSettings({ showTimer: v })}
               />
             </div>
+
+            <CacheStatsPanel />
           </div>
 
           {/* Footer */}
@@ -184,6 +187,140 @@ function Field({
       {children}
     </div>
   )
+}
+
+// ---------------------------------------------------------------------------
+// Cache stats panel — read-only snapshot of GET /api/v1/cache/stats. Lives
+// at the bottom of the drawer because it's diagnostic, not configurable.
+// ---------------------------------------------------------------------------
+
+function CacheStatsPanel() {
+  // `loading` starts true because the mount effect kicks off the first
+  // fetch before any user interaction. Refresh-button clicks flip it back
+  // on. Keeping the initial setLoading out of the effect avoids the
+  // react-hooks/set-state-in-effect lint rule.
+  const [stats, setStats] = useState<CacheStats | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // Single mount effect — cancellable so the drawer closing mid-flight
+  // doesn't try to update an unmounted component. Matches the pattern in
+  // WhatsNewModal.tsx.
+  useEffect(() => {
+    let cancelled = false
+    fetchCacheStats()
+      .then((data) => {
+        if (!cancelled) setStats(data)
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'failed to load')
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  async function refresh() {
+    setLoading(true)
+    setError(null)
+    try {
+      setStats(await fetchCacheStats())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to load')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="rounded-md border border-sand-300 dark:border-husk-50 bg-sand-100 dark:bg-husk-100 px-3 py-3">
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-1.5 text-sm font-medium text-coconut-600 dark:text-sand-200">
+          <Database size={14} />
+          Cache stats
+        </div>
+        <button
+          type="button"
+          onClick={() => void refresh()}
+          disabled={loading}
+          aria-label="Refresh cache stats"
+          className="rounded p-1 text-coconut-400 dark:text-sand-300 hover:text-coconut-700 dark:hover:text-sand-50 hover:bg-sand-200 dark:hover:bg-husk-200 transition-colors disabled:opacity-50"
+        >
+          <RefreshCw size={12} className={loading ? 'animate-spin' : ''} />
+        </button>
+      </div>
+
+      {error && (
+        <p className="text-xs text-red-600 dark:text-red-400">{error}</p>
+      )}
+
+      {!error && !stats && loading && (
+        <p className="text-xs text-coconut-400 dark:text-sand-300">Loading…</p>
+      )}
+
+      {stats && (
+        <dl className="grid grid-cols-2 gap-x-3 gap-y-1.5 text-xs">
+          <StatRow label="API responses" value={`${stats.api_entry_count} · ${formatBytes(stats.api_bytes)}`} />
+          <StatRow label="Images" value={`${stats.image_entry_count} · ${formatBytes(stats.image_bytes)}`} />
+          <StatRow label="Overrides" value={`${stats.override_count} · ${formatBytes(stats.override_bytes)}`} />
+          <StatRow
+            label="Concepts"
+            value={
+              stats.concept_warm_timestamp == null
+                ? 'not warmed'
+                : `${stats.concept_warm_names} · ${formatAge(stats.concept_warm_timestamp)}`
+            }
+            warn={stats.concept_warm_timestamp == null}
+          />
+          <StatRow
+            label="Set cards"
+            value={
+              stats.set_cards_warm_timestamp == null
+                ? 'not warmed'
+                : `${stats.set_cards_warm_count} · ${formatAge(stats.set_cards_warm_timestamp)}`
+            }
+            warn={stats.set_cards_warm_timestamp == null}
+          />
+        </dl>
+      )}
+    </div>
+  )
+}
+
+function StatRow({ label, value, warn = false }: { label: string; value: string; warn?: boolean }) {
+  return (
+    <>
+      <dt className="text-coconut-400 dark:text-sand-300 truncate">{label}</dt>
+      <dd
+        className={`text-right tabular-nums ${
+          warn
+            ? 'text-amber-700 dark:text-amber-400'
+            : 'text-coconut-700 dark:text-sand-50'
+        }`}
+      >
+        {value}
+      </dd>
+    </>
+  )
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function formatAge(epochSeconds: number): string {
+  const seconds = Math.max(0, Date.now() / 1000 - epochSeconds)
+  if (seconds < 60) return 'just now'
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`
+  return `${Math.floor(seconds / 86400)}d ago`
 }
 
 function Toggle({

--- a/web/src/components/a11y.test.tsx
+++ b/web/src/components/a11y.test.tsx
@@ -30,6 +30,23 @@ vi.mock('../api/client', () => ({
   downloadSetCardsPdf: vi.fn(),
   parseLine: vi.fn(),
   addOverride: vi.fn(),
+  // Settings drawer mounts the cache-stats panel on open, which fetches
+  // on mount. Return a zeroed snapshot so the a11y scan sees the loaded
+  // state instead of the loading spinner.
+  fetchCacheStats: vi.fn().mockResolvedValue({
+    root: '/tmp/cache',
+    api_entry_count: 0,
+    api_bytes: 0,
+    api_oldest_mtime: null,
+    override_count: 0,
+    override_bytes: 0,
+    image_entry_count: 0,
+    image_bytes: 0,
+    concept_warm_timestamp: null,
+    concept_warm_names: 0,
+    set_cards_warm_timestamp: null,
+    set_cards_warm_count: 0,
+  }),
 }))
 
 const { storeState, storeApi } = vi.hoisted(() => {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -201,6 +201,27 @@ export interface ChangelogRelease {
 }
 
 /**
+ * Snapshot returned by `GET /api/v1/cache/stats` — same shape as
+ * `pkmn cache stats --json`. Counts are always present; the two warm
+ * timestamps are `null` when no warm pass has been recorded on this
+ * instance.
+ */
+export interface CacheStats {
+  root: string
+  api_entry_count: number
+  api_bytes: number
+  api_oldest_mtime: number | null
+  override_count: number
+  override_bytes: number
+  image_entry_count: number
+  image_bytes: number
+  concept_warm_timestamp: number | null
+  concept_warm_names: number
+  set_cards_warm_timestamp: number | null
+  set_cards_warm_count: number
+}
+
+/**
  * One entry in the recent-searches history. Captured the moment the
  * user clicks **Look up** so the panel reflects what was actually
  * submitted (even if the run later errored or was stopped).

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -202,9 +202,11 @@ export interface ChangelogRelease {
 
 /**
  * Snapshot returned by `GET /api/v1/cache/stats` — same shape as
- * `pkmn cache stats --json`. Counts are always present; the two warm
- * timestamps are `null` when no warm pass has been recorded on this
- * instance.
+ * `pkmn cache stats --json`. Counts are always present. Three fields
+ * can be `null`:
+ * - `api_oldest_mtime` when the API cache holds no entries
+ * - `concept_warm_timestamp` when no concept-warm pass has been recorded
+ * - `set_cards_warm_timestamp` when no set-cards-warm pass has been recorded
  */
 export interface CacheStats {
   root: string


### PR DESCRIPTION
Closes #311

## What

Two surfaces over the same on-disk snapshot:

1. **`GET /api/v1/cache/stats`** ([api/routes/cache.py](api/routes/cache.py)) returns the same JSON shape as `pkmn cache stats --json` (every field on `cache.CacheStats`, with `root` stringified). Tolerates `OSError` from `cache_root()`'s `mkdir` on read-only / misconfigured filesystems and falls back to a zeroed snapshot so the diagnostics endpoint never 500s on the surface meant to diagnose failures. Wired into [docs/deployment.md](docs/deployment.md#inspecting-deployed-cache-state).
2. **Cache-stats panel in the Settings drawer** ([web/src/components/SettingsDrawer.tsx](web/src/components/SettingsDrawer.tsx)) consumes the new endpoint inline so contributors / operators can see API + image + override counts and warm-pass freshness without leaving the SPA. Refresh button on the panel re-fetches on demand; "not warmed" renders in amber for the concept and set-cards slices when the manifests are missing.

```bash
curl -s https://mgz-pkmn.onrender.com/api/v1/cache/stats | jq
```

## Why

`pkmn cache stats` reads `~/.cache/mgz-pkmn` on the local filesystem,
so on a remote deploy there's no way to confirm `MGZ_PKMN_WARM_ON_STARTUP`
actually landed, see how many concept / set-card entries are warmed, or
catch a regression where warm passes stop firing — short of grepping
Render's log stream, which disappears after the retention window. The
endpoint answers that on demand; the drawer panel makes the answer
visible from the same surface where someone is already configuring the
SPA.

## Auth posture

Public read, no auth. Entry counts, byte totals, and warm timestamps
aren't sensitive — they don't expose anything an attacker could exploit
that scraping the public endpoints wouldn't already reveal. If that
ever changes, the route is small enough to gate behind an env-var token
without reshaping the schema.

## How to verify

1. `uv run uvicorn api.main:app --port 8000` + `npm --prefix web run dev`.
2. `curl -s http://localhost:8000/api/v1/cache/stats | jq` — fresh-install shape (zeros, both `*_warm_timestamp` fields null).
3. Open the SPA → Settings → scroll to the **Cache stats** panel. Same values, refresh button works.
4. `pkmn cache warm-concepts --limit 5` then re-hit the endpoint and click refresh in the drawer — `concept_warm_timestamp` is now a float and the "not warmed" amber row becomes `47 · just now`.
5. `curl -i http://localhost:8000/api/v1/cache/stats | head` — confirm `Cache-Control: no-store`.

## Preview

<img width="1400" height="900" alt="image" src="https://github.com/user-attachments/assets/0ab3d3ff-768c-40cb-bc88-5d616534531a" />

## Tests

- `tests/test_api_routes.py::CacheStatsRouteTests` — 5 cases: empty-cache shape, warmed-cache shape, `Cache-Control: no-store`, `fields()` equality between the response and `cache.CacheStats` (catches schema drift), and the `OSError → zeroed snapshot` fallback.
- `web/src/components/SettingsDrawer.test.tsx` — 3 new cases: panel renders the values returned by `/cache/stats`, refresh button re-fetches, fetch errors render an inline message without crashing the drawer.