### PR TITLE
feat(release+site): auto-rebuild Pages on release; milestone-driven roadmap teaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,3 +86,23 @@ jobs:
             ```bash
             pip install mgz-pkmn==${{ steps.pypi.outputs.version }}
             ```
+
+  rebuild-site:
+    name: Rebuild marketing site
+    needs: github-release
+    runs-on: ubuntu-latest
+    # Don't fail the release if the hook is missing or the rebuild trigger
+    # bounces — the GitHub Release is already cut and PyPI is published.
+    continue-on-error: true
+    steps:
+      - name: Trigger Cloudflare Pages deploy hook
+        env:
+          HOOK: ${{ secrets.CF_PAGES_DEPLOY_HOOK }}
+        run: |
+          if [ -z "$HOOK" ]; then
+            echo "::warning::CF_PAGES_DEPLOY_HOOK not set; skipping site rebuild."
+            echo "Set the secret to: Cloudflare Pages → site → Settings → Build & deployments → Deploy hooks."
+            exit 0
+          fi
+          curl --fail-with-body -sS -X POST "$HOOK"
+          echo "Cloudflare Pages rebuild triggered."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,24 @@ Versions follow [Semantic Versioning](https://semver.org/).
   Pinned by 25+ tests in `tests/test_warm_card_images.py` and
   `tests/test_card_images_api.py`.
 
+- Release + site: **Marketing site auto-rebuilds after a release, and
+  the "Where it's going." teaser is now milestone-driven**
+  ([#362](https://github.com/mgzwarrior/mgz-pkmn/issues/362)).
+  `release.yml` now fires a Cloudflare Pages deploy hook
+  (`CF_PAGES_DEPLOY_HOOK`) after the GitHub Release is cut, so the
+  hero pill and roadmap teaser pick up the new version once the demo
+  API has rotated rather than waiting for the next `site/**` push.
+  [RoadmapTeaser.astro](site/src/components/RoadmapTeaser.astro)
+  now build-time-fetches the repo's milestones via the GitHub API and
+  renders the most-recently-closed milestone as **Shipped**, the open
+  milestone with the soonest due date as **In flight**, and the next
+  open milestone as **Planned** — body copy comes from each
+  milestone's description, falling back to a generic per-state line
+  when empty. The previous hard-coded cards remain as the fallback
+  when the GitHub call fails, matching the changelog helper's
+  fail-open pattern. The rebuild job is `continue-on-error: true`,
+  so a missing or bouncing deploy hook never blocks the release.
+
 ### Fixed
 
 - Web: **Cache-stats panel upcasts byte counts through GB / TB**

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -419,6 +419,10 @@ need an explicit release action:
 
 - **Marketing site** (`site/`) → Cloudflare Pages auto-deploys on
   push to `main` ([ADR-0011](adr/0011-marketing-site-stack.md)).
+  `release.yml` *also* fires the Pages deploy hook after the GitHub
+  Release is cut, so the hero pill and roadmap teaser pick up the new
+  version once the demo API has rotated. Requires the
+  [`CF_PAGES_DEPLOY_HOOK`](#cloudflare-pages-deploy-hook) secret.
 - **Demo API + SPA** (`api/` + `web/`) → Render auto-deploys on
   push to `main` from the [`render.yaml`](../render.yaml) blueprint
   ([ADR-0016](adr/0016-deployment-topology.md), [docs/deployment.md](deployment.md)).
@@ -426,7 +430,10 @@ need an explicit release action:
   in-app "What's new" panel both read from
   `GET /api/v1/changelog`, which parses `CHANGELOG.md` — so as
   long as the release PR's changelog rotation lands, those
-  surfaces self-update on the next deploy.
+  surfaces self-update on the next deploy. The roadmap teaser
+  ("Where it's going.") pulls its three cards from the GitHub
+  milestones API at build time and falls back to a hard-coded set
+  if the call fails.
 
 ### Running this from Claude Code
 
@@ -516,3 +523,16 @@ Scope the PAT to this repository with **Contents: read and write**.
 Rotate it on the standard cadence and update the
 `RELEASE_PAT` secret under repo Settings → Secrets and variables →
 Actions.
+
+### Cloudflare Pages deploy hook
+
+The `rebuild-site` job in `release.yml` curls a Cloudflare Pages
+deploy hook so the marketing site rebuilds against the freshly
+published changelog (otherwise the hero pill and roadmap teaser keep
+showing the previous version until the next `site/**` push).
+
+Capture the hook from the Cloudflare Pages dashboard → site →
+**Settings → Build & deployments → Deploy hooks**, and store the
+returned URL as the repo secret `CF_PAGES_DEPLOY_HOOK`. The job is
+`continue-on-error: true` and warns (without failing) if the secret
+is unset, so the release itself is never blocked on the rebuild.

--- a/site/src/components/RoadmapTeaser.astro
+++ b/site/src/components/RoadmapTeaser.astro
@@ -1,9 +1,11 @@
 ---
 import { fetchRoadmapMilestones, type RoadmapState } from "../lib/github.ts";
+import { renderInlineMarkdown } from "../lib/changelog.ts";
 
 interface Milestone {
   label: string;
   state: RoadmapState;
+  /** HTML-safe body markup (already run through `renderInlineMarkdown`). */
   body: string;
   href: string;
 }
@@ -11,7 +13,9 @@ interface Milestone {
 // Hard-coded fallback used when the GitHub milestones API is unreachable
 // at build time, or returns fewer than three usable milestones. Mirrors
 // the changelog helper's "fail open, build still succeeds" pattern.
-const fallback: Milestone[] = [
+// Bodies are passed through `renderInlineMarkdown` alongside the live
+// data so any inline links / code / bold render consistently.
+const fallbackRaw: { label: string; state: RoadmapState; body: string; href: string }[] = [
   {
     label: "1.1 — Shipped",
     state: "done",
@@ -31,6 +35,10 @@ const fallback: Milestone[] = [
     href: "https://github.com/mgzwarrior/mgz-pkmn/milestone/3",
   },
 ];
+const fallback: Milestone[] = fallbackRaw.map((m) => ({
+  ...m,
+  body: renderInlineMarkdown(m.body),
+}));
 
 const stateSuffix: Record<RoadmapState, string> = {
   done: "Shipped",
@@ -49,7 +57,10 @@ const milestones: Milestone[] = dynamic
   ? dynamic.map((m) => ({
       label: `${m.title} — ${stateSuffix[m.state]}`,
       state: m.state,
-      body: m.body ?? stateFallbackBody[m.state],
+      // Milestone descriptions support the same inline-markdown subset as
+      // changelog bullets ([text](url), `code`, **bold**); render through
+      // the shared helper so links land as <a>, not literal `[text](url)`.
+      body: renderInlineMarkdown(m.body ?? stateFallbackBody[m.state]),
       href: m.url,
     }))
   : fallback;
@@ -87,7 +98,11 @@ const stateStyle = {
             >
               {m.label}
             </span>
-            <p class="mt-4 text-sm leading-relaxed text-coconut-400 dark:text-sand-300 flex-1">{m.body}</p>
+            <p
+              class="mt-4 text-sm leading-relaxed text-coconut-400 dark:text-sand-300 flex-1"
+              set:html={m.body}
+            />
+
             <a
               href={m.href}
               class="mt-5 inline-flex items-center gap-1 text-sm font-semibold text-palm-500 hover:text-palm-400 dark:text-sun-300 dark:hover:text-sun-200"

--- a/site/src/components/RoadmapTeaser.astro
+++ b/site/src/components/RoadmapTeaser.astro
@@ -1,5 +1,17 @@
 ---
-const milestones = [
+import { fetchRoadmapMilestones, type RoadmapState } from "../lib/github.ts";
+
+interface Milestone {
+  label: string;
+  state: RoadmapState;
+  body: string;
+  href: string;
+}
+
+// Hard-coded fallback used when the GitHub milestones API is unreachable
+// at build time, or returns fewer than three usable milestones. Mirrors
+// the changelog helper's "fail open, build still succeeds" pattern.
+const fallback: Milestone[] = [
   {
     label: "1.1 — Shipped",
     state: "done",
@@ -19,6 +31,28 @@ const milestones = [
     href: "https://github.com/mgzwarrior/mgz-pkmn/milestone/3",
   },
 ];
+
+const stateSuffix: Record<RoadmapState, string> = {
+  done: "Shipped",
+  active: "In flight",
+  planned: "Planned",
+};
+
+const stateFallbackBody: Record<RoadmapState, string> = {
+  done: "Shipped. See the milestone for the changelog.",
+  active: "Currently in flight. See the milestone for open work.",
+  planned: "Up next. See the milestone for the planned scope.",
+};
+
+const dynamic = await fetchRoadmapMilestones();
+const milestones: Milestone[] = dynamic
+  ? dynamic.map((m) => ({
+      label: `${m.title} — ${stateSuffix[m.state]}`,
+      state: m.state,
+      body: m.body ?? stateFallbackBody[m.state],
+      href: m.url,
+    }))
+  : fallback;
 
 const stateStyle = {
   done: "bg-palm-50 text-palm-600 border-palm-200 dark:bg-palm-500/15 dark:text-palm-200 dark:border-palm-500/30",
@@ -49,7 +83,7 @@ const stateStyle = {
         milestones.map((m) => (
           <li class="flex flex-col rounded-xl border border-sand-300 bg-sand-100 p-6 shadow-xs dark:border-husk-50 dark:bg-husk-200/40 dark:shadow-none">
             <span
-              class={`self-start rounded-full border px-3 py-1 text-xs font-semibold ${stateStyle[m.state as keyof typeof stateStyle]}`}
+              class={`self-start rounded-full border px-3 py-1 text-xs font-semibold ${stateStyle[m.state]}`}
             >
               {m.label}
             </span>

--- a/site/src/lib/github.ts
+++ b/site/src/lib/github.ts
@@ -175,6 +175,113 @@ export async function fetchContributors(limit = 12): Promise<Contributor[]> {
 }
 
 // ---------------------------------------------------------------------------
+// Roadmap milestones — drives the "Where it's going." teaser on the
+// landing page. We pull `state=all` so the most-recently-closed milestone
+// shows as the "done" card alongside the active/planned open ones.
+// ---------------------------------------------------------------------------
+
+export type RoadmapState = "done" | "active" | "planned";
+
+export interface RoadmapMilestone {
+  state: RoadmapState;
+  /** Milestone title with the leading `v` stripped (e.g. `1.2`). */
+  title: string;
+  /** Milestone description, or `null` when empty. */
+  body: string | null;
+  url: string;
+}
+
+interface GhMilestone {
+  number: number;
+  title: string;
+  description: string | null;
+  state: "open" | "closed";
+  due_on: string | null;
+  closed_at: string | null;
+  html_url: string;
+}
+
+function stripVPrefix(title: string): string {
+  return title.replace(/^v/i, "");
+}
+
+/**
+ * Tuple key for ordering semver-shaped milestone titles (`v1.4`, `v2.0`,
+ * `v1.10`) by version rather than string or GitHub milestone number.
+ * Non-numeric segments fall through to lexical compare so unusual titles
+ * still sort deterministically.
+ */
+function versionKey(title: string): number[] {
+  return stripVPrefix(title)
+    .split(".")
+    .map((part) => {
+      const n = Number.parseInt(part, 10);
+      return Number.isFinite(n) ? n : Number.MAX_SAFE_INTEGER;
+    });
+}
+
+function compareVersions(a: string, b: string): number {
+  const ak = versionKey(a);
+  const bk = versionKey(b);
+  const len = Math.max(ak.length, bk.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (ak[i] ?? 0) - (bk[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return a.localeCompare(b);
+}
+
+/**
+ * Pick the three milestones that drive the roadmap teaser:
+ *   - `done`: the most recently closed milestone
+ *   - `active`: the open milestone with the soonest due date (ties broken
+ *     by lowest number); falls back to the lowest-numbered open milestone
+ *     when none are dated
+ *   - `planned`: the next open milestone after the active one, by number
+ *
+ * Returns `null` when any of the three slots can't be filled or the
+ * GitHub call fails; the caller renders the hard-coded fallback in that
+ * case.
+ */
+export async function fetchRoadmapMilestones(): Promise<RoadmapMilestone[] | null> {
+  const url = `${API}/repos/${OWNER}/${REPO}/milestones?state=all&per_page=100`;
+  const data = await safeFetchJson<GhMilestone[]>(url);
+  if (!data) return null;
+
+  const closed = data
+    .filter((m) => m.state === "closed" && m.closed_at)
+    .sort((a, b) => (b.closed_at ?? "").localeCompare(a.closed_at ?? ""));
+  const open = data
+    .filter((m) => m.state === "open")
+    .sort((a, b) => {
+      // Dated milestones first, soonest due wins; undated fall back to
+      // semver-ordered title so `v1.4` lands before `v2.0`.
+      if (a.due_on && b.due_on) return a.due_on.localeCompare(b.due_on);
+      if (a.due_on) return -1;
+      if (b.due_on) return 1;
+      return compareVersions(a.title, b.title);
+    });
+
+  const done = closed[0];
+  const active = open[0];
+  // "Next open milestone after active" is the version that immediately
+  // follows the active one — pick by semver title order, not GitHub's
+  // internal milestone number.
+  const planned = open
+    .slice(1)
+    .sort((a, b) => compareVersions(a.title, b.title))[0];
+  if (!done || !active || !planned) return null;
+
+  const toCard = (m: GhMilestone, state: RoadmapState): RoadmapMilestone => ({
+    state,
+    title: stripVPrefix(m.title),
+    body: m.description?.trim() ? m.description.trim() : null,
+    url: m.html_url,
+  });
+  return [toCard(done, "done"), toCard(active, "active"), toCard(planned, "planned")];
+}
+
+// ---------------------------------------------------------------------------
 // Relative-time formatter shared across the three surfaces.
 // ---------------------------------------------------------------------------
 

--- a/site/src/lib/github.ts
+++ b/site/src/lib/github.ts
@@ -234,10 +234,13 @@ function compareVersions(a: string, b: string): number {
 /**
  * Pick the three milestones that drive the roadmap teaser:
  *   - `done`: the most recently closed milestone
- *   - `active`: the open milestone with the soonest due date (ties broken
- *     by lowest number); falls back to the lowest-numbered open milestone
- *     when none are dated
- *   - `planned`: the next open milestone after the active one, by number
+ *   - `active`: the open milestone with the soonest due date, ties broken
+ *     by semver-ordered title then by GitHub milestone number for stability;
+ *     falls back to the lowest semver-ordered open milestone when none are
+ *     dated
+ *   - `planned`: the open milestone whose version is the smallest greater
+ *     than `active`'s — i.e. the next version after the active one, never
+ *     a lower version even when `active` was picked by due-date
  *
  * Returns `null` when any of the three slots can't be filled or the
  * GitHub call fails; the caller renders the hard-coded fallback in that
@@ -254,22 +257,31 @@ export async function fetchRoadmapMilestones(): Promise<RoadmapMilestone[] | nul
   const open = data
     .filter((m) => m.state === "open")
     .sort((a, b) => {
-      // Dated milestones first, soonest due wins; undated fall back to
-      // semver-ordered title so `v1.4` lands before `v2.0`.
-      if (a.due_on && b.due_on) return a.due_on.localeCompare(b.due_on);
-      if (a.due_on) return -1;
-      if (b.due_on) return 1;
-      return compareVersions(a.title, b.title);
+      // Dated milestones first, soonest due wins; ties on due_on (and
+      // any two undated milestones) fall back to semver-ordered title
+      // so `v1.4` lands before `v2.0`, with milestone number as a final
+      // stable tie-break.
+      if (a.due_on && b.due_on) {
+        const dueDiff = a.due_on.localeCompare(b.due_on);
+        if (dueDiff !== 0) return dueDiff;
+      } else if (a.due_on) return -1;
+      else if (b.due_on) return 1;
+      const semverDiff = compareVersions(a.title, b.title);
+      if (semverDiff !== 0) return semverDiff;
+      return a.number - b.number;
     });
 
   const done = closed[0];
   const active = open[0];
-  // "Next open milestone after active" is the version that immediately
-  // follows the active one — pick by semver title order, not GitHub's
-  // internal milestone number.
-  const planned = open
-    .slice(1)
-    .sort((a, b) => compareVersions(a.title, b.title))[0];
+  // "Next open milestone after active" is the smallest open version
+  // strictly greater than active's — never a lower version even when
+  // active was picked by due-date (e.g. an actively-dated `v2.0` should
+  // not produce a `v1.4` planned card).
+  const planned = active
+    ? open
+        .filter((m) => m !== active && compareVersions(m.title, active.title) > 0)
+        .sort((a, b) => compareVersions(a.title, b.title))[0]
+    : undefined;
   if (!done || !active || !planned) return null;
 
   const toCard = (m: GhMilestone, state: RoadmapState): RoadmapMilestone => ({


### PR DESCRIPTION
Closes #362

## What

- `release.yml` grows a `rebuild-site` job that curls `CF_PAGES_DEPLOY_HOOK` after the GitHub Release is cut. The job is `continue-on-error: true` and warns (without failing) if the secret is unset, so the release itself is never blocked on the rebuild.
- `site/src/components/RoadmapTeaser.astro` now build-time-fetches the repo's milestones via a new `fetchRoadmapMilestones` helper in `site/src/lib/github.ts`. It renders:
  - the **most-recently-closed** milestone as `Shipped`
  - the **open milestone with the soonest due date** (semver tie-break) as `In flight`
  - the **next open milestone by version** as `Planned`
- Body copy comes from each milestone's description; a generic per-state line covers empty descriptions, and the previous hard-coded card set covers a complete GitHub API failure (mirrors the changelog helper's fail-open pattern).
- `docs/contributing.md` documents the new `CF_PAGES_DEPLOY_HOOK` secret and notes the teaser is now milestone-driven.

## Why

Cutting v1.2 left the hero pill stuck on `1.1.1` until a Cloudflare Pages deploy hook was fired manually. The "Where it's going." cards were even more brittle — pure strings in the component, hand-edited every release. Both pieces are now self-healing on the next release cut.

The fail-open posture (warn-don't-fail on missing secret, hard-coded fallback on GitHub fetch failure) keeps the release flow and the site build resilient if either piece of plumbing is misconfigured.

## How to verify

1. Local dev — `cd site && npm run dev`, then check the roadmap cards reflect live milestones (currently `1.2 — Shipped` / `1.3 — In flight` / `1.4 — Planned`) and the hero pill matches the latest shipped version.
2. After this PR merges, **add the `CF_PAGES_DEPLOY_HOOK` secret** (Cloudflare Pages → site → Settings → Build & deployments → Deploy hooks → copy URL into repo Settings → Secrets → Actions). Until then, the new release job warns and exits cleanly.
3. End-to-end verification per the issue's acceptance criteria lands on the v1.3 cut: the release tag fires the Pages hook, and the rebuilt site shows `Now shipping 1.3.0` plus a fresh `1.3 — Shipped` / next-active / next-planned roadmap.

Verified locally:

- `make check` → 566 tests pass, ruff + web ESLint clean.
- `cd web && npm run build` → green.
- Astro dev: hero pill renders `Now shipping 1.2.0`; roadmap cards render the three live milestones via the GitHub API.