### PR TITLE
fix(release): wait for demo API to rotate before firing Pages hook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,33 @@ jobs:
     # bounces — the GitHub Release is already cut and PyPI is published.
     continue-on-error: true
     steps:
+      # The marketing site fetches GET /api/v1/changelog at build time
+      # (see site/src/lib/changelog.ts), so kicking the Pages build the
+      # instant the GitHub Release lands can race Render's redeploy and
+      # bake the *previous* version into the static HTML. Poll the demo
+      # API's /version endpoint until it reports the new tag before
+      # firing the deploy hook. Falls through and fires anyway after a
+      # 10-minute budget so the job never blocks indefinitely on a slow
+      # or stuck Render rollout.
+      - name: Wait for demo API to rotate
+        env:
+          EXPECTED: ${{ github.ref_name }}
+          API_BASE: https://mgz-pkmn.onrender.com
+        run: |
+          expected="${EXPECTED#v}"
+          deadline=$(( $(date +%s) + 600 ))
+          while [ "$(date +%s)" -lt "$deadline" ]; do
+            actual=$(curl -sS --max-time 10 "${API_BASE}/version" \
+              | jq -r '.version // empty' 2>/dev/null || true)
+            if [ "$actual" = "$expected" ]; then
+              echo "Demo API rotated to ${actual}."
+              exit 0
+            fi
+            echo "Demo API still on '${actual:-unknown}'; waiting…"
+            sleep 15
+          done
+          echo "::warning::Demo API did not rotate to ${expected} within 10 min; firing the deploy hook anyway."
+
       - name: Trigger Cloudflare Pages deploy hook
         env:
           HOOK: ${{ secrets.CF_PAGES_DEPLOY_HOOK }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,7 +112,7 @@ jobs:
           deadline=$(( $(date +%s) + 600 ))
           while [ "$(date +%s)" -lt "$deadline" ]; do
             body=$(curl --fail-with-body -sS --max-time 10 "${API_BASE}/version" || true)
-            actual=$(printf '%s' "$body" | jq -r '.version // empty' 2>/dev/null || true)
+            actual=$(printf '%s' "$body" | python3 -c 'import json,sys; data=sys.stdin.read().strip(); print(json.loads(data).get("version", "") if data else "")' 2>/dev/null || true)
             if [ -z "$actual" ]; then
               echo "Demo API /version returned: ${body:-<empty>}"
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,8 +111,11 @@ jobs:
           expected="${EXPECTED#v}"
           deadline=$(( $(date +%s) + 600 ))
           while [ "$(date +%s)" -lt "$deadline" ]; do
-            actual=$(curl -sS --max-time 10 "${API_BASE}/version" \
-              | jq -r '.version // empty' 2>/dev/null || true)
+            body=$(curl --fail-with-body -sS --max-time 10 "${API_BASE}/version" || true)
+            actual=$(printf '%s' "$body" | jq -r '.version // empty' 2>/dev/null || true)
+            if [ -z "$actual" ]; then
+              echo "Demo API /version returned: ${body:-<empty>}"
+            fi
             if [ "$actual" = "$expected" ]; then
               echo "Demo API rotated to ${actual}."
               exit 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
   v1.3.0 fired the hook ~5 seconds after the GitHub Release was
   cut — before Render had finished rolling out the new API — so
   Astro's build-time call to `GET /api/v1/changelog` baked the
-  *previous* version into the static HTML and the hero pill stayed
+  previous version into the static HTML and the hero pill stayed
   on `Now shipping 1.2.0` until the hook was re-fired manually.
-  `release.yml` now polls `${API}/version` until it reports the
+  `release.yml` now polls `https://mgz-pkmn.onrender.com/version` until it reports the
   new tag's version (15 s interval, 10 min budget) before firing
   the hook, with a warn-and-continue fall-through so a slow or
   stuck Render rollout never blocks the rebuild indefinitely.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Release: **`rebuild-site` waits for the demo API to rotate before
+  firing the Pages deploy hook**
+  ([#399](https://github.com/mgzwarrior/mgz-pkmn/issues/399)). Cutting
+  v1.3.0 fired the hook ~5 seconds after the GitHub Release was
+  cut — before Render had finished rolling out the new API — so
+  Astro's build-time call to `GET /api/v1/changelog` baked the
+  *previous* version into the static HTML and the hero pill stayed
+  on `Now shipping 1.2.0` until the hook was re-fired manually.
+  `release.yml` now polls `${API}/version` until it reports the
+  new tag's version (15 s interval, 10 min budget) before firing
+  the hook, with a warn-and-continue fall-through so a slow or
+  stuck Render rollout never blocks the rebuild indefinitely.
+
 ## [1.3.0] - 2026-06-02
 
 ### Added


### PR DESCRIPTION
Closes #399

## What

Adds a `Wait for demo API to rotate` step to `release.yml`'s `rebuild-site` job. It polls `https://mgz-pkmn.onrender.com/version` until the returned JSON's `version` matches the new tag (stripped of the leading `v`), then fires the Cloudflare Pages deploy hook. 15-second interval, 10-minute budget; if the budget expires it logs a `::warning::` and fires the hook anyway, so a slow or stuck Render rollout never blocks the rebuild indefinitely.

## Why

Cutting v1.3.0 (#398) fired the deploy hook ~5 seconds after the GitHub Release was cut — before Render had finished rolling out the new API. Astro's frontmatter calls `GET /api/v1/changelog` at build time, so Pages baked the *previous* version into the static HTML. The hero pill stayed on `Now shipping 1.2.0` and the roadmap teaser fell back to the hard-coded cards.

Manually re-firing the hook ~9 minutes later (`gh run rerun --job`) was still not enough — see #399 for the full timeline.

## How to verify

- [x] `make check` is green.
- [x] After this lands + v1.3.1 is cut, the marketing site reports `Now shipping 1.3.1` without manual intervention, and the roadmap teaser rotates to the live milestone cards.

If 1.3.1 *also* ends up stuck, the issue is downstream of this workflow — either the `CF_PAGES_DEPLOY_HOOK` is wired to a non-production branch in Cloudflare or the Pages build worker can't reach the demo API. We'll know from the workflow logs (the new wait step will print what `/version` returned).