### PR TITLE
fix(deploy): move previews into the service block + bump disk to 50 GB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,23 @@ Versions follow [Semantic Versioning](https://semver.org/).
   spins a preview environment automatically (see
   [Render's Blueprint spec](https://render.com/docs/blueprint-spec#previews)).
 
+- Deploy: **`render.yaml` blueprint-sync fixes after #389**
+  ([#392](https://github.com/mgzwarrior/mgz-pkmn/issues/392)). The
+  next blueprint sync after [#391](https://github.com/mgzwarrior/mgz-pkmn/pull/391)
+  failed with two errors. (1) The top-level `previews.generation`
+  field added in #389 governs *multi-service* preview environments;
+  for a single-service blueprint the field that actually opts the
+  web service into PR preview deploys is
+  `services[].previews.generation`, so move it there. Hobby
+  workspaces still reject the field at sync time — previews
+  require a paid workspace tier. (2) The persistent disk was
+  resized in-dashboard to 50 GB after the per-card image warm
+  ([#371](https://github.com/mgzwarrior/mgz-pkmn/issues/371))
+  landed ~17 GB on disk; Render disallows shrinking a disk
+  in-place, so the blueprint's `sizeGB: 10` was blocking every
+  sync. Bumped the blueprint to `sizeGB: 50` to match the live
+  disk.
+
 - Web: **Per-line timing chips now persist after a bulk lookup
   finishes** ([#376](https://github.com/mgzwarrior/mgz-pkmn/issues/376)).
   The [ProcessingQueue](web/src/components/ProcessingQueue.tsx) early-

--- a/render.yaml
+++ b/render.yaml
@@ -1,9 +1,3 @@
-# Auto-spin a preview environment for every PR against main. Omitting this
-# block defaults to off and Render disables previews on each blueprint sync
-# (#389). See https://render.com/docs/blueprint-spec#previews.
-previews:
-  generation: automatic
-
 services:
   - type: web
     name: mgz-pkmn
@@ -18,17 +12,26 @@ services:
     branch: main
     autoDeploy: true
     healthCheckPath: /health
+    # Opt this service into a PR preview deploy on every pull request against
+    # main. Per-service `previews.generation` is what controls individual PR
+    # previews; omitting it defaults to off and Render disables previews on
+    # each blueprint sync (#389). Requires a paid workspace tier — Hobby
+    # workspaces reject the field at sync time. See
+    # https://render.com/docs/blueprint-spec#previews.
+    previews:
+      generation: automatic
     # Persistent disk so the cache survives redeploys (see #369). The mount
     # path matches the `XDG_CACHE_HOME` env var below; the cache module
     # (`src/mgz_pkmn/cache.py::_cache_root_path`) reads `XDG_CACHE_HOME` as
     # the *parent* directory and appends `mgz-pkmn`, so this resolves to
-    # `/var/cache/mgz-pkmn`. 10 GB is comfortable headroom for the full
-    # English-card catalog warm planned in epic #368 (~90-180 MB structural
-    # JSON + ~3-5 GB images + run-history SQLite + manifests).
+    # `/var/cache/mgz-pkmn`. Bumped to 50 GB after the per-card image warm
+    # (#371) landed ~17 GB on top of the structural cache, leaving headroom
+    # for the full English catalog plus future Scrydex-era additions.
+    # Render disallows shrinking a disk in-place — only increases sync.
     disk:
       name: cache
       mountPath: /var/cache
-      sizeGB: 10
+      sizeGB: 50
     envVars:
       # Live API key for lookups against pokemontcg.io. Build-time use of
       # this var was retired in #369 along with the Dockerfile's


### PR DESCRIPTION
Closes #392

## What

- Move the `previews: generation: automatic` block from the top
  level of [`render.yaml`](render.yaml) into the `mgz-pkmn` web
  service.
- Bump `services[0].disk.sizeGB` from `10` to `50` to match the
  live persistent disk.

## Why

After [#391](https://github.com/mgzwarrior/mgz-pkmn/pull/391) merged, the next blueprint sync against Render failed:

```
Preview Environments are not available for Hobby workspaces
services[0].disk.sizeGB
  cannot decrease disk size from 50 to 10
```

1. **Wrong scope for the previews field.** Top-level
   `previews.generation` governs *multi-service preview
   environments* (grouping). For a single-service blueprint the
   field that actually opts the web service into PR previews is
   `services[].previews.generation`. Reference:
   [Render Blueprint spec — previews](https://render.com/docs/blueprint-spec#previews).
2. **Disk shrink rejection.** The persistent disk was resized
   in-dashboard to 50 GB after the per-card image warm
   ([#371](https://github.com/mgzwarrior/mgz-pkmn/issues/371))
   landed ~17 GB on top of the structural cache. Render disallows
   shrinking a disk in place, so the blueprint's `sizeGB: 10` was
   blocking every sync. The blueprint has to catch up to the live
   size before the next sync will succeed.

### Workspace-tier caveat

Render's preview environments require a **paid workspace tier**;
Hobby workspaces reject the `previews` field at sync time. This
PR lands the correct config so previews flip on the moment the
workspace is upgraded — but until then, the live PR-preview
behaviour is unchanged. The workspace upgrade is out of scope for
this PR.

## How to verify

- After merge, the next blueprint sync should accept both edits
  on a paid workspace (no `previews` validator error, no
  disk-shrink error).
- On a paid workspace, opening a PR against `main` should
  automatically create a preview deploy on Render (no manual
  click).