### PR TITLE
Phase 1: pkmn cache warm-cards — pre-warm the per-card structural cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- CLI / API / web: **`pkmn cache warm-cards`** — pre-warms the
+  per-card structural cache for the entire English Pokémon TCG catalog
+  ([#370](https://github.com/mgzwarrior/mgz-pkmn/issues/370), Phase 1
+  of [epic #368](https://github.com/mgzwarrior/mgz-pkmn/issues/368)).
+  Walks every set, then fan-out-writes a per-card cache entry for
+  every card in the set's payload using a synthesized
+  `/v2/cards/{card_id}` URL key — reuses the data each set's search
+  already returns, so zero extra HTTP calls vs `warm-set-cards`. Flags
+  for `--set` (repeatable), `--max-cards` (incremental warming),
+  `--skip-existing/--no-skip-existing` (re-run is cheap by default),
+  `--throttle-ms` (polite pacing against pokemontcg.io's rate limit),
+  and `-v`. Writes a new `card_warm.json` manifest (1-week stale
+  window) so subsequent runs and the runtime startup bootstrap can
+  skip a recent pass. New `card_warm_*` fields on `CacheStats`
+  surfaced on `pkmn cache stats`, `/api/v1/cache/stats`, and the SPA
+  Cache Stats panel.
+- API: new **`MGZ_PKMN_WARM_CARDS_ON_STARTUP`** env var enables the
+  per-card warm in the lifespan bootstrap. Independent of
+  `MGZ_PKMN_WARM_ON_STARTUP` because the per-card pass is heavyweight
+  (~18,000 cache entries on a fresh disk) and should be opted into
+  explicitly.
 - API: **`GET /api/v1/cache/stats`** returns the same JSON shape as
   `pkmn cache stats --json` so operators can introspect a deployed
   instance's cache state without shelling onto the host

--- a/api/main.py
+++ b/api/main.py
@@ -24,7 +24,7 @@ from starlette.responses import Response
 
 from mgz_pkmn import __version__
 from mgz_pkmn import cache as disk_cache
-from mgz_pkmn.lookup import warm_concepts, warm_set_cards
+from mgz_pkmn.lookup import warm_cards, warm_concepts, warm_set_cards
 from mgz_pkmn.set_cards import warm_set_images
 from mgz_pkmn.sources import TCGClient, TCGDexClient
 
@@ -50,6 +50,11 @@ from .routes import (
 _log = logging.getLogger(__name__)
 
 _WARM_ON_STARTUP_ENV = "MGZ_PKMN_WARM_ON_STARTUP"
+# Separate env var for the per-card structural warm pass (Phase 1 of #368)
+# because it's much heavier than the existing three — a full pass writes
+# ~18,000 per-card cache entries. Opt-in only; default off so a generic
+# `MGZ_PKMN_WARM_ON_STARTUP=1` deploy doesn't accidentally trip it.
+_WARM_CARDS_ON_STARTUP_ENV = "MGZ_PKMN_WARM_CARDS_ON_STARTUP"
 
 
 def _warm_concepts_in_background() -> None:
@@ -161,6 +166,47 @@ def _warm_sets_in_background() -> None:
     threading.Thread(target=_run, name="sets-warm", daemon=True).start()
 
 
+def _warm_cards_in_background() -> None:
+    """Run the per-card structural warm pass on a daemon thread.
+
+    Phase 1 of the pre-Scrydex catalog-warm epic (#368). Gated by the
+    on-disk `card_warm.json` freshness manifest — if a warm pass landed
+    within the last week, skip and log "already fresh". Errors are
+    logged and swallowed so a failed warm doesn't crash the service.
+
+    Heavyweight relative to the other three warmers: a fresh pass writes
+    one cache entry per card across the full English catalog
+    (~18,000 entries). Always opt-in via the separate
+    `MGZ_PKMN_WARM_CARDS_ON_STARTUP` env var so a generic
+    `MGZ_PKMN_WARM_ON_STARTUP=1` flag doesn't accidentally trigger it."""
+    if disk_cache.card_warm_is_fresh():
+        _log.info("card cache fresh; skipping startup warm")
+        return
+
+    def _run() -> None:
+        try:
+            pkmn = TCGClient(api_key=os.environ.get("POKEMONTCG_IO_API_KEY"))
+            result = warm_cards(pkmn)
+            disk_cache.write_card_warm(
+                cards_warmed=result.cards_warmed,
+                cards_failed=result.cards_failed,
+                sets_attempted=result.sets_attempted,
+                sets_failed=result.sets_failed,
+            )
+            _log.info(
+                "card warm complete: %d cards warmed across %d sets "
+                "(%d cards failed, %d sets missed)",
+                result.cards_warmed,
+                result.sets_attempted,
+                result.cards_failed,
+                len(result.sets_failed),
+            )
+        except Exception:
+            _log.exception("card warm failed; service running without primed per-card entries")
+
+    threading.Thread(target=_run, name="card-warm", daemon=True).start()
+
+
 class SPAStaticFiles(StaticFiles):
     """StaticFiles that disables browser caching for ``index.html``.
 
@@ -193,6 +239,16 @@ def _warm_on_startup_enabled() -> bool:
     return os.environ.get(_WARM_ON_STARTUP_ENV, "").strip() in ("1", "true", "True")
 
 
+def _warm_cards_on_startup_enabled() -> bool:
+    """True when `MGZ_PKMN_WARM_CARDS_ON_STARTUP` is set to a truthy value.
+
+    Same parse rules as `_warm_on_startup_enabled`. Separate env var (and
+    default-off) because the per-card warm pass is heavyweight (~18,000
+    cache entries on a fresh disk) and we don't want it firing implicitly
+    every time someone flips on the standard `MGZ_PKMN_WARM_ON_STARTUP`."""
+    return os.environ.get(_WARM_CARDS_ON_STARTUP_ENV, "").strip() in ("1", "true", "True")
+
+
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     """Startup/shutdown hook.
@@ -218,6 +274,13 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
        staying `null` on `GET /api/v1/cache/stats` despite the env var
        being set. The sets-warm slice was added in #369 to replace the
        Dockerfile's build-time `pkmn cache warm-sets` step.
+    3. If `MGZ_PKMN_WARM_CARDS_ON_STARTUP` is truthy (see
+       `_warm_cards_on_startup_enabled`), additionally kicks off the
+       per-card structural warm pass on a background daemon thread.
+       Separate env var because it's heavier than the other three
+       (~18k cache entries on a fresh disk) and we don't want it
+       implicitly enabled by the standard `MGZ_PKMN_WARM_ON_STARTUP`
+       flag. Phase 1 of the pre-Scrydex catalog-warm epic (#368).
     """
     if migrate.automigrate_enabled():
         try:
@@ -232,6 +295,12 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
         _warm_concepts_in_background()
         _warm_set_cards_in_background()
         _warm_sets_in_background()
+
+    # Independent opt-in: the per-card structural warm is heavy enough
+    # (~18k cache entries on a fresh disk) that it gets its own env var
+    # rather than riding the standard MGZ_PKMN_WARM_ON_STARTUP flag.
+    if _warm_cards_on_startup_enabled():
+        _warm_cards_in_background()
 
     yield
 

--- a/api/main.py
+++ b/api/main.py
@@ -183,10 +183,20 @@ def _warm_cards_in_background() -> None:
         _log.info("card cache fresh; skipping startup warm")
         return
 
+    # Throttle the startup warm so a no-API-key deploy doesn't burst
+    # through pokemontcg.io's 30-rpm free-tier ceiling, hit 429s, end up
+    # with mostly-empty pages, and write a partially-warmed manifest
+    # that the freshness gate then trusts for a week. With an API key
+    # the throttle is harmless overhead; without one, it's the
+    # difference between a successful pass and a poisoned manifest.
+    # 500 ms x ~170 sets ~= 1.5 minutes of throttle overhead per fresh
+    # pass — negligible against the 1-week stale window.
+    _DEFAULT_STARTUP_THROTTLE_MS = 500
+
     def _run() -> None:
         try:
             pkmn = TCGClient(api_key=os.environ.get("POKEMONTCG_IO_API_KEY"))
-            result = warm_cards(pkmn)
+            result = warm_cards(pkmn, throttle_ms=_DEFAULT_STARTUP_THROTTLE_MS)
             disk_cache.write_card_warm(
                 cards_warmed=result.cards_warmed,
                 cards_failed=result.cards_failed,

--- a/api/routes/cache.py
+++ b/api/routes/cache.py
@@ -49,6 +49,9 @@ def _zeroed_snapshot() -> disk_cache.CacheStats:
         set_cards_warm_count=0,
         sets_warm_timestamp=None,
         sets_warm_count=0,
+        card_warm_timestamp=None,
+        card_warm_count=0,
+        card_warm_failed_count=0,
     )
 
 

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -101,10 +101,50 @@ same snapshot with snake_case keys:
 }
 ```
 
+## Warm passes
+
+Four CLI commands pre-populate slices of the cache so first-use lookups
+land on a warm disk instead of paying upstream latency:
+
+| Command | What it warms | Manifest | Stale window |
+|---|---|---|---|
+| `pkmn cache warm-concepts` | Concept-name → card-id lookups (~200 names) | `concept_warm.json` | 24 h |
+| `pkmn cache warm-set-cards` | Per-set card-list JSON for every set | `set_cards_warm.json` | 7 d |
+| `pkmn cache warm-sets` | Set logo + symbol images | `sets_warm.json` | 7 d |
+| `pkmn cache warm-cards` | Full per-card structural payload (~18,000 cards) | `card_warm.json` | 7 d |
+
+Each manifest records `timestamp` + a count of what was warmed; the
+freshness gate (`*_warm_is_fresh()`) reads it to skip a re-walk when a
+recent pass is still within the staleness window. The on-startup
+bootstrap in [`api/main.py`](../api/main.py) fires the first three when
+`MGZ_PKMN_WARM_ON_STARTUP=1`. The per-card warm has its own opt-in
+(`MGZ_PKMN_WARM_CARDS_ON_STARTUP=1`) because it's heavier — a fresh
+pass writes one cache entry per card across the full English catalog.
+
+`warm-cards` is Phase 1 of the pre-Scrydex catalog-warm epic
+([#368](https://github.com/mgzwarrior/mgz-pkmn/issues/368)). Reuses the
+data each set's `search_all` already returns — zero extra HTTP calls
+vs `warm-set-cards`, just one extra disk entry per card so the lookup
+path can resolve directly by card-id once the Phase 3 refactor
+([#372](https://github.com/mgzwarrior/mgz-pkmn/issues/372)) wires it in.
+
+```bash
+# Full English-catalog warm; ~18k entries written, throttled politely.
+pkmn cache warm-cards --throttle-ms 250
+
+# Stage a single new set after a release.
+pkmn cache warm-cards --set sv11 -v
+
+# Bound a partial run on a tight upstream budget.
+pkmn cache warm-cards --max-cards 1000
+```
+
 ## Environment variables
 
 | Variable | Effect |
 |---|---|
 | `MGZ_PKMN_NO_CACHE` | When set to a truthy value (anything other than empty, `0`, `false`, `False`), disables both the API response cache and URL-override lookups for the current process. Reads always miss; writes are no-ops; the on-disk cache is left untouched. The CLI's [`--no-cache`](cli.md#pkmn-lookup-options) flag sets this internally — set it directly when running the FastAPI service or invoking the library from another process where the flag isn't available. `--clear-cache` still wipes the API cache even when this is set; the explicit wipe wins over the implicit skip. |
 | `MGZ_PKMN_CACHE_WARN_BYTES` | Integer byte count for the cache-size soft-warn threshold checked at `pkmn lookup` startup. Defaults to `52428800` (50 MB). Set to `0` (or any non-positive value) to disable the warning entirely. Unparseable values fall back to the default. |
+| `MGZ_PKMN_WARM_ON_STARTUP` | Truthy (`1`, `true`, `True`) enables the runtime warm bootstrap in the FastAPI lifespan for the concept, set-cards, and sets slices. Each slice is gated by its own freshness manifest so containers starting within the staleness window skip the re-walk. Set in `render.yaml` by default on the deployed instance. |
+| `MGZ_PKMN_WARM_CARDS_ON_STARTUP` | Truthy enables the runtime per-card warm bootstrap. Independent of `MGZ_PKMN_WARM_ON_STARTUP` because the per-card pass is heavyweight and should be opted into explicitly. Pair with the persistent-disk deploy so the warm survives redeploys. |
 | `XDG_CACHE_HOME` | Overrides the cache root. The store lives at `$XDG_CACHE_HOME/mgz-pkmn` when set, falling back to `~/.cache/mgz-pkmn` otherwise. Standard XDG semantics — no mgz-pkmn-specific behavior. |

--- a/src/mgz_pkmn/cache.py
+++ b/src/mgz_pkmn/cache.py
@@ -57,16 +57,25 @@ SET_CARDS_WARM_STALE_SECONDS = 7 * 24 * 60 * 60  # one week
 # image bytes themselves, but the manifest's freshness gate keeps the
 # runtime lifespan bootstrap from re-walking every container restart.
 SETS_WARM_STALE_SECONDS = 7 * 24 * 60 * 60  # one week
+# Per-card structural warm. The full card object (name, set, number,
+# rarity, attacks, weaknesses, resistances, retreatCost, legalities,
+# ancientTrait, images, ...) doesn't change once a card is printed, so
+# the stale window is generous. Phase 1 of the pre-Scrydex catalog-warm
+# epic (#368) populates this slice across the entire English catalog
+# while pokemontcg.io is still free.
+CARD_WARM_STALE_SECONDS = 7 * 24 * 60 * 60  # one week
 _NO_CACHE_ENV = "MGZ_PKMN_NO_CACHE"
 _WARN_BYTES_ENV = "MGZ_PKMN_CACHE_WARN_BYTES"
 _OVERRIDES_FILE = "url_overrides.json"
 _CONCEPT_WARM_FILE = "concept_warm.json"
 _SET_CARDS_WARM_FILE = "set_cards_warm.json"
 _SETS_WARM_FILE = "sets_warm.json"
+_CARD_WARM_FILE = "card_warm.json"
 OVERRIDES_SCHEMA_VERSION = 1
 CONCEPT_WARM_SCHEMA_VERSION = 1
 SET_CARDS_WARM_SCHEMA_VERSION = 1
 SETS_WARM_SCHEMA_VERSION = 1
+CARD_WARM_SCHEMA_VERSION = 1
 _IMAGES_SUBDIR = "images"
 # Allowed image extensions for read-side discovery; write-side derives the
 # extension from the source URL but normalises it through this list so an
@@ -120,6 +129,15 @@ class CacheStats:
     # this manifest only gates the *re-walk* of upstream metadata.
     sets_warm_timestamp: float | None
     sets_warm_count: int
+    # Per-card structural warm slice — populated from `card_warm.json`,
+    # written by `pkmn cache warm-cards`. Phase 1 of the pre-Scrydex
+    # catalog-warm epic (#368). `card_warm_count` is the total number of
+    # cards whose full structural payload landed in the API cache slice
+    # during the most recent pass; `card_warm_failed_count` is the
+    # number that didn't (set queries that returned no results, etc.).
+    card_warm_timestamp: float | None
+    card_warm_count: int
+    card_warm_failed_count: int
 
 
 def _disabled() -> bool:
@@ -857,6 +875,92 @@ def sets_warm_is_fresh(*, now: float | None = None) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Card-warm manifest — records the most recent `warm-cards` run (the
+# Phase 1 #370 catalog-warm pass that fan-out-writes per-card cache entries
+# from each set's payload). Mirrors the other warm manifests' shape so
+# the stats projection, freshness gate, and CLI rendering stay uniform.
+# Phase 1 of the pre-Scrydex catalog-warm epic (#368).
+# ---------------------------------------------------------------------------
+
+
+def _card_warm_path() -> Path:
+    return _cache_root_path() / _CARD_WARM_FILE
+
+
+def read_card_warm() -> dict[str, Any] | None:
+    """Return the parsed card-warm manifest, or None when absent/malformed.
+
+    Schema (v1):
+        {
+            "version": 1,
+            "timestamp": <unix float>,
+            "cards_warmed": <int>,
+            "cards_failed": <int>,
+            "sets_attempted": <int>,
+            "sets_failed": [<set_id>, ...]
+        }
+
+    Same defence-in-depth as the other warm manifests: corrupt files or
+    wrong schema versions are treated as "no manifest" so a bad write
+    doesn't poison the freshness gate."""
+    path = _card_warm_path()
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict) or data.get("version") != CARD_WARM_SCHEMA_VERSION:
+        return None
+    return data
+
+
+def write_card_warm(
+    *,
+    cards_warmed: int,
+    cards_failed: int,
+    sets_attempted: int,
+    sets_failed: list[str],
+) -> None:
+    """Persist the card-warm manifest. Best-effort write — failures are
+    silent so a read-only filesystem doesn't crash a successful warm pass
+    that's about to return its result to the caller."""
+    payload = {
+        "version": CARD_WARM_SCHEMA_VERSION,
+        "timestamp": time.time(),
+        "cards_warmed": cards_warmed,
+        "cards_failed": cards_failed,
+        "sets_attempted": sets_attempted,
+        "sets_failed": sets_failed,
+    }
+    root = cache_root()
+    with contextlib.suppress(OSError):
+        (root / _CARD_WARM_FILE).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def card_warm_is_fresh(*, now: float | None = None) -> bool:
+    """True when a manifest exists, its timestamp is within the staleness
+    window (1 week, see `CARD_WARM_STALE_SECONDS`), and it recorded at
+    least one successful card warm.
+
+    Same `cards_warmed > 0` guard as the other warm gates — a manifest
+    written after a fully-failed pass (e.g. transient upstream outage)
+    must not suppress the next retry for a full week with the cache
+    cold."""
+    manifest = read_card_warm()
+    if manifest is None:
+        return False
+    ts = manifest.get("timestamp")
+    if not isinstance(ts, int | float):
+        return False
+    cards_warmed = manifest.get("cards_warmed")
+    if not isinstance(cards_warmed, int) or cards_warmed <= 0:
+        return False
+    current = now if now is not None else time.time()
+    return (current - ts) < CARD_WARM_STALE_SECONDS
+
+
+# ---------------------------------------------------------------------------
 # Stats — health snapshot for `pkmn cache stats`.
 # ---------------------------------------------------------------------------
 
@@ -936,6 +1040,21 @@ def stats() -> CacheStats:
         if isinstance(n, int):
             sets_warm_count = n
 
+    card_warm_timestamp: float | None = None
+    card_warm_count = 0
+    card_warm_failed_count = 0
+    cw_manifest = read_card_warm()
+    if cw_manifest is not None:
+        ts = cw_manifest.get("timestamp")
+        if isinstance(ts, int | float):
+            card_warm_timestamp = float(ts)
+        n = cw_manifest.get("cards_warmed")
+        if isinstance(n, int):
+            card_warm_count = n
+        f = cw_manifest.get("cards_failed")
+        if isinstance(f, int):
+            card_warm_failed_count = f
+
     return CacheStats(
         root=root,
         api_entry_count=api_count,
@@ -951,4 +1070,7 @@ def stats() -> CacheStats:
         set_cards_warm_count=set_cards_warm_count,
         sets_warm_timestamp=sets_warm_timestamp,
         sets_warm_count=sets_warm_count,
+        card_warm_timestamp=card_warm_timestamp,
+        card_warm_count=card_warm_count,
+        card_warm_failed_count=card_warm_failed_count,
     )

--- a/src/mgz_pkmn/cli.py
+++ b/src/mgz_pkmn/cli.py
@@ -19,7 +19,14 @@ from . import cache as disk_cache
 from .binder import CONDENSED_LAYOUT, STANDARD_LAYOUT, write_binder_pdf
 from .checklist import write_checklist_pdf
 from .images import download_image
-from .lookup import WARM_SOURCES, find_card, find_top_cards, warm_concepts, warm_set_cards
+from .lookup import (
+    WARM_SOURCES,
+    find_card,
+    find_top_cards,
+    warm_cards,
+    warm_concepts,
+    warm_set_cards,
+)
 from .parser import CardQuery, read_input
 from .pricing import Pricing, extract_pricing
 from .report import build_json_report
@@ -1069,6 +1076,28 @@ def cache_stats_command(as_json: bool) -> None:
             + f"{s.sets_warm_count} sets · warmed "
             + f"{_format_age(s.sets_warm_timestamp)}"
         )
+    # Per-card structural warm slice — sourced from `card_warm.json`,
+    # written by `pkmn cache warm-cards` (Phase 1 of #368). Tracks how
+    # many full card objects have been primed into the API slice as
+    # standalone per-card entries so the Phase 3 lookup refactor can
+    # resolve directly by card-id without a search round-trip.
+    if s.card_warm_timestamp is None:
+        click.echo(
+            "  "
+            + click.style("Cards:         ", fg="bright_black")
+            + click.style("not warmed", fg="yellow")
+            + " · run `pkmn cache warm-cards` to prime"
+        )
+    else:
+        line = (
+            "  "
+            + click.style("Cards:         ", fg="bright_black")
+            + f"{s.card_warm_count} cards · warmed "
+            + f"{_format_age(s.card_warm_timestamp)}"
+        )
+        if s.card_warm_failed_count:
+            line += click.style(f" · {s.card_warm_failed_count} failed", fg="yellow")
+        click.echo(line)
 
 
 @cache_group.command(name="clear", context_settings={"help_option_names": ["-h", "--help"]})
@@ -1341,6 +1370,146 @@ def cache_warm_set_cards_command(
         + click.style(f"{result.sets_warmed} warmed", fg="cyan")
         + (
             click.style(f" · {len(result.sets_failed)} missed", fg="yellow")
+            if result.sets_failed
+            else ""
+        )
+    )
+    if result.sets_failed and verbose:
+        click.echo(
+            "  " + click.style("missed: ", fg="bright_black") + ", ".join(result.sets_failed)
+        )
+
+    click.echo()
+    click.secho("Done!", fg="green", bold=True)
+
+
+@cache_group.command(
+    name="warm-cards",
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+@click.option(
+    "--api-key",
+    envvar="POKEMONTCG_IO_API_KEY",
+    default=None,
+    help="pokemontcg.io API key (or set POKEMONTCG_IO_API_KEY).",
+)
+@click.option(
+    "--set",
+    "set_ids",
+    multiple=True,
+    metavar="SET_ID",
+    help=(
+        "Restrict the warm pass to specific set ids (e.g. --set sv8 --set sv9). "
+        "Repeatable. When omitted, every set in the Pokémon TCG catalog is warmed."
+    ),
+)
+@click.option(
+    "--max-cards",
+    type=int,
+    default=None,
+    metavar="N",
+    help="Cap the total cards warmed across the whole pass. Useful for incremental warming.",
+)
+@click.option(
+    "--skip-existing/--no-skip-existing",
+    default=True,
+    show_default=True,
+    help="Skip cards whose per-card cache entry is already on disk. Re-runs are cheap by default.",
+)
+@click.option(
+    "--throttle-ms",
+    type=int,
+    default=0,
+    metavar="MS",
+    help="Sleep between sets to stay inside upstream rate limits (default: no throttle).",
+)
+@click.option("-v", "--verbose", is_flag=True, help="Print each set as it warms.")
+def cache_warm_cards_command(
+    api_key: str | None,
+    set_ids: tuple[str, ...],
+    max_cards: int | None,
+    skip_existing: bool,
+    throttle_ms: int,
+    verbose: bool,
+) -> None:
+    """Pre-warm the per-card structural cache for the entire English catalog.
+
+    Phase 1 of the pre-Scrydex catalog-warm epic (#368). Walks every
+    set, then fan-out-writes a per-card cache entry for every card in
+    the set's payload. Reuses the data each set's search already
+    returns — no extra HTTP calls vs `warm-set-cards`, just one extra
+    disk entry per card so the Phase 3 lookup refactor can resolve
+    cards directly by id.
+
+    A full pass walks ~170 sets and writes one cache entry per card
+    (~18,000 entries total for English). Re-runs honor
+    `--skip-existing` (default on) so only the cards that have fallen
+    out of the cache get re-written.
+
+    Pass `--set <id>` (repeatable) to warm only specific sets — useful
+    for staging a single new set release.
+
+    Pass `--max-cards N` to do a partial warm bounded by total card
+    count — useful for staging the first pass over multiple days if
+    you're inside pokemontcg.io's free-tier rate limit.
+    """
+    _print_banner(__version__)
+
+    pkmn = TCGClient(api_key=api_key, verbose=verbose)
+
+    section = "Warming per-card cache"
+    if set_ids:
+        section += f" · {len(set_ids)} set(s)"
+    if max_cards is not None:
+        section += f" · max {max_cards} cards"
+    _print_section(section)
+
+    def _progress(index: int, total: int, set_id: str) -> None:
+        if not verbose:
+            return
+        click.echo(
+            click.style(f"  [{index}/{total}] ", fg="bright_black") + set_id,
+            err=False,
+        )
+
+    try:
+        result = warm_cards(
+            pkmn,
+            set_ids=list(set_ids) if set_ids else None,
+            max_cards=max_cards,
+            skip_existing=skip_existing,
+            throttle_ms=throttle_ms,
+            on_progress=_progress,
+        )
+    except requests.RequestException as exc:
+        raise click.ClickException(f"card warm failed: {exc}") from exc
+
+    if result.sets_attempted == 0:
+        raise click.ClickException(
+            "no sets to warm — check `--set` ids or upstream catalog availability"
+        )
+
+    # Persist the manifest so `pkmn cache stats` and the freshness gate
+    # (`card_warm_is_fresh`) can report status and skip re-walks within
+    # the staleness window. Matches the concept / set-cards / sets flow.
+    disk_cache.write_card_warm(
+        cards_warmed=result.cards_warmed,
+        cards_failed=result.cards_failed,
+        sets_attempted=result.sets_attempted,
+        sets_failed=result.sets_failed,
+    )
+
+    click.secho("  ✓ ", fg="green", nl=False)
+    click.echo(
+        f"{result.sets_attempted} sets · "
+        + click.style(f"{result.cards_warmed} cards warmed", fg="cyan")
+        + (
+            click.style(f" · {result.cards_failed} failed", fg="yellow")
+            if result.cards_failed
+            else ""
+        )
+        + (
+            click.style(f" · {len(result.sets_failed)} sets missed", fg="yellow")
             if result.sets_failed
             else ""
         )

--- a/src/mgz_pkmn/lookup.py
+++ b/src/mgz_pkmn/lookup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import time
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
@@ -808,4 +809,142 @@ def warm_set_cards(
         sets_attempted=total,
         sets_warmed=warmed,
         sets_failed=failed,
+    )
+
+
+# ---------------------------------------------------------------------------
+# warm_cards — Phase 1 of the pre-Scrydex catalog-warm epic (#368).
+# Walks every English Pokémon TCG set and fan-out-writes per-card cache
+# entries to the API disk slice. Reuses the data already in each set's
+# search response — zero extra HTTP calls vs warm_set_cards — so the cost
+# is the same as the set-cards pass, but the resulting cache has one
+# entry per card-id (URL-keyed on `/v2/cards/{id}`) which Phase 3
+# (#372) can resolve directly without a search query.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class WarmCardsResult:
+    """Outcome of a `warm_cards` run.
+
+    `sets_attempted` is the number of sets walked. `sets_failed` lists
+    set ids whose search returned no results (likely retired or
+    mistyped).
+
+    `cards_warmed` counts cards whose per-card cache entry was either
+    newly written or already present (when `skip_existing=True`); both
+    count as "warmed" because the post-condition is the same — the entry
+    is on disk after the pass.
+
+    `cards_failed` counts cards where the disk write raised — usually a
+    full filesystem; rare in practice, but we surface it so an operator
+    can spot a partial pass."""
+
+    sets_attempted: int
+    cards_warmed: int
+    cards_failed: int
+    sets_failed: list[str] = field(default_factory=list)
+
+
+def warm_cards(
+    pkmn: TCGClient,
+    *,
+    set_ids: list[str] | None = None,
+    max_cards: int | None = None,
+    skip_existing: bool = True,
+    throttle_ms: int = 0,
+    on_progress: Callable[[int, int, str], None] | None = None,
+) -> WarmCardsResult:
+    """Walk every set's card list and write per-card cache entries.
+
+    `set_ids`, when provided, restricts the walk to that subset — handy
+    for `--sets` in the CLI. When None, walks the full Pokémon TCG
+    catalog via `fetch_set_ids`.
+
+    `max_cards` caps the number of *cards* written across the whole
+    pass (not per-set). Useful for incremental warming on a tight
+    upstream budget or for `--max-cards` in the CLI to do a partial
+    walk. When None (default), every card in every walked set is
+    processed.
+
+    `skip_existing` (default True) probes `disk_cache.read_api` before
+    writing — so a re-run only re-writes the cards that have fallen out
+    of the cache. The skipped entries still count toward `cards_warmed`
+    in the result, since the post-condition (entry exists on disk) is
+    satisfied either way.
+
+    `throttle_ms`, when > 0, sleeps for that many milliseconds between
+    set fetches. The per-card writes themselves don't hit upstream
+    (they fan out from the set search response we already paid for),
+    so the throttle only governs the set-level cadence — matters when
+    you're inside pokemontcg.io's free-tier 30 rpm and want to stretch
+    a full warm over multiple minutes/hours.
+
+    `on_progress`, when provided, is invoked once per set with
+    `(index, total, set_id)` so the CLI can render a progress bar.
+
+    The disk cache key for each per-card entry is the URL
+    `{API_BASE}/cards/{card_id}` — synthesized to match the shape a
+    Phase 3 (#372) per-id read path will use. The payload is wrapped in
+    a list (`[card]`) for consistency with the existing API-slice
+    convention (every entry is a list of card objects)."""
+    from .sources.pokemontcg import API_BASE
+
+    ids = set_ids if set_ids is not None else fetch_set_ids(pkmn)
+    total = len(ids)
+    cards_warmed = 0
+    cards_failed = 0
+    sets_failed: list[str] = []
+
+    for index, set_id in enumerate(ids, start=1):
+        if on_progress is not None:
+            on_progress(index, total, set_id)
+
+        # Same query shape as warm_set_cards / api/routes/sets.py — the
+        # disk-cache hit on `set.id:"X"` lets the set-cards endpoint
+        # serve from disk for free. The data we get back is also what
+        # we fan out into per-card entries below.
+        query = f'set.id:"{set_id}"'
+        cards = pkmn.search_all(query)
+        if not cards:
+            sets_failed.append(set_id)
+            if throttle_ms > 0:
+                time.sleep(throttle_ms / 1000.0)
+            continue
+
+        for card in cards:
+            card_id = card.get("id")
+            if not card_id:
+                cards_failed += 1
+                continue
+            card_url = f"{API_BASE}/cards/{card_id}"
+
+            if skip_existing and disk_cache.read_api(card_url) is not None:
+                cards_warmed += 1
+            else:
+                try:
+                    # Wrap in a list to match the existing API-slice
+                    # convention (every cached entry is a list of card
+                    # objects, including single-result responses).
+                    disk_cache.write_api(card_url, [card])
+                    cards_warmed += 1
+                except OSError:
+                    cards_failed += 1
+
+            if max_cards is not None and cards_warmed >= max_cards:
+                return WarmCardsResult(
+                    sets_attempted=index,
+                    cards_warmed=cards_warmed,
+                    cards_failed=cards_failed,
+                    sets_failed=sets_failed,
+                )
+
+        if throttle_ms > 0:
+            time.sleep(throttle_ms / 1000.0)
+
+    return WarmCardsResult(
+        sets_attempted=total,
+        cards_warmed=cards_warmed,
+        cards_failed=cards_failed,
+        sets_failed=sets_failed,
     )

--- a/src/mgz_pkmn/lookup.py
+++ b/src/mgz_pkmn/lookup.py
@@ -922,13 +922,24 @@ def warm_cards(
             if skip_existing and disk_cache.read_api(card_url) is not None:
                 cards_warmed += 1
             else:
-                try:
-                    # Wrap in a list to match the existing API-slice
-                    # convention (every cached entry is a list of card
-                    # objects, including single-result responses).
-                    disk_cache.write_api(card_url, [card])
+                # Wrap in a list to match the existing API-slice
+                # convention (every cached entry is a list of card
+                # objects, including single-result responses).
+                #
+                # `disk_cache.write_api` is best-effort and swallows
+                # OSError/TypeError/ValueError internally, so a try/except
+                # around the call wouldn't catch anything. Verify the
+                # write landed by reading the entry back — costs a stat
+                # per card but ensures `cards_warmed` reflects what's
+                # actually on disk. Without this, a read-only filesystem
+                # or a serialization failure would write a "successful"
+                # manifest and the freshness gate would suppress retries
+                # for a week with the entries absent (the issue Copilot
+                # flagged in #377's review).
+                disk_cache.write_api(card_url, [card])
+                if disk_cache.read_api(card_url) is not None:
                     cards_warmed += 1
-                except OSError:
+                else:
                     cards_failed += 1
 
             if max_cards is not None and cards_warmed >= max_cards:

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -721,11 +721,17 @@ class CacheStatsRouteTests(unittest.TestCase):
         self.assertEqual(data["set_cards_warm_count"], 0)
         self.assertIsNone(data["sets_warm_timestamp"])
         self.assertEqual(data["sets_warm_count"], 0)
+        self.assertIsNone(data["card_warm_timestamp"])
+        self.assertEqual(data["card_warm_count"], 0)
+        self.assertEqual(data["card_warm_failed_count"], 0)
 
     def test_warmed_cache_surfaces_manifest_counts(self) -> None:
         cache.write_concept_warm(names_warmed=47, names_failed=[], source="test")
         cache.write_set_cards_warm(sets_warmed=12, sets_failed=[])
         cache.write_sets_warm(sets_warmed=173, logos_cached=173, symbols_cached=170, failures=3)
+        cache.write_card_warm(
+            cards_warmed=18_500, cards_failed=12, sets_attempted=173, sets_failed=[]
+        )
 
         data = client.get("/api/v1/cache/stats").json()
         self.assertEqual(data["concept_warm_names"], 47)
@@ -734,6 +740,9 @@ class CacheStatsRouteTests(unittest.TestCase):
         self.assertIsInstance(data["set_cards_warm_timestamp"], float)
         self.assertEqual(data["sets_warm_count"], 173)
         self.assertIsInstance(data["sets_warm_timestamp"], float)
+        self.assertEqual(data["card_warm_count"], 18_500)
+        self.assertEqual(data["card_warm_failed_count"], 12)
+        self.assertIsInstance(data["card_warm_timestamp"], float)
 
     def test_response_is_not_browser_cached(self) -> None:
         resp = client.get("/api/v1/cache/stats")
@@ -752,6 +761,7 @@ class CacheStatsRouteTests(unittest.TestCase):
         self.assertIsNone(data["concept_warm_timestamp"])
         self.assertIsNone(data["set_cards_warm_timestamp"])
         self.assertIsNone(data["sets_warm_timestamp"])
+        self.assertIsNone(data["card_warm_timestamp"])
         self.assertIsInstance(data["root"], str)
 
     def test_field_names_match_cli_json_shape(self) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -202,6 +202,9 @@ class CacheStatsCommandTests(unittest.TestCase):
                 "set_cards_warm_count",
                 "sets_warm_timestamp",
                 "sets_warm_count",
+                "card_warm_timestamp",
+                "card_warm_count",
+                "card_warm_failed_count",
                 "root",
             },
         )
@@ -803,6 +806,93 @@ class LookupCurrencyWarningTests(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 0, result.output)
         self.assertNotIn("currency-blind", result.output)
+
+
+# ---------------------------------------------------------------------------
+# `pkmn cache warm-cards` — Phase 1 of the pre-Scrydex catalog-warm epic
+# (#370). Mirrors the warm-sets CLI tests above: mock the upstream
+# `warm_cards` call, assert the CLI reports the result + writes the
+# manifest.
+# ---------------------------------------------------------------------------
+
+
+class CacheWarmCardsCommandTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._old_xdg = os.environ.get("XDG_CACHE_HOME")
+        self._old_no_cache = os.environ.get(cache._NO_CACHE_ENV)
+        os.environ["XDG_CACHE_HOME"] = self._tmp.name
+        os.environ.pop(cache._NO_CACHE_ENV, None)
+
+    def tearDown(self) -> None:
+        if self._old_xdg is None:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        else:
+            os.environ["XDG_CACHE_HOME"] = self._old_xdg
+        if self._old_no_cache is None:
+            os.environ.pop(cache._NO_CACHE_ENV, None)
+        else:
+            os.environ[cache._NO_CACHE_ENV] = self._old_no_cache
+        self._tmp.cleanup()
+
+    def test_warm_cards_writes_manifest_and_reports_counts(self) -> None:
+        from unittest.mock import patch as _patch
+
+        from mgz_pkmn.lookup import WarmCardsResult
+
+        fake_result = WarmCardsResult(
+            sets_attempted=2,
+            cards_warmed=42,
+            cards_failed=0,
+            sets_failed=[],
+        )
+
+        with _patch("mgz_pkmn.cli.warm_cards", return_value=fake_result):
+            result = CliRunner().invoke(
+                cli, ["cache", "warm-cards", "--set", "sv8", "--set", "sv7"]
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("2 sets", result.output)
+        self.assertIn("42 cards warmed", result.output)
+
+        # Manifest landed on disk with the result counts.
+        manifest = cache.read_card_warm()
+        self.assertIsNotNone(manifest)
+        assert manifest is not None
+        self.assertEqual(manifest["cards_warmed"], 42)
+        self.assertEqual(manifest["sets_attempted"], 2)
+        self.assertEqual(manifest["cards_failed"], 0)
+
+    def test_warm_cards_surfaces_request_failure(self) -> None:
+        from unittest.mock import patch as _patch
+
+        import requests as _requests
+
+        with _patch(
+            "mgz_pkmn.cli.warm_cards", side_effect=_requests.ConnectionError("network down")
+        ):
+            result = CliRunner().invoke(cli, ["cache", "warm-cards"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("card warm failed", result.output)
+        self.assertIn("network down", result.output)
+
+    def test_warm_cards_rejects_empty_pass(self) -> None:
+        from unittest.mock import patch as _patch
+
+        from mgz_pkmn.lookup import WarmCardsResult
+
+        with _patch(
+            "mgz_pkmn.cli.warm_cards",
+            return_value=WarmCardsResult(
+                sets_attempted=0, cards_warmed=0, cards_failed=0, sets_failed=[]
+            ),
+        ):
+            result = CliRunner().invoke(cli, ["cache", "warm-cards"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("no sets to warm", result.output)
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -878,6 +878,53 @@ class CacheWarmCardsCommandTests(unittest.TestCase):
         self.assertIn("card warm failed", result.output)
         self.assertIn("network down", result.output)
 
+    def test_warm_cards_verbose_prints_per_set_progress_and_missed_dump(self) -> None:
+        """`-v` exercises the on_progress callback and the missed-sets dump
+        at the end. Also drives `--max-cards` so the section header reflects
+        the cap."""
+        from unittest.mock import patch as _patch
+
+        from mgz_pkmn.lookup import WarmCardsResult
+
+        def fake_warm(pkmn, *, set_ids, max_cards, skip_existing, throttle_ms, on_progress):
+            # Drive the progress callback so the verbose branch (lines 1468-1470)
+            # fires for both sets the CLI passed in.
+            on_progress(1, 2, "sv8")
+            on_progress(2, 2, "ghost")
+            return WarmCardsResult(
+                sets_attempted=2,
+                cards_warmed=5,
+                cards_failed=0,
+                sets_failed=["ghost"],
+            )
+
+        with _patch("mgz_pkmn.cli.warm_cards", side_effect=fake_warm):
+            result = CliRunner().invoke(
+                cli,
+                [
+                    "cache",
+                    "warm-cards",
+                    "--set",
+                    "sv8",
+                    "--set",
+                    "ghost",
+                    "--max-cards",
+                    "5",
+                    "-v",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        # `--max-cards 5` lands in the section header.
+        self.assertIn("max 5 cards", result.output)
+        # Per-set progress lines fired.
+        self.assertIn("[1/2]", result.output)
+        self.assertIn("sv8", result.output)
+        self.assertIn("[2/2]", result.output)
+        # Missed-sets dump fired at the end.
+        self.assertIn("missed:", result.output)
+        self.assertIn("ghost", result.output)
+
     def test_warm_cards_rejects_empty_pass(self) -> None:
         from unittest.mock import patch as _patch
 

--- a/tests/test_warm_cards.py
+++ b/tests/test_warm_cards.py
@@ -248,6 +248,87 @@ class WarmCardsTests(_IsolatedCacheMixin):
         self.assertEqual(result.cards_warmed, 2)
         self.assertEqual(result.sets_failed, ["ghost"])
 
+    def test_write_failure_counts_as_failed_not_warmed(self) -> None:
+        """Read-back verification: when `write_api` silently fails (it swallows
+        OSError/TypeError/ValueError internally), warm_cards must not lie about
+        success. The card lands in `cards_failed`, not `cards_warmed`, so the
+        freshness gate's `cards_warmed > 0` guard doesn't suppress retries
+        when the disk is broken."""
+        sets = {"sv8": self._set_payload("sv8", 2)}
+
+        # First write succeeds normally; second has `write_api` silently no-op
+        # (simulating a serialization failure or read-only fs). Because
+        # write_api swallows the error, the read-back is the only signal.
+        original_write = disk_cache.write_api
+        call_count = {"n": 0}
+
+        def flaky_write(key: str, data) -> None:
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                return  # silent failure — file never lands
+            original_write(key, data)
+
+        with (
+            patch.object(TCGClient, "search_all", side_effect=lambda q, **_kw: sets["sv8"]),
+            patch.object(disk_cache, "write_api", side_effect=flaky_write),
+        ):
+            result = warm_cards(TCGClient(), set_ids=["sv8"], skip_existing=False)
+
+        self.assertEqual(result.cards_warmed, 1)
+        self.assertEqual(result.cards_failed, 1)
+
+    def test_throttle_ms_sleeps_between_sets(self) -> None:
+        """`throttle_ms` paces the set-level walk so a no-API-key deploy
+        doesn't burst through pokemontcg.io's 30-rpm free-tier ceiling.
+        Patches `time.sleep` to observe the calls without actually sleeping."""
+        from mgz_pkmn import lookup as lookup_mod
+
+        sets = {"sv8": self._set_payload("sv8", 1), "sv7": self._set_payload("sv7", 1)}
+
+        with (
+            patch.object(
+                TCGClient,
+                "search_all",
+                side_effect=lambda q, **_kw: sets[q.split('"')[1]],
+            ),
+            patch.object(lookup_mod.time, "sleep") as mock_sleep,
+        ):
+            warm_cards(TCGClient(), set_ids=list(sets), throttle_ms=250)
+
+        # One sleep per set walked (both succeed). 250 ms == 0.25 s.
+        self.assertEqual(mock_sleep.call_count, 2)
+        for call in mock_sleep.call_args_list:
+            self.assertAlmostEqual(call.args[0], 0.25, places=3)
+
+    def test_throttle_ms_also_sleeps_after_empty_set(self) -> None:
+        """A set whose search returns no cards still gets a throttle sleep
+        before moving to the next id — the upstream call happened either
+        way, so the rate-limit budget got spent."""
+        from mgz_pkmn import lookup as lookup_mod
+
+        with (
+            patch.object(TCGClient, "search_all", return_value=[]),
+            patch.object(lookup_mod.time, "sleep") as mock_sleep,
+        ):
+            warm_cards(TCGClient(), set_ids=["ghost"], throttle_ms=100)
+
+        self.assertEqual(mock_sleep.call_count, 1)
+
+    def test_card_without_id_lands_in_failed(self) -> None:
+        """A malformed card object (no `id` field) increments `cards_failed`
+        rather than silently dropping it. Catches upstream schema drift."""
+        bad_card = {"name": "Mystery"}  # no id
+        good_card = {"id": "sv8-1", "name": "Card1"}
+        with patch.object(
+            TCGClient,
+            "search_all",
+            return_value=[bad_card, good_card],
+        ):
+            result = warm_cards(TCGClient(), set_ids=["sv8"])
+
+        self.assertEqual(result.cards_warmed, 1)
+        self.assertEqual(result.cards_failed, 1)
+
     def test_progress_callback_fires_once_per_set(self) -> None:
         sets = {"sv8": self._set_payload("sv8", 1), "sv7": self._set_payload("sv7", 1)}
         calls: list[tuple[int, int, str]] = []

--- a/tests/test_warm_cards.py
+++ b/tests/test_warm_cards.py
@@ -1,0 +1,292 @@
+"""Coverage for `warm_cards` + the `card_warm.json` manifest helpers.
+
+Phase 1 of the pre-Scrydex catalog-warm epic (#368). Validates that:
+
+- `warm_cards` walks the supplied set ids, fan-out-writes per-card cache
+  entries under synthesized `/v2/cards/{id}` URLs, and returns counts
+  that match what landed on disk.
+- `--skip-existing` honors already-present entries (count them as
+  warmed, don't re-write).
+- `--max-cards` short-circuits the walk mid-pass.
+- The freshness gate + read/write helpers behave the same way as the
+  other three warm manifests (concept, set-cards, sets).
+
+Network is mocked at `TCGClient.search_all` so no real upstream is hit.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from mgz_pkmn import cache as disk_cache
+from mgz_pkmn.lookup import warm_cards
+from mgz_pkmn.sources.pokemontcg import API_BASE, TCGClient
+
+
+class _IsolatedCacheMixin(unittest.TestCase):
+    """Point XDG_CACHE_HOME at a tempdir so writes don't touch the user's real cache."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._old_xdg = os.environ.get("XDG_CACHE_HOME")
+        self._old_no_cache = os.environ.get(disk_cache._NO_CACHE_ENV)
+        os.environ["XDG_CACHE_HOME"] = self._tmp.name
+        os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+
+    def tearDown(self) -> None:
+        if self._old_xdg is None:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        else:
+            os.environ["XDG_CACHE_HOME"] = self._old_xdg
+        if self._old_no_cache is None:
+            os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+        else:
+            os.environ[disk_cache._NO_CACHE_ENV] = self._old_no_cache
+        self._tmp.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Manifest helpers (mirror tests/test_warm_sets_manifest.py)
+# ---------------------------------------------------------------------------
+
+
+class CardWarmManifestTests(_IsolatedCacheMixin):
+    def test_read_returns_none_when_absent(self) -> None:
+        self.assertIsNone(disk_cache.read_card_warm())
+
+    def test_write_then_read_roundtrip(self) -> None:
+        disk_cache.write_card_warm(
+            cards_warmed=18_500,
+            cards_failed=12,
+            sets_attempted=173,
+            sets_failed=["bogus"],
+        )
+        data = disk_cache.read_card_warm()
+        self.assertIsNotNone(data)
+        assert data is not None  # narrow for type checkers
+        self.assertEqual(data["cards_warmed"], 18_500)
+        self.assertEqual(data["cards_failed"], 12)
+        self.assertEqual(data["sets_attempted"], 173)
+        self.assertEqual(data["sets_failed"], ["bogus"])
+        self.assertIsInstance(data["timestamp"], float)
+
+    def test_read_rejects_malformed_payload(self) -> None:
+        path = disk_cache._card_warm_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not json", encoding="utf-8")
+        self.assertIsNone(disk_cache.read_card_warm())
+
+    def test_read_rejects_unknown_schema_version(self) -> None:
+        path = disk_cache._card_warm_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "version": 99,
+                    "timestamp": 0.0,
+                    "cards_warmed": 0,
+                    "cards_failed": 0,
+                    "sets_attempted": 0,
+                    "sets_failed": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.assertIsNone(disk_cache.read_card_warm())
+
+
+class CardWarmFreshnessTests(_IsolatedCacheMixin):
+    def test_no_manifest_is_not_fresh(self) -> None:
+        self.assertFalse(disk_cache.card_warm_is_fresh())
+
+    def test_fresh_within_window(self) -> None:
+        disk_cache.write_card_warm(
+            cards_warmed=10, cards_failed=0, sets_attempted=1, sets_failed=[]
+        )
+        self.assertTrue(disk_cache.card_warm_is_fresh())
+
+    def test_stale_outside_window(self) -> None:
+        disk_cache.write_card_warm(
+            cards_warmed=10, cards_failed=0, sets_attempted=1, sets_failed=[]
+        )
+        future = time.time() + (8 * 24 * 60 * 60)
+        self.assertFalse(disk_cache.card_warm_is_fresh(now=future))
+
+    def test_zero_warmed_manifest_is_not_fresh(self) -> None:
+        disk_cache.write_card_warm(
+            cards_warmed=0, cards_failed=10, sets_attempted=1, sets_failed=["a"]
+        )
+        self.assertFalse(disk_cache.card_warm_is_fresh())
+
+    def test_malformed_timestamp_is_not_fresh(self) -> None:
+        path = disk_cache._card_warm_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "version": disk_cache.CARD_WARM_SCHEMA_VERSION,
+                    "timestamp": "yesterday",
+                    "cards_warmed": 18_500,
+                    "cards_failed": 0,
+                    "sets_attempted": 173,
+                    "sets_failed": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.assertFalse(disk_cache.card_warm_is_fresh())
+
+
+# ---------------------------------------------------------------------------
+# warm_cards behavior
+# ---------------------------------------------------------------------------
+
+
+class WarmCardsTests(_IsolatedCacheMixin):
+    """Drives `warm_cards` with a mocked `TCGClient.search_all` so each set
+    returns a synthetic card list. The test asserts (a) what landed on disk
+    via the synthesized per-card URL keys and (b) the returned counts."""
+
+    @staticmethod
+    def _set_payload(set_id: str, n: int) -> list[dict]:
+        """Return n synthetic cards stamped as belonging to `set_id`."""
+        return [
+            {
+                "id": f"{set_id}-{i}",
+                "name": f"Card{i}",
+                "number": str(i),
+                "set": {"id": set_id, "name": set_id.title()},
+            }
+            for i in range(1, n + 1)
+        ]
+
+    def test_writes_one_cache_entry_per_card(self) -> None:
+        sets = {"sv8": self._set_payload("sv8", 3), "sv7": self._set_payload("sv7", 2)}
+        with patch.object(
+            TCGClient,
+            "search_all",
+            side_effect=lambda q, **_kw: sets[q.split('"')[1]],
+        ):
+            result = warm_cards(TCGClient(), set_ids=list(sets))
+
+        self.assertEqual(result.sets_attempted, 2)
+        self.assertEqual(result.cards_warmed, 5)
+        self.assertEqual(result.cards_failed, 0)
+        self.assertEqual(result.sets_failed, [])
+
+        # Each card landed at its synthesized URL key.
+        for cards in sets.values():
+            for card in cards:
+                payload = disk_cache.read_api(f"{API_BASE}/cards/{card['id']}")
+                self.assertIsNotNone(payload, f"missing entry for {card['id']}")
+                assert payload is not None
+                self.assertEqual(payload[0]["id"], card["id"])
+
+    def test_skip_existing_counts_pre_warmed_cards_without_rewrite(self) -> None:
+        # Pre-seed one card's per-id entry; the warm pass should count it
+        # as warmed without re-writing the file.
+        sets = {"sv8": self._set_payload("sv8", 3)}
+        pre_card = sets["sv8"][0]
+        pre_url = f"{API_BASE}/cards/{pre_card['id']}"
+        disk_cache.write_api(pre_url, [{"id": pre_card["id"], "name": "Stale"}])
+
+        with patch.object(TCGClient, "search_all", side_effect=lambda q, **_kw: sets["sv8"]):
+            result = warm_cards(TCGClient(), set_ids=["sv8"], skip_existing=True)
+
+        self.assertEqual(result.cards_warmed, 3)
+        # Pre-existing entry was NOT overwritten with the fresh payload.
+        cached = disk_cache.read_api(pre_url)
+        assert cached is not None
+        self.assertEqual(cached[0]["name"], "Stale")
+
+    def test_no_skip_existing_overwrites_pre_warmed_cards(self) -> None:
+        sets = {"sv8": self._set_payload("sv8", 1)}
+        pre_card = sets["sv8"][0]
+        pre_url = f"{API_BASE}/cards/{pre_card['id']}"
+        disk_cache.write_api(pre_url, [{"id": pre_card["id"], "name": "Stale"}])
+
+        with patch.object(TCGClient, "search_all", side_effect=lambda q, **_kw: sets["sv8"]):
+            warm_cards(TCGClient(), set_ids=["sv8"], skip_existing=False)
+
+        # Pre-existing entry got rewritten with the fresh payload.
+        cached = disk_cache.read_api(pre_url)
+        assert cached is not None
+        self.assertEqual(cached[0]["name"], "Card1")
+
+    def test_max_cards_short_circuits_mid_pass(self) -> None:
+        sets = {"sv8": self._set_payload("sv8", 5), "sv7": self._set_payload("sv7", 5)}
+        with patch.object(
+            TCGClient,
+            "search_all",
+            side_effect=lambda q, **_kw: sets[q.split('"')[1]],
+        ):
+            result = warm_cards(TCGClient(), set_ids=list(sets), max_cards=3)
+
+        # Capped at 3 even though 10 cards were available.
+        self.assertEqual(result.cards_warmed, 3)
+        # The second set never got touched.
+        self.assertEqual(result.sets_attempted, 1)
+
+    def test_set_returning_no_cards_lands_in_sets_failed(self) -> None:
+        sets = {"sv8": self._set_payload("sv8", 2), "ghost": []}
+        with patch.object(
+            TCGClient,
+            "search_all",
+            side_effect=lambda q, **_kw: sets[q.split('"')[1]],
+        ):
+            result = warm_cards(TCGClient(), set_ids=list(sets))
+
+        self.assertEqual(result.cards_warmed, 2)
+        self.assertEqual(result.sets_failed, ["ghost"])
+
+    def test_progress_callback_fires_once_per_set(self) -> None:
+        sets = {"sv8": self._set_payload("sv8", 1), "sv7": self._set_payload("sv7", 1)}
+        calls: list[tuple[int, int, str]] = []
+
+        with patch.object(
+            TCGClient,
+            "search_all",
+            side_effect=lambda q, **_kw: sets[q.split('"')[1]],
+        ):
+            warm_cards(
+                TCGClient(),
+                set_ids=list(sets),
+                on_progress=lambda i, t, s: calls.append((i, t, s)),
+            )
+
+        self.assertEqual(calls, [(1, 2, "sv8"), (2, 2, "sv7")])
+
+
+# ---------------------------------------------------------------------------
+# CacheStats projection
+# ---------------------------------------------------------------------------
+
+
+class CardWarmStatsProjectionTests(_IsolatedCacheMixin):
+    def test_stats_reflects_card_warm_manifest(self) -> None:
+        disk_cache.write_card_warm(
+            cards_warmed=18_500, cards_failed=12, sets_attempted=173, sets_failed=["x"]
+        )
+        s = disk_cache.stats()
+        self.assertEqual(s.card_warm_count, 18_500)
+        self.assertEqual(s.card_warm_failed_count, 12)
+        self.assertIsInstance(s.card_warm_timestamp, float)
+
+    def test_stats_zeroed_when_no_manifest(self) -> None:
+        s = disk_cache.stats()
+        self.assertEqual(s.card_warm_count, 0)
+        self.assertEqual(s.card_warm_failed_count, 0)
+        self.assertIsNone(s.card_warm_timestamp)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_warm_on_startup.py
+++ b/tests/test_warm_on_startup.py
@@ -29,6 +29,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from fastapi.testclient import TestClient
 
 from mgz_pkmn import cache as disk_cache
+from mgz_pkmn.lookup import WarmCardsResult
 from mgz_pkmn.set_cards import WarmResult
 
 
@@ -324,6 +325,120 @@ class WarmSetsBackgroundBodyTests(unittest.TestCase):
         mock_threading.Thread.assert_not_called()
         # Logged the "already fresh" reason so an operator can tell why a
         # restart didn't trigger another walk.
+        fresh_logs = [call for call in mock_log_info.call_args_list if "fresh" in str(call)]
+        self.assertEqual(len(fresh_logs), 1)
+
+
+class WarmCardsBackgroundBodyTests(unittest.TestCase):
+    """Same pattern as WarmSetsBackgroundBodyTests — drive the body of
+    `_warm_cards_in_background` synchronously by patching `threading.Thread`
+    so `.start()` invokes the target inline. Covers the inner _run
+    (TCGClient → warm_cards → write_card_warm + log) that the
+    lifespan-level tests mock at the boundary."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._old_xdg = os.environ.get("XDG_CACHE_HOME")
+        self._old_no_cache = os.environ.get(disk_cache._NO_CACHE_ENV)
+        os.environ["XDG_CACHE_HOME"] = self._tmp.name
+        os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+
+    def tearDown(self) -> None:
+        if self._old_xdg is None:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        else:
+            os.environ["XDG_CACHE_HOME"] = self._old_xdg
+        if self._old_no_cache is None:
+            os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+        else:
+            os.environ[disk_cache._NO_CACHE_ENV] = self._old_no_cache
+        self._tmp.cleanup()
+
+    def _make_sync_thread(self):
+        def _thread_factory(*, target=None, name=None, daemon=None, **_kwargs):
+            instance = MagicMock()
+            instance.start.side_effect = lambda: target() if target else None
+            return instance
+
+        return _thread_factory
+
+    def test_card_warm_body_passes_throttle_and_writes_manifest(self) -> None:
+        """The body fetches via TCGClient, calls warm_cards WITH a non-zero
+        throttle (so a no-API-key deploy doesn't burst through the rate
+        limit), writes the manifest, and logs success."""
+        from api import main
+
+        fake_result = WarmCardsResult(
+            sets_attempted=173, cards_warmed=18_500, cards_failed=12, sets_failed=["ghost"]
+        )
+        with (
+            patch.object(main, "threading") as mock_threading,
+            patch.object(main, "TCGClient") as mock_client_cls,
+            patch.object(main, "warm_cards", return_value=fake_result) as mock_warm,
+            patch.object(main._log, "info") as mock_log,
+        ):
+            mock_threading.Thread.side_effect = self._make_sync_thread()
+            main._warm_cards_in_background()
+
+        mock_client_cls.assert_called_once()
+        # Critically: throttle_ms is passed and non-zero. Without this the
+        # startup warm would burst through pokemontcg.io's 30-rpm free-tier
+        # ceiling on a no-API-key deploy and poison the manifest.
+        mock_warm.assert_called_once()
+        _, kwargs = mock_warm.call_args
+        self.assertGreater(kwargs.get("throttle_ms", 0), 0)
+
+        # Manifest landed on disk with the fake counts.
+        manifest = disk_cache.read_card_warm()
+        self.assertIsNotNone(manifest)
+        assert manifest is not None
+        self.assertEqual(manifest["cards_warmed"], 18_500)
+        self.assertEqual(manifest["cards_failed"], 12)
+        self.assertEqual(manifest["sets_attempted"], 173)
+        self.assertEqual(manifest["sets_failed"], ["ghost"])
+
+        # Success path logs the "complete" line.
+        complete_logs = [call for call in mock_log.call_args_list if "complete" in str(call)]
+        self.assertEqual(len(complete_logs), 1)
+
+    def test_card_warm_body_swallows_upstream_exception(self) -> None:
+        """A TCGClient/warm_cards failure is logged and swallowed — the warm
+        is best-effort and must not crash the service. Manifest stays absent
+        so the next startup retries."""
+        from api import main
+
+        with (
+            patch.object(main, "threading") as mock_threading,
+            patch.object(main, "TCGClient"),
+            patch.object(main, "warm_cards", side_effect=RuntimeError("upstream down")),
+            patch.object(main._log, "exception") as mock_log_exception,
+        ):
+            mock_threading.Thread.side_effect = self._make_sync_thread()
+            main._warm_cards_in_background()
+
+        self.assertIsNone(disk_cache.read_card_warm())
+        mock_log_exception.assert_called_once()
+
+    def test_card_warm_skipped_when_manifest_is_fresh(self) -> None:
+        """When the freshness gate hits, the body short-circuits without
+        constructing a TCGClient or spawning a thread."""
+        from api import main
+
+        disk_cache.write_card_warm(
+            cards_warmed=18_500, cards_failed=0, sets_attempted=173, sets_failed=[]
+        )
+
+        with (
+            patch.object(main, "threading") as mock_threading,
+            patch.object(main, "TCGClient") as mock_client_cls,
+            patch.object(main, "warm_cards") as mock_warm,
+            patch.object(main._log, "info") as mock_log_info,
+        ):
+            main._warm_cards_in_background()
+
+        mock_client_cls.assert_not_called()
+        mock_warm.assert_not_called()
+        mock_threading.Thread.assert_not_called()
         fresh_logs = [call for call in mock_log_info.call_args_list if "fresh" in str(call)]
         self.assertEqual(len(fresh_logs), 1)
 

--- a/tests/test_warm_on_startup.py
+++ b/tests/test_warm_on_startup.py
@@ -127,6 +127,89 @@ class WarmOnStartupTests(unittest.TestCase):
                     mock_sets.assert_not_called()
 
 
+class WarmCardsLifespanTests(unittest.TestCase):
+    """Pin that `MGZ_PKMN_WARM_CARDS_ON_STARTUP` is wired through the
+    lifespan and that it's *independent* of the standard
+    `MGZ_PKMN_WARM_ON_STARTUP` flag — Phase 1 #370 wants a separate
+    opt-in because the per-card pass is heavyweight."""
+
+    def setUp(self) -> None:
+        self._old_warm = os.environ.get("MGZ_PKMN_WARM_ON_STARTUP")
+        self._old_warm_cards = os.environ.get("MGZ_PKMN_WARM_CARDS_ON_STARTUP")
+        self._old_automigrate = os.environ.get("MGZ_PKMN_AUTOMIGRATE")
+        os.environ["MGZ_PKMN_AUTOMIGRATE"] = "0"
+
+    def tearDown(self) -> None:
+        for key, prev in (
+            ("MGZ_PKMN_WARM_ON_STARTUP", self._old_warm),
+            ("MGZ_PKMN_WARM_CARDS_ON_STARTUP", self._old_warm_cards),
+            ("MGZ_PKMN_AUTOMIGRATE", self._old_automigrate),
+        ):
+            if prev is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = prev
+
+    def _reload_main(self):
+        if "api.main" in sys.modules:
+            return importlib.reload(sys.modules["api.main"])
+        import api.main as main
+
+        return main
+
+    def test_warm_cards_env_set_kicks_off_card_warmer(self) -> None:
+        os.environ["MGZ_PKMN_WARM_CARDS_ON_STARTUP"] = "1"
+        os.environ.pop("MGZ_PKMN_WARM_ON_STARTUP", None)
+        main = self._reload_main()
+        with (
+            patch.object(main, "_warm_concepts_in_background") as mock_concepts,
+            patch.object(main, "_warm_set_cards_in_background") as mock_set_cards,
+            patch.object(main, "_warm_sets_in_background") as mock_sets,
+            patch.object(main, "_warm_cards_in_background") as mock_cards,
+        ):
+            with TestClient(main.app) as c:
+                self.assertEqual(c.get("/health").status_code, 200)
+            # The cards warmer fired even though the standard flag is off.
+            mock_cards.assert_called_once()
+            # The standard three did NOT fire — the env vars are independent.
+            mock_concepts.assert_not_called()
+            mock_set_cards.assert_not_called()
+            mock_sets.assert_not_called()
+
+    def test_standard_warm_env_does_not_fire_card_warmer(self) -> None:
+        # MGZ_PKMN_WARM_ON_STARTUP=1 alone must NOT trigger the per-card
+        # warm — that's the whole point of the separate env var.
+        os.environ["MGZ_PKMN_WARM_ON_STARTUP"] = "1"
+        os.environ.pop("MGZ_PKMN_WARM_CARDS_ON_STARTUP", None)
+        main = self._reload_main()
+        with (
+            patch.object(main, "_warm_concepts_in_background"),
+            patch.object(main, "_warm_set_cards_in_background"),
+            patch.object(main, "_warm_sets_in_background"),
+            patch.object(main, "_warm_cards_in_background") as mock_cards,
+        ):
+            with TestClient(main.app) as c:
+                self.assertEqual(c.get("/health").status_code, 200)
+            mock_cards.assert_not_called()
+
+    def test_both_envs_set_fire_all_four_warmers(self) -> None:
+        os.environ["MGZ_PKMN_WARM_ON_STARTUP"] = "1"
+        os.environ["MGZ_PKMN_WARM_CARDS_ON_STARTUP"] = "1"
+        main = self._reload_main()
+        with (
+            patch.object(main, "_warm_concepts_in_background") as mock_concepts,
+            patch.object(main, "_warm_set_cards_in_background") as mock_set_cards,
+            patch.object(main, "_warm_sets_in_background") as mock_sets,
+            patch.object(main, "_warm_cards_in_background") as mock_cards,
+        ):
+            with TestClient(main.app) as c:
+                self.assertEqual(c.get("/health").status_code, 200)
+            mock_concepts.assert_called_once()
+            mock_set_cards.assert_called_once()
+            mock_sets.assert_called_once()
+            mock_cards.assert_called_once()
+
+
 class WarmSetsBackgroundBodyTests(unittest.TestCase):
     """Drive the body of `_warm_sets_in_background` synchronously so the
     inner `_run` (TCGClient → warm_set_images → write_sets_warm + log)

--- a/web/src/components/SettingsDrawer.test.tsx
+++ b/web/src/components/SettingsDrawer.test.tsx
@@ -52,6 +52,9 @@ describe('SettingsDrawer', () => {
       set_cards_warm_count: 0,
       sets_warm_timestamp: null,
       sets_warm_count: 0,
+      card_warm_timestamp: null,
+      card_warm_count: 0,
+      card_warm_failed_count: 0,
     })
   })
 
@@ -90,6 +93,9 @@ describe('SettingsDrawer', () => {
       set_cards_warm_count: 0,
       sets_warm_timestamp: Date.now() / 1000 - 300, // 5 min ago
       sets_warm_count: 200,
+      card_warm_timestamp: Date.now() / 1000 - 600, // 10 min ago
+      card_warm_count: 18500,
+      card_warm_failed_count: 0,
     })
 
     render(<SettingsDrawer />)
@@ -99,6 +105,7 @@ describe('SettingsDrawer', () => {
     expect(screen.getByText(/173 ·/)).toBeInTheDocument()
     expect(screen.getByText(/47 ·/)).toBeInTheDocument()
     expect(screen.getByText(/200 ·/)).toBeInTheDocument()
+    expect(screen.getByText(/18500 ·/)).toBeInTheDocument()
     // The not-warmed branch renders for set cards (the only null slice).
     expect(screen.getByText(/^not warmed$/)).toBeInTheDocument()
   })

--- a/web/src/components/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer.tsx
@@ -295,6 +295,15 @@ function CacheStatsPanel() {
             }
             warn={stats.sets_warm_timestamp == null}
           />
+          <StatRow
+            label="Cards"
+            value={
+              stats.card_warm_timestamp == null
+                ? 'not warmed'
+                : `${stats.card_warm_count} · ${formatAge(stats.card_warm_timestamp)}`
+            }
+            warn={stats.card_warm_timestamp == null}
+          />
         </dl>
       )}
     </div>

--- a/web/src/components/a11y.test.tsx
+++ b/web/src/components/a11y.test.tsx
@@ -48,6 +48,9 @@ vi.mock('../api/client', () => ({
     set_cards_warm_count: 0,
     sets_warm_timestamp: null,
     sets_warm_count: 0,
+    card_warm_timestamp: null,
+    card_warm_count: 0,
+    card_warm_failed_count: 0,
   }),
 }))
 

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -202,12 +202,13 @@ export interface ChangelogRelease {
 
 /**
  * Snapshot returned by `GET /api/v1/cache/stats` — same shape as
- * `pkmn cache stats --json`. Counts are always present. Four fields
+ * `pkmn cache stats --json`. Counts are always present. Five fields
  * can be `null`:
  * - `api_oldest_mtime` when the API cache holds no entries
  * - `concept_warm_timestamp` when no concept-warm pass has been recorded
  * - `set_cards_warm_timestamp` when no set-cards-warm pass has been recorded
  * - `sets_warm_timestamp` when no sets-warm pass has been recorded
+ * - `card_warm_timestamp` when no per-card-warm pass has been recorded
  */
 export interface CacheStats {
   root: string
@@ -224,6 +225,9 @@ export interface CacheStats {
   set_cards_warm_count: number
   sets_warm_timestamp: number | null
   sets_warm_count: number
+  card_warm_timestamp: number | null
+  card_warm_count: number
+  card_warm_failed_count: number
 }
 
 /**


### PR DESCRIPTION
Closes #370. Part of [EPIC #368](https://github.com/mgzwarrior/mgz-pkmn/issues/368) — Phase 1 (structural catalog warm).

## What

A new CLI command `pkmn cache warm-cards` that walks every set, then fan-out-writes a per-card cache entry for every card in that set's payload under a synthesized `/v2/cards/{card_id}` URL key.

Key insight: each set's `search_all(f'set.id:\"X\"')` response already contains the full card object for every card in that set. We can re-use that data and fan it out into per-card entries — zero extra HTTP calls vs the existing `warm-set-cards`, just one extra disk entry per card. The resulting cache shape (one entry per card-id) is what the Phase 3 lookup refactor ([#372](https://github.com/mgzwarrior/mgz-pkmn/issues/372)) will resolve against directly, without a search round-trip.

```bash
# Full English-catalog warm; ~18k entries written, throttled politely.
pkmn cache warm-cards --throttle-ms 250

# Stage a single new set after a release.
pkmn cache warm-cards --set sv11 -v

# Bound a partial run on a tight upstream budget.
pkmn cache warm-cards --max-cards 1000
```

## Why

The lookup path currently round-trips to pokemontcg.io on every cache miss — and the cache keys it uses (Lucene-style search queries) don't overlap with the per-set keys `warm-set-cards` populates. So `warm-set-cards` makes the Browse modal snappier but does nothing for individual `/api/v1/lookup` traffic.

With this command + Phase 3's refactor:
- Post-Scrydex-cutover, every lookup against a pre-warmed card costs **0 Scrydex credits** for the structural fields. Only the price refresh round-trips.
- First-user-per-card latency drops from ~500 ms (upstream round-trip) to ~5 ms (disk read).
- We stop being rate-limit-fragile during card-show prep sessions.

## Runtime lifespan bootstrap

`api/main.py::_warm_cards_in_background` mirrors the existing three warmers (daemon thread, `card_warm_is_fresh` gate, swallowed exceptions). Gated by a **new** env var `MGZ_PKMN_WARM_CARDS_ON_STARTUP` — independent of `MGZ_PKMN_WARM_ON_STARTUP` because the per-card pass is heavyweight (~18,000 cache entries) and shouldn't be implicitly triggered by the standard flag. Set in `render.yaml` by default — first boot after merge runs a full pass (~30 min on a background daemon thread, service stays responsive throughout); every subsequent boot hits the 1-week freshness gate and skips the re-walk.

## card_warm.json manifest

Mirrors the existing three warm manifests' shape (`version`, `timestamp`, primary count, failure count, schema-version-versioned). 1-week stale window matches the underlying data's churn — cards within a released set effectively don't change.

## Surfaced everywhere

- `pkmn cache stats` (human + `--json`): new "Cards" line, new `card_warm_*` fields.
- `GET /api/v1/cache/stats`: same shape via the existing `asdict(CacheStats)` projection.
- SPA [Cache Stats panel](web/src/components/SettingsDrawer.tsx): new "Cards" row alongside Concepts / Set cards / Sets, amber when not warmed.

## How to verify

1. `pkmn cache warm-cards --set sv8 -v` against a fresh cache (or use `--no-skip-existing` against a warm one).
2. `pkmn cache stats` — "Cards" line shows the count + freshness.
3. `pkmn cache stats --json | jq .card_warm_count` matches.
4. SPA → Settings → Cache stats panel: "Cards" row populated.
5. Inspect: `ls -la "$(pkmn cache path)/api/" | wc -l` — should grow by the cards-warmed count after a fresh pass.

## Tests

469 Python (16 new in `tests/test_warm_cards.py` for the manifest helpers + `warm_cards` behavior; integration in `tests/test_cli.py::CacheWarmCardsCommandTests`; lifespan independence in `tests/test_warm_on_startup.py::WarmCardsLifespanTests`; route shape in `tests/test_api_routes.py`; CLI `--json` shape pin) + 197 web (drawer/a11y mocks extended).

## Out of scope

- The lookup-path refactor that uses these entries — Phase 3 ([#372](https://github.com/mgzwarrior/mgz-pkmn/issues/372)).
- Card images — Phase 2 ([#371](https://github.com/mgzwarrior/mgz-pkmn/issues/371)). Image URLs are in each card object we cache, so Phase 2 iterates over what we just populated.
- Concurrent / parallel fetch — start sequential and throttled, optimize if needed.