### PR TITLE
feat(api): pkmn cache warm-card-images + self-hosted SPA image serving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- API + CLI: **Self-hosted per-card images via `pkmn cache warm-card-images`**
+  ([#371](https://github.com/mgzwarrior/mgz-pkmn/issues/371)). Phase 2
+  of the pre-Scrydex catalog-warm epic
+  ([#368](https://github.com/mgzwarrior/mgz-pkmn/issues/368)). Three
+  pieces wired together so the SPA gets self-hosted card images
+  transparently: (1) a new `pkmn cache warm-card-images` subcommand
+  with `--sizes / --max-bytes / --skip-existing / --throttle-ms /
+  --prefer-popular` flags walks the catalog and downloads `large` and
+  `small` image bytes into `cache/images/cards/{size}/<card_id>.<ext>`
+  on the persistent disk (warmer in
+  [`src/mgz_pkmn/card_images.py`](src/mgz_pkmn/card_images.py)); (2)
+  a new `GET /api/v1/cards/{card_id}/image/{size}` route in
+  [`api/routes/cards.py`](api/routes/cards.py) streams those files
+  with a 30-day immutable browser-cache header, mirroring the existing
+  `get_set_logo` route's 404-on-miss contract; (3) the lookup
+  response and `/sets/{id}/cards` trim now rewrite
+  `images.{large,small}` and `thumb` URLs to point at that route
+  whenever the file is cached on disk — cache miss leaves the upstream
+  pokemontcg.io URL in place so cold deploys still serve a working
+  `<img>`. A new `MGZ_PKMN_WARM_CARD_IMAGES_ON_STARTUP=1` env var
+  (default off, separate from the existing two warm flags) opts a
+  deploy into the runtime image warm bootstrap. New `CacheStats`
+  fields (`card_images_warm_timestamp`, `card_images_warm_count`,
+  `card_images_warm_bytes`, `card_images_warm_budget_reached`)
+  surface state in `pkmn cache stats` and `GET /api/v1/cache/stats`.
+  Pinned by 25+ tests in `tests/test_warm_card_images.py` and
+  `tests/test_card_images_api.py`.
+
 ### Fixed
 
 - Web: **Per-line timing chips now persist after a bulk lookup

--- a/api/main.py
+++ b/api/main.py
@@ -24,6 +24,7 @@ from starlette.responses import Response
 
 from mgz_pkmn import __version__
 from mgz_pkmn import cache as disk_cache
+from mgz_pkmn.card_images import warm_card_images
 from mgz_pkmn.lookup import warm_cards, warm_concepts, warm_set_cards
 from mgz_pkmn.set_cards import warm_set_images
 from mgz_pkmn.sources import TCGClient, TCGDexClient
@@ -37,6 +38,7 @@ from .routes import (
     cache as cache_route,
 )
 from .routes import (
+    cards,
     changelog,
     export,
     lookup,
@@ -89,6 +91,10 @@ _WARM_ON_STARTUP_ENV = "MGZ_PKMN_WARM_ON_STARTUP"
 # ~18,000 per-card cache entries. Opt-in only; default off so a generic
 # `MGZ_PKMN_WARM_ON_STARTUP=1` deploy doesn't accidentally trip it.
 _WARM_CARDS_ON_STARTUP_ENV = "MGZ_PKMN_WARM_CARDS_ON_STARTUP"
+# Separate env var for the per-card *image* warm pass (Phase 2 of #368)
+# because it's even heavier than the structural warm — a full pass
+# downloads ~36K image files (~3-5 GB on disk). Always opt-in.
+_WARM_CARD_IMAGES_ON_STARTUP_ENV = "MGZ_PKMN_WARM_CARD_IMAGES_ON_STARTUP"
 
 
 def _warm_concepts_in_background() -> None:
@@ -251,6 +257,59 @@ def _warm_cards_in_background() -> None:
     threading.Thread(target=_run, name="card-warm", daemon=True).start()
 
 
+def _warm_card_images_in_background() -> None:
+    """Run the per-card image warm pass on a daemon thread.
+
+    Phase 2 of the pre-Scrydex catalog-warm epic (#368). Gated by the
+    on-disk `card_images_warm.json` freshness manifest — if a warm
+    pass landed within the last week, skip and log "already fresh".
+    Errors are logged and swallowed so a failed warm doesn't crash the
+    service.
+
+    Heaviest of all the warmers by an order of magnitude: a fresh pass
+    downloads ~36K image files (large + small for ~18K cards) for a
+    cumulative ~3-5 GB on disk. Always opt-in via the separate
+    `MGZ_PKMN_WARM_CARD_IMAGES_ON_STARTUP` env var — even a deploy
+    with the standard `MGZ_PKMN_WARM_ON_STARTUP=1` and
+    `MGZ_PKMN_WARM_CARDS_ON_STARTUP=1` won't trigger it accidentally."""
+    if disk_cache.card_images_warm_is_fresh():
+        _log.info("card-images cache fresh; skipping startup warm")
+        return
+
+    # Same throttle reasoning as `_warm_cards_in_background`. The image
+    # CDN is more forgiving than the API surface, but a 500 ms set-level
+    # sleep keeps us safely off any per-IP rate limit Cloudfront might
+    # apply during a long sequential pull.
+    _DEFAULT_STARTUP_THROTTLE_MS = 500
+
+    def _run() -> None:
+        try:
+            pkmn = TCGClient(api_key=os.environ.get("POKEMONTCG_IO_API_KEY"))
+            result = warm_card_images(pkmn, throttle_ms=_DEFAULT_STARTUP_THROTTLE_MS)
+            disk_cache.write_card_images_warm(
+                images_warmed=result.images_warmed,
+                images_failed=result.images_failed,
+                bytes_written=result.bytes_written,
+                budget_reached=result.budget_reached,
+                sets_attempted=result.sets_attempted,
+                sets_failed=result.sets_failed,
+            )
+            _log.info(
+                "card-images warm complete: %d images warmed (%d bytes) "
+                "across %d sets (%d failed, %d sets missed, budget_reached=%s)",
+                result.images_warmed,
+                result.bytes_written,
+                result.sets_attempted,
+                result.images_failed,
+                len(result.sets_failed),
+                result.budget_reached,
+            )
+        except Exception:
+            _log.exception("card-images warm failed; service running without primed card images")
+
+    threading.Thread(target=_run, name="card-images-warm", daemon=True).start()
+
+
 class SPAStaticFiles(StaticFiles):
     """StaticFiles that disables browser caching for ``index.html``.
 
@@ -291,6 +350,19 @@ def _warm_cards_on_startup_enabled() -> bool:
     cache entries on a fresh disk) and we don't want it firing implicitly
     every time someone flips on the standard `MGZ_PKMN_WARM_ON_STARTUP`."""
     return os.environ.get(_WARM_CARDS_ON_STARTUP_ENV, "").strip() in ("1", "true", "True")
+
+
+def _warm_card_images_on_startup_enabled() -> bool:
+    """True when `MGZ_PKMN_WARM_CARD_IMAGES_ON_STARTUP` is set truthy.
+
+    Same parse rules as the other gates. Always opt-in because the
+    image warm pass is the heaviest of all (~3-5 GB on disk for the
+    full catalog) — see Phase 2 of #368."""
+    return os.environ.get(_WARM_CARD_IMAGES_ON_STARTUP_ENV, "").strip() in (
+        "1",
+        "true",
+        "True",
+    )
 
 
 @asynccontextmanager
@@ -346,6 +418,11 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     if _warm_cards_on_startup_enabled():
         _warm_cards_in_background()
 
+    # Heaviest of all: ~36K image downloads (~3-5 GB) on a cold disk.
+    # Always behind its own flag — see Phase 2 of #368.
+    if _warm_card_images_on_startup_enabled():
+        _warm_card_images_in_background()
+
     yield
 
 
@@ -376,6 +453,7 @@ app.include_router(lookup.router, prefix="/api/v1", tags=["lookup"])
 app.include_router(export.router, prefix="/api/v1", tags=["export"])
 app.include_router(sets.router, prefix="/api/v1", tags=["sets"])
 app.include_router(set_cards.router, prefix="/api/v1", tags=["set-cards"])
+app.include_router(cards.router, prefix="/api/v1", tags=["cards"])
 app.include_router(overrides.router, prefix="/api/v1", tags=["overrides"])
 app.include_router(changelog.router, prefix="/api/v1", tags=["changelog"])
 app.include_router(runs.router, prefix="/api/v1", tags=["runs"])

--- a/api/routes/cache.py
+++ b/api/routes/cache.py
@@ -52,6 +52,10 @@ def _zeroed_snapshot() -> disk_cache.CacheStats:
         card_warm_timestamp=None,
         card_warm_count=0,
         card_warm_failed_count=0,
+        card_images_warm_timestamp=None,
+        card_images_warm_count=0,
+        card_images_warm_bytes=0,
+        card_images_warm_budget_reached=False,
     )
 
 

--- a/api/routes/cards.py
+++ b/api/routes/cards.py
@@ -103,7 +103,7 @@ _PROBE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".webp", ".svg")
 
 
 @router.get("/cards/{card_id}/image/{size}")
-async def get_card_image(
+def get_card_image(
     card_id: Annotated[str, _CARD_ID_PATH],
     size: Literal["large", "small"],
 ) -> Response:
@@ -120,6 +120,14 @@ async def get_card_image(
     card-image payloads are small (~80-150 KB) and reading them into
     memory keeps the user-controlled `card_id` from flowing into
     FastAPI's file-serving sink.
+
+    Declared as a plain `def` (not `async def`) so FastAPI runs it in
+    its threadpool — the disk reads below are blocking, and an
+    `async def` would stall the event loop under load. The previous
+    `FileResponse`-based shape sidestepped this because
+    `FileResponse` does the read with `sendfile` in a threadpool
+    internally; switching to bytes-in-`Response` lost that, so the
+    plain-def is what restores it (caught in Copilot review of #371).
 
     The route resolves the filename itself rather than delegating to
     `disk_cache.read_image` — `read_image` calls `_safe_image_key`

--- a/api/routes/cards.py
+++ b/api/routes/cards.py
@@ -52,23 +52,29 @@ def rewrite_card_image_urls(card: dict | None, *, card_id: str | None = None) ->
     id or a `None` card short-circuits to the input unchanged — we
     never invent a route for something we can't address.
 
-    Mutates and returns the same dict (no deep copy) — every caller in
-    the boundary already projects card data into a new dict before
-    serialising, so the mutation can't leak into shared state."""
+    Always returns a *fresh* dict (never mutates the input). The
+    `Row.card` payload that flows through `lookup._row_to_dict` is
+    later persisted via `row_to_run_row(card_json=row.card)` when the
+    `/bulk` SSE stream completes, and in-place rewriting would leak
+    `/api/v1/cards/...` URLs into stored run history (caught in
+    Copilot review of #371). The shallow copy is cheap (cards are
+    small dicts) and bounds the side effect to this single response.
+    """
     if card is None:
         return None
     images = card.get("images")
-    if not isinstance(images, dict):
-        return card
     resolved_id = card_id or card.get("id")
-    if not resolved_id:
-        return card
-    rewritten = dict(images)
+    if not isinstance(images, dict) or not resolved_id:
+        # No rewrite to do — still return a copy so callers don't have
+        # to reason about whether we returned the input or a fresh dict.
+        return dict(card)
+    rewritten_images = dict(images)
     for size, category in (("large", LARGE_CATEGORY), ("small", SMALL_CATEGORY)):
-        if rewritten.get(size) and disk_cache.read_image(category, resolved_id) is not None:
-            rewritten[size] = _CARD_IMAGE_URL_TEMPLATE.format(card_id=resolved_id, size=size)
-    card["images"] = rewritten
-    return card
+        if rewritten_images.get(size) and disk_cache.read_image(category, resolved_id) is not None:
+            rewritten_images[size] = _CARD_IMAGE_URL_TEMPLATE.format(card_id=resolved_id, size=size)
+    result = dict(card)
+    result["images"] = rewritten_images
+    return result
 
 
 # Pokemon TCG card ids are short alphanumeric strings with a `-` between
@@ -93,7 +99,7 @@ _SAFE_CARD_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,96}$")
 # Extensions to probe in cache lookup order. Mirrors
 # `cache._IMAGE_EXTENSIONS` but kept local so the route never imports
 # a path-shaped value from a tainted code path.
-_PROBE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".webp")
+_PROBE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".webp", ".svg")
 
 
 @router.get("/cards/{card_id}/image/{size}")

--- a/api/routes/cards.py
+++ b/api/routes/cards.py
@@ -18,6 +18,8 @@ Phase 2 of the pre-Scrydex catalog-warm epic (#368) — partner of the
 from __future__ import annotations
 
 import mimetypes
+import os
+import re
 from typing import Annotated, Literal
 
 from fastapi import APIRouter, HTTPException, Response
@@ -81,6 +83,18 @@ _CARD_ID_PATH = PathParam(pattern=r"^[A-Za-z0-9_-]{1,96}$", max_length=96)
 # error rather than a 404 the operator has to debug.
 _SIZE_BY_NAME = {"large": LARGE_CATEGORY, "small": SMALL_CATEGORY}
 
+# Re-validation regex used by the route. FastAPI's `_CARD_ID_PATH`
+# already enforces the same pattern at request parse time, but the
+# explicit `re.fullmatch` inside the handler is the canonical
+# sanitiser shape CodeQL's path-injection query recognises — and the
+# guard is genuinely cheap, so the belt-and-braces is free.
+_SAFE_CARD_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,96}$")
+
+# Extensions to probe in cache lookup order. Mirrors
+# `cache._IMAGE_EXTENSIONS` but kept local so the route never imports
+# a path-shaped value from a tainted code path.
+_PROBE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".webp")
+
 
 @router.get("/cards/{card_id}/image/{size}")
 async def get_card_image(
@@ -99,32 +113,61 @@ async def get_card_image(
     Returns the bytes via `Response` rather than `FileResponse` because
     card-image payloads are small (~80-150 KB) and reading them into
     memory keeps the user-controlled `card_id` from flowing into
-    FastAPI's file-serving sink — CodeQL's path-traversal query
-    doesn't recognise the regex on `_CARD_ID_PATH` as a sanitiser
-    even though it makes traversal structurally impossible. Read +
-    return is the cleanest sever of that taint flow.
+    FastAPI's file-serving sink.
+
+    The route resolves the filename itself rather than delegating to
+    `disk_cache.read_image` — `read_image` calls `_safe_image_key`
+    (an `re.sub`-based collapse), which is a real sanitiser but is
+    not one CodeQL's path-injection query recognises. The explicit
+    `re.fullmatch` guard + `os.path.commonpath` containment check
+    below ARE recognised sanitisers, so the analyzer can prove the
+    file open is safe.
     """
+    # Re-validate explicitly. FastAPI's path regex already enforced
+    # this, but the in-handler check is what CodeQL's tainted_path
+    # query needs to see as a sanitiser barrier.
+    if not _SAFE_CARD_ID_RE.fullmatch(card_id):
+        raise HTTPException(status_code=404)
+
     category = _SIZE_BY_NAME[size]
-    path = disk_cache.read_image(category, card_id)
-    if path is None:
-        raise HTTPException(
-            status_code=404,
-            detail=(
-                f"no cached {size} image for card '{card_id}' — "
-                "run `pkmn cache warm-card-images` to populate the catalog"
-            ),
+    cache_dir = os.path.realpath(
+        os.path.join(str(disk_cache._cache_root_path()), "images", category)
+    )
+
+    for ext in _PROBE_EXTENSIONS:
+        candidate = os.path.realpath(os.path.join(cache_dir, card_id + ext))
+        # `os.path.commonpath([safe_root, candidate]) == safe_root` is
+        # the canonical CodeQL-recognised containment check. After it
+        # passes, `candidate` is provably inside `cache_dir`.
+        try:
+            if os.path.commonpath([cache_dir, candidate]) != cache_dir:
+                continue
+        except ValueError:
+            # commonpath raises on mixed drives (Windows) — treat as miss.
+            continue
+        if not os.path.isfile(candidate):
+            continue
+        try:
+            with open(candidate, "rb") as f:
+                content = f.read()
+        except OSError:
+            # File vanished between the existence check and the read
+            # (concurrent eviction, network FS hiccup). Treat as a miss.
+            continue
+        media_type, _ = mimetypes.guess_type(candidate)
+        return Response(
+            content=content,
+            media_type=media_type or "application/octet-stream",
+            # 30-day immutable browser cache — card images never change
+            # once a set ships. Mirrors `get_set_logo` in
+            # api/routes/sets.py.
+            headers={"Cache-Control": "public, max-age=2592000, immutable"},
         )
-    try:
-        content = path.read_bytes()
-    except OSError:
-        # File vanished between the existence check and the read
-        # (concurrent eviction, network FS hiccup). Treat as a miss.
-        raise HTTPException(status_code=404) from None
-    media_type, _ = mimetypes.guess_type(path.name)
-    return Response(
-        content=content,
-        media_type=media_type or "application/octet-stream",
-        # 30-day immutable browser cache — card images never change once
-        # a set ships. Mirrors `get_set_logo` in api/routes/sets.py.
-        headers={"Cache-Control": "public, max-age=2592000, immutable"},
+
+    raise HTTPException(
+        status_code=404,
+        detail=(
+            f"no cached {size} image for card '{card_id}' — "
+            "run `pkmn cache warm-card-images` to populate the catalog"
+        ),
     )

--- a/api/routes/cards.py
+++ b/api/routes/cards.py
@@ -107,9 +107,19 @@ async def get_card_image(
                 "run `pkmn cache warm-card-images` to populate the catalog"
             ),
         )
-    media_type, _ = mimetypes.guess_type(path.name)
+    # Defense-in-depth: confirm the resolved path is inside the cache
+    # root before streaming. `card_id` is already doubly-sanitised
+    # (FastAPI path regex + `_safe_image_key` inside `read_image`), so
+    # this check should never fire — but it's the canonical CodeQL
+    # sanitiser pattern for path-traversal taint analysis, and a
+    # 404-on-mismatch leaks no info even if the upstream guards drift.
+    cache_root = disk_cache._cache_root_path().resolve()
+    resolved = path.resolve()
+    if not resolved.is_relative_to(cache_root):
+        raise HTTPException(status_code=404)
+    media_type, _ = mimetypes.guess_type(resolved.name)
     return FileResponse(
-        path,
+        resolved,
         media_type=media_type or "application/octet-stream",
         # 30-day immutable browser cache — card images never change once
         # a set ships. Mirrors `get_set_logo` in api/routes/sets.py.

--- a/api/routes/cards.py
+++ b/api/routes/cards.py
@@ -20,9 +20,8 @@ from __future__ import annotations
 import mimetypes
 from typing import Annotated, Literal
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Response
 from fastapi import Path as PathParam
-from fastapi.responses import FileResponse
 
 from mgz_pkmn import cache as disk_cache
 from mgz_pkmn.card_images import LARGE_CATEGORY, SMALL_CATEGORY
@@ -87,8 +86,8 @@ _SIZE_BY_NAME = {"large": LARGE_CATEGORY, "small": SMALL_CATEGORY}
 async def get_card_image(
     card_id: Annotated[str, _CARD_ID_PATH],
     size: Literal["large", "small"],
-) -> FileResponse:
-    """Stream the cached card image, or 404 if not cached.
+) -> Response:
+    """Return the cached card image bytes, or 404 if not cached.
 
     Reads from `cache/images/cards/{large,small}/<card_id>.<ext>`,
     populated by `pkmn cache warm-card-images` or by the runtime
@@ -96,6 +95,14 @@ async def get_card_image(
     Strictly a cache reader — never fetches upstream on miss, so a cold
     cache surfaces a clean 404 with a hint about the warmer instead of
     hammering pokemontcg.io's CDN for every image render.
+
+    Returns the bytes via `Response` rather than `FileResponse` because
+    card-image payloads are small (~80-150 KB) and reading them into
+    memory keeps the user-controlled `card_id` from flowing into
+    FastAPI's file-serving sink — CodeQL's path-traversal query
+    doesn't recognise the regex on `_CARD_ID_PATH` as a sanitiser
+    even though it makes traversal structurally impossible. Read +
+    return is the cleanest sever of that taint flow.
     """
     category = _SIZE_BY_NAME[size]
     path = disk_cache.read_image(category, card_id)
@@ -107,19 +114,15 @@ async def get_card_image(
                 "run `pkmn cache warm-card-images` to populate the catalog"
             ),
         )
-    # Defense-in-depth: confirm the resolved path is inside the cache
-    # root before streaming. `card_id` is already doubly-sanitised
-    # (FastAPI path regex + `_safe_image_key` inside `read_image`), so
-    # this check should never fire — but it's the canonical CodeQL
-    # sanitiser pattern for path-traversal taint analysis, and a
-    # 404-on-mismatch leaks no info even if the upstream guards drift.
-    cache_root = disk_cache._cache_root_path().resolve()
-    resolved = path.resolve()
-    if not resolved.is_relative_to(cache_root):
-        raise HTTPException(status_code=404)
-    media_type, _ = mimetypes.guess_type(resolved.name)
-    return FileResponse(
-        resolved,
+    try:
+        content = path.read_bytes()
+    except OSError:
+        # File vanished between the existence check and the read
+        # (concurrent eviction, network FS hiccup). Treat as a miss.
+        raise HTTPException(status_code=404) from None
+    media_type, _ = mimetypes.guess_type(path.name)
+    return Response(
+        content=content,
         media_type=media_type or "application/octet-stream",
         # 30-day immutable browser cache — card images never change once
         # a set ships. Mirrors `get_set_logo` in api/routes/sets.py.

--- a/api/routes/cards.py
+++ b/api/routes/cards.py
@@ -1,0 +1,117 @@
+"""Per-card HTTP surface — currently just the cached image-serving route.
+
+`GET /api/v1/cards/{card_id}/image/{size}` streams the cached card image
+out of the unified disk image cache (see `mgz_pkmn.cache.read_image`).
+Returns 404 when the requested card isn't in the cache yet — the
+boundary URL-rewriter in `api/routes/lookup.py` and
+`api/routes/sets.py` swaps `images.small/large` URLs to this route
+only when the file is on disk, so a deployed instance never serves a
+broken `<img>` to the SPA: a cache miss means the SPA still sees the
+upstream pokemontcg.io URL.
+
+Phase 2 of the pre-Scrydex catalog-warm epic (#368) — partner of the
+`pkmn cache warm-card-images` command and the
+`MGZ_PKMN_WARM_CARD_IMAGES_ON_STARTUP=1` runtime hook. See ADR-0014
+(if/when written) for the broader self-hosted-images rationale.
+"""
+
+from __future__ import annotations
+
+import mimetypes
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, HTTPException
+from fastapi import Path as PathParam
+from fastapi.responses import FileResponse
+
+from mgz_pkmn import cache as disk_cache
+from mgz_pkmn.card_images import LARGE_CATEGORY, SMALL_CATEGORY
+
+router = APIRouter()
+
+
+# Relative-URL template for the boundary rewriter — same-origin so the
+# SPA's `<img>` tag picks the right host without us having to thread
+# `request.base_url` through every projection. Mirrors how
+# `web/src/api/client.ts:setLogoUrl` builds `/api/v1/sets/{id}/logo`.
+_CARD_IMAGE_URL_TEMPLATE = "/api/v1/cards/{card_id}/image/{size}"
+
+
+def rewrite_card_image_urls(card: dict | None, *, card_id: str | None = None) -> dict | None:
+    """Return `card` with `images.{large,small}` swapped to the API route
+    whenever the underlying file is present on disk.
+
+    Cache miss → returns the upstream URL untouched. That graceful
+    degradation matters: a fresh deploy whose warm pass hasn't
+    completed yet still serves a working `<img src>` to the SPA, just
+    pointed at pokemontcg.io instead of our disk.
+
+    `card_id` defaults to `card['id']`; passing it explicitly avoids
+    re-reading the field for callers that already have it. A missing
+    id or a `None` card short-circuits to the input unchanged — we
+    never invent a route for something we can't address.
+
+    Mutates and returns the same dict (no deep copy) — every caller in
+    the boundary already projects card data into a new dict before
+    serialising, so the mutation can't leak into shared state."""
+    if card is None:
+        return None
+    images = card.get("images")
+    if not isinstance(images, dict):
+        return card
+    resolved_id = card_id or card.get("id")
+    if not resolved_id:
+        return card
+    rewritten = dict(images)
+    for size, category in (("large", LARGE_CATEGORY), ("small", SMALL_CATEGORY)):
+        if rewritten.get(size) and disk_cache.read_image(category, resolved_id) is not None:
+            rewritten[size] = _CARD_IMAGE_URL_TEMPLATE.format(card_id=resolved_id, size=size)
+    card["images"] = rewritten
+    return card
+
+
+# Pokemon TCG card ids are short alphanumeric strings with a `-` between
+# the set and the number (e.g. `sv8-1`, `base1-4`). Mirror the set-id
+# guard in api/routes/sets.py — same character class, same `max_length`
+# upper bound. 96 chars is comfortable headroom over the longest id we
+# see today (about 12) and still bounds pathological inputs.
+_CARD_ID_PATH = PathParam(pattern=r"^[A-Za-z0-9_-]{1,96}$", max_length=96)
+
+# `large` and `small` are the only two image variants pokemontcg.io
+# exposes — keep the path enum tight so a typo gets a 422 with a clear
+# error rather than a 404 the operator has to debug.
+_SIZE_BY_NAME = {"large": LARGE_CATEGORY, "small": SMALL_CATEGORY}
+
+
+@router.get("/cards/{card_id}/image/{size}")
+async def get_card_image(
+    card_id: Annotated[str, _CARD_ID_PATH],
+    size: Literal["large", "small"],
+) -> FileResponse:
+    """Stream the cached card image, or 404 if not cached.
+
+    Reads from `cache/images/cards/{large,small}/<card_id>.<ext>`,
+    populated by `pkmn cache warm-card-images` or by the runtime
+    on-startup hook (`MGZ_PKMN_WARM_CARD_IMAGES_ON_STARTUP=1`).
+    Strictly a cache reader — never fetches upstream on miss, so a cold
+    cache surfaces a clean 404 with a hint about the warmer instead of
+    hammering pokemontcg.io's CDN for every image render.
+    """
+    category = _SIZE_BY_NAME[size]
+    path = disk_cache.read_image(category, card_id)
+    if path is None:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"no cached {size} image for card '{card_id}' — "
+                "run `pkmn cache warm-card-images` to populate the catalog"
+            ),
+        )
+    media_type, _ = mimetypes.guess_type(path.name)
+    return FileResponse(
+        path,
+        media_type=media_type or "application/octet-stream",
+        # 30-day immutable browser cache — card images never change once
+        # a set ships. Mirrors `get_set_logo` in api/routes/sets.py.
+        headers={"Cache-Control": "public, max-age=2592000, immutable"},
+    )

--- a/api/routes/lookup.py
+++ b/api/routes/lookup.py
@@ -29,6 +29,7 @@ from mgz_pkmn.spreadsheet import Row
 from ..db.models import Run
 from ..db.serialize import build_run_summary, row_to_run_row
 from ..db.session import get_session_factory
+from .cards import rewrite_card_image_urls
 
 logger = logging.getLogger(__name__)
 
@@ -112,9 +113,12 @@ def _terminal_stage(matched: bool, reason: str) -> str:
 def _row_to_dict(row: Row, reason: str) -> dict[str, Any]:
     card = row.card or {}
     matched = row.card is not None
+    # Rewrite cached image URLs to our self-hosted route (#371). Cache
+    # miss leaves the upstream URL in place so the SPA still renders.
+    serialised_card = rewrite_card_image_urls(card if card else None)
     return {
         "query": _query_to_dict(row.query),
-        "card": card if card else None,
+        "card": serialised_card,
         "pricing": _pricing_to_dict(row.pricing),
         "tag": row.tag,
         "matched": matched,

--- a/api/routes/sets.py
+++ b/api/routes/sets.py
@@ -37,6 +37,7 @@ from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import FileResponse
 
 from mgz_pkmn import cache as disk_cache
+from mgz_pkmn.card_images import SMALL_CATEGORY
 from mgz_pkmn.pricing import extract_pricing
 from mgz_pkmn.sources import TCGClient
 
@@ -165,19 +166,25 @@ def _trim_card(card: dict[str, Any]) -> dict[str, Any]:
     grid, filter chips, or add-to-list bridge actually uses."""
     images = card.get("images") or {}
     pricing = extract_pricing(card, None)
+    card_id = card.get("id")
+    # `images.small` is the thumbnail-sized variant pokemontcg.io
+    # exposes (~245x342). The grid uses it directly — no extra
+    # server-side resize. `large` is intentionally omitted; the
+    # full-size art lives behind a single-card hover/click.
+    thumb = images.get("small")
+    # Phase 2 (#371): rewrite to our self-hosted route when the image
+    # is cached on disk. Cache miss leaves the upstream URL in place
+    # so a cold cache still renders a working thumb.
+    if thumb and card_id and disk_cache.read_image(SMALL_CATEGORY, card_id) is not None:
+        thumb = f"/api/v1/cards/{card_id}/image/small"
     return {
-        "id": card.get("id"),
+        "id": card_id,
         "name": card.get("name"),
         "number": card.get("number"),
         "rarity": card.get("rarity"),
         "supertype": card.get("supertype"),
         "subtypes": card.get("subtypes") or [],
-        # `images.small` is the thumbnail-sized variant pokemontcg.io
-        # exposes (~245x342). The grid uses it directly — no extra
-        # server-side resize. `large` is intentionally omitted; the
-        # full-size art lives behind a single-card hover/click and can
-        # be lazy-fetched from pokemontcg.io's CDN directly.
-        "thumb": images.get("small"),
+        "thumb": thumb,
         "market": pricing.market,
     }
 

--- a/src/mgz_pkmn/cache.py
+++ b/src/mgz_pkmn/cache.py
@@ -71,11 +71,13 @@ _CONCEPT_WARM_FILE = "concept_warm.json"
 _SET_CARDS_WARM_FILE = "set_cards_warm.json"
 _SETS_WARM_FILE = "sets_warm.json"
 _CARD_WARM_FILE = "card_warm.json"
+_CARD_IMAGES_WARM_FILE = "card_images_warm.json"
 OVERRIDES_SCHEMA_VERSION = 1
 CONCEPT_WARM_SCHEMA_VERSION = 1
 SET_CARDS_WARM_SCHEMA_VERSION = 1
 SETS_WARM_SCHEMA_VERSION = 1
 CARD_WARM_SCHEMA_VERSION = 1
+CARD_IMAGES_WARM_SCHEMA_VERSION = 1
 _IMAGES_SUBDIR = "images"
 # Allowed image extensions for read-side discovery; write-side derives the
 # extension from the source URL but normalises it through this list so an
@@ -138,6 +140,18 @@ class CacheStats:
     card_warm_timestamp: float | None
     card_warm_count: int
     card_warm_failed_count: int
+    # Card-images warm slice — populated from `card_images_warm.json`,
+    # written by `pkmn cache warm-card-images`. Phase 2 of the
+    # pre-Scrydex catalog-warm epic (#368). `card_images_warm_count` is
+    # how many (card, size) image pairs landed on disk during the most
+    # recent pass; `card_images_warm_bytes` is the cumulative bytes
+    # downloaded by that pass (zero on a fully-skipped re-warm).
+    # `card_images_warm_budget_reached` mirrors whether the pass exited
+    # because `--max-bytes` was hit.
+    card_images_warm_timestamp: float | None
+    card_images_warm_count: int
+    card_images_warm_bytes: int
+    card_images_warm_budget_reached: bool
 
 
 def _disabled() -> bool:
@@ -961,6 +975,95 @@ def card_warm_is_fresh(*, now: float | None = None) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Card-images warm manifest — Phase 2 of the pre-Scrydex catalog-warm
+# epic (#368). Tracks how many per-card image bytes the most recent
+# `pkmn cache warm-card-images` pass landed on disk under
+# `cache/images/cards/{large,small}/`. Mirrors the other warm manifests'
+# shape so the stats projection / freshness gate / CLI rendering stay
+# uniform. Shares `CARD_WARM_STALE_SECONDS` as the staleness window —
+# card-image bytes are at least as immutable as card structural data.
+# ---------------------------------------------------------------------------
+
+
+def _card_images_warm_path() -> Path:
+    return _cache_root_path() / _CARD_IMAGES_WARM_FILE
+
+
+def read_card_images_warm() -> dict[str, Any] | None:
+    """Return the parsed card-images-warm manifest, or None if absent/malformed.
+
+    Schema (v1):
+        {
+            "version": 1,
+            "timestamp": <unix float>,
+            "images_warmed": <int>,
+            "images_failed": <int>,
+            "bytes_written": <int>,
+            "budget_reached": <bool>,
+            "sets_attempted": <int>,
+            "sets_failed": [<set_id>, ...]
+        }
+
+    Same defence-in-depth as the other warm manifests."""
+    path = _card_images_warm_path()
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict) or data.get("version") != CARD_IMAGES_WARM_SCHEMA_VERSION:
+        return None
+    return data
+
+
+def write_card_images_warm(
+    *,
+    images_warmed: int,
+    images_failed: int,
+    bytes_written: int,
+    budget_reached: bool,
+    sets_attempted: int,
+    sets_failed: list[str],
+) -> None:
+    """Persist the card-images-warm manifest. Best-effort write."""
+    payload = {
+        "version": CARD_IMAGES_WARM_SCHEMA_VERSION,
+        "timestamp": time.time(),
+        "images_warmed": images_warmed,
+        "images_failed": images_failed,
+        "bytes_written": bytes_written,
+        "budget_reached": budget_reached,
+        "sets_attempted": sets_attempted,
+        "sets_failed": sets_failed,
+    }
+    root = cache_root()
+    with contextlib.suppress(OSError):
+        (root / _CARD_IMAGES_WARM_FILE).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def card_images_warm_is_fresh(*, now: float | None = None) -> bool:
+    """True when a manifest exists, its timestamp is within the staleness
+    window (`CARD_WARM_STALE_SECONDS` — one week), and the manifest
+    recorded at least one warmed image.
+
+    A `budget_reached=True` manifest is still considered fresh: the
+    gate's job is to suppress the next *full* re-walk, not to chase the
+    budget tail on every boot."""
+    manifest = read_card_images_warm()
+    if manifest is None:
+        return False
+    ts = manifest.get("timestamp")
+    if not isinstance(ts, int | float):
+        return False
+    images_warmed = manifest.get("images_warmed")
+    if not isinstance(images_warmed, int) or images_warmed <= 0:
+        return False
+    current = now if now is not None else time.time()
+    return (current - ts) < CARD_WARM_STALE_SECONDS
+
+
+# ---------------------------------------------------------------------------
 # Stats — health snapshot for `pkmn cache stats`.
 # ---------------------------------------------------------------------------
 
@@ -1055,6 +1158,25 @@ def stats() -> CacheStats:
         if isinstance(f, int):
             card_warm_failed_count = f
 
+    card_images_warm_timestamp: float | None = None
+    card_images_warm_count = 0
+    card_images_warm_bytes = 0
+    card_images_warm_budget_reached = False
+    ciw_manifest = read_card_images_warm()
+    if ciw_manifest is not None:
+        ts = ciw_manifest.get("timestamp")
+        if isinstance(ts, int | float):
+            card_images_warm_timestamp = float(ts)
+        n = ciw_manifest.get("images_warmed")
+        if isinstance(n, int):
+            card_images_warm_count = n
+        b = ciw_manifest.get("bytes_written")
+        if isinstance(b, int):
+            card_images_warm_bytes = b
+        br = ciw_manifest.get("budget_reached")
+        if isinstance(br, bool):
+            card_images_warm_budget_reached = br
+
     return CacheStats(
         root=root,
         api_entry_count=api_count,
@@ -1073,4 +1195,8 @@ def stats() -> CacheStats:
         card_warm_timestamp=card_warm_timestamp,
         card_warm_count=card_warm_count,
         card_warm_failed_count=card_warm_failed_count,
+        card_images_warm_timestamp=card_images_warm_timestamp,
+        card_images_warm_count=card_images_warm_count,
+        card_images_warm_bytes=card_images_warm_bytes,
+        card_images_warm_budget_reached=card_images_warm_budget_reached,
     )

--- a/src/mgz_pkmn/card_images.py
+++ b/src/mgz_pkmn/card_images.py
@@ -1,0 +1,256 @@
+"""Warm per-card image bytes onto the unified disk image cache.
+
+Phase 2 of the pre-Scrydex catalog-warm epic (#368). For every card the
+warmer can reach (via the same set-walk that `warm_cards` and
+`warm_set_cards` already do), this pulls the `images.large` and
+`images.small` URLs and persists the bytes under the existing image-cache
+layout — `cache/images/cards/large/<card_id>.<ext>` and
+`cache/images/cards/small/<card_id>.<ext>`. The serving route at
+`/api/v1/cards/{id}/image/{size}` then streams those files instead of
+proxying upstream, and the API boundary rewrites `images.small/large` on
+lookup responses so the SPA's `<img>` tags hit our disk for free.
+
+The warmer is gated by a hard `--max-bytes` budget so a runaway pass
+can't fill the persistent disk. Once cumulative downloaded bytes cross
+the cap, the pass exits cleanly with `budget_reached=True` on the
+result; the manifest reflects exactly how far it got so a future
+incremental pass can pick up where this one stopped (the existing
+`skip_existing` short-circuit makes the incremental re-run cheap)."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+
+import requests
+
+from . import cache as disk_cache
+from .lookup import fetch_set_ids
+from .sources import TCGClient
+
+# `large` and `small` are the only two image variants pokemontcg.io
+# exposes. We keep them as parallel categories under the unified image
+# cache so each size gets its own URL and the serving route can pick
+# the right one without sniffing extensions.
+LARGE_CATEGORY = "cards/large"
+SMALL_CATEGORY = "cards/small"
+_CATEGORY_BY_SIZE: dict[str, str] = {
+    "large": LARGE_CATEGORY,
+    "small": SMALL_CATEGORY,
+}
+
+# Order matters: matches the order the issue lists in `--sizes
+# large,small` and gives a deterministic walk for tests / progress
+# reporting.
+SIZE_LARGE = "large"
+SIZE_SMALL = "small"
+DEFAULT_SIZES: tuple[str, ...] = (SIZE_LARGE, SIZE_SMALL)
+
+
+@dataclass(frozen=True)
+class WarmCardImagesResult:
+    """Outcome of a `warm_card_images` run.
+
+    `sets_attempted` / `sets_failed` mirror `warm_cards` — sets whose
+    search returned no results are recorded so an operator can spot a
+    stale id without trawling logs.
+
+    `images_warmed` counts size-image pairs that exist on disk after the
+    pass (newly fetched + already present when `skip_existing=True`).
+    `images_failed` is the number of fetch attempts where the writer
+    returned no path (network error, write failure, etc.).
+
+    `bytes_written` is cumulative downloaded bytes for *this* pass —
+    skipped-existing entries don't add to it. Used to drive the
+    `--max-bytes` budget cap.
+
+    `budget_reached` is True when the pass exited early because
+    `bytes_written + next download` would exceed `max_bytes`. The
+    manifest persists this so subsequent passes don't have to recompute
+    the budget state from scratch."""
+
+    sets_attempted: int
+    images_warmed: int
+    images_failed: int
+    bytes_written: int
+    budget_reached: bool = False
+    sets_failed: list[str] = field(default_factory=list)
+
+
+def warm_card_images(
+    pkmn: TCGClient,
+    *,
+    set_ids: list[str] | None = None,
+    sizes: Iterable[str] = DEFAULT_SIZES,
+    max_bytes: int | None = None,
+    skip_existing: bool = True,
+    throttle_ms: int = 0,
+    on_progress: Callable[[int, int, str], None] | None = None,
+) -> WarmCardImagesResult:
+    """Walk every set's card list and warm each card's image bytes.
+
+    `set_ids`, when provided, restricts the walk to that subset (handy
+    for `--sets` in the CLI and for tests). When None, walks the full
+    Pokémon TCG catalog via `fetch_set_ids` — same source as the other
+    warmers, so a cached set list is shared.
+
+    `sizes` picks which image variants to warm. Order is preserved so
+    callers can prioritise (e.g. `("small",)` for a tight-disk warm,
+    `("large",)` to skip ahead to the modal-quality variant). Unknown
+    size names are skipped silently — the CLI guards against typos at
+    parse time, and warming functions are best-effort by design.
+
+    `max_bytes`, when set, is a hard cap on cumulative *downloaded*
+    bytes for this pass. Already-cached images don't count toward it
+    (they were paid for in a prior pass). The check is "would the next
+    write push us over?" — we never partially write past the cap.
+
+    `skip_existing` (default True) short-circuits the per-image fetch
+    when `read_image` already returns a path. Mirrors `warm_cards` and
+    makes incremental re-runs effectively free.
+
+    `throttle_ms`, when > 0, sleeps for that many milliseconds between
+    *set* fetches. Per-card image downloads themselves aren't throttled
+    individually — the upstream image CDN is on cloudfront/cloudflare,
+    not the rate-limited pokemontcg.io API surface, so the per-set
+    sleep is sufficient to stay polite. (If we later see image-CDN
+    throttling, we can add a per-image sleep here.)
+
+    `on_progress`, when provided, is invoked once per set with
+    `(index, total, set_id)`.
+    """
+    requested_sizes: list[str] = [s for s in sizes if s in _CATEGORY_BY_SIZE]
+
+    ids = set_ids if set_ids is not None else fetch_set_ids(pkmn)
+    total = len(ids)
+    images_warmed = 0
+    images_failed = 0
+    bytes_written = 0
+    sets_failed: list[str] = []
+
+    for index, set_id in enumerate(ids, start=1):
+        if on_progress is not None:
+            on_progress(index, total, set_id)
+
+        # Same query shape as warm_cards / warm_set_cards. The disk-cache
+        # hit on `set.id:"X"` keeps this pass free of extra API calls on
+        # a freshly-warmed `card_warm.json` / `set_cards_warm.json`
+        # neighbour slice.
+        query = f'set.id:"{set_id}"'
+        cards = pkmn.search_all(query)
+        if not cards:
+            sets_failed.append(set_id)
+            if throttle_ms > 0:
+                time.sleep(throttle_ms / 1000.0)
+            continue
+
+        for card in cards:
+            card_id = card.get("id")
+            if not card_id:
+                continue
+            images = card.get("images") or {}
+            for size in requested_sizes:
+                url = images.get(size)
+                if not url:
+                    continue
+                category = _CATEGORY_BY_SIZE[size]
+                if skip_existing and disk_cache.read_image(category, card_id) is not None:
+                    images_warmed += 1
+                    continue
+
+                if max_bytes is not None and bytes_written >= max_bytes:
+                    return WarmCardImagesResult(
+                        sets_attempted=index,
+                        images_warmed=images_warmed,
+                        images_failed=images_failed,
+                        bytes_written=bytes_written,
+                        budget_reached=True,
+                        sets_failed=sets_failed,
+                    )
+
+                content = _download_bytes(pkmn.session, url)
+                if content is None:
+                    images_failed += 1
+                    continue
+
+                path = disk_cache.write_image(category, card_id, content, ext=url)
+                if path is None:
+                    images_failed += 1
+                    continue
+                images_warmed += 1
+                bytes_written += len(content)
+
+        if throttle_ms > 0:
+            time.sleep(throttle_ms / 1000.0)
+
+    return WarmCardImagesResult(
+        sets_attempted=total,
+        images_warmed=images_warmed,
+        images_failed=images_failed,
+        bytes_written=bytes_written,
+        sets_failed=sets_failed,
+    )
+
+
+def _download_bytes(session: requests.Session, url: str, *, timeout: float = 30.0) -> bytes | None:
+    """GET `url` and return its body, or None on any HTTP / network error.
+
+    Mirrors `disk_cache.download_and_cache_image`'s error handling but
+    returns the bytes directly so the warmer can measure download size
+    *before* committing it to disk — the caller needs the length to
+    drive the `--max-bytes` budget."""
+    try:
+        resp = session.get(url, timeout=timeout)
+        resp.raise_for_status()
+    except requests.RequestException:
+        return None
+    return resp.content
+
+
+def parse_bytes_budget(raw: str) -> int:
+    """Parse a human-friendly byte budget string (`"5GB"`, `"500MB"`,
+    `"1024"`, etc.) into an integer byte count.
+
+    Accepts an optional suffix in {`B`, `KB`, `MB`, `GB`, `TB`}, case
+    insensitive, with or without intervening whitespace. Returns the
+    raw integer when no suffix is present. Raises `ValueError` on
+    anything else — the CLI translates that into a click parse error
+    so the operator sees the bad value at submit time, not partway
+    through a long warm pass."""
+    s = raw.strip().upper().replace(" ", "")
+    if not s:
+        raise ValueError("empty byte budget")
+    multipliers: dict[str, int] = {
+        "B": 1,
+        "KB": 1024,
+        "MB": 1024**2,
+        "GB": 1024**3,
+        "TB": 1024**4,
+    }
+    for suffix in ("TB", "GB", "MB", "KB", "B"):
+        if s.endswith(suffix):
+            num_part = s[: -len(suffix)] or "0"
+            try:
+                value = float(num_part)
+            except ValueError as exc:
+                raise ValueError(f"invalid byte budget: {raw!r}") from exc
+            if value < 0:
+                raise ValueError(f"byte budget must be non-negative: {raw!r}")
+            return int(value * multipliers[suffix])
+    try:
+        return int(s)
+    except ValueError as exc:
+        raise ValueError(f"invalid byte budget: {raw!r}") from exc
+
+
+__all__ = [
+    "DEFAULT_SIZES",
+    "LARGE_CATEGORY",
+    "SIZE_LARGE",
+    "SIZE_SMALL",
+    "SMALL_CATEGORY",
+    "WarmCardImagesResult",
+    "parse_bytes_budget",
+    "warm_card_images",
+]

--- a/src/mgz_pkmn/card_images.py
+++ b/src/mgz_pkmn/card_images.py
@@ -174,6 +174,23 @@ def warm_card_images(
                     images_failed += 1
                     continue
 
+                # Post-download, pre-write budget check. The pre-check
+                # above stops cleanly when we're already at the cap, but
+                # it can't see *this* download's size — and a download
+                # larger than the remaining budget would otherwise push
+                # us past the hard cap. This second check enforces the
+                # docstring's "would the next write push us over?"
+                # contract exactly (caught in Copilot review of #371).
+                if max_bytes is not None and bytes_written + len(content) > max_bytes:
+                    return WarmCardImagesResult(
+                        sets_attempted=index,
+                        images_warmed=images_warmed,
+                        images_failed=images_failed,
+                        bytes_written=bytes_written,
+                        budget_reached=True,
+                        sets_failed=sets_failed,
+                    )
+
                 path = disk_cache.write_image(category, card_id, content, ext=url)
                 if path is None:
                     images_failed += 1
@@ -239,9 +256,17 @@ def parse_bytes_budget(raw: str) -> int:
                 raise ValueError(f"byte budget must be non-negative: {raw!r}")
             return int(value * multipliers[suffix])
     try:
-        return int(s)
+        value = int(s)
     except ValueError as exc:
         raise ValueError(f"invalid byte budget: {raw!r}") from exc
+    # The suffix branch above already rejects negative values; mirror
+    # that here for the raw-int path so `--max-bytes -1` fails fast
+    # instead of silently producing a negative budget that short-
+    # circuits the warmer with budget_reached=True (caught in Copilot
+    # review of #371).
+    if value < 0:
+        raise ValueError(f"byte budget must be non-negative: {raw!r}")
+    return value
 
 
 __all__ = [

--- a/src/mgz_pkmn/cli.py
+++ b/src/mgz_pkmn/cli.py
@@ -17,6 +17,7 @@ import requests
 from . import __version__
 from . import cache as disk_cache
 from .binder import CONDENSED_LAYOUT, STANDARD_LAYOUT, write_binder_pdf
+from .card_images import DEFAULT_SIZES, parse_bytes_budget, warm_card_images
 from .checklist import write_checklist_pdf
 from .images import download_image
 from .lookup import (
@@ -1098,6 +1099,30 @@ def cache_stats_command(as_json: bool) -> None:
         if s.card_warm_failed_count:
             line += click.style(f" · {s.card_warm_failed_count} failed", fg="yellow")
         click.echo(line)
+    # Card-images warm slice — sourced from `card_images_warm.json`,
+    # written by `pkmn cache warm-card-images` (Phase 2 of #368). Tracks
+    # how many (card, size) image pairs landed on disk during the most
+    # recent pass plus the total bytes downloaded — the latter is the
+    # one number operators actually want when deciding whether the
+    # persistent disk has headroom for another pass.
+    if s.card_images_warm_timestamp is None:
+        click.echo(
+            "  "
+            + click.style("Card images:   ", fg="bright_black")
+            + click.style("not warmed", fg="yellow")
+            + " · run `pkmn cache warm-card-images` to prime"
+        )
+    else:
+        line = (
+            "  "
+            + click.style("Card images:   ", fg="bright_black")
+            + f"{s.card_images_warm_count} images · "
+            + f"{_format_bytes(s.card_images_warm_bytes)} · warmed "
+            + f"{_format_age(s.card_images_warm_timestamp)}"
+        )
+        if s.card_images_warm_budget_reached:
+            line += click.style(" · budget reached", fg="yellow")
+        click.echo(line)
 
 
 @cache_group.command(name="clear", context_settings={"help_option_names": ["-h", "--help"]})
@@ -1514,6 +1539,193 @@ def cache_warm_cards_command(
             else ""
         )
     )
+    if result.sets_failed and verbose:
+        click.echo(
+            "  " + click.style("missed: ", fg="bright_black") + ", ".join(result.sets_failed)
+        )
+
+    click.echo()
+    click.secho("Done!", fg="green", bold=True)
+
+
+def _parse_sizes(ctx: click.Context, param: click.Parameter, value: str) -> tuple[str, ...]:
+    """Validate / normalise the --sizes flag.
+
+    Comma-separated list of `large` / `small` (in any order). Empty
+    tokens are dropped (so `--sizes large,` doesn't fail). Unknown
+    sizes raise a click parse error so the operator notices the typo
+    at submit time, not partway through a multi-hour warm pass."""
+    parsed: list[str] = []
+    for raw in value.split(","):
+        token = raw.strip().lower()
+        if not token:
+            continue
+        if token not in DEFAULT_SIZES:
+            raise click.BadParameter(
+                f"unknown size {token!r}; expected one of {','.join(DEFAULT_SIZES)}"
+            )
+        if token not in parsed:
+            parsed.append(token)
+    if not parsed:
+        raise click.BadParameter("at least one size required")
+    return tuple(parsed)
+
+
+def _parse_max_bytes(ctx: click.Context, param: click.Parameter, value: str | None) -> int | None:
+    """Validate / parse --max-bytes via card_images.parse_bytes_budget."""
+    if value is None:
+        return None
+    try:
+        return parse_bytes_budget(value)
+    except ValueError as exc:
+        raise click.BadParameter(str(exc)) from exc
+
+
+@cache_group.command(
+    name="warm-card-images",
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+@click.option(
+    "--api-key",
+    envvar="POKEMONTCG_IO_API_KEY",
+    default=None,
+    help="pokemontcg.io API key (or set POKEMONTCG_IO_API_KEY).",
+)
+@click.option(
+    "--set",
+    "set_ids",
+    multiple=True,
+    metavar="SET_ID",
+    help=(
+        "Restrict the warm pass to specific set ids (e.g. --set sv8 --set sv9). "
+        "Repeatable. When omitted, every set in the Pokémon TCG catalog is warmed."
+    ),
+)
+@click.option(
+    "--sizes",
+    callback=_parse_sizes,
+    default=",".join(DEFAULT_SIZES),
+    show_default=True,
+    metavar="LIST",
+    help="Comma-separated image sizes to warm: any subset of large,small.",
+)
+@click.option(
+    "--max-bytes",
+    callback=_parse_max_bytes,
+    default=None,
+    metavar="SIZE",
+    help=(
+        "Hard cap on cumulative downloaded bytes for this pass "
+        "(suffixes: KB, MB, GB, TB). Stops cleanly when reached."
+    ),
+)
+@click.option(
+    "--skip-existing/--no-skip-existing",
+    default=True,
+    show_default=True,
+    help="Skip images already on disk. Re-runs are cheap by default.",
+)
+@click.option(
+    "--throttle-ms",
+    type=int,
+    default=0,
+    metavar="MS",
+    help="Sleep between set fetches (default: no throttle).",
+)
+@click.option(
+    "--prefer-popular",
+    is_flag=True,
+    default=False,
+    help=(
+        "Reserved for future lookup-frequency-aware ordering (see issue #371). Currently a no-op."
+    ),
+)
+@click.option("-v", "--verbose", is_flag=True, help="Print each set as it warms.")
+def cache_warm_card_images_command(
+    api_key: str | None,
+    set_ids: tuple[str, ...],
+    sizes: tuple[str, ...],
+    max_bytes: int | None,
+    skip_existing: bool,
+    throttle_ms: int,
+    prefer_popular: bool,
+    verbose: bool,
+) -> None:
+    """Pre-download per-card image bytes to the persistent disk image cache.
+
+    Phase 2 of the pre-Scrydex catalog-warm epic (#368). Walks every
+    set, then for each card fetches the requested `--sizes`
+    (`large,small` by default) and persists the bytes under
+    `cache/images/cards/{size}/<card_id>.<ext>`. The API serving route
+    at `/api/v1/cards/{id}/image/{size}` streams those files directly,
+    and the SPA's `<img>` tags are transparently rewritten to use it.
+
+    First-pass cost: ~36K image fetches (~18K cards x large + small)
+    at ~80-150 KB each -> 3-5 GB on disk. `--max-bytes` caps the
+    budget so a runaway pass can't fill the persistent disk; staging
+    across multiple runs is supported by the default `--skip-existing`."""
+    _print_banner(__version__)
+    _ = prefer_popular  # currently a no-op; see issue #371.
+
+    pkmn = TCGClient(api_key=api_key, verbose=verbose)
+
+    section = "Warming card images"
+    if set_ids:
+        section += f" · {len(set_ids)} set(s)"
+    section += f" · sizes={','.join(sizes)}"
+    if max_bytes is not None:
+        section += f" · max {_format_bytes(max_bytes)}"
+    _print_section(section)
+
+    def _progress(index: int, total: int, set_id: str) -> None:
+        if not verbose:
+            return
+        click.echo(
+            click.style(f"  [{index}/{total}] ", fg="bright_black") + set_id,
+            err=False,
+        )
+
+    try:
+        result = warm_card_images(
+            pkmn,
+            set_ids=list(set_ids) if set_ids else None,
+            sizes=sizes,
+            max_bytes=max_bytes,
+            skip_existing=skip_existing,
+            throttle_ms=throttle_ms,
+            on_progress=_progress,
+        )
+    except requests.RequestException as exc:
+        raise click.ClickException(f"card-image warm failed: {exc}") from exc
+
+    if result.sets_attempted == 0:
+        raise click.ClickException(
+            "no sets to warm — check `--set` ids or upstream catalog availability"
+        )
+
+    disk_cache.write_card_images_warm(
+        images_warmed=result.images_warmed,
+        images_failed=result.images_failed,
+        bytes_written=result.bytes_written,
+        budget_reached=result.budget_reached,
+        sets_attempted=result.sets_attempted,
+        sets_failed=result.sets_failed,
+    )
+
+    click.secho("  ✓ ", fg="green", nl=False)
+    summary = (
+        f"{result.sets_attempted} sets · "
+        + click.style(f"{result.images_warmed} images warmed", fg="cyan")
+        + f" · {_format_bytes(result.bytes_written)} downloaded"
+    )
+    if result.images_failed:
+        summary += click.style(f" · {result.images_failed} failed", fg="yellow")
+    if result.sets_failed:
+        summary += click.style(f" · {len(result.sets_failed)} sets missed", fg="yellow")
+    if result.budget_reached:
+        summary += click.style(" · budget reached", fg="yellow")
+    click.echo(summary)
+
     if result.sets_failed and verbose:
         click.echo(
             "  " + click.style("missed: ", fg="bright_black") + ", ".join(result.sets_failed)

--- a/tests/test_card_images_api.py
+++ b/tests/test_card_images_api.py
@@ -1,0 +1,187 @@
+"""API-surface coverage for the Phase 2 card-image route + URL rewriter.
+
+`GET /api/v1/cards/{id}/image/{size}` streams cached image bytes from
+disk or 404s with a hint pointing at `pkmn cache warm-card-images`.
+
+`api/routes/cards.rewrite_card_image_urls` swaps `images.{large,small}`
+entries on lookup-response cards (and the `thumb` field on
+`_trim_card` in `api/routes/sets.py`) to the new route whenever the
+underlying file is present — cache miss leaves the upstream URL in
+place so a cold deploy still serves a working `<img>`.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from api.main import app
+from api.routes.cards import rewrite_card_image_urls
+from api.routes.sets import _trim_card
+from mgz_pkmn import cache as disk_cache
+from mgz_pkmn.card_images import LARGE_CATEGORY, SMALL_CATEGORY
+
+
+class _IsolatedCacheMixin(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._old_xdg = os.environ.get("XDG_CACHE_HOME")
+        self._old_no_cache = os.environ.get(disk_cache._NO_CACHE_ENV)
+        self._old_automigrate = os.environ.get("MGZ_PKMN_AUTOMIGRATE")
+        os.environ["XDG_CACHE_HOME"] = self._tmp.name
+        os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+        os.environ["MGZ_PKMN_AUTOMIGRATE"] = "0"
+
+    def tearDown(self) -> None:
+        if self._old_xdg is None:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        else:
+            os.environ["XDG_CACHE_HOME"] = self._old_xdg
+        if self._old_no_cache is None:
+            os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+        else:
+            os.environ[disk_cache._NO_CACHE_ENV] = self._old_no_cache
+        if self._old_automigrate is None:
+            os.environ.pop("MGZ_PKMN_AUTOMIGRATE", None)
+        else:
+            os.environ["MGZ_PKMN_AUTOMIGRATE"] = self._old_automigrate
+        self._tmp.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Route: GET /api/v1/cards/{id}/image/{size}
+# ---------------------------------------------------------------------------
+
+
+class CardImageRouteTests(_IsolatedCacheMixin):
+    def test_serves_cached_large_image_with_long_cache_header(self) -> None:
+        disk_cache.write_image(LARGE_CATEGORY, "sv8-1", b"fake-png-bytes", ext=".png")
+        with TestClient(app) as client:
+            resp = client.get("/api/v1/cards/sv8-1/image/large")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content, b"fake-png-bytes")
+        self.assertEqual(resp.headers["cache-control"], "public, max-age=2592000, immutable")
+        # mimetypes guessed from the .png extension.
+        self.assertIn("png", resp.headers["content-type"])
+
+    def test_serves_cached_small_image(self) -> None:
+        disk_cache.write_image(SMALL_CATEGORY, "sv8-1", b"sm", ext=".png")
+        with TestClient(app) as client:
+            resp = client.get("/api/v1/cards/sv8-1/image/small")
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.content, b"sm")
+
+    def test_404_on_cache_miss_with_warmer_hint(self) -> None:
+        with TestClient(app) as client:
+            resp = client.get("/api/v1/cards/sv8-1/image/large")
+        self.assertEqual(resp.status_code, 404)
+        # The detail should mention the warmer so an operator hitting
+        # the endpoint directly knows what to run.
+        self.assertIn("warm-card-images", resp.json()["detail"])
+
+    def test_unknown_size_returns_422(self) -> None:
+        with TestClient(app) as client:
+            resp = client.get("/api/v1/cards/sv8-1/image/medium")
+        # Literal["large", "small"] enforced by FastAPI → 422 unprocessable.
+        self.assertEqual(resp.status_code, 422)
+
+    def test_path_traversal_attempt_returns_422(self) -> None:
+        with TestClient(app) as client:
+            # `..` triggers the `_CARD_ID_PATH` regex rejection (it
+            # only allows `[A-Za-z0-9_-]`).
+            resp = client.get("/api/v1/cards/..%2Fevil/image/large")
+        self.assertIn(resp.status_code, (404, 422))
+
+
+# ---------------------------------------------------------------------------
+# URL rewriter: rewrite_card_image_urls
+# ---------------------------------------------------------------------------
+
+
+class RewriteCardImageURLsTests(_IsolatedCacheMixin):
+    def _card_with_upstream_urls(self) -> dict:
+        return {
+            "id": "sv8-1",
+            "name": "Test",
+            "images": {
+                "large": "https://images.example/upstream_lg.png",
+                "small": "https://images.example/upstream_sm.png",
+            },
+        }
+
+    def test_cache_miss_leaves_upstream_urls_unchanged(self) -> None:
+        original = self._card_with_upstream_urls()
+        rewritten = rewrite_card_image_urls(dict(original))
+        assert rewritten is not None
+        self.assertEqual(rewritten["images"], original["images"])
+
+    def test_cache_hit_rewrites_to_api_route(self) -> None:
+        disk_cache.write_image(LARGE_CATEGORY, "sv8-1", b"lg", ext=".png")
+        disk_cache.write_image(SMALL_CATEGORY, "sv8-1", b"sm", ext=".png")
+        rewritten = rewrite_card_image_urls(self._card_with_upstream_urls())
+        assert rewritten is not None
+        self.assertEqual(rewritten["images"]["large"], "/api/v1/cards/sv8-1/image/large")
+        self.assertEqual(rewritten["images"]["small"], "/api/v1/cards/sv8-1/image/small")
+
+    def test_partial_cache_only_rewrites_present_size(self) -> None:
+        # Only `small` is on disk — `large` keeps its upstream URL.
+        disk_cache.write_image(SMALL_CATEGORY, "sv8-1", b"sm", ext=".png")
+        rewritten = rewrite_card_image_urls(self._card_with_upstream_urls())
+        assert rewritten is not None
+        self.assertEqual(rewritten["images"]["small"], "/api/v1/cards/sv8-1/image/small")
+        self.assertEqual(rewritten["images"]["large"], "https://images.example/upstream_lg.png")
+
+    def test_none_input_returns_none(self) -> None:
+        self.assertIsNone(rewrite_card_image_urls(None))
+
+    def test_card_without_images_dict_returns_unchanged(self) -> None:
+        card = {"id": "sv8-1", "name": "Test"}
+        out = rewrite_card_image_urls(card)
+        self.assertEqual(out, card)
+
+    def test_card_without_id_returns_unchanged(self) -> None:
+        card = {"name": "Test", "images": {"large": "https://x/upstream.png"}}
+        out = rewrite_card_image_urls(card)
+        self.assertEqual(out, card)
+
+
+# ---------------------------------------------------------------------------
+# set_cards `_trim_card` thumb rewrite
+# ---------------------------------------------------------------------------
+
+
+class TrimCardThumbRewriteTests(_IsolatedCacheMixin):
+    def _raw_card(self) -> dict:
+        return {
+            "id": "sv8-1",
+            "name": "Test",
+            "number": "1",
+            "rarity": "Common",
+            "supertype": "Pokémon",
+            "subtypes": ["Basic"],
+            "images": {
+                "small": "https://images.example/upstream_sm.png",
+                "large": "https://images.example/upstream_lg.png",
+            },
+        }
+
+    def test_thumb_keeps_upstream_url_when_not_cached(self) -> None:
+        trimmed = _trim_card(self._raw_card())
+        self.assertEqual(trimmed["thumb"], "https://images.example/upstream_sm.png")
+
+    def test_thumb_rewrites_to_api_route_when_cached(self) -> None:
+        disk_cache.write_image(SMALL_CATEGORY, "sv8-1", b"sm", ext=".png")
+        trimmed = _trim_card(self._raw_card())
+        self.assertEqual(trimmed["thumb"], "/api/v1/cards/sv8-1/image/small")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_card_images_api.py
+++ b/tests/test_card_images_api.py
@@ -16,6 +16,7 @@ import os
 import sys
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
 
 from fastapi.testclient import TestClient
@@ -99,6 +100,25 @@ class CardImageRouteTests(_IsolatedCacheMixin):
             # only allows `[A-Za-z0-9_-]`).
             resp = client.get("/api/v1/cards/..%2Fevil/image/large")
         self.assertIn(resp.status_code, (404, 422))
+
+    def test_oserror_on_read_falls_through_to_404(self) -> None:
+        # File is on disk at probe time but raises OSError on open
+        # (concurrent eviction, NFS hiccup). Route must treat as a
+        # miss rather than 500.
+        disk_cache.write_image(LARGE_CATEGORY, "sv8-2", b"x", ext=".png")
+        original_open = open
+
+        def flaky_open(path, *args, **kwargs):
+            if "sv8-2.png" in str(path):
+                raise OSError("evicted between isfile and read")
+            return original_open(path, *args, **kwargs)
+
+        with (
+            unittest.mock.patch("api.routes.cards.open", side_effect=flaky_open),
+            TestClient(app) as client,
+        ):
+            resp = client.get("/api/v1/cards/sv8-2/image/large")
+        self.assertEqual(resp.status_code, 404)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_card_images_api.py
+++ b/tests/test_card_images_api.py
@@ -139,6 +139,28 @@ class RewriteCardImageURLsTests(_IsolatedCacheMixin):
         self.assertEqual(rewritten["images"]["small"], "/api/v1/cards/sv8-1/image/small")
         self.assertEqual(rewritten["images"]["large"], "https://images.example/upstream_lg.png")
 
+    def test_does_not_mutate_input_card(self) -> None:
+        # Regression for Copilot review on #371: _row_to_dict passes
+        # `row.card` directly, and the same Row is later persisted via
+        # row_to_run_row(card_json=row.card). In-place mutation would
+        # leak `/api/v1/cards/.../image/...` URLs into run history.
+        disk_cache.write_image(SMALL_CATEGORY, "sv8-1", b"sm", ext=".png")
+        original = self._card_with_upstream_urls()
+        before = {
+            "id": original["id"],
+            "name": original["name"],
+            "images": dict(original["images"]),
+        }
+        result = rewrite_card_image_urls(original)
+        # The input dict is untouched.
+        self.assertEqual(original["images"], before["images"])
+        # The returned dict has the rewritten URL.
+        assert result is not None
+        self.assertEqual(result["images"]["small"], "/api/v1/cards/sv8-1/image/small")
+        # And it's a fresh dict — mutating it doesn't affect the input.
+        result["images"]["small"] = "mutated"
+        self.assertEqual(original["images"]["small"], before["images"]["small"])
+
     def test_none_input_returns_none(self) -> None:
         self.assertIsNone(rewrite_card_image_urls(None))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -946,5 +946,227 @@ class CacheWarmCardsCommandTests(unittest.TestCase):
         self.assertIn("no sets to warm", result.output)
 
 
+# ---------------------------------------------------------------------------
+# `pkmn cache warm-card-images` — Phase 2 of the pre-Scrydex catalog-warm
+# epic (#371). Mirrors CacheWarmCardsCommandTests above: mock the upstream
+# `warm_card_images` call, assert the CLI reports the result + writes the
+# manifest, and exercise the flag parsers (--sizes / --max-bytes).
+# ---------------------------------------------------------------------------
+
+
+class CacheWarmCardImagesCommandTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._old_xdg = os.environ.get("XDG_CACHE_HOME")
+        self._old_no_cache = os.environ.get(cache._NO_CACHE_ENV)
+        os.environ["XDG_CACHE_HOME"] = self._tmp.name
+        os.environ.pop(cache._NO_CACHE_ENV, None)
+
+    def tearDown(self) -> None:
+        if self._old_xdg is None:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        else:
+            os.environ["XDG_CACHE_HOME"] = self._old_xdg
+        if self._old_no_cache is None:
+            os.environ.pop(cache._NO_CACHE_ENV, None)
+        else:
+            os.environ[cache._NO_CACHE_ENV] = self._old_no_cache
+        self._tmp.cleanup()
+
+    def test_warm_card_images_writes_manifest_and_reports_summary(self) -> None:
+        from unittest.mock import patch as _patch
+
+        from mgz_pkmn.card_images import WarmCardImagesResult
+
+        fake_result = WarmCardImagesResult(
+            sets_attempted=3,
+            images_warmed=120,
+            images_failed=2,
+            bytes_written=10 * 1024 * 1024,
+            budget_reached=False,
+            sets_failed=[],
+        )
+        with _patch("mgz_pkmn.cli.warm_card_images", return_value=fake_result):
+            result = CliRunner().invoke(
+                cli, ["cache", "warm-card-images", "--set", "sv8", "--set", "sv7", "--set", "base1"]
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("3 sets", result.output)
+        self.assertIn("120 images warmed", result.output)
+        self.assertIn("10.0 MB downloaded", result.output)
+        self.assertIn("2 failed", result.output)
+
+        manifest = cache.read_card_images_warm()
+        self.assertIsNotNone(manifest)
+        assert manifest is not None
+        self.assertEqual(manifest["images_warmed"], 120)
+        self.assertEqual(manifest["bytes_written"], 10 * 1024 * 1024)
+        self.assertFalse(manifest["budget_reached"])
+
+    def test_warm_card_images_max_bytes_and_sizes_parsers(self) -> None:
+        """Exercise --max-bytes (parses 100MB → bytes) and --sizes small."""
+        from unittest.mock import patch as _patch
+
+        from mgz_pkmn.card_images import WarmCardImagesResult
+
+        captured: dict = {}
+
+        def fake_warm(pkmn, **kwargs):
+            captured.update(kwargs)
+            return WarmCardImagesResult(
+                sets_attempted=1,
+                images_warmed=1,
+                images_failed=0,
+                bytes_written=500,
+                budget_reached=True,
+                sets_failed=[],
+            )
+
+        with _patch("mgz_pkmn.cli.warm_card_images", side_effect=fake_warm):
+            result = CliRunner().invoke(
+                cli,
+                [
+                    "cache",
+                    "warm-card-images",
+                    "--set",
+                    "sv8",
+                    "--max-bytes",
+                    "100MB",
+                    "--sizes",
+                    "small",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(captured["max_bytes"], 100 * 1024 * 1024)
+        self.assertEqual(captured["sizes"], ("small",))
+        # Section header reflects both flags.
+        self.assertIn("sizes=small", result.output)
+        self.assertIn("max 100.0 MB", result.output)
+        # `budget_reached=True` lands in the result line.
+        self.assertIn("budget reached", result.output)
+
+    def test_warm_card_images_invalid_sizes_rejected_at_parse_time(self) -> None:
+        result = CliRunner().invoke(cli, ["cache", "warm-card-images", "--sizes", "huge"])
+        self.assertNotEqual(result.exit_code, 0)
+        # Click renders BadParameter as 'Invalid value for ...'.
+        self.assertIn("unknown size", result.output.lower())
+
+    def test_warm_card_images_invalid_max_bytes_rejected_at_parse_time(self) -> None:
+        result = CliRunner().invoke(
+            cli, ["cache", "warm-card-images", "--max-bytes", "five gigabytes"]
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("invalid byte budget", result.output.lower())
+
+    def test_warm_card_images_verbose_prints_per_set_progress_and_missed_dump(self) -> None:
+        from unittest.mock import patch as _patch
+
+        from mgz_pkmn.card_images import WarmCardImagesResult
+
+        def fake_warm(pkmn, **kwargs):
+            kwargs["on_progress"](1, 2, "sv8")
+            kwargs["on_progress"](2, 2, "ghost")
+            return WarmCardImagesResult(
+                sets_attempted=2,
+                images_warmed=4,
+                images_failed=0,
+                bytes_written=4096,
+                budget_reached=False,
+                sets_failed=["ghost"],
+            )
+
+        with _patch("mgz_pkmn.cli.warm_card_images", side_effect=fake_warm):
+            result = CliRunner().invoke(
+                cli,
+                ["cache", "warm-card-images", "--set", "sv8", "--set", "ghost", "-v"],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("[1/2]", result.output)
+        self.assertIn("sv8", result.output)
+        self.assertIn("[2/2]", result.output)
+        self.assertIn("missed:", result.output)
+        self.assertIn("ghost", result.output)
+
+    def test_warm_card_images_surfaces_request_failure(self) -> None:
+        from unittest.mock import patch as _patch
+
+        import requests as _requests
+
+        with _patch(
+            "mgz_pkmn.cli.warm_card_images",
+            side_effect=_requests.ConnectionError("network down"),
+        ):
+            result = CliRunner().invoke(cli, ["cache", "warm-card-images"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("card-image warm failed", result.output)
+        self.assertIn("network down", result.output)
+
+    def test_warm_card_images_rejects_empty_pass(self) -> None:
+        from unittest.mock import patch as _patch
+
+        from mgz_pkmn.card_images import WarmCardImagesResult
+
+        with _patch(
+            "mgz_pkmn.cli.warm_card_images",
+            return_value=WarmCardImagesResult(
+                sets_attempted=0,
+                images_warmed=0,
+                images_failed=0,
+                bytes_written=0,
+                budget_reached=False,
+                sets_failed=[],
+            ),
+        ):
+            result = CliRunner().invoke(cli, ["cache", "warm-card-images"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("no sets to warm", result.output)
+
+
+# ---------------------------------------------------------------------------
+# `pkmn cache stats` rendering of the card_images warm slice (#371).
+# ---------------------------------------------------------------------------
+
+
+class CacheStatsCardImagesRowTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._old_xdg = os.environ.get("XDG_CACHE_HOME")
+        os.environ["XDG_CACHE_HOME"] = self._tmp.name
+
+    def tearDown(self) -> None:
+        if self._old_xdg is None:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        else:
+            os.environ["XDG_CACHE_HOME"] = self._old_xdg
+        self._tmp.cleanup()
+
+    def test_stats_shows_not_warmed_when_no_manifest(self) -> None:
+        result = CliRunner().invoke(cli, ["cache", "stats"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("Card images:", result.output)
+        self.assertIn("not warmed", result.output)
+        self.assertIn("warm-card-images", result.output)
+
+    def test_stats_shows_count_bytes_and_budget_when_manifest_present(self) -> None:
+        cache.write_card_images_warm(
+            images_warmed=200,
+            images_failed=0,
+            bytes_written=3 * 1024 * 1024 * 1024,
+            budget_reached=True,
+            sets_attempted=10,
+            sets_failed=[],
+        )
+        result = CliRunner().invoke(cli, ["cache", "stats"])
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertIn("200 images", result.output)
+        self.assertIn("3.0 GB", result.output)
+        self.assertIn("budget reached", result.output)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -205,6 +205,10 @@ class CacheStatsCommandTests(unittest.TestCase):
                 "card_warm_timestamp",
                 "card_warm_count",
                 "card_warm_failed_count",
+                "card_images_warm_timestamp",
+                "card_images_warm_count",
+                "card_images_warm_bytes",
+                "card_images_warm_budget_reached",
                 "root",
             },
         )

--- a/tests/test_warm_card_images.py
+++ b/tests/test_warm_card_images.py
@@ -341,6 +341,95 @@ class WarmCardImagesTests(_IsolatedCacheMixin):
         self.assertEqual(result.sets_failed, ["ghost"])
         self.assertEqual(result.images_warmed, 0)
 
+    def test_progress_callback_fires_once_per_set(self) -> None:
+        cards = [_card("sv8", 1)]
+        calls: list[tuple[int, int, str]] = []
+        with (
+            patch.object(TCGClient, "search_all", return_value=cards),
+            self._patch_download(),
+        ):
+            warm_card_images(
+                TCGClient(),
+                set_ids=["sv8", "sv7"],
+                on_progress=lambda i, t, s: calls.append((i, t, s)),
+            )
+        self.assertEqual([c[2] for c in calls], ["sv8", "sv7"])
+        self.assertEqual(calls[0][:2], (1, 2))
+
+    def test_throttle_sleeps_between_sets_including_empty(self) -> None:
+        from mgz_pkmn import card_images as card_images_mod_local
+
+        with (
+            patch.object(
+                TCGClient,
+                "search_all",
+                side_effect=[[_card("sv8", 1)], []],  # one populated, one empty
+            ),
+            self._patch_download(),
+            patch.object(card_images_mod_local.time, "sleep") as mock_sleep,
+        ):
+            warm_card_images(TCGClient(), set_ids=["sv8", "ghost"], throttle_ms=100)
+        # One sleep after the populated set, one after the empty set.
+        self.assertEqual(mock_sleep.call_count, 2)
+        for call in mock_sleep.call_args_list:
+            self.assertAlmostEqual(call.args[0], 0.1, places=3)
+
+    def test_card_without_id_is_skipped(self) -> None:
+        cards = [{"id": None, "images": {"small": "https://x/sm.png"}}]
+        with (
+            patch.object(TCGClient, "search_all", return_value=cards),
+            self._patch_download(),
+        ):
+            result = warm_card_images(TCGClient(), set_ids=["sv8"])
+        self.assertEqual(result.images_warmed, 0)
+        self.assertEqual(result.images_failed, 0)
+
+    def test_write_image_failure_counts_as_images_failed(self) -> None:
+        # If disk_cache.write_image returns None (read-only fs, serialisation
+        # bug), the warmer must not count the image as warmed.
+        cards = [_card("sv8", 1)]
+        with (
+            patch.object(TCGClient, "search_all", return_value=cards),
+            self._patch_download(),
+            patch.object(disk_cache, "write_image", return_value=None),
+        ):
+            result = warm_card_images(TCGClient(), set_ids=["sv8"])
+        self.assertEqual(result.images_warmed, 0)
+        self.assertEqual(result.images_failed, 2)
+
+
+class DownloadBytesTests(unittest.TestCase):
+    """Exercise the real `_download_bytes` helper with a stub session so
+    both the success and the RequestException branches are covered."""
+
+    def test_returns_response_content_on_success(self) -> None:
+        from mgz_pkmn import card_images as card_images_mod_local
+
+        class StubResp:
+            content = b"hello"
+
+            def raise_for_status(self):
+                pass
+
+        class StubSession:
+            def get(self, _url, timeout=30.0):
+                return StubResp()
+
+        out = card_images_mod_local._download_bytes(StubSession(), "https://x/y.png")
+        self.assertEqual(out, b"hello")
+
+    def test_returns_none_on_requests_exception(self) -> None:
+        import requests as req_lib
+
+        from mgz_pkmn import card_images as card_images_mod_local
+
+        class StubSession:
+            def get(self, _url, timeout=30.0):
+                raise req_lib.ConnectionError("down")
+
+        out = card_images_mod_local._download_bytes(StubSession(), "https://x/y.png")
+        self.assertIsNone(out)
+
 
 # ---------------------------------------------------------------------------
 # parse_bytes_budget
@@ -380,6 +469,14 @@ class ParseBytesBudgetTests(unittest.TestCase):
             parse_bytes_budget("-1")
         with self.assertRaises(ValueError):
             parse_bytes_budget("-1024")
+
+    def test_non_numeric_with_suffix_raises(self) -> None:
+        # The numeric prefix must parse as float — `foo MB` hits the
+        # except ValueError inside the suffix branch.
+        with self.assertRaises(ValueError):
+            parse_bytes_budget("foo MB")
+        with self.assertRaises(ValueError):
+            parse_bytes_budget("abcGB")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_warm_card_images.py
+++ b/tests/test_warm_card_images.py
@@ -1,0 +1,385 @@
+"""Coverage for `warm_card_images` + the `card_images_warm.json` manifest.
+
+Phase 2 of the pre-Scrydex catalog-warm epic (#368). Validates that:
+
+- `warm_card_images` walks the supplied set ids, downloads each card's
+  `large` and `small` image bytes, persists them under the unified
+  image cache, and returns counts that match what landed on disk.
+- `--skip-existing` honors already-present entries.
+- `--max-bytes` short-circuits the walk with `budget_reached=True` and
+  never partially writes past the cap.
+- The freshness gate + read/write helpers behave the same way as the
+  other warm manifests.
+
+Network is mocked at `TCGClient.search_all` (for set payloads) and at
+`mgz_pkmn.card_images._download_bytes` (for image fetches) so no real
+upstream is hit.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from mgz_pkmn import cache as disk_cache
+from mgz_pkmn import card_images as card_images_mod
+from mgz_pkmn.card_images import (
+    LARGE_CATEGORY,
+    SMALL_CATEGORY,
+    parse_bytes_budget,
+    warm_card_images,
+)
+from mgz_pkmn.sources.pokemontcg import TCGClient
+
+
+class _IsolatedCacheMixin(unittest.TestCase):
+    """Point XDG_CACHE_HOME at a tempdir so writes don't touch the user's real cache."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._old_xdg = os.environ.get("XDG_CACHE_HOME")
+        self._old_no_cache = os.environ.get(disk_cache._NO_CACHE_ENV)
+        os.environ["XDG_CACHE_HOME"] = self._tmp.name
+        os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+
+    def tearDown(self) -> None:
+        if self._old_xdg is None:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        else:
+            os.environ["XDG_CACHE_HOME"] = self._old_xdg
+        if self._old_no_cache is None:
+            os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+        else:
+            os.environ[disk_cache._NO_CACHE_ENV] = self._old_no_cache
+        self._tmp.cleanup()
+
+
+def _card(set_id: str, n: int) -> dict:
+    """Build a synthetic card with both image sizes pointing at fake URLs."""
+    cid = f"{set_id}-{n}"
+    return {
+        "id": cid,
+        "name": f"Card{n}",
+        "set": {"id": set_id, "name": set_id.title()},
+        "images": {
+            "large": f"https://images.example/{cid}_lg.png",
+            "small": f"https://images.example/{cid}_sm.png",
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Manifest helpers (mirror tests/test_warm_cards.py)
+# ---------------------------------------------------------------------------
+
+
+class CardImagesWarmManifestTests(_IsolatedCacheMixin):
+    def test_read_returns_none_when_absent(self) -> None:
+        self.assertIsNone(disk_cache.read_card_images_warm())
+
+    def test_write_then_read_roundtrip(self) -> None:
+        disk_cache.write_card_images_warm(
+            images_warmed=100,
+            images_failed=2,
+            bytes_written=1_234_567,
+            budget_reached=False,
+            sets_attempted=10,
+            sets_failed=["bogus"],
+        )
+        data = disk_cache.read_card_images_warm()
+        self.assertIsNotNone(data)
+        assert data is not None
+        self.assertEqual(data["images_warmed"], 100)
+        self.assertEqual(data["images_failed"], 2)
+        self.assertEqual(data["bytes_written"], 1_234_567)
+        self.assertFalse(data["budget_reached"])
+        self.assertEqual(data["sets_attempted"], 10)
+        self.assertEqual(data["sets_failed"], ["bogus"])
+        self.assertIsInstance(data["timestamp"], float)
+
+    def test_read_rejects_malformed_payload(self) -> None:
+        path = disk_cache._card_images_warm_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not json", encoding="utf-8")
+        self.assertIsNone(disk_cache.read_card_images_warm())
+
+    def test_read_rejects_unknown_schema_version(self) -> None:
+        path = disk_cache._card_images_warm_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "version": 99,
+                    "timestamp": 0.0,
+                    "images_warmed": 0,
+                    "images_failed": 0,
+                    "bytes_written": 0,
+                    "budget_reached": False,
+                    "sets_attempted": 0,
+                    "sets_failed": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.assertIsNone(disk_cache.read_card_images_warm())
+
+
+class CardImagesWarmFreshnessTests(_IsolatedCacheMixin):
+    def test_no_manifest_is_not_fresh(self) -> None:
+        self.assertFalse(disk_cache.card_images_warm_is_fresh())
+
+    def test_fresh_within_window(self) -> None:
+        disk_cache.write_card_images_warm(
+            images_warmed=10,
+            images_failed=0,
+            bytes_written=1024,
+            budget_reached=False,
+            sets_attempted=1,
+            sets_failed=[],
+        )
+        self.assertTrue(disk_cache.card_images_warm_is_fresh())
+
+    def test_stale_outside_window(self) -> None:
+        disk_cache.write_card_images_warm(
+            images_warmed=10,
+            images_failed=0,
+            bytes_written=1024,
+            budget_reached=False,
+            sets_attempted=1,
+            sets_failed=[],
+        )
+        future = time.time() + (8 * 24 * 60 * 60)
+        self.assertFalse(disk_cache.card_images_warm_is_fresh(now=future))
+
+    def test_zero_warmed_manifest_is_not_fresh(self) -> None:
+        # Same guard as the other warm gates — a manifest written after a
+        # fully-failed pass must not suppress the next retry for a week.
+        disk_cache.write_card_images_warm(
+            images_warmed=0,
+            images_failed=12,
+            bytes_written=0,
+            budget_reached=False,
+            sets_attempted=1,
+            sets_failed=["a"],
+        )
+        self.assertFalse(disk_cache.card_images_warm_is_fresh())
+
+    def test_budget_reached_manifest_is_still_fresh(self) -> None:
+        # `budget_reached` should not flip the gate — the partial pass
+        # *did* land bytes on disk and we don't want the next boot to
+        # immediately re-walk just to chase the budget tail.
+        disk_cache.write_card_images_warm(
+            images_warmed=5,
+            images_failed=0,
+            bytes_written=999_999,
+            budget_reached=True,
+            sets_attempted=1,
+            sets_failed=[],
+        )
+        self.assertTrue(disk_cache.card_images_warm_is_fresh())
+
+
+# ---------------------------------------------------------------------------
+# warm_card_images behavior
+# ---------------------------------------------------------------------------
+
+
+class WarmCardImagesTests(_IsolatedCacheMixin):
+    def _patch_download(self, **byte_sizes: int):
+        """Return a patch-context that swaps `_download_bytes` to return
+        fixed-length bytes objects so we can predict bytes_written exactly."""
+        default = 1024
+
+        def fake_download(_session, url: str, *, timeout: float = 30.0) -> bytes | None:
+            return b"x" * byte_sizes.get(url, default)
+
+        return patch.object(card_images_mod, "_download_bytes", side_effect=fake_download)
+
+    def test_writes_one_image_per_size_per_card(self) -> None:
+        cards = [_card("sv8", 1), _card("sv8", 2)]
+        with (
+            patch.object(TCGClient, "search_all", return_value=cards),
+            self._patch_download(),
+        ):
+            result = warm_card_images(TCGClient(), set_ids=["sv8"])
+
+        self.assertEqual(result.sets_attempted, 1)
+        self.assertEqual(result.images_warmed, 4)  # 2 cards x (large+small)
+        self.assertEqual(result.images_failed, 0)
+        self.assertFalse(result.budget_reached)
+        self.assertEqual(result.bytes_written, 4 * 1024)
+        # Files landed on disk under the expected categories.
+        for c in cards:
+            self.assertIsNotNone(disk_cache.read_image(LARGE_CATEGORY, c["id"]))
+            self.assertIsNotNone(disk_cache.read_image(SMALL_CATEGORY, c["id"]))
+
+    def test_skip_existing_does_not_re_download(self) -> None:
+        cards = [_card("sv8", 1)]
+        # Pre-seed both sizes so the warm pass should fully skip the
+        # downloader.
+        disk_cache.write_image(LARGE_CATEGORY, cards[0]["id"], b"existing-lg", ext=".png")
+        disk_cache.write_image(SMALL_CATEGORY, cards[0]["id"], b"existing-sm", ext=".png")
+        with (
+            patch.object(TCGClient, "search_all", return_value=cards),
+            patch.object(card_images_mod, "_download_bytes") as mock_download,
+        ):
+            result = warm_card_images(TCGClient(), set_ids=["sv8"])
+
+        mock_download.assert_not_called()
+        # Pre-existing entries still count as warmed (post-condition is
+        # "image is on disk"), but no bytes were downloaded this pass.
+        self.assertEqual(result.images_warmed, 2)
+        self.assertEqual(result.bytes_written, 0)
+
+    def test_max_bytes_stops_cleanly_without_partial_write(self) -> None:
+        # 4 image fetches at 1 KB each would download 4 KB; cap at 2 KB
+        # → exactly 2 images land, the rest are skipped, budget_reached=True.
+        cards = [_card("sv8", 1), _card("sv8", 2)]
+        with (
+            patch.object(TCGClient, "search_all", return_value=cards),
+            self._patch_download(),
+        ):
+            result = warm_card_images(TCGClient(), set_ids=["sv8"], max_bytes=2048)
+
+        self.assertEqual(result.images_warmed, 2)
+        self.assertEqual(result.bytes_written, 2048)
+        self.assertTrue(result.budget_reached)
+        # Verify exactly 2 image files exist on disk for sv8.
+        sv8_dir = disk_cache._cache_root_path() / "images" / "cards"
+        on_disk = list(sv8_dir.rglob("sv8-*"))
+        self.assertEqual(len(on_disk), 2)
+
+    def test_skip_existing_bytes_dont_count_toward_budget(self) -> None:
+        # Pre-seed one card's images on disk. With skip-existing=True
+        # (default) the warmer treats them as already-warmed without
+        # downloading or counting bytes — so a small budget still
+        # warms the second card cleanly.
+        cards = [_card("sv8", 1), _card("sv8", 2)]
+        disk_cache.write_image(LARGE_CATEGORY, cards[0]["id"], b"pre", ext=".png")
+        disk_cache.write_image(SMALL_CATEGORY, cards[0]["id"], b"pre", ext=".png")
+        with (
+            patch.object(TCGClient, "search_all", return_value=cards),
+            self._patch_download(),
+        ):
+            result = warm_card_images(TCGClient(), set_ids=["sv8"], max_bytes=2048)
+
+        self.assertEqual(result.images_warmed, 4)  # 2 pre-warmed + 2 freshly written
+        self.assertEqual(result.bytes_written, 2048)  # only the new writes
+        self.assertFalse(result.budget_reached)
+
+    def test_sizes_filter_restricts_what_gets_warmed(self) -> None:
+        cards = [_card("sv8", 1)]
+        with (
+            patch.object(TCGClient, "search_all", return_value=cards),
+            self._patch_download(),
+        ):
+            result = warm_card_images(TCGClient(), set_ids=["sv8"], sizes=("small",))
+
+        self.assertEqual(result.images_warmed, 1)
+        self.assertIsNone(disk_cache.read_image(LARGE_CATEGORY, cards[0]["id"]))
+        self.assertIsNotNone(disk_cache.read_image(SMALL_CATEGORY, cards[0]["id"]))
+
+    def test_card_without_images_dict_is_skipped(self) -> None:
+        no_images_card = {"id": "sv8-99", "name": "Promo"}  # no images key
+        with (
+            patch.object(TCGClient, "search_all", return_value=[no_images_card]),
+            self._patch_download(),
+        ):
+            result = warm_card_images(TCGClient(), set_ids=["sv8"])
+        self.assertEqual(result.images_warmed, 0)
+        self.assertEqual(result.images_failed, 0)
+
+    def test_download_failure_increments_images_failed(self) -> None:
+        cards = [_card("sv8", 1)]
+        with (
+            patch.object(TCGClient, "search_all", return_value=cards),
+            patch.object(card_images_mod, "_download_bytes", return_value=None),
+        ):
+            result = warm_card_images(TCGClient(), set_ids=["sv8"])
+
+        # Both sizes fail; both increment failed; nothing landed on disk.
+        self.assertEqual(result.images_warmed, 0)
+        self.assertEqual(result.images_failed, 2)
+        self.assertIsNone(disk_cache.read_image(LARGE_CATEGORY, cards[0]["id"]))
+
+    def test_set_returning_no_cards_lands_in_sets_failed(self) -> None:
+        with (
+            patch.object(TCGClient, "search_all", return_value=[]),
+            self._patch_download(),
+        ):
+            result = warm_card_images(TCGClient(), set_ids=["ghost"])
+
+        self.assertEqual(result.sets_failed, ["ghost"])
+        self.assertEqual(result.images_warmed, 0)
+
+
+# ---------------------------------------------------------------------------
+# parse_bytes_budget
+# ---------------------------------------------------------------------------
+
+
+class ParseBytesBudgetTests(unittest.TestCase):
+    def test_raw_int_string(self) -> None:
+        self.assertEqual(parse_bytes_budget("1024"), 1024)
+
+    def test_suffixes(self) -> None:
+        self.assertEqual(parse_bytes_budget("1KB"), 1024)
+        self.assertEqual(parse_bytes_budget("1MB"), 1024**2)
+        self.assertEqual(parse_bytes_budget("1GB"), 1024**3)
+        self.assertEqual(parse_bytes_budget("1TB"), 1024**4)
+
+    def test_case_and_whitespace_tolerant(self) -> None:
+        self.assertEqual(parse_bytes_budget(" 5 gb "), 5 * 1024**3)
+        self.assertEqual(parse_bytes_budget("500mb"), 500 * 1024**2)
+
+    def test_fractional_values(self) -> None:
+        self.assertEqual(parse_bytes_budget("1.5GB"), int(1.5 * 1024**3))
+
+    def test_invalid_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            parse_bytes_budget("five gigabytes")
+        with self.assertRaises(ValueError):
+            parse_bytes_budget("")
+        with self.assertRaises(ValueError):
+            parse_bytes_budget("-1MB")
+
+
+# ---------------------------------------------------------------------------
+# CacheStats projection
+# ---------------------------------------------------------------------------
+
+
+class CardImagesWarmStatsProjectionTests(_IsolatedCacheMixin):
+    def test_stats_reflects_card_images_warm_manifest(self) -> None:
+        disk_cache.write_card_images_warm(
+            images_warmed=36_000,
+            images_failed=14,
+            bytes_written=3_500_000_000,
+            budget_reached=True,
+            sets_attempted=173,
+            sets_failed=["x"],
+        )
+        s = disk_cache.stats()
+        self.assertEqual(s.card_images_warm_count, 36_000)
+        self.assertEqual(s.card_images_warm_bytes, 3_500_000_000)
+        self.assertTrue(s.card_images_warm_budget_reached)
+        self.assertIsInstance(s.card_images_warm_timestamp, float)
+
+    def test_stats_zeroed_when_no_manifest(self) -> None:
+        s = disk_cache.stats()
+        self.assertEqual(s.card_images_warm_count, 0)
+        self.assertEqual(s.card_images_warm_bytes, 0)
+        self.assertFalse(s.card_images_warm_budget_reached)
+        self.assertIsNone(s.card_images_warm_timestamp)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_warm_card_images.py
+++ b/tests/test_warm_card_images.py
@@ -239,6 +239,27 @@ class WarmCardImagesTests(_IsolatedCacheMixin):
         self.assertEqual(result.images_warmed, 2)
         self.assertEqual(result.bytes_written, 0)
 
+    def test_max_bytes_never_exceeded_when_next_download_too_large(self) -> None:
+        # Regression for Copilot review on #371: the pre-download
+        # check stops only when `bytes_written >= max_bytes`. Without
+        # a post-download check, a download larger than the remaining
+        # budget would still be written and push us past the cap.
+        # Here: budget is 1500, first image is 1024 (fits, leaves 476
+        # remaining), second image is 1024 (would push to 2048).
+        # Expected: 1 image written, 1024 bytes_written, budget_reached.
+        cards = [_card("sv8", 1)]
+        with (
+            patch.object(TCGClient, "search_all", return_value=cards),
+            self._patch_download(),  # default 1024 bytes per image
+        ):
+            result = warm_card_images(TCGClient(), set_ids=["sv8"], max_bytes=1500)
+        # First image (large) fits within 1500; second (small) would
+        # push to 2048 > 1500 → not written.
+        self.assertEqual(result.images_warmed, 1)
+        self.assertEqual(result.bytes_written, 1024)
+        self.assertTrue(result.budget_reached)
+        self.assertLessEqual(result.bytes_written, 1500)
+
     def test_max_bytes_stops_cleanly_without_partial_write(self) -> None:
         # 4 image fetches at 1 KB each would download 4 KB; cap at 2 KB
         # → exactly 2 images land, the rest are skipped, budget_reached=True.
@@ -350,6 +371,15 @@ class ParseBytesBudgetTests(unittest.TestCase):
             parse_bytes_budget("")
         with self.assertRaises(ValueError):
             parse_bytes_budget("-1MB")
+
+    def test_raw_negative_int_raises(self) -> None:
+        # Regression for Copilot review on #371: a raw negative int
+        # like `-1` used to bypass the negative-value guard because it
+        # took the no-suffix `int(s)` branch.
+        with self.assertRaises(ValueError):
+            parse_bytes_budget("-1")
+        with self.assertRaises(ValueError):
+            parse_bytes_budget("-1024")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_warm_on_startup.py
+++ b/tests/test_warm_on_startup.py
@@ -211,6 +211,74 @@ class WarmCardsLifespanTests(unittest.TestCase):
             mock_cards.assert_called_once()
 
 
+class WarmCardImagesLifespanTests(unittest.TestCase):
+    """Pin that `MGZ_PKMN_WARM_CARD_IMAGES_ON_STARTUP` is wired through
+    the lifespan and that it stays independent of the other flags —
+    Phase 2 (#371) makes this the heaviest opt-in (~3-5 GB on disk)."""
+
+    def setUp(self) -> None:
+        self._old_warm = os.environ.get("MGZ_PKMN_WARM_ON_STARTUP")
+        self._old_warm_cards = os.environ.get("MGZ_PKMN_WARM_CARDS_ON_STARTUP")
+        self._old_warm_images = os.environ.get("MGZ_PKMN_WARM_CARD_IMAGES_ON_STARTUP")
+        self._old_automigrate = os.environ.get("MGZ_PKMN_AUTOMIGRATE")
+        os.environ["MGZ_PKMN_AUTOMIGRATE"] = "0"
+
+    def tearDown(self) -> None:
+        for key, prev in (
+            ("MGZ_PKMN_WARM_ON_STARTUP", self._old_warm),
+            ("MGZ_PKMN_WARM_CARDS_ON_STARTUP", self._old_warm_cards),
+            ("MGZ_PKMN_WARM_CARD_IMAGES_ON_STARTUP", self._old_warm_images),
+            ("MGZ_PKMN_AUTOMIGRATE", self._old_automigrate),
+        ):
+            if prev is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = prev
+
+    def _reload_main(self):
+        if "api.main" in sys.modules:
+            return importlib.reload(sys.modules["api.main"])
+        import api.main as main
+
+        return main
+
+    def test_card_images_env_set_kicks_off_image_warmer(self) -> None:
+        os.environ["MGZ_PKMN_WARM_CARD_IMAGES_ON_STARTUP"] = "1"
+        os.environ.pop("MGZ_PKMN_WARM_ON_STARTUP", None)
+        os.environ.pop("MGZ_PKMN_WARM_CARDS_ON_STARTUP", None)
+        main = self._reload_main()
+        with (
+            patch.object(main, "_warm_concepts_in_background") as mock_concepts,
+            patch.object(main, "_warm_set_cards_in_background") as mock_set_cards,
+            patch.object(main, "_warm_sets_in_background") as mock_sets,
+            patch.object(main, "_warm_cards_in_background") as mock_cards,
+            patch.object(main, "_warm_card_images_in_background") as mock_images,
+        ):
+            with TestClient(main.app) as c:
+                self.assertEqual(c.get("/health").status_code, 200)
+            mock_images.assert_called_once()
+            mock_concepts.assert_not_called()
+            mock_set_cards.assert_not_called()
+            mock_sets.assert_not_called()
+            mock_cards.assert_not_called()
+
+    def test_other_warm_envs_alone_do_not_fire_image_warmer(self) -> None:
+        os.environ["MGZ_PKMN_WARM_ON_STARTUP"] = "1"
+        os.environ["MGZ_PKMN_WARM_CARDS_ON_STARTUP"] = "1"
+        os.environ.pop("MGZ_PKMN_WARM_CARD_IMAGES_ON_STARTUP", None)
+        main = self._reload_main()
+        with (
+            patch.object(main, "_warm_concepts_in_background"),
+            patch.object(main, "_warm_set_cards_in_background"),
+            patch.object(main, "_warm_sets_in_background"),
+            patch.object(main, "_warm_cards_in_background"),
+            patch.object(main, "_warm_card_images_in_background") as mock_images,
+        ):
+            with TestClient(main.app) as c:
+                self.assertEqual(c.get("/health").status_code, 200)
+            mock_images.assert_not_called()
+
+
 class WarmSetsBackgroundBodyTests(unittest.TestCase):
     """Drive the body of `_warm_sets_in_background` synchronously so the
     inner `_run` (TCGClient → warm_set_images → write_sets_warm + log)

--- a/tests/test_warm_on_startup.py
+++ b/tests/test_warm_on_startup.py
@@ -29,6 +29,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from fastapi.testclient import TestClient
 
 from mgz_pkmn import cache as disk_cache
+from mgz_pkmn.card_images import WarmCardImagesResult
 from mgz_pkmn.lookup import WarmCardsResult
 from mgz_pkmn.set_cards import WarmResult
 
@@ -503,6 +504,121 @@ class WarmCardsBackgroundBodyTests(unittest.TestCase):
             patch.object(main._log, "info") as mock_log_info,
         ):
             main._warm_cards_in_background()
+
+        mock_client_cls.assert_not_called()
+        mock_warm.assert_not_called()
+        mock_threading.Thread.assert_not_called()
+        fresh_logs = [call for call in mock_log_info.call_args_list if "fresh" in str(call)]
+        self.assertEqual(len(fresh_logs), 1)
+
+
+class WarmCardImagesBackgroundBodyTests(unittest.TestCase):
+    """Same pattern as WarmCardsBackgroundBodyTests — drive the body of
+    `_warm_card_images_in_background` synchronously by patching
+    `threading.Thread` so `.start()` invokes the target inline. Covers
+    the inner _run (TCGClient → warm_card_images → write_card_images_warm
+    + log) that the lifespan-level tests mock at the boundary."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._old_xdg = os.environ.get("XDG_CACHE_HOME")
+        self._old_no_cache = os.environ.get(disk_cache._NO_CACHE_ENV)
+        os.environ["XDG_CACHE_HOME"] = self._tmp.name
+        os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+
+    def tearDown(self) -> None:
+        if self._old_xdg is None:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        else:
+            os.environ["XDG_CACHE_HOME"] = self._old_xdg
+        if self._old_no_cache is None:
+            os.environ.pop(disk_cache._NO_CACHE_ENV, None)
+        else:
+            os.environ[disk_cache._NO_CACHE_ENV] = self._old_no_cache
+        self._tmp.cleanup()
+
+    def _make_sync_thread(self):
+        def _thread_factory(*, target=None, name=None, daemon=None, **_kwargs):
+            instance = MagicMock()
+            instance.start.side_effect = lambda: target() if target else None
+            return instance
+
+        return _thread_factory
+
+    def test_card_images_warm_body_passes_throttle_and_writes_manifest(self) -> None:
+        from api import main
+
+        fake_result = WarmCardImagesResult(
+            sets_attempted=173,
+            images_warmed=36_000,
+            images_failed=4,
+            bytes_written=3_500_000_000,
+            budget_reached=False,
+            sets_failed=["ghost"],
+        )
+        with (
+            patch.object(main, "threading") as mock_threading,
+            patch.object(main, "TCGClient") as mock_client_cls,
+            patch.object(main, "warm_card_images", return_value=fake_result) as mock_warm,
+            patch.object(main._log, "info") as mock_log,
+        ):
+            mock_threading.Thread.side_effect = self._make_sync_thread()
+            main._warm_card_images_in_background()
+
+        mock_client_cls.assert_called_once()
+        # Throttle is non-zero so a no-API-key deploy doesn't burst
+        # through pokemontcg.io's image CDN rate limit during a fresh
+        # multi-hour pass.
+        mock_warm.assert_called_once()
+        _, kwargs = mock_warm.call_args
+        self.assertGreater(kwargs.get("throttle_ms", 0), 0)
+
+        manifest = disk_cache.read_card_images_warm()
+        self.assertIsNotNone(manifest)
+        assert manifest is not None
+        self.assertEqual(manifest["images_warmed"], 36_000)
+        self.assertEqual(manifest["images_failed"], 4)
+        self.assertEqual(manifest["bytes_written"], 3_500_000_000)
+        self.assertFalse(manifest["budget_reached"])
+        self.assertEqual(manifest["sets_failed"], ["ghost"])
+
+        complete_logs = [call for call in mock_log.call_args_list if "complete" in str(call)]
+        self.assertEqual(len(complete_logs), 1)
+
+    def test_card_images_warm_body_swallows_upstream_exception(self) -> None:
+        from api import main
+
+        with (
+            patch.object(main, "threading") as mock_threading,
+            patch.object(main, "TCGClient"),
+            patch.object(main, "warm_card_images", side_effect=RuntimeError("CDN down")),
+            patch.object(main._log, "exception") as mock_log_exception,
+        ):
+            mock_threading.Thread.side_effect = self._make_sync_thread()
+            main._warm_card_images_in_background()
+
+        self.assertIsNone(disk_cache.read_card_images_warm())
+        mock_log_exception.assert_called_once()
+
+    def test_card_images_warm_skipped_when_manifest_is_fresh(self) -> None:
+        from api import main
+
+        disk_cache.write_card_images_warm(
+            images_warmed=36_000,
+            images_failed=0,
+            bytes_written=3_500_000_000,
+            budget_reached=False,
+            sets_attempted=173,
+            sets_failed=[],
+        )
+
+        with (
+            patch.object(main, "threading") as mock_threading,
+            patch.object(main, "TCGClient") as mock_client_cls,
+            patch.object(main, "warm_card_images") as mock_warm,
+            patch.object(main._log, "info") as mock_log_info,
+        ):
+            main._warm_card_images_in_background()
 
         mock_client_cls.assert_not_called()
         mock_warm.assert_not_called()


### PR DESCRIPTION
Closes #371. Phase 2 of the pre-Scrydex catalog-warm epic ([#368](https://github.com/mgzwarrior/mgz-pkmn/issues/368)).

## What

End-to-end self-hosted card images: a new CLI warmer fills the disk cache, a new API route streams from it, and the lookup / set-cards responses transparently rewrite their image URLs to point at the route whenever the file is on disk.

- **`pkmn cache warm-card-images`** ([cli.py](src/mgz_pkmn/cli.py) → [card_images.py](src/mgz_pkmn/card_images.py)) walks every set, fetches `large` + `small` image bytes per card, and persists them under `cache/images/cards/{large,small}/<card_id>.<ext>`. Flags: `--sizes / --max-bytes / --skip-existing / --throttle-ms / --prefer-popular` (the last is reserved for future lookup-frequency-aware ordering, currently a no-op).
- **`GET /api/v1/cards/{card_id}/image/{size}`** ([cards.py](api/routes/cards.py)) streams cached bytes with a 30-day immutable browser-cache header. 404 on miss with a hint pointing at the warmer; never fetches upstream — a cold cache surfaces a clean 404 instead of hammering pokemontcg.io.
- **URL rewriter** (`rewrite_card_image_urls()` in [cards.py](api/routes/cards.py)) is wired into `lookup._row_to_dict` for every lookup / bulk SSE response and inline into `sets._trim_card`'s `thumb` field for the Browse grid. Cache hit → URL points at our route. Cache miss → upstream URL stays in place, so a cold deploy keeps serving working `<img>` tags.
- **`MGZ_PKMN_WARM_CARD_IMAGES_ON_STARTUP=1`** runtime hook in [api/main.py](api/main.py) is the deploy-time switch. Always behind its own env var because it's the heaviest of all the warmers (~36K fetches, ~3-5 GB on a cold disk).
- **New `card_images_warm.json` manifest** with `images_warmed / images_failed / bytes_written / budget_reached / sets_attempted / sets_failed`. `CacheStats` extends with `card_images_warm_timestamp / card_images_warm_count / card_images_warm_bytes / card_images_warm_budget_reached` and both `pkmn cache stats` + `GET /api/v1/cache/stats` surface them.

## Why

Two reinforcing reasons from the issue:

1. **Zero-credit images on Scrydex** — their best-practices doc explicitly recommends self-hosting card images. Doing it now against pokemontcg.io (while it's still free) hosts the bytes on our persistent disk and never re-fetches.
2. **SPA snappiness** — every `<img>` in the results table, card detail modal, and Browse grid currently round-trips to pokemontcg.io's CDN. Self-hosting drops latency and removes the third-party dependency from the user-perceived render. We already do this for set logos (`get_set_logo` in `api/routes/sets.py`); this just extends the same pattern to per-card images.

## How to verify

```bash
make dev   # api
cd web && npm run dev   # spa
```

Pre-seed a known card's image so the rewrite has something to point at (in production the warmer does this):

```python
from mgz_pkmn import cache as disk_cache
from mgz_pkmn.card_images import SMALL_CATEGORY, LARGE_CATEGORY
import requests
for size, cat, url in [
    ("small", SMALL_CATEGORY, "https://images.pokemontcg.io/base4/4.png"),
    ("large", LARGE_CATEGORY, "https://images.pokemontcg.io/base4/4_hires.png"),
]:
    r = requests.get(url, timeout=30); r.raise_for_status()
    disk_cache.write_image(cat, "base4-4", r.content, ext=url)
```

Then open http://localhost:5173, paste `Charizard | Base Set | 4/102`, hit **Look up**, and confirm:

- DevTools Network shows `GET /api/v1/cards/base4-4/image/small` returning 200 (not a request to `images.pokemontcg.io`).
- The Charizard `<img src>` in the results table resolves to `/api/v1/cards/base4-4/image/small`.
- Any **uncached** card in the same lookup (e.g. add `Pikachu | Jungle`) still renders — its `<img src>` stays pointed at `https://images.pokemontcg.io/...`, proving the graceful-degradation path.

Verified end-to-end against the local dev server during development — Charizard fetched from our route, Pikachu fell back to upstream, both rendered.

<!-- Screenshot inline in chat (Charizard cached vs Pikachu fallback) — drag-and-drop into this body to attach. -->

## Tests

- **`tests/test_warm_card_images.py`** — 25 tests covering manifest helpers, freshness gate edges, warmer behaviour (full pass, skip-existing, max-bytes stop-without-partial-write, sizes filter, download failure, sets-failed), and the CacheStats projection.
- **`tests/test_card_images_api.py`** — 12 tests covering the route (200 / 404 / 422 / path-traversal) and the URL rewriter (hit, miss, partial cache, None input, missing id, `_trim_card` thumb rewrite).
- **`tests/test_warm_on_startup.py`** — new `WarmCardImagesLifespanTests` pins the third env var as independent of the existing two.
- **`tests/test_cli.py`** — `--json` schema set updated for the new fields.

525 tests pass total; `make check` + `npm run build` green.

## Out of scope (per the issue)

- Lazy on-demand image warming — could land as an optimization later; doesn't conflict with this command.
- Image format conversion (WebP → AVIF) — we store what upstream gives us.