### PR TITLE
chore: release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-06-02
+
 ### Added
 
 - API + CLI: **Split lookup cache + stale-while-revalidate on pricing**
@@ -880,7 +882,8 @@ UI, multi-source card lookup, all output formats, and release infrastructure.
 - Incomplete URL substring sanitization (CodeQL alerts).
 - Workflow permissions hardening (CodeQL alerts).
 
-[Unreleased]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.0.1...v1.1.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,5 +8,5 @@ authors:
 url: "https://mgz-pkmn.com"
 repository-code: "https://github.com/mgzwarrior/mgz-pkmn"
 license: "MIT"
-version: "1.2.0"
-date-released: "2026-05-31"
+version: "1.3.0"
+date-released: "2026-06-02"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mgz-pkmn-api"
-version = "1.2.0"
+version = "1.3.0"
 description = "FastAPI service for the mgz-pkmn card lookup tool."
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mgz-pkmn"
-version = "1.2.0"
+version = "1.3.0"
 description = "CLI and web app to look up Pokemon cards across open data sources, fetch images and prices, and emit an .xlsx, PDF binder, set-completion checklist, and JSON report for card-show prep."
 readme = "README.md"
 license = "MIT"

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mgz-pkmn-site",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mgz-pkmn-site",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.0.0",
         "astro": "^5.18.2",

--- a/site/package.json
+++ b/site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mgz-pkmn-site",
   "type": "module",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "scripts": {
     "dev": "astro dev",

--- a/src/mgz_pkmn/__init__.py
+++ b/src/mgz_pkmn/__init__.py
@@ -1,6 +1,6 @@
 """Pokemon card list -> spreadsheet for card shows."""
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 
 from mgz_pkmn.parser import CardQuery, parse_lines
 

--- a/uv.lock
+++ b/uv.lock
@@ -537,7 +537,7 @@ wheels = [
 
 [[package]]
 name = "mgz-pkmn"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Closes #397

## What

Cuts the **v1.3.0** release. Aligns every surface on the same version in one PR:

| Surface | File(s) | Was → Now |
|---|---|---|
| CLI | `pyproject.toml`, `src/mgz_pkmn/__init__.py`, `uv.lock` | 1.2.0 → 1.3.0 |
| API | `api/pyproject.toml` | 1.2.0 → 1.3.0 |
| Web SPA | `web/package.json`, `web/package-lock.json` | 1.2.0 → 1.3.0 |
| Marketing site | `site/package.json`, `site/package-lock.json` | 1.2.0 → 1.3.0 |
| Citation | `CITATION.cff` (`version` + `date-released`) | 1.2.0 / 2026-05-31 → 1.3.0 / 2026-06-02 |

Rotates `CHANGELOG.md`: renames the long `[Unreleased]` section to `[1.3.0] - 2026-06-02`, inserts a fresh empty `[Unreleased]` block above it, and updates the compare-links footer.

## Why

The version bump PR **is** the release. Once this merges to `main`, the auto-release flow tags `v1.3.0`, publishes to PyPI with PEP 740 attestation, and cuts a GitHub Release. The new `rebuild-site` job (landed in #396) then fires the Cloudflare Pages deploy hook so the marketing site's hero pill rotates to *Now shipping 1.3.0* and the milestone-driven roadmap teaser updates to *1.3 — Shipped / 1.4 — In flight / 2.0 — Planned* without manual intervention.

v1.3.0 ships the pre-Scrydex catalog-warm epic (#368): persistent disk, full structural + image cache warm against pokemontcg.io while it's still free, and a split structural / volatile cache with stale-while-revalidate on pricing. Phases 4 + 5 (Scrydex cutover + webhooks) carry into v1.4.

## How to verify

- [x] `make check` is green.
- [x] `cd web && npm run build` is green.
- [x] `cd site && npm run build` is green.
- [x] After merge: `release-on-version-bump` tags `v1.3.0`, `release.yml` publishes to PyPI + GitHub Release, `rebuild-site` job fires the Pages hook.
- [x] `uv run pkmn --version` reports `pkmn, version 1.3.0`.
- [x] `curl https://mgz-pkmn.onrender.com/version` returns `{"version": "1.3.0"}`.
- [x] `GET /api/v1/changelog` parses `[1.3.0] - 2026-06-02` as the latest shipped release.
- [x] Marketing site shows *Now shipping 1.3.0* and the roadmap rotates to *1.3 — Shipped*.

## Out of scope

- Backport release notes to the Wiki (`sync-wiki.yml` handles this).