### PR TITLE
deploy(render): enable MGZ_PKMN_WARM_CARD_IMAGES_ON_STARTUP=1

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -281,11 +281,40 @@ def _warm_card_images_in_background() -> None:
     # sleep keeps us safely off any per-IP rate limit Cloudfront might
     # apply during a long sequential pull.
     _DEFAULT_STARTUP_THROTTLE_MS = 500
+    # Heartbeat cadence for the per-set progress callback below. The
+    # full pass walks ~170 sets at ~500 ms throttle + per-card image
+    # fetches (~minutes per set on a fresh disk), so a "log every 20
+    # sets" cadence yields ~8 heartbeat lines over the multi-hour run
+    # — enough signal to confirm the warm is making progress without
+    # spamming the log stream.
+    _PROGRESS_LOG_EVERY_N_SETS = 20
 
     def _run() -> None:
         try:
             pkmn = TCGClient(api_key=os.environ.get("POKEMONTCG_IO_API_KEY"))
-            result = warm_card_images(pkmn, throttle_ms=_DEFAULT_STARTUP_THROTTLE_MS)
+            # Operator-visible "the heavy warm is now running" line so a
+            # Render log stream isn't silent for hours between
+            # "Application startup complete" and the eventual "warm
+            # complete". Pairs with the periodic progress callback below.
+            _log.info(
+                "card-images warm starting on background thread "
+                "(throttle=%dms, log heartbeat every %d sets)",
+                _DEFAULT_STARTUP_THROTTLE_MS,
+                _PROGRESS_LOG_EVERY_N_SETS,
+            )
+
+            def _progress(index: int, total: int, set_id: str) -> None:
+                # First set + every Nth + the final set, so an operator
+                # always sees the initial confirmation and the wrap-up
+                # tick even if total isn't a multiple of the cadence.
+                if index == 1 or index == total or index % _PROGRESS_LOG_EVERY_N_SETS == 0:
+                    _log.info("card-images warm progress: [%d/%d] %s", index, total, set_id)
+
+            result = warm_card_images(
+                pkmn,
+                throttle_ms=_DEFAULT_STARTUP_THROTTLE_MS,
+                on_progress=_progress,
+            )
             disk_cache.write_card_images_warm(
                 images_warmed=result.images_warmed,
                 images_failed=result.images_failed,

--- a/render.yaml
+++ b/render.yaml
@@ -57,3 +57,18 @@ services:
       # serve-forever shape we want.
       - key: MGZ_PKMN_WARM_CARDS_ON_STARTUP
         value: "1"
+      # Phase 2 of the pre-Scrydex catalog-warm epic (#368, #371). The
+      # per-card *image* warm is the heaviest of all the warmers — a
+      # fresh pass downloads ~36K image files (large + small for the
+      # ~18K-card English catalog), totalling ~3-5 GB on the 10 GB
+      # persistent disk above. First boot after this lands takes
+      # *hours* on a background daemon thread (service stays responsive
+      # throughout — /health doesn't gate on warm completion); every
+      # boot after that hits the `card_images_warm.json` freshness gate
+      # (1-week TTL) and skips. With the persistent disk in place this
+      # delivers the SPA snappiness win the epic is built around —
+      # every `<img>` tag in the results table, card detail modal, and
+      # Browse grid now serves from /api/v1/cards/{id}/image/{size}
+      # instead of round-tripping to pokemontcg.io's CDN.
+      - key: MGZ_PKMN_WARM_CARD_IMAGES_ON_STARTUP
+        value: "1"

--- a/tests/test_warm_on_startup.py
+++ b/tests/test_warm_on_startup.py
@@ -584,6 +584,56 @@ class WarmCardImagesBackgroundBodyTests(unittest.TestCase):
 
         complete_logs = [call for call in mock_log.call_args_list if "complete" in str(call)]
         self.assertEqual(len(complete_logs), 1)
+        # Operator-visible "starting" line fires before warm_card_images
+        # is invoked, so a Render log stream isn't silent for hours
+        # between "Application startup complete" and "warm complete".
+        starting_logs = [call for call in mock_log.call_args_list if "starting" in str(call)]
+        self.assertEqual(len(starting_logs), 1)
+
+    def test_card_images_warm_body_emits_heartbeat_progress(self) -> None:
+        """The on_progress callback wired into the warmer logs the first
+        set, every 20th, and the final one — confirming the heartbeat
+        cadence holds across a realistic catalog size."""
+        from api import main
+
+        # Drive the progress callback for a realistic 173-set catalog
+        # so we can assert the exact heartbeat indices that should log.
+        def fake_warm(_client, **kwargs):
+            on_progress = kwargs["on_progress"]
+            for i in range(1, 174):
+                on_progress(i, 173, f"sv{i}")
+            from mgz_pkmn.card_images import WarmCardImagesResult
+
+            return WarmCardImagesResult(
+                sets_attempted=173,
+                images_warmed=10,
+                images_failed=0,
+                bytes_written=1024,
+                budget_reached=False,
+                sets_failed=[],
+            )
+
+        with (
+            patch.object(main, "threading") as mock_threading,
+            patch.object(main, "TCGClient"),
+            patch.object(main, "warm_card_images", side_effect=fake_warm),
+            patch.object(main._log, "info") as mock_log,
+        ):
+            mock_threading.Thread.side_effect = self._make_sync_thread()
+            main._warm_card_images_in_background()
+
+        progress_logs = [call for call in mock_log.call_args_list if "progress" in str(call)]
+        # First (1), every 20th (20, 40, 60, 80, 100, 120, 140, 160),
+        # and the final (173) — 10 progress lines total.
+        self.assertEqual(len(progress_logs), 10)
+        # Confirm the indices via the positional args (the message uses
+        # `%d` placeholders so the formatted string isn't in the call).
+        first_args = progress_logs[0].args
+        last_args = progress_logs[-1].args
+        self.assertEqual(first_args[1], 1)  # index
+        self.assertEqual(first_args[2], 173)  # total
+        self.assertEqual(last_args[1], 173)
+        self.assertEqual(last_args[2], 173)
 
     def test_card_images_warm_body_swallows_upstream_exception(self) -> None:
         from api import main


### PR DESCRIPTION
Closes #386.

## What

Sets `MGZ_PKMN_WARM_CARD_IMAGES_ON_STARTUP=1` on the Render web service in [render.yaml](render.yaml), mirroring how #379 promoted `MGZ_PKMN_WARM_CARDS_ON_STARTUP=1` to default after Phase 1 landed.

## Why

Phase 2 ([#385](https://github.com/mgzwarrior/mgz-pkmn/pull/385), [#371](https://github.com/mgzwarrior/mgz-pkmn/issues/371)) ships the warmer, the `GET /api/v1/cards/{id}/image/{size}` serving route, and the URL rewriter in `lookup._row_to_dict` / `sets._trim_card`. But the runtime startup hook is opt-in behind its own env var (default off), so without flipping it on the deployed instance every `<img>` tag in the SPA still round-trips to pokemontcg.io's CDN — none of the latency / Scrydex-prep benefits land in production.

## Cost

| | |
|---|---|
| Disk | ~3-5 GB on the 10 GB persistent disk (~20 MB used today) |
| First-boot time | ~hours of background download on the daemon thread; `/health` stays up throughout |
| Subsequent boots | Hit the `card_images_warm.json` freshness gate (1-week TTL) and skip |

## Depends on

[#385](https://github.com/mgzwarrior/mgz-pkmn/pull/385) — must merge first. This PR is technically a no-op against current `main` (the env var is dormant until `_warm_card_images_in_background` exists), so the merge order is harmless either way, but the warm only starts firing once both are in.

## How to verify

After both PRs are merged and Render redeploys:

```bash
curl -s https://mgz-pkmn.onrender.com/api/v1/cache/stats | jq '.card_images_warm_timestamp, .card_images_warm_count, .card_images_warm_bytes'
```

Within an hour of first boot the timestamp should be non-null and `card_images_warm_count` climbing. After completion (a few hours), the Render log stream should include the `card-images warm complete: ... bytes ... budget_reached=False` line. Hit the SPA and confirm at least one cached card's `<img src>` resolves to `/api/v1/cards/.../image/...` instead of `https://images.pokemontcg.io/...`.