### PR TITLE
fix(deploy): render.yaml declares plan: starter so the disk block validates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,6 @@ Versions follow [Semantic Versioning](https://semver.org/).
   cascaded into the missing-logs symptom in #378. Also refreshes
   [`docs/deployment.md`](docs/deployment.md) to match the new plan and
   drops the now-obsolete "free-tier cold-start" caveat.
-
-### Fixed
-
 - API: **Warm-bootstrap log lines now reach Render's log stream**
   ([#378](https://github.com/mgzwarrior/mgz-pkmn/issues/378)).
   `api/main.py` never configured the root logger, so Python's default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Deploy: **`render.yaml` declares `plan: starter`** instead of
+  `plan: free` ([#380](https://github.com/mgzwarrior/mgz-pkmn/issues/380)).
+  Render's blueprint validator rejects `disks are not supported for
+  free tier services` whenever a blueprint pairs a `disk:` block with
+  a free plan, so the post-#369 sync had been failing silently — none
+  of the persistent disk, `XDG_CACHE_HOME=/var/cache`,
+  `MGZ_PKMN_WARM_ON_STARTUP` (new addition), or
+  `MGZ_PKMN_WARM_CARDS_ON_STARTUP` env vars from #375 / #377 / #379
+  were actually applied to the live service. The deployed instance
+  was still caching to `/root/.cache/mgz-pkmn` (ephemeral writable
+  layer) and the card warm bootstrap was never triggered, which
+  cascaded into the missing-logs symptom in #378. Also refreshes
+  [`docs/deployment.md`](docs/deployment.md) to match the new plan and
+  drops the now-obsolete "free-tier cold-start" caveat.
+
+### Fixed
+
 - API: **Warm-bootstrap log lines now reach Render's log stream**
   ([#378](https://github.com/mgzwarrior/mgz-pkmn/issues/378)).
   `api/main.py` never configured the root logger, so Python's default

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -96,16 +96,23 @@ POKEMONTCG_IO_API_KEY=your-key make docker-run
 # open http://localhost:8000
 ```
 
-## Deploy to Render (free tier)
+## Deploy to Render (Starter)
 
 The repo ships a [`render.yaml`](../render.yaml) blueprint with
 **auto-deploy on**: every push to `main` rebuilds and redeploys
-automatically. One-time setup:
+automatically. The blueprint declares `plan: starter` because the
+persistent disk required by the pre-Scrydex catalog warm
+([#368](https://github.com/mgzwarrior/mgz-pkmn/issues/368)) isn't
+available on Render's free tier — Render's validator rejects
+`disks are not supported for free tier services` for any blueprint
+that pairs a `disk:` block with `plan: free`.
+
+One-time setup:
 
 1. **Create the service** — in the Render dashboard,
    *New → Blueprint*, point it at this repo. It picks up `render.yaml`
-   and creates a Docker web service on the free plan with `autoDeploy`
-   on.
+   and creates a Docker web service on the Starter plan with `autoDeploy`
+   on and a 10 GB persistent disk attached at `/var/cache`.
 2. **Set the API key** — in the service's *Environment* tab, set
    `POKEMONTCG_IO_API_KEY`.
 3. **(Optional) Capture the deploy hook** — *Settings → Deploy Hook*,
@@ -113,6 +120,10 @@ automatically. One-time setup:
    `RENDER_DEPLOY_HOOK`. This enables the manual *Deploy* GitHub
    Action for forced rebuilds (see below). Not required for routine
    deployment, since auto-deploy handles that.
+
+If you ever switch the blueprint's `plan:` (e.g. downgrading for
+testing), the next blueprint sync may fail validation; flip
+`plan: starter` back and trigger *Manual sync* to recover.
 
 ### Forced rebuilds (when needed)
 
@@ -129,10 +140,11 @@ GitHub → *Actions* → *Deploy* → *Run workflow*, optionally toggling
 *Clear build cache before deploying*. The job POSTs to the deploy
 hook and Render starts a fresh build from `main`.
 
-> **Free-tier caveat:** Render's free web service spins down after
-> ~15 min of idle traffic; the next request takes ~30s to wake it.
-> Fine for hobby use. Upgrade to *Starter* (or move to Fly.io) if cold
-> starts hurt.
+> **Plan note:** The Starter plan stays up between requests (no
+> idle-spin-down), so demo links don't show a 30s cold start. The
+> persistent disk + always-on service is also what makes the
+> [pre-Scrydex catalog warm epic](https://github.com/mgzwarrior/mgz-pkmn/issues/368)
+> viable — every redeploy reuses what previous deploys warmed.
 
 ## Persistent disk + cache location
 

--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,12 @@ services:
   - type: web
     name: mgz-pkmn
     runtime: docker
-    plan: free
+    # Starter (not free) because the `disk:` block below requires a paid
+    # plan — Render's blueprint validator rejects `disks are not supported
+    # for free tier services` if the declared plan is free, even if the
+    # actual service has been upgraded in the dashboard. The plan in this
+    # file is the source of truth Render syncs against.
+    plan: starter
     region: oregon
     branch: main
     autoDeploy: true
@@ -30,8 +35,8 @@ services:
       - key: XDG_CACHE_HOME
         value: /var/cache
       # Warm the concept + set-cards + set-image caches on startup so the
-      # first user after a deploy (or a free-tier spin-up) gets cache hits
-      # instead of paying the full upstream round trip. The warmers run on
+      # first user after a deploy gets cache hits instead of paying the
+      # full upstream round trip. The warmers run on
       # background daemon threads — startup and the /health check aren't
       # blocked — and their on-disk freshness manifests (24 h concepts /
       # 1 week set-cards / 1 week sets) keep restarts within the window


### PR DESCRIPTION
Closes #380.

## What

One-line `render.yaml` change: `plan: free` → `plan: starter`. Plus the docs + CHANGELOG to match.

## Why

Since [#369](https://github.com/mgzwarrior/mgz-pkmn/pull/369) merged, Render's blueprint sync has been failing with:

> **services[0]** disks are not supported for free tier services

Render's validator rejects any blueprint that declares a `disk:` block alongside `plan: free`. The whole diff is treated atomically, so **none** of the post-#369 infrastructure changes have actually applied to the live service — not the 10 GB disk, not `XDG_CACHE_HOME=/var/cache`, not `MGZ_PKMN_WARM_CARDS_ON_STARTUP=1`.

This single mismatch chains into everything else we've been chasing:

| Symptom | Caused by |
|---|---|
| `/api/v1/cache/stats` shows `root: /root/.cache/mgz-pkmn` | `XDG_CACHE_HOME` never applied |
| `card_warm_timestamp: null` after every deploy | `MGZ_PKMN_WARM_CARDS_ON_STARTUP` never applied |
| Cache wipes on every redeploy | No persistent disk attached |
| Missing warm-bootstrap logs ([#378](https://github.com/mgzwarrior/mgz-pkmn/pull/379)) | Card warm never fires; concept + sets warm into ephemeral cache so the persistence half of the story doesn't show in `/api/v1/cache/stats` over time |

The maintainer's service has been on Starter since before this fix; the blueprint just needs to declare the same so validation passes.

## How to verify after merge

1. Render dashboard → Blueprints → **mgz-pkmn → Manual sync**.
2. Validator shows "blueprint validated" / similar success state instead of the disks-not-supported error.
3. Render attaches the 10 GB disk at `/var/cache` and applies the env var diffs, then auto-redeploys.
4. Once the deploy lands:
   ```bash
   curl -s https://mgz-pkmn.onrender.com/api/v1/cache/stats | jq .root
   # expect: "/var/cache/mgz-pkmn"   (was: "/root/.cache/mgz-pkmn")
   ```
5. Render's Environment tab shows `XDG_CACHE_HOME`, `MGZ_PKMN_WARM_ON_STARTUP`, `MGZ_PKMN_WARM_CARDS_ON_STARTUP` all present.
6. Render's Logs view during the deploy shows the four `[api.main]` INFO lines from the warm bootstraps (PR #379's logging fix was correct; it just had nothing to log because the bootstraps weren't actually running on persistent state).

## Cosmetic touch-ups in the same diff

- The stale `(or a free-tier spin-up)` comment in render.yaml is removed.
- `docs/deployment.md` retitled "Deploy to Render (Starter)", drops the now-obsolete 30s-cold-start caveat, and explicitly calls out the plan/disk validator pairing so a future downgrade attempt doesn't trip the same trap.

## No code changes

Pure infrastructure config + docs. CI should sail through (`render.yaml` isn't covered by the Python or web tests).