### PR TITLE
fix(web): persist per-line timer chips after a bulk lookup finishes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Web: **Per-line timing chips now persist after a bulk lookup
+  finishes** ([#376](https://github.com/mgzwarrior/mgz-pkmn/issues/376)).
+  The [ProcessingQueue](web/src/components/ProcessingQueue.tsx) early-
+  returned `null` the moment `isRunning` flipped to false, so the per-
+  stage chips and their elapsed-time badges vanished as soon as the
+  SSE stream ended — making it impossible to compare individual queries
+  against each other after the fact (cache-hit vs upstream-fetch
+  benchmarks, slow-outlier debugging, etc.). The panel now stays
+  mounted post-run with the heading "Last lookup", and any spinner on
+  a line that was abandoned mid-stage (Stop, SSE error) freezes
+  instead of animating indefinitely. The global `LookupTimer` summary
+  and during-run UX are unchanged. Pinned by three new tests in
+  [ProcessingQueue.test.tsx](web/src/components/ProcessingQueue.test.tsx).
+
 - Deploy: **`render.yaml` declares `plan: starter`** instead of
   `plan: free` ([#380](https://github.com/mgzwarrior/mgz-pkmn/issues/380)).
   Render's blueprint validator rejects `disks are not supported for

--- a/web/src/components/ProcessingQueue.test.tsx
+++ b/web/src/components/ProcessingQueue.test.tsx
@@ -38,6 +38,16 @@ vi.mock('../store', () => ({
 }))
 
 describe('ProcessingQueue', () => {
+  beforeEach(() => {
+    mockState.isRunning = true
+    mockState.runStartedAt = 1000
+    mockState.processingLines = [
+      { line: 'Charizard | Base Set | 4', status: 'resolved' as const, endedAt: 1500 },
+      { line: 'Pikachu | Jungle', status: 'error' as const, endedAt: 1800 },
+      { line: 'top:5 Mew ex', status: 'pending' as const },
+    ] as Array<Record<string, unknown>>
+  })
+
   it('renders one entry per input line and a done/total count', () => {
     mockState.settings.showTimer = false
     render(<ProcessingQueue />)
@@ -78,6 +88,7 @@ describe('ProcessingQueue', () => {
 describe('ProcessingQueue stage chips', () => {
   beforeEach(() => {
     mockState.settings = { ...baseSettings }
+    mockState.isRunning = true
     mockState.processingLines = [
       { line: 'Charizard | Base Set | 4', status: 'pending', stage: 'looking_up', stageStartedAt: 1000 },
       { line: 'Mew', status: 'pending', stage: 'fallback', stageStartedAt: 1000 },
@@ -129,5 +140,48 @@ describe('ProcessingQueue stage chips', () => {
     // Open: the legend lists every stage, including ones no line is in.
     expect(screen.getByText('URL hint')).toBeInTheDocument()
     expect(screen.getByText('Pricing')).toBeInTheDocument()
+  })
+})
+
+describe('ProcessingQueue post-run persistence (#376)', () => {
+  beforeEach(() => {
+    mockState.settings = { ...baseSettings, showTimer: true }
+    mockState.isRunning = false
+    mockState.runStartedAt = 1000
+    mockState.processingLines = [
+      { line: 'Charizard', status: 'resolved', stage: 'resolved', stageStartedAt: 1400, endedAt: 1500 },
+      { line: 'Pikachu', status: 'error', stage: 'error', stageStartedAt: 1700, endedAt: 1800 },
+      // A mid-stage pending line — what an abandoned Stop / SSE error
+      // leaves behind. Should still render (no early-return) but its
+      // spinner must not animate now that the run is over.
+      { line: 'Mew', status: 'pending', stage: 'looking_up', stageStartedAt: 1200 },
+    ]
+  })
+
+  it('keeps the queue mounted with per-line elapsed badges after the run completes', () => {
+    render(<ProcessingQueue />)
+    expect(screen.getByText(/last lookup/i)).toBeInTheDocument()
+    expect(screen.queryByText(/looking up cards/i)).not.toBeInTheDocument()
+    expect(screen.getByText('Charizard')).toBeInTheDocument()
+    expect(screen.getByText('Pikachu')).toBeInTheDocument()
+    // 1500 - 1000 = 500ms, 1800 - 1000 = 800ms — the timing data that
+    // the bug report needs surfaced after the run.
+    expect(screen.getByText('500ms')).toBeInTheDocument()
+    expect(screen.getByText('800ms')).toBeInTheDocument()
+  })
+
+  it('freezes the spinner for abandoned mid-stage lines once the run ends', () => {
+    const { container } = render(<ProcessingQueue />)
+    // Stage-color class `text-sky-500` belongs to `looking_up`; that
+    // chip is the Mew line still spinning conceptually. After the run
+    // we want the icon present but not animating.
+    const spinning = container.querySelectorAll('.animate-spin')
+    expect(spinning.length).toBe(0)
+  })
+
+  it('still hides the queue entirely when there are no lines to show', () => {
+    mockState.processingLines = []
+    const { container } = render(<ProcessingQueue />)
+    expect(container.firstChild).toBeNull()
   })
 })

--- a/web/src/components/ProcessingQueue.tsx
+++ b/web/src/components/ProcessingQueue.tsx
@@ -1,12 +1,13 @@
 /**
- * ProcessingQueue — per-line status panel shown while a bulk lookup is
- * in flight. Each input line moves through the lookup pipeline one stage
- * at a time (parsed → looking up → fallback / URL hint → pricing →
- * resolved / no match / error), driven by the `stage` field on the SSE
- * stream. The chip's color and label reflect the latest stage; a hover
- * tooltip reports how long the line has spent in it. The panel unmounts
- * as soon as the run finishes (whether by completion, Stop, or error) so
- * abandoned pending entries don't spin indefinitely.
+ * ProcessingQueue — per-line status panel for a bulk lookup. Each input
+ * line moves through the lookup pipeline one stage at a time (parsed →
+ * looking up → fallback / URL hint → pricing → resolved / no match /
+ * error), driven by the `stage` field on the SSE stream. The chip's
+ * color and label reflect the latest stage; a hover tooltip reports
+ * how long the line spent in it. The panel stays mounted after a run
+ * completes so per-line elapsed badges remain readable for benchmarking
+ * — see #376. Spinner animation freezes once the run ends so any line
+ * that was abandoned mid-stage (Stop, SSE error) doesn't spin forever.
  */
 import { useEffect, useState } from 'react'
 import {
@@ -76,18 +77,15 @@ export function ProcessingQueue() {
   const now = useNow(isRunning)
 
   if (processingLines.length === 0) return null
-  // Hide as soon as the run finishes — covers both the success case
-  // (where every line is already resolved/error) and the abort/error
-  // case (where some lines would otherwise stay pending forever).
-  if (!isRunning) return null
 
   const done = processingLines.filter((l) => l.status !== 'pending').length
   const total = processingLines.length
+  const heading = isRunning ? 'Looking up cards…' : 'Last lookup'
 
   return (
     <div className="rounded-md border border-sand-300 bg-sand-100 dark:border-husk-50 dark:bg-husk-200/60 px-4 py-3">
       <div className="mb-2 flex items-center justify-between gap-2">
-        <span className="text-xs font-medium text-coconut-500 dark:text-sand-300">Looking up cards…</span>
+        <span className="text-xs font-medium text-coconut-500 dark:text-sand-300">{heading}</span>
         <div className="flex items-center gap-3">
           <button
             type="button"
@@ -115,6 +113,7 @@ export function ProcessingQueue() {
             runStartedAt={runStartedAt}
             showTimer={settings.showTimer}
             now={now}
+            isRunning={isRunning}
           />
         ))}
       </ul>
@@ -142,15 +141,19 @@ function StageLegend() {
   )
 }
 
-function stageIcon(line: ProcessingLine) {
+function stageIcon(line: ProcessingLine, isRunning: boolean) {
+  // Freeze the spinner once the run ends — an abandoned mid-stage line
+  // (Stop, SSE error) shouldn't spin indefinitely now that the queue
+  // persists post-run.
+  const spinClass = isRunning ? 'animate-spin' : ''
   // Before the first stage frame arrives, fall back to the generic
   // in-flight spinner (matches the historical pending appearance).
   if (!line.stage) {
-    return <Loader2 size={12} className="flex-shrink-0 animate-spin text-sky-500 dark:text-sky-300" />
+    return <Loader2 size={12} className={`flex-shrink-0 ${spinClass} text-sky-500 dark:text-sky-300`} />
   }
   const cfg = STAGE_CONFIG[line.stage]
   if (!cfg.terminal) {
-    return <Loader2 size={12} className={`flex-shrink-0 animate-spin ${cfg.color}`} />
+    return <Loader2 size={12} className={`flex-shrink-0 ${spinClass} ${cfg.color}`} />
   }
   if (line.stage === 'resolved') {
     return <CheckCircle2 size={12} className={`flex-shrink-0 ${cfg.color}`} />
@@ -166,11 +169,13 @@ function LineStatus({
   runStartedAt,
   showTimer,
   now,
+  isRunning,
 }: {
   line: ProcessingLine
   runStartedAt: number | null
   showTimer: boolean
   now: number
+  isRunning: boolean
 }) {
   const cfg = line.stage ? STAGE_CONFIG[line.stage] : null
 
@@ -201,7 +206,7 @@ function LineStatus({
       title={tooltip}
       aria-label={tooltip ? `${line.line} — ${tooltip}` : undefined}
     >
-      {stageIcon(line)}
+      {stageIcon(line, isRunning)}
       <span className="truncate">{line.line}</span>
       {cfg && (
         <span className={`ml-auto flex-shrink-0 text-[10px] ${cfg.color}`}>{cfg.label}</span>


### PR DESCRIPTION
Closes #376.

## What

[ProcessingQueue](web/src/components/ProcessingQueue.tsx) used to early-return `null` the moment `isRunning` flipped to false, so the per-stage chips and elapsed badges vanished as soon as the SSE stream ended. The fix is option (1) from the issue: drop the early return, swap the heading to **"Last lookup"** when `!isRunning`, and freeze the spinner animation post-run so an abandoned mid-stage line (Stop / SSE error) doesn't spin forever. The empty-state freshness gate (`processingLines.length === 0`) and the global [LookupTimer](web/src/components/LookupTimer.tsx) summary are unchanged.

## Why

Post-#369 the cache survives redeploys and the [pre-Scrydex catalog-warm epic #368](https://github.com/mgzwarrior/mgz-pkmn/issues/368) is making per-card latency the load-bearing perf metric — a pre-warmed card should resolve at ~5 ms, a cache miss should look obviously different. Without per-line timing visible after the run there's no way to spot which cards were cache hits, debug a slow outlier, or A/B against a different warm strategy.

## How to verify

```bash
cd web && npm run dev   # in one shell
make dev                # API in another
```

Open http://localhost:5173, toggle on **Settings → Show lookup timer**, paste:

```
Charizard | Base Set | 4/102
Pikachu | Jungle
asdf nonexistent card
```

Click **Look up**, then once the run finishes:

- The queue stays mounted under a **Last lookup** heading (was previously gone).
- Each line still shows its terminal stage chip + an elapsed-ms badge: in my local run that was `Resolved · 0ms`, `Resolved · 1ms`, `No match · 309ms`.
- No spinner is animating — the `Mew` / abandoned-pending path was tested by Stopping a longer run mid-stream; the chip stays at its last stage but doesn't spin.
- Kick off another lookup; the queue gets replaced atomically with the new pending rows (no leftover lines from the prior run).

Three new tests in `ProcessingQueue.test.tsx` pin the post-run visibility branch (heading swap, badges still readable, no `animate-spin` anywhere, and the empty-state still hides the queue entirely).

<!-- Screenshot inline in chat — drag-and-drop into this body to attach. -->

## Related

- [#310](https://github.com/mgzwarrior/mgz-pkmn/issues/310) — `X-Cache` header (will pair with this so a row reads `5 ms · HIT` vs `812 ms · MISS` at a glance).
- [#368](https://github.com/mgzwarrior/mgz-pkmn/issues/368) — pre-Scrydex catalog-warm epic; per-card timing is how we'll validate that pays off.