### PR TITLE
Phase 0a: persistent disk + runtime warm-sets bootstrap + sets_warm.json manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,35 @@ Versions follow [Semantic Versioning](https://semver.org/).
   warmed" in amber for the concept and set-cards slices when the
   manifests are missing.
 
+### Changed
+
+- Deploy: **Persistent disk + runtime-only cache warming** — the Render
+  deployment now provisions a 10 GB persistent disk mounted at
+  `/var/cache` and points `XDG_CACHE_HOME` at it
+  ([#369](https://github.com/mgzwarrior/mgz-pkmn/issues/369)). The
+  cache root resolves to `/var/cache/mgz-pkmn`, so every slice
+  (API responses, set images, card images, URL overrides, the
+  run-history SQLite file, all three warm-pass manifests) now survives
+  redeploys instead of being thrown away on every push to `main`. The
+  Dockerfile's build-time `pkmn cache warm-sets` step is retired in
+  favor of a runtime lifespan bootstrap (`_warm_sets_in_background`)
+  gated by a new `sets_warm.json` freshness manifest (1-week TTL).
+  Image is ~20 MB smaller and builds ~30s faster as a result; a single
+  warm pass after the first deploy now serves every subsequent deploy
+  until the manifest expires. Foundation for the
+  [pre-Scrydex catalog-warm epic #368](https://github.com/mgzwarrior/mgz-pkmn/issues/368).
+
+### Added
+
+- CLI / API / web: **`sets_warm.json` manifest + new `sets_warm_*`
+  fields** on `CacheStats`. Surfaced as a new line on
+  [`pkmn cache stats`](src/mgz_pkmn/cli.py) ("Sets: 173 sets · warmed
+  Xh ago" or "not warmed"), a new row on the SPA's Cache Stats panel
+  ([`web/src/components/SettingsDrawer.tsx`](web/src/components/SettingsDrawer.tsx)),
+  and two new fields on `GET /api/v1/cache/stats`. Operators now have
+  the same freshness signal for the set-image slice that the concept
+  and set-cards slices already had.
+
 ### Fixed
 
 - API: **`MGZ_PKMN_WARM_ON_STARTUP=1` actually fires again** — the

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,34 +38,16 @@ COPY CHANGELOG.md ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --extra api --no-dev --frozen
 
-# Bake a warmed set-image cache into the image so the deployed service starts
-# hot. Render's free plan has no persistent disk, so without this every cold
-# start (deploy or post-idle spin-up) pays the full image-download cost on
-# the first set lookup. The warm pass walks pokemontcg.io's set catalog
-# (~200 sets) and persists each logo+symbol — ~20 MB total on disk.
-#
-# `POKEMONTCG_IO_API_KEY` is passed in as a build arg (Render reads it from
-# the service's envVars). When unset (e.g. a local `docker build` with no
-# key), the warm step is skipped cleanly so the image still builds — it just
-# starts with a cold cache.
-#
-# The warm step is best-effort: `warm-sets` already retries transient
-# pokemontcg.io timeouts, but a sustained upstream outage would still exit
-# non-zero. A cold cache is an acceptable degraded state (see the no-key
-# branch below), so trap that exit with `|| echo` rather than letting a
-# flaky API fail the whole deploy.
-#
-# Sits before `COPY api/` and `COPY --from=web-builder` so layer caching
-# isn't invalidated by every api/ or web/ change — only by src/ or deps.
-ARG POKEMONTCG_IO_API_KEY=""
-ENV XDG_CACHE_HOME=/app/.cache
-RUN if [ -n "$POKEMONTCG_IO_API_KEY" ]; then \
-        POKEMONTCG_IO_API_KEY="$POKEMONTCG_IO_API_KEY" \
-            uv run pkmn cache warm-sets \
-            || echo "cache warm failed (pokemontcg.io unreachable?); image will start with a cold cache"; \
-    else \
-        echo "POKEMONTCG_IO_API_KEY not set at build time; skipping cache warm (image will start with a cold cache)"; \
-    fi
+# Note: the previous Dockerfile baked a warmed set-image cache into the
+# image with a build-time `pkmn cache warm-sets` step. That made sense when
+# Render's free tier reset the writable filesystem on every redeploy. With
+# the persistent disk allocated in #369 (mounted at `/var/cache`, with
+# `XDG_CACHE_HOME=/var/cache` in render.yaml's envVars), set logos and
+# symbols are now warmed at runtime by the lifespan bootstrap in
+# `api.main._warm_sets_in_background` onto durable storage — a single warm
+# pass after the first deploy serves every subsequent deploy until the
+# `sets_warm.json` manifest's TTL (1 week) expires. Image is ~20 MB smaller
+# and builds ~30 s faster as a result.
 
 # Copy API code and the built SPA from stage 1.
 COPY api/ ./api/

--- a/api/main.py
+++ b/api/main.py
@@ -25,6 +25,7 @@ from starlette.responses import Response
 from mgz_pkmn import __version__
 from mgz_pkmn import cache as disk_cache
 from mgz_pkmn.lookup import warm_concepts, warm_set_cards
+from mgz_pkmn.set_cards import warm_set_images
 from mgz_pkmn.sources import TCGClient, TCGDexClient
 
 # Import the module (not the names) so tests can monkeypatch
@@ -120,6 +121,46 @@ def _warm_set_cards_in_background() -> None:
     threading.Thread(target=_run, name="set-cards-warm", daemon=True).start()
 
 
+def _warm_sets_in_background() -> None:
+    """Run the set-image (logos + symbols) warm pass on a daemon thread.
+
+    Mirrors the concept and set-cards warmers. Gated by the on-disk
+    `sets_warm.json` freshness manifest — if a warm pass landed within
+    the last week, skip and log "already fresh". Errors are logged and
+    swallowed so a failed warm doesn't crash the service.
+
+    This bootstrap is what replaces the build-time `pkmn cache warm-sets`
+    step that used to live in the Dockerfile. With #369 dropping the
+    bake, set logos and symbols are warmed at runtime onto the persistent
+    disk — meaning a single warm pass after the first deploy serves
+    every subsequent deploy until the manifest's TTL expires."""
+    if disk_cache.sets_warm_is_fresh():
+        _log.info("sets cache fresh; skipping startup warm")
+        return
+
+    def _run() -> None:
+        try:
+            pkmn = TCGClient(api_key=os.environ.get("POKEMONTCG_IO_API_KEY"))
+            result = warm_set_images(pkmn)
+            disk_cache.write_sets_warm(
+                sets_warmed=result.sets,
+                logos_cached=result.logos_cached,
+                symbols_cached=result.symbols_cached,
+                failures=result.failures,
+            )
+            _log.info(
+                "sets warm complete: %d sets · %d logos · %d symbols · %d failures",
+                result.sets,
+                result.logos_cached,
+                result.symbols_cached,
+                result.failures,
+            )
+        except Exception:
+            _log.exception("sets warm failed; service running without primed set images")
+
+    threading.Thread(target=_run, name="sets-warm", daemon=True).start()
+
+
 class SPAStaticFiles(StaticFiles):
     """StaticFiles that disables browser caching for ``index.html``.
 
@@ -164,17 +205,19 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
        as a prestart step instead (init containers, Render pre-deploy,
        etc.).
     2. If `MGZ_PKMN_WARM_ON_STARTUP` is truthy (`1`, `true`, or `True`
-       — see `_warm_on_startup_enabled`), kicks off the concept and
-       set-cards warm passes on background daemon threads so first-use
-       lookups land on a warm cache. Each warmer has its own freshness
-       manifest (24 h concepts / 1 week set-cards), so containers
-       starting within the window skip the re-walk and log "already
-       fresh". These were previously wired via `@app.on_event("startup")`
-       but Starlette silently drops `on_event` handlers when a custom
-       `lifespan` is provided (see #367), so the warm pass never fired
-       on a deployed instance — visible as `concept_warm_timestamp` /
-       `set_cards_warm_timestamp` staying `null` on
-       `GET /api/v1/cache/stats` despite the env var being set.
+       — see `_warm_on_startup_enabled`), kicks off the concept,
+       set-cards, and set-image warm passes on background daemon threads
+       so first-use lookups land on a warm cache. Each warmer has its
+       own freshness manifest (24 h concepts / 1 week set-cards / 1
+       week sets), so containers starting within the window skip the
+       re-walk and log "already fresh". These were previously wired via
+       `@app.on_event("startup")` but Starlette silently drops
+       `on_event` handlers when a custom `lifespan` is provided (see
+       #367), so the warm pass never fired on a deployed instance —
+       visible as `concept_warm_timestamp` / `set_cards_warm_timestamp`
+       staying `null` on `GET /api/v1/cache/stats` despite the env var
+       being set. The sets-warm slice was added in #369 to replace the
+       Dockerfile's build-time `pkmn cache warm-sets` step.
     """
     if migrate.automigrate_enabled():
         try:
@@ -188,6 +231,7 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     if _warm_on_startup_enabled():
         _warm_concepts_in_background()
         _warm_set_cards_in_background()
+        _warm_sets_in_background()
 
     yield
 

--- a/api/routes/cache.py
+++ b/api/routes/cache.py
@@ -47,6 +47,8 @@ def _zeroed_snapshot() -> disk_cache.CacheStats:
         concept_warm_names=0,
         set_cards_warm_timestamp=None,
         set_cards_warm_count=0,
+        sets_warm_timestamp=None,
+        sets_warm_count=0,
     )
 
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -134,6 +134,39 @@ hook and Render starts a fresh build from `main`.
 > Fine for hobby use. Upgrade to *Starter* (or move to Fly.io) if cold
 > starts hurt.
 
+## Persistent disk + cache location
+
+The deployment provisions a Render persistent disk mounted at
+`/var/cache` (declared in [`render.yaml`](../render.yaml)). `XDG_CACHE_HOME`
+is set to that same mount path, and [`src/mgz_pkmn/cache.py::_cache_root_path`](../src/mgz_pkmn/cache.py)
+reads `XDG_CACHE_HOME` as the *parent* directory and appends `mgz-pkmn`,
+so the project cache root resolves to `/var/cache/mgz-pkmn` on the
+deployed instance. Everything under that path — API response cache,
+image cache (set logos/symbols, card art), URL overrides, the run-history
+SQLite file, the three warm-pass manifests — persists across redeploys.
+
+If you change the mount path in Render, update `XDG_CACHE_HOME` to match
+in the same edit. The cache module appends `mgz-pkmn` itself, so always
+point the env var at the *parent* directory; pointing it at
+`/var/cache/mgz-pkmn` would produce `/var/cache/mgz-pkmn/mgz-pkmn`.
+
+### Cache warming
+
+Three runtime warm passes fire on startup when `MGZ_PKMN_WARM_ON_STARTUP=1`
+(set by default in `render.yaml`). Each writes its own freshness manifest
+so container restarts within the staleness window skip the re-walk:
+
+| Pass | Manifest | Stale window | Walks |
+|---|---|---|---|
+| Concepts | `concept_warm.json` | 24 h | ~200 concept-name → card-id lookups |
+| Set cards | `set_cards_warm.json` | 7 d | Per-set card-list JSON (~170 sets) |
+| Sets (images) | `sets_warm.json` | 7 d | Set logo + symbol images (~200 × 2) |
+
+The set-image warm previously lived as a Dockerfile build-time step.
+With the persistent disk in place it runs at runtime onto durable
+storage — a single warm after the first deploy serves every subsequent
+deploy until the manifest TTL expires.
+
 ## Inspecting deployed cache state
 
 `pkmn cache stats` reads `~/.cache/mgz-pkmn` on the local filesystem, so
@@ -146,8 +179,8 @@ curl -s https://mgz-pkmn.onrender.com/api/v1/cache/stats | jq
 
 Same field names as `pkmn cache stats --json`, so the two surfaces are
 pipe-compatible. Use it to confirm `MGZ_PKMN_WARM_ON_STARTUP` actually
-landed (`concept_warm_timestamp` / `set_cards_warm_timestamp` are
-non-null after a successful warm pass) and to spot drift between the
-entry counts you expected and what's actually on disk. The response is
-served with `Cache-Control: no-store` because the underlying state
-changes on every warm pass and cache write.
+landed (`concept_warm_timestamp` / `set_cards_warm_timestamp` /
+`sets_warm_timestamp` are non-null after a successful warm pass) and to
+spot drift between the entry counts you expected and what's actually on
+disk. The response is served with `Cache-Control: no-store` because the
+underlying state changes on every warm pass and cache write.

--- a/render.yaml
+++ b/render.yaml
@@ -7,19 +7,36 @@ services:
     branch: main
     autoDeploy: true
     healthCheckPath: /health
+    # Persistent disk so the cache survives redeploys (see #369). The mount
+    # path matches the `XDG_CACHE_HOME` env var below; the cache module
+    # (`src/mgz_pkmn/cache.py::_cache_root_path`) reads `XDG_CACHE_HOME` as
+    # the *parent* directory and appends `mgz-pkmn`, so this resolves to
+    # `/var/cache/mgz-pkmn`. 10 GB is comfortable headroom for the full
+    # English-card catalog warm planned in epic #368 (~90-180 MB structural
+    # JSON + ~3-5 GB images + run-history SQLite + manifests).
+    disk:
+      name: cache
+      mountPath: /var/cache
+      sizeGB: 10
     envVars:
-      # Used at both build time (the Dockerfile's `pkmn cache warm-sets`
-      # step bakes set logos+symbols into the image) and runtime (the API
-      # uses it for live lookups). Render automatically passes envVars to
-      # the Docker build as build args when the Dockerfile declares them
-      # via `ARG`, so a single entry covers both.
+      # Live API key for lookups against pokemontcg.io. Build-time use of
+      # this var was retired in #369 along with the Dockerfile's
+      # `warm-sets` bake; runtime warming on persistent disk took over.
       - key: POKEMONTCG_IO_API_KEY
         sync: false
-      # Warm the concept + set-cards API caches on startup so the first
-      # user after a deploy (or a free-tier spin-up) gets cache hits
+      # Point the cache module at the persistent disk mount. Without this,
+      # the cache root falls back to `~/.cache/mgz-pkmn` (the container's
+      # ephemeral writable layer) and nothing survives a redeploy.
+      - key: XDG_CACHE_HOME
+        value: /var/cache
+      # Warm the concept + set-cards + set-image caches on startup so the
+      # first user after a deploy (or a free-tier spin-up) gets cache hits
       # instead of paying the full upstream round trip. The warmers run on
       # background daemon threads — startup and the /health check aren't
       # blocked — and their on-disk freshness manifests (24 h concepts /
-      # 1 week set-cards) keep restarts within the window from re-walking.
+      # 1 week set-cards / 1 week sets) keep restarts within the window
+      # from re-walking. With the persistent disk above, a single warm
+      # pass after the first deploy now serves every subsequent deploy
+      # until the manifest TTL expires.
       - key: MGZ_PKMN_WARM_ON_STARTUP
         value: "1"

--- a/src/mgz_pkmn/cache.py
+++ b/src/mgz_pkmn/cache.py
@@ -52,14 +52,21 @@ CONCEPT_WARM_STALE_SECONDS = 24 * 60 * 60  # one day — once-per-day startup ga
 # response cache's own TTL: once a set-cards warm pass lands, every
 # entry it primed survives until the API cache itself expires.
 SET_CARDS_WARM_STALE_SECONDS = 7 * 24 * 60 * 60  # one week
+# Set-image warm pass (set logos + symbols, ~200 sets x 2 images = ~400
+# HTTP requests). Same weekly cadence as set-cards: indefinite TTL on the
+# image bytes themselves, but the manifest's freshness gate keeps the
+# runtime lifespan bootstrap from re-walking every container restart.
+SETS_WARM_STALE_SECONDS = 7 * 24 * 60 * 60  # one week
 _NO_CACHE_ENV = "MGZ_PKMN_NO_CACHE"
 _WARN_BYTES_ENV = "MGZ_PKMN_CACHE_WARN_BYTES"
 _OVERRIDES_FILE = "url_overrides.json"
 _CONCEPT_WARM_FILE = "concept_warm.json"
 _SET_CARDS_WARM_FILE = "set_cards_warm.json"
+_SETS_WARM_FILE = "sets_warm.json"
 OVERRIDES_SCHEMA_VERSION = 1
 CONCEPT_WARM_SCHEMA_VERSION = 1
 SET_CARDS_WARM_SCHEMA_VERSION = 1
+SETS_WARM_SCHEMA_VERSION = 1
 _IMAGES_SUBDIR = "images"
 # Allowed image extensions for read-side discovery; write-side derives the
 # extension from the source URL but normalises it through this list so an
@@ -105,6 +112,14 @@ class CacheStats:
     # sets had their full card list primed during the most recent pass.
     set_cards_warm_timestamp: float | None
     set_cards_warm_count: int
+    # Sets (logos/symbols) warm slice — populated from `sets_warm.json`,
+    # written by `pkmn cache warm-sets` and by the runtime startup warm
+    # bootstrap. Tracks how many sets had their logo + symbol images
+    # primed during the most recent pass. None timestamp renders as
+    # "not warmed". Image bytes themselves still carry indefinite TTL —
+    # this manifest only gates the *re-walk* of upstream metadata.
+    sets_warm_timestamp: float | None
+    sets_warm_count: int
 
 
 def _disabled() -> bool:
@@ -750,6 +765,98 @@ def set_cards_warm_is_fresh(*, now: float | None = None) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Sets-warm manifest — records the most recent `warm-sets` (logos+symbols)
+# run. Mirrors the set-cards manifest shape so the stats projection and the
+# freshness gate stay uniform across the three warm slices.
+#
+# This manifest exists because we moved set-image warming from a one-shot
+# build-time step in the Dockerfile to a runtime lifespan bootstrap (see
+# `api.main._warm_sets_in_background` and #369). Without a freshness gate,
+# every container start would re-walk ~200 sets x 2 images — wasted work
+# when the previous pass landed an hour ago. The week-long stale window
+# matches the set-cards slice; both are stable upstream data that only
+# moves when new sets ship.
+# ---------------------------------------------------------------------------
+
+
+def _sets_warm_path() -> Path:
+    return _cache_root_path() / _SETS_WARM_FILE
+
+
+def read_sets_warm() -> dict[str, Any] | None:
+    """Return the parsed sets-warm manifest, or None when absent/malformed.
+
+    Schema (v1):
+        {
+            "version": 1,
+            "timestamp": <unix float>,
+            "sets_warmed": <int>,
+            "logos_cached": <int>,
+            "symbols_cached": <int>,
+            "failures": <int>
+        }
+
+    Same defence-in-depth as the other warm manifests: corrupt files or
+    wrong schema versions are treated as "no manifest" so a bad write
+    doesn't poison the freshness gate."""
+    path = _sets_warm_path()
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict) or data.get("version") != SETS_WARM_SCHEMA_VERSION:
+        return None
+    return data
+
+
+def write_sets_warm(
+    *,
+    sets_warmed: int,
+    logos_cached: int,
+    symbols_cached: int,
+    failures: int,
+) -> None:
+    """Persist the sets-warm manifest. Best-effort write — failures are
+    silent so a read-only filesystem doesn't crash a successful warm pass
+    that's about to return its result to the caller."""
+    payload = {
+        "version": SETS_WARM_SCHEMA_VERSION,
+        "timestamp": time.time(),
+        "sets_warmed": sets_warmed,
+        "logos_cached": logos_cached,
+        "symbols_cached": symbols_cached,
+        "failures": failures,
+    }
+    root = cache_root()
+    with contextlib.suppress(OSError):
+        (root / _SETS_WARM_FILE).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def sets_warm_is_fresh(*, now: float | None = None) -> bool:
+    """True when a manifest exists, its timestamp is within the staleness
+    window (1 week, see `SETS_WARM_STALE_SECONDS`), and it recorded at
+    least one successful set walk.
+
+    Same `sets_warmed > 0` guard as the other warm gates — a manifest
+    written after a fully-failed pass (e.g. transient upstream outage)
+    must not suppress the next retry for a full week with no logos on
+    disk."""
+    manifest = read_sets_warm()
+    if manifest is None:
+        return False
+    ts = manifest.get("timestamp")
+    if not isinstance(ts, int | float):
+        return False
+    sets_warmed = manifest.get("sets_warmed")
+    if not isinstance(sets_warmed, int) or sets_warmed <= 0:
+        return False
+    current = now if now is not None else time.time()
+    return (current - ts) < SETS_WARM_STALE_SECONDS
+
+
+# ---------------------------------------------------------------------------
 # Stats — health snapshot for `pkmn cache stats`.
 # ---------------------------------------------------------------------------
 
@@ -818,6 +925,17 @@ def stats() -> CacheStats:
         if isinstance(n, int):
             set_cards_warm_count = n
 
+    sets_warm_timestamp: float | None = None
+    sets_warm_count = 0
+    sw_manifest = read_sets_warm()
+    if sw_manifest is not None:
+        ts = sw_manifest.get("timestamp")
+        if isinstance(ts, int | float):
+            sets_warm_timestamp = float(ts)
+        n = sw_manifest.get("sets_warmed")
+        if isinstance(n, int):
+            sets_warm_count = n
+
     return CacheStats(
         root=root,
         api_entry_count=api_count,
@@ -831,4 +949,6 @@ def stats() -> CacheStats:
         concept_warm_names=concept_warm_names,
         set_cards_warm_timestamp=set_cards_warm_timestamp,
         set_cards_warm_count=set_cards_warm_count,
+        sets_warm_timestamp=sets_warm_timestamp,
+        sets_warm_count=sets_warm_count,
     )

--- a/src/mgz_pkmn/cli.py
+++ b/src/mgz_pkmn/cli.py
@@ -1050,6 +1050,25 @@ def cache_stats_command(as_json: bool) -> None:
             + f"{s.set_cards_warm_count} sets · warmed "
             + f"{_format_age(s.set_cards_warm_timestamp)}"
         )
+    # Set-images warm slice — sourced from `sets_warm.json`, written by
+    # both `pkmn cache warm-sets` and the runtime startup bootstrap. The
+    # image bytes themselves have indefinite TTL (Images: line above), but
+    # this manifest tracks when the catalog was last walked end-to-end so
+    # operators can see whether new sets have been picked up.
+    if s.sets_warm_timestamp is None:
+        click.echo(
+            "  "
+            + click.style("Sets:          ", fg="bright_black")
+            + click.style("not warmed", fg="yellow")
+            + " · run `pkmn cache warm-sets` to prime"
+        )
+    else:
+        click.echo(
+            "  "
+            + click.style("Sets:          ", fg="bright_black")
+            + f"{s.sets_warm_count} sets · warmed "
+            + f"{_format_age(s.sets_warm_timestamp)}"
+        )
 
 
 @cache_group.command(name="clear", context_settings={"help_option_names": ["-h", "--help"]})
@@ -1121,6 +1140,17 @@ def cache_warm_sets_command(api_key: str | None, verbose: bool) -> None:
 
     if result.sets == 0:
         raise click.ClickException("pokemontcg.io returned no sets")
+
+    # Persist the manifest so `pkmn cache stats` and the runtime startup
+    # gate (`sets_warm_is_fresh`) can report freshness and skip re-walks
+    # within the staleness window. Matches the concept-warm / set-cards-
+    # warm flow.
+    disk_cache.write_sets_warm(
+        sets_warmed=result.sets,
+        logos_cached=result.logos_cached,
+        symbols_cached=result.symbols_cached,
+        failures=result.failures,
+    )
 
     click.secho("  ✓ ", fg="green", nl=False)
     click.echo(

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -719,16 +719,21 @@ class CacheStatsRouteTests(unittest.TestCase):
         self.assertEqual(data["concept_warm_names"], 0)
         self.assertIsNone(data["set_cards_warm_timestamp"])
         self.assertEqual(data["set_cards_warm_count"], 0)
+        self.assertIsNone(data["sets_warm_timestamp"])
+        self.assertEqual(data["sets_warm_count"], 0)
 
     def test_warmed_cache_surfaces_manifest_counts(self) -> None:
         cache.write_concept_warm(names_warmed=47, names_failed=[], source="test")
         cache.write_set_cards_warm(sets_warmed=12, sets_failed=[])
+        cache.write_sets_warm(sets_warmed=173, logos_cached=173, symbols_cached=170, failures=3)
 
         data = client.get("/api/v1/cache/stats").json()
         self.assertEqual(data["concept_warm_names"], 47)
         self.assertIsInstance(data["concept_warm_timestamp"], float)
         self.assertEqual(data["set_cards_warm_count"], 12)
         self.assertIsInstance(data["set_cards_warm_timestamp"], float)
+        self.assertEqual(data["sets_warm_count"], 173)
+        self.assertIsInstance(data["sets_warm_timestamp"], float)
 
     def test_response_is_not_browser_cached(self) -> None:
         resp = client.get("/api/v1/cache/stats")
@@ -746,6 +751,7 @@ class CacheStatsRouteTests(unittest.TestCase):
         self.assertIsNone(data["api_oldest_mtime"])
         self.assertIsNone(data["concept_warm_timestamp"])
         self.assertIsNone(data["set_cards_warm_timestamp"])
+        self.assertIsNone(data["sets_warm_timestamp"])
         self.assertIsInstance(data["root"], str)
 
     def test_field_names_match_cli_json_shape(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -200,6 +200,8 @@ class CacheStatsCommandTests(unittest.TestCase):
                 "concept_warm_names",
                 "set_cards_warm_timestamp",
                 "set_cards_warm_count",
+                "sets_warm_timestamp",
+                "sets_warm_count",
                 "root",
             },
         )
@@ -258,6 +260,16 @@ class CacheStatsCommandTests(unittest.TestCase):
         self.assertIsNotNone(cache.read_image("sets/logo", "sv7"))
         self.assertIsNotNone(cache.read_image("sets/symbol", "sv8"))
         self.assertIsNone(cache.read_image("sets/symbol", "sv7"))
+        # Manifest is written so `sets_warm_is_fresh()` returns True for
+        # the next caller (e.g. the lifespan startup bootstrap). Without
+        # this, every restart would re-walk upstream.
+        manifest = cache.read_sets_warm()
+        self.assertIsNotNone(manifest)
+        assert manifest is not None  # narrow for type checkers
+        self.assertEqual(manifest["sets_warmed"], 2)
+        self.assertEqual(manifest["logos_cached"], 2)
+        self.assertEqual(manifest["symbols_cached"], 1)
+        self.assertEqual(manifest["failures"], 0)
 
     def test_warm_sets_verbose_prints_per_set_progress(self) -> None:
         # `-v` should fire the on_progress callback so each set's id lands

--- a/tests/test_warm_on_startup.py
+++ b/tests/test_warm_on_startup.py
@@ -66,11 +66,13 @@ class WarmOnStartupTests(unittest.TestCase):
         with (
             patch.object(main, "_warm_concepts_in_background") as mock_concepts,
             patch.object(main, "_warm_set_cards_in_background") as mock_set_cards,
+            patch.object(main, "_warm_sets_in_background") as mock_sets,
         ):
             with TestClient(main.app) as c:
                 self.assertEqual(c.get("/health").status_code, 200)
             mock_concepts.assert_called_once()
             mock_set_cards.assert_called_once()
+            mock_sets.assert_called_once()
 
     def test_warm_env_unset_skips_warmers(self) -> None:
         os.environ.pop("MGZ_PKMN_WARM_ON_STARTUP", None)
@@ -78,11 +80,13 @@ class WarmOnStartupTests(unittest.TestCase):
         with (
             patch.object(main, "_warm_concepts_in_background") as mock_concepts,
             patch.object(main, "_warm_set_cards_in_background") as mock_set_cards,
+            patch.object(main, "_warm_sets_in_background") as mock_sets,
         ):
             with TestClient(main.app) as c:
                 self.assertEqual(c.get("/health").status_code, 200)
             mock_concepts.assert_not_called()
             mock_set_cards.assert_not_called()
+            mock_sets.assert_not_called()
 
     def test_warm_env_truthy_variants_all_fire(self) -> None:
         """Pin the env-var parse rules so future churn doesn't drop a variant."""
@@ -93,11 +97,13 @@ class WarmOnStartupTests(unittest.TestCase):
                 with (
                     patch.object(main, "_warm_concepts_in_background") as mock_concepts,
                     patch.object(main, "_warm_set_cards_in_background") as mock_set_cards,
+                    patch.object(main, "_warm_sets_in_background") as mock_sets,
                 ):
                     with TestClient(main.app) as c:
                         self.assertEqual(c.get("/health").status_code, 200)
                     mock_concepts.assert_called_once()
                     mock_set_cards.assert_called_once()
+                    mock_sets.assert_called_once()
 
     def test_warm_env_falsy_variants_all_skip(self) -> None:
         """Same as above for the other side — empty / 0 / false do not fire."""
@@ -108,11 +114,13 @@ class WarmOnStartupTests(unittest.TestCase):
                 with (
                     patch.object(main, "_warm_concepts_in_background") as mock_concepts,
                     patch.object(main, "_warm_set_cards_in_background") as mock_set_cards,
+                    patch.object(main, "_warm_sets_in_background") as mock_sets,
                 ):
                     with TestClient(main.app) as c:
                         self.assertEqual(c.get("/health").status_code, 200)
                     mock_concepts.assert_not_called()
                     mock_set_cards.assert_not_called()
+                    mock_sets.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_warm_on_startup.py
+++ b/tests/test_warm_on_startup.py
@@ -18,14 +18,18 @@ from __future__ import annotations
 import importlib
 import os
 import sys
+import tempfile
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from fastapi.testclient import TestClient
+
+from mgz_pkmn import cache as disk_cache
+from mgz_pkmn.set_cards import WarmResult
 
 
 class WarmOnStartupTests(unittest.TestCase):
@@ -121,6 +125,124 @@ class WarmOnStartupTests(unittest.TestCase):
                     mock_concepts.assert_not_called()
                     mock_set_cards.assert_not_called()
                     mock_sets.assert_not_called()
+
+
+class WarmSetsBackgroundBodyTests(unittest.TestCase):
+    """Drive the body of `_warm_sets_in_background` synchronously so the
+    inner `_run` (TCGClient → warm_set_images → write_sets_warm + log)
+    actually executes. The lifespan-level tests above mock the function
+    out at the boundary, so they don't reach this code path — without
+    these tests the entire warm body shows as uncovered on Codecov.
+
+    Pattern: patch `threading.Thread` so `.start()` invokes the target
+    inline, then patch `TCGClient` and `warm_set_images` so no network
+    happens. Cache root is redirected at a tempdir so the manifest write
+    doesn't touch the user's real cache.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._old_xdg = os.environ.get("XDG_CACHE_HOME")
+        self._old_no_cache = os.environ.get(disk_cache._NO_CACHE_ENV)
+        os.environ["XDG_CACHE_HOME"] = self._tmp.name
+        os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+
+    def tearDown(self) -> None:
+        if self._old_xdg is None:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        else:
+            os.environ["XDG_CACHE_HOME"] = self._old_xdg
+        if self._old_no_cache is None:
+            os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+        else:
+            os.environ[disk_cache._NO_CACHE_ENV] = self._old_no_cache
+        self._tmp.cleanup()
+
+    def _make_sync_thread(self):
+        """Return a Thread-shaped MagicMock whose `.start()` calls target() inline."""
+
+        def _thread_factory(*, target=None, name=None, daemon=None, **_kwargs):
+            instance = MagicMock()
+            instance.start.side_effect = lambda: target() if target else None
+            return instance
+
+        return _thread_factory
+
+    def test_sets_warm_body_writes_manifest_and_logs(self) -> None:
+        """When the freshness gate misses, the body fetches via TCGClient,
+        calls warm_set_images, writes the manifest, and logs success."""
+        from api import main
+
+        fake_result = WarmResult(sets=173, logos_cached=173, symbols_cached=170, failures=3)
+        with (
+            patch.object(main, "threading") as mock_threading,
+            patch.object(main, "TCGClient") as mock_client_cls,
+            patch.object(main, "warm_set_images", return_value=fake_result) as mock_warm,
+            patch.object(main._log, "info") as mock_log,
+        ):
+            mock_threading.Thread.side_effect = self._make_sync_thread()
+            main._warm_sets_in_background()
+
+        # TCGClient constructed once; warm_set_images called with its instance.
+        mock_client_cls.assert_called_once()
+        mock_warm.assert_called_once_with(mock_client_cls.return_value)
+
+        # Manifest landed on disk with the fake counts.
+        manifest = disk_cache.read_sets_warm()
+        self.assertIsNotNone(manifest)
+        assert manifest is not None  # narrow for type checkers
+        self.assertEqual(manifest["sets_warmed"], 173)
+        self.assertEqual(manifest["logos_cached"], 173)
+        self.assertEqual(manifest["symbols_cached"], 170)
+        self.assertEqual(manifest["failures"], 3)
+
+        # Success path logs the "complete" line.
+        complete_logs = [call for call in mock_log.call_args_list if "complete" in str(call)]
+        self.assertEqual(len(complete_logs), 1)
+
+    def test_sets_warm_body_swallows_upstream_exception(self) -> None:
+        """A TCGClient/warm_set_images failure must be logged and swallowed,
+        not raised — the warm pass is best-effort and shouldn't crash the
+        service. Manifest stays absent so the next startup retries."""
+        from api import main
+
+        with (
+            patch.object(main, "threading") as mock_threading,
+            patch.object(main, "TCGClient"),
+            patch.object(main, "warm_set_images", side_effect=RuntimeError("upstream down")),
+            patch.object(main._log, "exception") as mock_log_exception,
+        ):
+            mock_threading.Thread.side_effect = self._make_sync_thread()
+            # Should not raise.
+            main._warm_sets_in_background()
+
+        self.assertIsNone(disk_cache.read_sets_warm())
+        mock_log_exception.assert_called_once()
+
+    def test_sets_warm_skipped_when_manifest_is_fresh(self) -> None:
+        """When the freshness gate hits, the body short-circuits without
+        constructing a TCGClient or starting a thread."""
+        from api import main
+
+        disk_cache.write_sets_warm(
+            sets_warmed=173, logos_cached=173, symbols_cached=170, failures=0
+        )
+
+        with (
+            patch.object(main, "threading") as mock_threading,
+            patch.object(main, "TCGClient") as mock_client_cls,
+            patch.object(main, "warm_set_images") as mock_warm,
+            patch.object(main._log, "info") as mock_log_info,
+        ):
+            main._warm_sets_in_background()
+
+        mock_client_cls.assert_not_called()
+        mock_warm.assert_not_called()
+        mock_threading.Thread.assert_not_called()
+        # Logged the "already fresh" reason so an operator can tell why a
+        # restart didn't trigger another walk.
+        fresh_logs = [call for call in mock_log_info.call_args_list if "fresh" in str(call)]
+        self.assertEqual(len(fresh_logs), 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_warm_sets_manifest.py
+++ b/tests/test_warm_sets_manifest.py
@@ -113,6 +113,28 @@ class SetsFreshnessTests(_IsolatedCacheMixin):
         disk_cache.write_sets_warm(sets_warmed=0, logos_cached=0, symbols_cached=0, failures=5)
         self.assertFalse(disk_cache.sets_warm_is_fresh())
 
+    def test_malformed_timestamp_is_not_fresh(self) -> None:
+        # A manifest where the timestamp field exists but isn't a number
+        # (e.g. an older schema, a partial write, or a hand-edited file)
+        # must not be treated as fresh — the gate's job is to protect
+        # against poisoned-but-recent manifests.
+        path = disk_cache._sets_warm_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "version": disk_cache.SETS_WARM_SCHEMA_VERSION,
+                    "timestamp": "yesterday",
+                    "sets_warmed": 173,
+                    "logos_cached": 173,
+                    "symbols_cached": 170,
+                    "failures": 0,
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.assertFalse(disk_cache.sets_warm_is_fresh())
+
 
 class CacheStatsProjectionTests(_IsolatedCacheMixin):
     def test_stats_reflects_sets_warm_manifest(self) -> None:

--- a/tests/test_warm_sets_manifest.py
+++ b/tests/test_warm_sets_manifest.py
@@ -1,0 +1,133 @@
+"""Coverage for the `sets_warm.json` manifest helpers and freshness gate.
+
+Mirrors `tests/test_warm_set_cards.py`'s SetCardsManifestTests /
+SetCardsFreshnessTests structure so the three warm slices (concept,
+set-cards, sets) all read the same shape end-to-end. Added in #369 when
+runtime warming of set logos/symbols replaced the Dockerfile's build-time
+`pkmn cache warm-sets` step.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from mgz_pkmn import cache as disk_cache
+
+
+class _IsolatedCacheMixin(unittest.TestCase):
+    """Point XDG_CACHE_HOME at a tempdir so writes don't touch the user's real cache."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._old_xdg = os.environ.get("XDG_CACHE_HOME")
+        self._old_no_cache = os.environ.get(disk_cache._NO_CACHE_ENV)
+        os.environ["XDG_CACHE_HOME"] = self._tmp.name
+        os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+
+    def tearDown(self) -> None:
+        if self._old_xdg is None:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        else:
+            os.environ["XDG_CACHE_HOME"] = self._old_xdg
+        if self._old_no_cache is None:
+            os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+        else:
+            os.environ[disk_cache._NO_CACHE_ENV] = self._old_no_cache
+        self._tmp.cleanup()
+
+
+class SetsManifestTests(_IsolatedCacheMixin):
+    def test_read_returns_none_when_absent(self) -> None:
+        self.assertIsNone(disk_cache.read_sets_warm())
+
+    def test_write_then_read_roundtrip(self) -> None:
+        disk_cache.write_sets_warm(
+            sets_warmed=173, logos_cached=173, symbols_cached=170, failures=3
+        )
+        data = disk_cache.read_sets_warm()
+        self.assertIsNotNone(data)
+        assert data is not None  # narrow for type checkers
+        self.assertEqual(data["sets_warmed"], 173)
+        self.assertEqual(data["logos_cached"], 173)
+        self.assertEqual(data["symbols_cached"], 170)
+        self.assertEqual(data["failures"], 3)
+        self.assertIsInstance(data["timestamp"], float)
+
+    def test_read_rejects_malformed_payload(self) -> None:
+        path = disk_cache._sets_warm_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not json", encoding="utf-8")
+        self.assertIsNone(disk_cache.read_sets_warm())
+
+    def test_read_rejects_unknown_schema_version(self) -> None:
+        path = disk_cache._sets_warm_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "version": 99,
+                    "timestamp": 0.0,
+                    "sets_warmed": 0,
+                    "logos_cached": 0,
+                    "symbols_cached": 0,
+                    "failures": 0,
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.assertIsNone(disk_cache.read_sets_warm())
+
+
+class SetsFreshnessTests(_IsolatedCacheMixin):
+    def test_no_manifest_is_not_fresh(self) -> None:
+        self.assertFalse(disk_cache.sets_warm_is_fresh())
+
+    def test_fresh_within_window(self) -> None:
+        disk_cache.write_sets_warm(
+            sets_warmed=173, logos_cached=173, symbols_cached=170, failures=3
+        )
+        self.assertTrue(disk_cache.sets_warm_is_fresh())
+
+    def test_stale_outside_window(self) -> None:
+        disk_cache.write_sets_warm(
+            sets_warmed=173, logos_cached=173, symbols_cached=170, failures=3
+        )
+        # Pretend we're checking 8 days in the future — past the 7-day
+        # SETS_WARM_STALE_SECONDS window.
+        future = time.time() + (8 * 24 * 60 * 60)
+        self.assertFalse(disk_cache.sets_warm_is_fresh(now=future))
+
+    def test_zero_warmed_manifest_is_not_fresh(self) -> None:
+        # Even a recent manifest must not suppress the next retry when
+        # `sets_warmed` is zero — that's the "every upstream call failed"
+        # signal, so the lifespan bootstrap should re-attempt on the next
+        # container start.
+        disk_cache.write_sets_warm(sets_warmed=0, logos_cached=0, symbols_cached=0, failures=5)
+        self.assertFalse(disk_cache.sets_warm_is_fresh())
+
+
+class CacheStatsProjectionTests(_IsolatedCacheMixin):
+    def test_stats_reflects_sets_warm_manifest(self) -> None:
+        disk_cache.write_sets_warm(
+            sets_warmed=173, logos_cached=173, symbols_cached=170, failures=3
+        )
+        s = disk_cache.stats()
+        self.assertEqual(s.sets_warm_count, 173)
+        self.assertIsInstance(s.sets_warm_timestamp, float)
+
+    def test_stats_zeroed_when_no_manifest(self) -> None:
+        s = disk_cache.stats()
+        self.assertEqual(s.sets_warm_count, 0)
+        self.assertIsNone(s.sets_warm_timestamp)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/src/components/SettingsDrawer.test.tsx
+++ b/web/src/components/SettingsDrawer.test.tsx
@@ -50,6 +50,8 @@ describe('SettingsDrawer', () => {
       concept_warm_names: 0,
       set_cards_warm_timestamp: null,
       set_cards_warm_count: 0,
+      sets_warm_timestamp: null,
+      sets_warm_count: 0,
     })
   })
 
@@ -86,6 +88,8 @@ describe('SettingsDrawer', () => {
       concept_warm_names: 47,
       set_cards_warm_timestamp: null,
       set_cards_warm_count: 0,
+      sets_warm_timestamp: Date.now() / 1000 - 300, // 5 min ago
+      sets_warm_count: 200,
     })
 
     render(<SettingsDrawer />)
@@ -94,7 +98,8 @@ describe('SettingsDrawer', () => {
     await waitFor(() => expect(screen.getByText(/42 ·/)).toBeInTheDocument())
     expect(screen.getByText(/173 ·/)).toBeInTheDocument()
     expect(screen.getByText(/47 ·/)).toBeInTheDocument()
-    // The not-warmed branch renders for set cards.
+    expect(screen.getByText(/200 ·/)).toBeInTheDocument()
+    // The not-warmed branch renders for set cards (the only null slice).
     expect(screen.getByText(/^not warmed$/)).toBeInTheDocument()
   })
 

--- a/web/src/components/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer.tsx
@@ -286,6 +286,15 @@ function CacheStatsPanel() {
             }
             warn={stats.set_cards_warm_timestamp == null}
           />
+          <StatRow
+            label="Sets"
+            value={
+              stats.sets_warm_timestamp == null
+                ? 'not warmed'
+                : `${stats.sets_warm_count} · ${formatAge(stats.sets_warm_timestamp)}`
+            }
+            warn={stats.sets_warm_timestamp == null}
+          />
         </dl>
       )}
     </div>

--- a/web/src/components/a11y.test.tsx
+++ b/web/src/components/a11y.test.tsx
@@ -46,6 +46,8 @@ vi.mock('../api/client', () => ({
     concept_warm_names: 0,
     set_cards_warm_timestamp: null,
     set_cards_warm_count: 0,
+    sets_warm_timestamp: null,
+    sets_warm_count: 0,
   }),
 }))
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -202,11 +202,12 @@ export interface ChangelogRelease {
 
 /**
  * Snapshot returned by `GET /api/v1/cache/stats` — same shape as
- * `pkmn cache stats --json`. Counts are always present. Three fields
+ * `pkmn cache stats --json`. Counts are always present. Four fields
  * can be `null`:
  * - `api_oldest_mtime` when the API cache holds no entries
  * - `concept_warm_timestamp` when no concept-warm pass has been recorded
  * - `set_cards_warm_timestamp` when no set-cards-warm pass has been recorded
+ * - `sets_warm_timestamp` when no sets-warm pass has been recorded
  */
 export interface CacheStats {
   root: string
@@ -221,6 +222,8 @@ export interface CacheStats {
   concept_warm_names: number
   set_cards_warm_timestamp: number | null
   set_cards_warm_count: number
+  sets_warm_timestamp: number | null
+  sets_warm_count: number
 }
 
 /**


### PR DESCRIPTION
Closes #369. Part of [EPIC #368](https://github.com/mgzwarrior/mgz-pkmn/issues/368) — Phase 0 (foundation). Sister to [#374](https://github.com/mgzwarrior/mgz-pkmn/pull/374) (the lifespan-bug fix that made runtime warming actually fire).

## What

Four coordinated changes that move set-image warming from a build-time Dockerfile step onto the runtime lifespan + persistent disk:

1. **`render.yaml`** — adds a 10 GB persistent disk (`name: cache`, `mountPath: /var/cache`) and a matching `XDG_CACHE_HOME=/var/cache` env var. [`_cache_root_path()`](src/mgz_pkmn/cache.py) appends `mgz-pkmn` to whatever `XDG_CACHE_HOME` resolves to, so the project cache root lands at `/var/cache/mgz-pkmn` — XDG-correct, no double-namespacing.
2. **`Dockerfile`** — drops the `pkmn cache warm-sets` build-time RUN block + its `ARG POKEMONTCG_IO_API_KEY` / `ENV XDG_CACHE_HOME`. Image is ~20 MB smaller, builds ~30s faster. The original block's comments are replaced with a short note pointing at the runtime bootstrap.
3. **`sets_warm.json` manifest** — new schema (`version`, `timestamp`, `sets_warmed`, `logos_cached`, `symbols_cached`, `failures`) mirroring `concept_warm.json` / `set_cards_warm.json`. Read/write helpers, `sets_warm_is_fresh()` gate (1-week TTL), `CacheStats.sets_warm_*` fields, `stats()` projection, CLI rendering, `/api/v1/cache/stats` exposure, SPA Cache Stats panel row — all wired through.
4. **`api/main.py` lifespan** — `_warm_sets_in_background()` mirrors the existing two warmers (daemon thread, `sets_warm_is_fresh()` gate, swallowed exceptions). Folded into the lifespan alongside concepts + set-cards so a single `MGZ_PKMN_WARM_ON_STARTUP=1` enables all three.

## Why

The persistent disk you allocated on Render collapses the historical rationale for the build-time bake (ephemeral disks had to be re-warmed somehow). Once `XDG_CACHE_HOME` points at `/var/cache`, the runtime cache lives on durable storage — every slice (API responses, images, overrides, run-history SQLite, all three manifests) now survives redeploys. A single warm pass after the first deploy serves every subsequent deploy until the manifest TTL expires.

Foundation for the [pre-Scrydex catalog-warm epic](https://github.com/mgzwarrior/mgz-pkmn/issues/368): Phases 1-3 all depend on the runtime cache being durable.

## Mount-path rationale (recap of the #369 design discussion)

- **XDG-correct.** `_cache_root_path()` reads `XDG_CACHE_HOME` as the **parent** dir and appends `mgz-pkmn`. So `/var/cache` → `/var/cache/mgz-pkmn`. Setting the mount at `/var/cache/mgz-pkmn` directly would produce `/var/cache/mgz-pkmn/mgz-pkmn`.
- **FHS-blessed.** `/var/cache` is the conventional Linux location for regenerable cache data.
- **Conveys intent.** Future maintainers see "regenerable; do not back up" rather than "state I care about."

## How to verify

After this lands and Render redeploys:

1. `curl -s https://mgz-pkmn.onrender.com/api/v1/cache/stats | jq '.root'` → `"/var/cache/mgz-pkmn"`.
2. Wait ~2-3 min for the three background warm passes to settle on the first deploy.
3. Re-hit the endpoint: `concept_warm_timestamp`, `set_cards_warm_timestamp`, and the new `sets_warm_timestamp` should all be non-null floats. `sets_warm_count` should be ~173.
4. Push an unrelated change to `main` and let auto-deploy redeploy. Hit the endpoint immediately after — all three timestamps should still be non-null (within the staleness window the warmers skip the re-walk and log "already fresh").
5. Open the SPA → Settings → Cache stats panel. Same three rows, all populated.

## Tests

- `tests/test_warm_sets_manifest.py` (new, 9 cases) — read/write roundtrip, malformed payload rejection, schema-version drift rejection, freshness gate (within window, outside window, zero-warmed sentinel), `CacheStats` projection (warmed + unwarmed).
- `tests/test_warm_on_startup.py` — every case extended to assert `_warm_sets_in_background` is called/skipped alongside the existing two.
- `tests/test_api_routes.py::CacheStatsRouteTests` — empty + warmed + OSError-fallback cases now assert the new fields.
- `tests/test_cli.py::CacheWarmSetsTests` — adds an assertion that the manifest is written after `pkmn cache warm-sets`; `--json` shape pin updated.
- `web/src/components/SettingsDrawer.test.tsx` + `a11y.test.tsx` — mocks include the new fields so the panel renders its loaded branch.

442/442 Python tests, 197/197 web tests, web build green locally.

## Operator notes

- After merge, the **very first** deploy on persistent disk walks all three warm passes cold. ~30s for sets + ~minute or two each for concepts/set-cards on background daemon threads — the API is responsive throughout but the SPA's first set-picker open during that window may show text-only chips. Acceptable one-time transition.
- The disk mount path must be `/var/cache` (parent), **not** `/var/cache/mgz-pkmn`.