### PR TITLE
fix(web): upcast cache-stats byte counts through GB / TB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,35 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Web: **Cache-stats panel upcasts byte counts through GB / TB**
+  ([#390](https://github.com/mgzwarrior/mgz-pkmn/issues/390)). The
+  `formatBytes` helper in
+  [SettingsDrawer.tsx](web/src/components/SettingsDrawer.tsx) capped
+  at MB, so once the per-card image warm
+  ([#371](https://github.com/mgzwarrior/mgz-pkmn/issues/371))
+  landed ~17 GB on disk the *Images* row read as `17073.0 MB`
+  instead of `16.7 GB`. Function now mirrors the CLI's
+  `_format_bytes` (powers-of-1024, B / KB / MB / GB / TB,
+  one decimal once we leave the B range). Same pass renames the
+  *Overrides* row to *URL overrides* to match the CLI label —
+  the row tracks sticky `(name, set_hint) → PriceCharting URL`
+  entries from `url_overrides.json`, not a generic override
+  bucket. Pinned by a new test in
+  [SettingsDrawer.test.tsx](web/src/components/SettingsDrawer.test.tsx)
+  asserting B / KB / GB upcasting against the deployed instance's
+  17 GB image-warm result.
+
+- Docs: **`docs/cache.md` documents `pkmn cache warm-card-images`**
+  ([#390](https://github.com/mgzwarrior/mgz-pkmn/issues/390)). The
+  warm-passes table and env-variable reference were both missing
+  Phase 2 of the catalog-warm epic
+  ([#371](https://github.com/mgzwarrior/mgz-pkmn/issues/371)).
+  Added rows for the `warm-card-images` command and the
+  `MGZ_PKMN_WARM_CARD_IMAGES_ON_STARTUP` env var, plus the
+  deployed-instance final result (`40088 images warmed
+  (17904440414 bytes) across 173 sets`) as a planning reference
+  for disk size and first-deploy duration.
+
 - Deploy: **`render.yaml` re-enables PR preview environments**
   ([#389](https://github.com/mgzwarrior/mgz-pkmn/issues/389)). The
   blueprint had no `previews` block, so each sync against Render

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -112,6 +112,7 @@ land on a warm disk instead of paying upstream latency:
 | `pkmn cache warm-set-cards` | Per-set card-list JSON for every set | `set_cards_warm.json` | 7 d |
 | `pkmn cache warm-sets` | Set logo + symbol images | `sets_warm.json` | 7 d |
 | `pkmn cache warm-cards` | Full per-card structural payload (~18,000 cards) | `card_warm.json` | 7 d |
+| `pkmn cache warm-card-images` | `large` + `small` image bytes for every English card (~40,000 files / ~17 GB) | `card_images_warm.json` | 7 d |
 
 Each manifest records `timestamp` + a count of what was warmed; the
 freshness gate (`*_warm_is_fresh()`) reads it to skip a re-walk when a
@@ -120,6 +121,13 @@ bootstrap in [`api/main.py`](../api/main.py) fires the first three when
 `MGZ_PKMN_WARM_ON_STARTUP=1`. The per-card warm has its own opt-in
 (`MGZ_PKMN_WARM_CARDS_ON_STARTUP=1`) because it's heavier — a fresh
 pass writes one cache entry per card across the full English catalog.
+The per-card *image* warm has yet another opt-in
+(`MGZ_PKMN_WARM_CARD_IMAGES_ON_STARTUP=1`) because it's the heaviest of
+the four — a completed pass on the deployed instance reports
+`card-images warm complete: 40088 images warmed (17904440414 bytes)
+across 173 sets`, so plan disk size and first-deploy duration
+accordingly. Subsequent boots within the 1-week freshness window skip
+the re-walk.
 
 `warm-cards` is Phase 1 of the pre-Scrydex catalog-warm epic
 ([#368](https://github.com/mgzwarrior/mgz-pkmn/issues/368)). Reuses the
@@ -147,4 +155,5 @@ pkmn cache warm-cards --max-cards 1000
 | `MGZ_PKMN_CACHE_WARN_BYTES` | Integer byte count for the cache-size soft-warn threshold checked at `pkmn lookup` startup. Defaults to `52428800` (50 MB). Set to `0` (or any non-positive value) to disable the warning entirely. Unparseable values fall back to the default. |
 | `MGZ_PKMN_WARM_ON_STARTUP` | Truthy (`1`, `true`, `True`) enables the runtime warm bootstrap in the FastAPI lifespan for the concept, set-cards, and sets slices. Each slice is gated by its own freshness manifest so containers starting within the staleness window skip the re-walk. Set in `render.yaml` by default on the deployed instance. |
 | `MGZ_PKMN_WARM_CARDS_ON_STARTUP` | Truthy enables the runtime per-card warm bootstrap. Independent env var because the per-card pass is heavyweight (~18,000 cache entries on a fresh disk), but with the persistent disk in place a single first pass after deploy serves every subsequent deploy via the 1-week `card_warm.json` freshness gate. Also set in `render.yaml` by default. |
+| `MGZ_PKMN_WARM_CARD_IMAGES_ON_STARTUP` | Truthy enables the runtime per-card *image* warm bootstrap (Phase 2 of [#368](https://github.com/mgzwarrior/mgz-pkmn/issues/368)). Heaviest of the warm slices — a completed pass on the deployed instance lands ~40,000 image files / ~17 GB across ~170 sets, so it ships on its own env var (not the umbrella `MGZ_PKMN_WARM_ON_STARTUP`) and a separate `card_images_warm.json` freshness gate. Set in `render.yaml` by default. |
 | `XDG_CACHE_HOME` | Overrides the cache root. The store lives at `$XDG_CACHE_HOME/mgz-pkmn` when set, falling back to `~/.cache/mgz-pkmn` otherwise. Standard XDG semantics — no mgz-pkmn-specific behavior. |

--- a/web/src/components/SettingsDrawer.test.tsx
+++ b/web/src/components/SettingsDrawer.test.tsx
@@ -126,6 +126,37 @@ describe('SettingsDrawer', () => {
     await waitFor(() => expect(mockFetchCacheStats).toHaveBeenCalledTimes(2))
   })
 
+  it('cache-stats byte counts upcast through KB / MB / GB', async () => {
+    // 17_904_440_414 is the image-warm result from the deployed instance
+    // (#390) — the bug was rendering it as "17073.0 MB" instead of GB.
+    mockFetchCacheStats.mockResolvedValueOnce({
+      root: '/tmp/cache',
+      api_entry_count: 1,
+      api_bytes: 800, // < 1 KB -> "800 B"
+      api_oldest_mtime: null,
+      override_count: 1,
+      override_bytes: 1536, // 1.5 KB
+      image_entry_count: 40_088,
+      image_bytes: 17_904_440_414, // ~16.7 GB
+      concept_warm_timestamp: null,
+      concept_warm_names: 0,
+      set_cards_warm_timestamp: null,
+      set_cards_warm_count: 0,
+      sets_warm_timestamp: null,
+      sets_warm_count: 0,
+      card_warm_timestamp: null,
+      card_warm_count: 0,
+      card_warm_failed_count: 0,
+    })
+
+    render(<SettingsDrawer />)
+    fireEvent.click(screen.getByRole('button', { name: /settings/i }))
+
+    await waitFor(() => expect(screen.getByText(/800 B/)).toBeInTheDocument())
+    expect(screen.getByText(/1\.5 KB/)).toBeInTheDocument()
+    expect(screen.getByText(/16\.7 GB/)).toBeInTheDocument()
+  })
+
   it('cache-stats panel surfaces fetch errors without crashing', async () => {
     mockFetchCacheStats.mockRejectedValueOnce(new Error('boom'))
     render(<SettingsDrawer />)

--- a/web/src/components/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer.tsx
@@ -267,7 +267,7 @@ function CacheStatsPanel() {
         <dl className="grid grid-cols-2 gap-x-3 gap-y-1.5 text-xs">
           <StatRow label="API responses" value={`${stats.api_entry_count} · ${formatBytes(stats.api_bytes)}`} />
           <StatRow label="Images" value={`${stats.image_entry_count} · ${formatBytes(stats.image_bytes)}`} />
-          <StatRow label="Overrides" value={`${stats.override_count} · ${formatBytes(stats.override_bytes)}`} />
+          <StatRow label="URL overrides" value={`${stats.override_count} · ${formatBytes(stats.override_bytes)}`} />
           <StatRow
             label="Concepts"
             value={
@@ -327,10 +327,20 @@ function StatRow({ label, value, warn = false }: { label: string; value: string;
   )
 }
 
+// Mirrors `_format_bytes` in src/mgz_pkmn/cli.py — powers-of-1024 to match
+// `du -h`, one decimal once we leave the B range. Now that the per-card
+// image warm (#371) routinely lands the image cache in the multi-GB range,
+// capping at MB read as "17000.0 MB" instead of "17.5 GB".
 function formatBytes(n: number): string {
-  if (n < 1024) return `${n} B`
-  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
-  return `${(n / (1024 * 1024)).toFixed(1)} MB`
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let size = n
+  for (let i = 0; i < units.length; i++) {
+    if (size < 1024 || i === units.length - 1) {
+      return units[i] === 'B' ? `${Math.trunc(size)} B` : `${size.toFixed(1)} ${units[i]}`
+    }
+    size /= 1024
+  }
+  return `${size.toFixed(1)} ${units[units.length - 1]}`
 }
 
 function formatAge(epochSeconds: number): string {


### PR DESCRIPTION
Closes #390

## What

Three changes pinned to one issue:

1. **`formatBytes` in [`SettingsDrawer.tsx`](web/src/components/SettingsDrawer.tsx)** now mirrors the CLI's `_format_bytes` — powers-of-1024, B / KB / MB / GB / TB, one decimal once we leave the B range. Previous implementation capped at MB.
2. **Cache-stats label rename**: *Overrides* → *URL overrides*. The row tracks sticky `(name, set_hint) → PriceCharting URL` entries from `url_overrides.json`, not a generic override bucket — the bare label was ambiguous (the issue itself asked "what is the override line tracking?"). New label matches the CLI's `pkmn cache stats` output.
3. **`docs/cache.md` catches up to Phase 2 of the catalog-warm epic** ([#371](https://github.com/mgzwarrior/mgz-pkmn/issues/371)). The warm-passes table and env-var reference both gained a row for `pkmn cache warm-card-images` and `MGZ_PKMN_WARM_CARD_IMAGES_ON_STARTUP`, with the deployed instance's final-pass result (`40088 images warmed (17904440414 bytes) across 173 sets`) as a planning reference for disk size and first-deploy duration.

## Why

With the per-card image warm now resident on the persistent disk, the *Images* row of the cache-stats panel in the Settings drawer was rendering ~17 GB as `17073.0 MB` — technically correct, practically unreadable. Same panel had two other rough edges: the *Overrides* label didn't say what it tracked (PriceCharting URL stickies, not a generic bucket), and the operations docs hadn't been updated since Phase 2 landed.

## How to verify

Verified locally against a dev-server preview with `/api/v1/cache/stats` mocked to the deployed instance's actual numbers (`image_bytes: 17_904_440_414`, `override_bytes: 1536`, `api_bytes: 9_227_468`). Rendered values:

| Row | Before fix | After fix |
|---|---|---|
| API responses | `175 · 8.8 MB` | `175 · 8.8 MB` |
| Images | `175 · 17073.0 MB` | `40088 · 16.7 GB` |
| Overrides → URL overrides | `20 · 1.5 KB` (mislabeled) | `20 · 1.5 KB` (relabeled) |

Pinned by a new test in [`SettingsDrawer.test.tsx`](web/src/components/SettingsDrawer.test.tsx) asserting B / KB / GB upcasting against the same 17 GB image-warm value.

## Not in scope

- The `card_images_warm_*` fields exist on the API (`CacheStats` Python dataclass) but the SPA's `CacheStats` interface and the panel don't surface them yet. Worth its own follow-up issue — separate from the formatting bug.
- The JSON example in `docs/cache.md` ("Inspecting the cache" section) is also missing `image_*` and every `*_warm_*` field. Same story; deferred.