### PR TITLE
fix(api): MGZ_PKMN_WARM_ON_STARTUP fires again (folded into lifespan)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,16 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- API: **`MGZ_PKMN_WARM_ON_STARTUP=1` actually fires again** — the
+  warm bootstrap was wired via `@app.on_event("startup")`, but
+  Starlette silently drops `on_event` handlers when a custom `lifespan`
+  is provided (the one added for Alembic auto-migrate). The deployed
+  instance was reporting `concept_warm_timestamp` and
+  `set_cards_warm_timestamp` as `null` on `/api/v1/cache/stats` despite
+  the env var being set ([#367](https://github.com/mgzwarrior/mgz-pkmn/issues/367)).
+  Folded the warm bootstrap into the existing lifespan async generator
+  and pinned the behavior with `tests/test_warm_on_startup.py` so the
+  next person to add a startup hook can't silently shadow it again.
 - Web: **results table counts now live above the table** — the
   `N matched · N unmatched · N shown` summary moved from below the
   results to the right side of the table toolbar so it's visible

--- a/api/main.py
+++ b/api/main.py
@@ -163,7 +163,8 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
        `MGZ_PKMN_AUTOMIGRATE=0` to skip — useful when migrations are run
        as a prestart step instead (init containers, Render pre-deploy,
        etc.).
-    2. If `MGZ_PKMN_WARM_ON_STARTUP=1`, kicks off the concept and
+    2. If `MGZ_PKMN_WARM_ON_STARTUP` is truthy (`1`, `true`, or `True`
+       — see `_warm_on_startup_enabled`), kicks off the concept and
        set-cards warm passes on background daemon threads so first-use
        lookups land on a warm cache. Each warmer has its own freshness
        manifest (24 h concepts / 1 week set-cards), so containers

--- a/api/main.py
+++ b/api/main.py
@@ -142,14 +142,38 @@ class SPAStaticFiles(StaticFiles):
         return response
 
 
+def _warm_on_startup_enabled() -> bool:
+    """True when `MGZ_PKMN_WARM_ON_STARTUP` is set to a truthy value.
+
+    Centralised so the lifespan hook and any future caller (tests, an
+    admin endpoint) share the same parse rules instead of re-implementing
+    them inline.
+    """
+    return os.environ.get(_WARM_ON_STARTUP_ENV, "").strip() in ("1", "true", "True")
+
+
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     """Startup/shutdown hook.
 
-    On startup, runs `alembic upgrade head` against the configured DB under
-    a cross-worker lock (see ADR-0013 and `api.db.migrate`). Set
-    `MGZ_PKMN_AUTOMIGRATE=0` to skip — useful when migrations are run as a
-    prestart step instead (init containers, Render pre-deploy, etc.).
+    On startup, in order:
+
+    1. Runs `alembic upgrade head` against the configured DB under a
+       cross-worker lock (see ADR-0013 and `api.db.migrate`). Set
+       `MGZ_PKMN_AUTOMIGRATE=0` to skip — useful when migrations are run
+       as a prestart step instead (init containers, Render pre-deploy,
+       etc.).
+    2. If `MGZ_PKMN_WARM_ON_STARTUP=1`, kicks off the concept and
+       set-cards warm passes on background daemon threads so first-use
+       lookups land on a warm cache. Each warmer has its own freshness
+       manifest (24 h concepts / 1 week set-cards), so containers
+       starting within the window skip the re-walk and log "already
+       fresh". These were previously wired via `@app.on_event("startup")`
+       but Starlette silently drops `on_event` handlers when a custom
+       `lifespan` is provided (see #367), so the warm pass never fired
+       on a deployed instance — visible as `concept_warm_timestamp` /
+       `set_cards_warm_timestamp` staying `null` on
+       `GET /api/v1/cache/stats` despite the env var being set.
     """
     if migrate.automigrate_enabled():
         try:
@@ -159,6 +183,11 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
             raise
     else:
         _log.info("MGZ_PKMN_AUTOMIGRATE=0 — skipping startup migrations")
+
+    if _warm_on_startup_enabled():
+        _warm_concepts_in_background()
+        _warm_set_cards_in_background()
+
     yield
 
 
@@ -183,19 +212,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-# Opt-in startup hook: when MGZ_PKMN_WARM_ON_STARTUP=1, kick off both the
-# concept warm and the set-cards warm in the background so first-use
-# lookups served by this process are cache hits. Each warmer has its own
-# freshness manifest (24 h for concepts, 1 week for set cards) so the
-# heavier one doesn't re-thrash on every `uvicorn --reload` cycle.
-if os.environ.get(_WARM_ON_STARTUP_ENV, "").strip() in ("1", "true", "True"):
-
-    @app.on_event("startup")
-    def _startup_warm() -> None:
-        _warm_concepts_in_background()
-        _warm_set_cards_in_background()
-
 
 app.include_router(parse.router, prefix="/api/v1", tags=["parse"])
 app.include_router(lookup.router, prefix="/api/v1", tags=["lookup"])

--- a/tests/test_warm_on_startup.py
+++ b/tests/test_warm_on_startup.py
@@ -1,0 +1,119 @@
+"""Pin that `MGZ_PKMN_WARM_ON_STARTUP=1` actually fires the warm bootstrap.
+
+Regression coverage for #367: when the Alembic auto-migrate lifespan was
+added, the warm bootstrap kept being wired via `@app.on_event("startup")`
+— which Starlette silently ignores when a custom `lifespan` is provided.
+The warm pass never fired on deployed instances; `concept_warm_timestamp`
+and `set_cards_warm_timestamp` stayed `null` on `/api/v1/cache/stats`
+despite the env var being set. This test would have caught it.
+
+The shape mirrors `tests/test_persistence.py::AutomigrateOptOutTests` —
+patch the warm helpers at the api.main module level, drive a TestClient
+through the lifespan, then assert call counts. Auto-migrate is turned off
+in setUp so these tests don't reach SQLite.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+
+
+class WarmOnStartupTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._old_warm = os.environ.get("MGZ_PKMN_WARM_ON_STARTUP")
+        self._old_automigrate = os.environ.get("MGZ_PKMN_AUTOMIGRATE")
+        # Disable automigrate so the lifespan doesn't try to touch SQLite —
+        # we only care about the warm branch here.
+        os.environ["MGZ_PKMN_AUTOMIGRATE"] = "0"
+
+    def tearDown(self) -> None:
+        if self._old_warm is None:
+            os.environ.pop("MGZ_PKMN_WARM_ON_STARTUP", None)
+        else:
+            os.environ["MGZ_PKMN_WARM_ON_STARTUP"] = self._old_warm
+        if self._old_automigrate is None:
+            os.environ.pop("MGZ_PKMN_AUTOMIGRATE", None)
+        else:
+            os.environ["MGZ_PKMN_AUTOMIGRATE"] = self._old_automigrate
+
+    def _reload_main(self):
+        """Re-import api.main so the freshly-set env vars are picked up.
+
+        The lifespan reads `MGZ_PKMN_WARM_ON_STARTUP` per startup, so a
+        reload isn't strictly required — but importing `app` from a stale
+        module risks confusing future tests if api.main starts caching
+        config at import time. Cheap to be safe.
+        """
+        if "api.main" in sys.modules:
+            return importlib.reload(sys.modules["api.main"])
+        import api.main as main
+
+        return main
+
+    def test_warm_env_set_kicks_off_both_warmers(self) -> None:
+        os.environ["MGZ_PKMN_WARM_ON_STARTUP"] = "1"
+        main = self._reload_main()
+        with (
+            patch.object(main, "_warm_concepts_in_background") as mock_concepts,
+            patch.object(main, "_warm_set_cards_in_background") as mock_set_cards,
+        ):
+            with TestClient(main.app) as c:
+                self.assertEqual(c.get("/health").status_code, 200)
+            mock_concepts.assert_called_once()
+            mock_set_cards.assert_called_once()
+
+    def test_warm_env_unset_skips_warmers(self) -> None:
+        os.environ.pop("MGZ_PKMN_WARM_ON_STARTUP", None)
+        main = self._reload_main()
+        with (
+            patch.object(main, "_warm_concepts_in_background") as mock_concepts,
+            patch.object(main, "_warm_set_cards_in_background") as mock_set_cards,
+        ):
+            with TestClient(main.app) as c:
+                self.assertEqual(c.get("/health").status_code, 200)
+            mock_concepts.assert_not_called()
+            mock_set_cards.assert_not_called()
+
+    def test_warm_env_truthy_variants_all_fire(self) -> None:
+        """Pin the env-var parse rules so future churn doesn't drop a variant."""
+        for value in ("1", "true", "True"):
+            with self.subTest(value=value):
+                os.environ["MGZ_PKMN_WARM_ON_STARTUP"] = value
+                main = self._reload_main()
+                with (
+                    patch.object(main, "_warm_concepts_in_background") as mock_concepts,
+                    patch.object(main, "_warm_set_cards_in_background") as mock_set_cards,
+                ):
+                    with TestClient(main.app) as c:
+                        self.assertEqual(c.get("/health").status_code, 200)
+                    mock_concepts.assert_called_once()
+                    mock_set_cards.assert_called_once()
+
+    def test_warm_env_falsy_variants_all_skip(self) -> None:
+        """Same as above for the other side — empty / 0 / false do not fire."""
+        for value in ("", "0", "false", "False"):
+            with self.subTest(value=value):
+                os.environ["MGZ_PKMN_WARM_ON_STARTUP"] = value
+                main = self._reload_main()
+                with (
+                    patch.object(main, "_warm_concepts_in_background") as mock_concepts,
+                    patch.object(main, "_warm_set_cards_in_background") as mock_set_cards,
+                ):
+                    with TestClient(main.app) as c:
+                        self.assertEqual(c.get("/health").status_code, 200)
+                    mock_concepts.assert_not_called()
+                    mock_set_cards.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #367

## What

Move the warm bootstrap from the dead-code `@app.on_event("startup")` block into the existing `lifespan` async generator in [`api/main.py`](api/main.py), after the Alembic migration step and before `yield`. Extract the env-var parse into a `_warm_on_startup_enabled()` helper so the lifespan and tests share the same truthy rules. Delete the now-dead `on_event` block.

## Why

Starlette silently drops `on_event` handlers when a custom `lifespan` is provided ([their docs](https://www.starlette.io/lifespan/) call this out). When the Alembic auto-migrate lifespan landed, the warm bootstrap registered earlier via `@app.on_event("startup")` stopped firing — no warning, no error.

Symptom in production: `/api/v1/cache/stats` reported `concept_warm_timestamp` and `set_cards_warm_timestamp` as `null` despite `MGZ_PKMN_WARM_ON_STARTUP=1` set in [`render.yaml`](render.yaml). The image slice (346 entries · 19.4 MB) still showed populated, which masked the regression — that comes from the Dockerfile's build-time `pkmn cache warm-sets`, which bakes into the Docker layer and ships with the image regardless of runtime state. Easy to assume "warm-on-startup works because there's stuff in the cache" until you check the per-slice manifests.

Found this while answering Matt's "why are concepts/set cards not warmed" question on [#364](https://github.com/mgzwarrior/mgz-pkmn/pull/364)'s deployed instance.

## How to verify

1. Local: `MGZ_PKMN_WARM_ON_STARTUP=1 uv run uvicorn api.main:app --port 8000`
2. Wait ~30s for the background threads to finish their first pass.
3. `curl -s http://localhost:8000/api/v1/cache/stats | jq` — both `concept_warm_timestamp` and `set_cards_warm_timestamp` should be non-null floats.
4. Restart the API within the freshness window — the `_is_fresh` gate should skip and log "already fresh".
5. After merge + deploy, hit `https://mgz-pkmn.onrender.com/api/v1/cache/stats` a minute or two after the cold-start completes. Same fields non-null.

## Tests

New `tests/test_warm_on_startup.py` (4 cases) pins:

- Warmers fire when `MGZ_PKMN_WARM_ON_STARTUP=1`.
- Warmers don't fire when the env var is unset.
- `"1"` / `"true"` / `"True"` all count as truthy (subTest).
- `""` / `"0"` / `"false"` / `"False"` all count as falsy (subTest).

Pattern mirrors the existing `tests/test_persistence.py::AutomigrateOptOutTests` (patch the helper on the api.main module, drive a `TestClient` through the lifespan, assert call counts). So the next person to add a startup hook gets a test failure instead of a silent drop.

## Related

Part of [EPIC #368](https://github.com/mgzwarrior/mgz-pkmn/issues/368) — Phase 0 (foundation). Every phase past this one needs the runtime warm path to actually fire.