### PR TITLE
chore: release v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-06-02
+
 ### Fixed
 
 - Release: **`rebuild-site` waits for the demo API to rotate before
@@ -897,7 +899,8 @@ UI, multi-source card lookup, all output formats, and release infrastructure.
 - Incomplete URL substring sanitization (CodeQL alerts).
 - Workflow permissions hardening (CodeQL alerts).
 
-[Unreleased]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.3.1...HEAD
+[1.3.1]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.1.0...v1.1.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,5 +8,5 @@ authors:
 url: "https://mgz-pkmn.com"
 repository-code: "https://github.com/mgzwarrior/mgz-pkmn"
 license: "MIT"
-version: "1.3.0"
+version: "1.3.1"
 date-released: "2026-06-02"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mgz-pkmn-api"
-version = "1.3.0"
+version = "1.3.1"
 description = "FastAPI service for the mgz-pkmn card lookup tool."
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mgz-pkmn"
-version = "1.3.0"
+version = "1.3.1"
 description = "CLI and web app to look up Pokemon cards across open data sources, fetch images and prices, and emit an .xlsx, PDF binder, set-completion checklist, and JSON report for card-show prep."
 readme = "README.md"
 license = "MIT"

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mgz-pkmn-site",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mgz-pkmn-site",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@tailwindcss/vite": "^4.0.0",
         "astro": "^5.18.2",

--- a/site/package.json
+++ b/site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mgz-pkmn-site",
   "type": "module",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "private": true,
   "scripts": {
     "dev": "astro dev",

--- a/src/mgz_pkmn/__init__.py
+++ b/src/mgz_pkmn/__init__.py
@@ -1,6 +1,6 @@
 """Pokemon card list -> spreadsheet for card shows."""
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 from mgz_pkmn.parser import CardQuery, parse_lines
 

--- a/uv.lock
+++ b/uv.lock
@@ -537,7 +537,7 @@ wheels = [
 
 [[package]]
 name = "mgz-pkmn"
-version = "1.3.0"
+version = "1.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Closes #401

## What

Cuts the **v1.3.1** patch release. Aligns every surface on the same version in one PR:

| Surface | File(s) | Was → Now |
|---|---|---|
| CLI | `pyproject.toml`, `src/mgz_pkmn/__init__.py`, `uv.lock` | 1.3.0 → 1.3.1 |
| API | `api/pyproject.toml` | 1.3.0 → 1.3.1 |
| Web SPA | `web/package.json`, `web/package-lock.json` | 1.3.0 → 1.3.1 |
| Marketing site | `site/package.json`, `site/package-lock.json` | 1.3.0 → 1.3.1 |
| Citation | `CITATION.cff` | 1.3.0 → 1.3.1 (`date-released` stays 2026-06-02) |

Rotates `CHANGELOG.md`: renames the `[Unreleased]` section (which holds the `rebuild-site` race fix from #400) to `[1.3.1] - 2026-06-02`, inserts a fresh empty `[Unreleased]` block above it, and updates the compare-links footer.

## Why

Patch release to ship the `rebuild-site` race fix (#400) and validate it end-to-end. v1.3.0's release fired the Cloudflare Pages deploy hook ~5 seconds after the GitHub Release was cut — before Render had finished rolling out the new API — so Astro's build-time call to `/api/v1/changelog` baked the previous version into the static HTML.

The merged fix polls `/version` until the demo API reports the new tag's version before firing the deploy hook (15 s interval, 10 min budget, warn-and-continue fall-through). v1.3.1 is the first release that exercises that path.

## How to verify

- [x] `make check` is green.
- [x] `cd web && npm run build` is green.
- [x] `cd site && npm run build` is green.
- [x] After merge: `release-on-version-bump` tags `v1.3.1`, `release.yml` publishes to PyPI + GitHub Release, `rebuild-site` waits for the demo API to rotate then fires the Pages hook.
- [x] `curl https://mgz-pkmn.onrender.com/version` returns `{"version": "1.3.1"}`.
- [x] **Marketing site shows `Now shipping 1.3.1` without manual hook re-firing** — this is the actual validation of #400.

If the marketing site still ends up stuck on 1.3.0 after this release, the issue is downstream of `release.yml` (e.g. the `CF_PAGES_DEPLOY_HOOK` is wired to a non-production branch in Cloudflare, or the Pages build worker can't reach the demo API). The new `Wait for demo API to rotate` step's logs will show what `/version` returned during the build, which will help narrow it down.

## Out of scope

- Backport release notes to the Wiki (`sync-wiki.yml` handles this).