### PR TITLE
feat(api): auth foundation — signed-cookie sessions, /me, env kill switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- API: **Auth scaffold foundation** ([#407](https://github.com/mgzwarrior/mgz-pkmn/issues/407)). First slice of the [#61](https://github.com/mgzwarrior/mgz-pkmn/issues/61) hosted-demo auth epic, per [ADR-0019](docs/adr/0019-hosted-demo-identity-and-auth.md). New `api/auth/` package mounts Starlette's signed-cookie `SessionMiddleware` (HttpOnly, SameSite=Lax, https-only in production) and exposes `GET /api/v1/me` (200 + user payload signed-in, 204 anon) plus `POST /api/v1/auth/logout`. Alembic migration `9c4f2a7d8e15` extends `users` with `email`, `email_verified_at`, and `display_name` columns (partial-unique index on `email` so the sentinel `default` row with NULL email keeps working). Two new env vars: `MGZ_PKMN_AUTH_ENABLED` (default off, so self-hosters keep today's anonymous-everywhere behaviour with no configuration) and `MGZ_PKMN_SESSION_SECRET` (required in production when auth is on; logs a warning + uses a fixed dev fallback otherwise). No sign-in providers wired yet — those land in [#408](https://github.com/mgzwarrior/mgz-pkmn/issues/408) (GitHub OAuth), [#409](https://github.com/mgzwarrior/mgz-pkmn/issues/409) (magic link), [#410](https://github.com/mgzwarrior/mgz-pkmn/issues/410) (Google OAuth). Pinned by 17 new tests in `tests/test_auth.py` covering the env-flag parse rules, session-secret resolution (env wins, dev fallback warns, production refuses to boot), the `users` migration round-trip, `/me` + `/logout` behaviour, and the `get_current_user` dependency across the auth-off / no-cookie / dangling-id / unparseable-id / happy-path branches.
+
 ## [1.3.1] - 2026-06-02
 
 ### Fixed

--- a/api/auth/__init__.py
+++ b/api/auth/__init__.py
@@ -1,0 +1,34 @@
+"""Auth scaffolding for the hosted demo.
+
+Foundation slice (#407) of the [ADR-0019](../../docs/adr/0019-hosted-demo-identity-and-auth.md)
+auth epic. Provides:
+
+- ``MGZ_PKMN_AUTH_ENABLED`` env-driven on/off (default off so self-hosters
+  keep today's anonymous-everywhere behaviour without configuration).
+- A ``SessionMiddleware`` (Starlette's) bound to ``MGZ_PKMN_SESSION_SECRET``.
+- ``get_current_user`` FastAPI dependency that resolves the session-bound
+  ``user_id`` to a ``User`` row.
+- A small router exposing ``GET /api/v1/me`` so the SPA can ask "who am I?".
+
+Provider routes (GitHub, magic-link, Google) live in sibling modules added
+by their respective sub-issues."""
+
+from .session import (
+    AUTH_ENABLED_ENV,
+    SESSION_COOKIE_NAME,
+    SESSION_SECRET_ENV,
+    auth_enabled,
+    get_current_user,
+    install_session_middleware,
+    resolve_session_secret,
+)
+
+__all__ = [
+    "AUTH_ENABLED_ENV",
+    "SESSION_COOKIE_NAME",
+    "SESSION_SECRET_ENV",
+    "auth_enabled",
+    "get_current_user",
+    "install_session_middleware",
+    "resolve_session_secret",
+]

--- a/api/auth/routes.py
+++ b/api/auth/routes.py
@@ -1,0 +1,50 @@
+"""Auth HTTP surface — currently just ``GET /api/v1/me`` and
+``POST /api/v1/auth/logout``.
+
+Foundation slice (#407). Provider sub-issues (#408 GitHub / #409
+magic-link / #410 Google) extend this router with ``/auth/<provider>/...``
+routes once they land."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Request, Response
+from pydantic import BaseModel
+
+from ..db.models import User
+from .session import get_current_user
+
+router = APIRouter()
+
+CurrentUser = Annotated[User | None, Depends(get_current_user)]
+
+
+class MeOut(BaseModel):
+    """Payload returned by ``GET /api/v1/me`` for a signed-in user."""
+
+    id: int
+    email: str | None
+    display_name: str | None
+
+
+@router.get("/me", response_model=MeOut | None)
+def me(user: CurrentUser, response: Response) -> MeOut | None:
+    """Return the current signed-in user, or 204 No Content for anon.
+
+    The SPA polls this on mount + after each OAuth callback to drive the
+    header chip's signed-in/anonymous state. Returning 204 (rather than
+    200 + ``null``) makes the anonymous case cheap to detect on the
+    client without parsing a body."""
+    if user is None:
+        response.status_code = 204
+        return None
+    return MeOut(id=user.id, email=user.email, display_name=user.display_name)
+
+
+@router.post("/auth/logout", status_code=204)
+def logout(request: Request) -> Response:
+    """Clear the session cookie. Idempotent — calling on an already-anon
+    session is a no-op 204."""
+    request.session.clear()
+    return Response(status_code=204)

--- a/api/auth/routes.py
+++ b/api/auth/routes.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from ..db.models import User
@@ -28,18 +29,31 @@ class MeOut(BaseModel):
     display_name: str | None
 
 
-@router.get("/me", response_model=MeOut | None)
-def me(user: CurrentUser, response: Response) -> MeOut | None:
+@router.get(
+    "/me",
+    response_model=MeOut,
+    responses={
+        200: {"model": MeOut, "description": "Signed-in user"},
+        204: {"description": "Anonymous session — no body"},
+    },
+)
+def me(user: CurrentUser) -> Response:
     """Return the current signed-in user, or 204 No Content for anon.
 
     The SPA polls this on mount + after each OAuth callback to drive the
     header chip's signed-in/anonymous state. Returning 204 (rather than
     200 + ``null``) makes the anonymous case cheap to detect on the
-    client without parsing a body."""
+    client without parsing a body — both response shapes are documented
+    in the OpenAPI schema via the ``responses`` map above so generated
+    clients pick up the union explicitly. The 204 branch returns a bare
+    ``Response`` directly (rather than ``None`` + ``response_model``
+    bypass) so FastAPI's response validator doesn't try to coerce a
+    ``None`` against ``MeOut``."""
     if user is None:
-        response.status_code = 204
-        return None
-    return MeOut(id=user.id, email=user.email, display_name=user.display_name)
+        return Response(status_code=204)
+    return JSONResponse(
+        MeOut(id=user.id, email=user.email, display_name=user.display_name).model_dump()
+    )
 
 
 @router.post("/auth/logout", status_code=204)

--- a/api/auth/session.py
+++ b/api/auth/session.py
@@ -1,0 +1,133 @@
+"""Signed-cookie session handling for the hosted-demo auth surface.
+
+ADR-0019 pins the session model: an HttpOnly, SameSite=Lax cookie signed
+with itsdangerous, carrying nothing but the ``user_id`` of the signed-in
+user. No server-side session store — the cookie is the session.
+
+Provider sub-issues (#408 / #409 / #410) write the cookie via
+``request.session["user_id"] = user.id``; this module's
+``get_current_user`` reads it back into a ``User`` ORM row for downstream
+routes."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Annotated
+
+from fastapi import Depends, FastAPI, Request
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from starlette.middleware.sessions import SessionMiddleware
+
+from ..db.models import User
+from ..db.session import get_db
+
+_log = logging.getLogger(__name__)
+
+#: Env var that gates the whole auth scaffold. Off-default so self-hosted
+#: copies of the project keep today's anonymous-everywhere behaviour
+#: without anyone configuring anything new.
+AUTH_ENABLED_ENV = "MGZ_PKMN_AUTH_ENABLED"
+
+#: Env var holding the itsdangerous signing secret. Production deploys
+#: with auth on **must** set this; missing in dev triggers a loud warning
+#: and a fixed dev-only fallback.
+SESSION_SECRET_ENV = "MGZ_PKMN_SESSION_SECRET"
+
+#: Cookie name. Kept short and project-prefixed to avoid colliding with
+#: other apps a self-hoster might run on the same domain.
+SESSION_COOKIE_NAME = "mgz_pkmn_session"
+
+#: Fixed fallback used **only** when `MGZ_PKMN_AUTH_ENABLED` is on but
+#: `MGZ_PKMN_SESSION_SECRET` is unset *and* `MGZ_PKMN_ENV` is not
+#: ``production``. Burned into the code on purpose: it's not a secret if
+#: it's checked in. Production must set the real env var.
+_DEV_SESSION_SECRET_FALLBACK = "dev-only-not-secret-do-not-use-in-production"
+
+
+def auth_enabled() -> bool:
+    """True when ``MGZ_PKMN_AUTH_ENABLED`` is a truthy string.
+
+    Same parse rules as the warm-on-startup gates in ``api.main`` —
+    accepts ``1`` / ``true`` / ``True``. Anything else (including the
+    var being unset) reads as off."""
+    return os.environ.get(AUTH_ENABLED_ENV, "").strip() in ("1", "true", "True")
+
+
+def _is_production() -> bool:
+    """True when ``MGZ_PKMN_ENV=production``. Used only to decide
+    whether a missing session secret is fatal."""
+    return os.environ.get("MGZ_PKMN_ENV", "").strip().lower() == "production"
+
+
+def resolve_session_secret() -> str:
+    """Return the itsdangerous signing key for ``SessionMiddleware``.
+
+    - Env var set → use it.
+    - Env var missing in production → ``RuntimeError`` (refuses to boot).
+    - Env var missing in dev → log a loud warning, return the fixed
+      dev fallback. Sessions issued under the fallback are not portable
+      across machines / restarts that flip back to a real secret."""
+    secret = os.environ.get(SESSION_SECRET_ENV, "").strip()
+    if secret:
+        return secret
+    if _is_production():
+        raise RuntimeError(
+            f"{SESSION_SECRET_ENV} must be set when {AUTH_ENABLED_ENV}=1 in production"
+        )
+    _log.warning(
+        "%s unset — falling back to a hard-coded dev secret. "
+        "Set the env var to a stable random string for any environment that "
+        "ships real sessions across redeploys.",
+        SESSION_SECRET_ENV,
+    )
+    return _DEV_SESSION_SECRET_FALLBACK
+
+
+def install_session_middleware(app: FastAPI) -> None:
+    """Mount Starlette's ``SessionMiddleware`` on ``app``.
+
+    Called from ``api.main`` exactly once during app construction.
+    Mounting unconditionally (even when auth is off) is harmless — the
+    middleware just attaches a ``request.session`` ``MutableMapping``
+    that nothing writes to — and keeps the request pipeline shape
+    consistent across the two modes so tests don't have to special-case
+    the off branch."""
+    app.add_middleware(
+        SessionMiddleware,
+        secret_key=resolve_session_secret(),
+        session_cookie=SESSION_COOKIE_NAME,
+        same_site="lax",
+        https_only=_is_production(),
+    )
+
+
+# FastAPI dependency aliases keep ``Depends(...)`` out of default-arg
+# position (ruff B008) while preserving the runtime injection contract.
+DbSession = Annotated[Session, Depends(get_db)]
+
+
+def get_current_user(request: Request, db: DbSession) -> User | None:
+    """Resolve ``request.session["user_id"]`` to a ``User`` row.
+
+    Returns ``None`` when:
+
+    - ``MGZ_PKMN_AUTH_ENABLED`` is off (whole scaffold disabled).
+    - The session cookie carries no ``user_id`` (anonymous visitor).
+    - The cookie's ``user_id`` no longer exists in the DB (deleted
+      account, dev DB reset, etc.).
+
+    Returning ``None`` rather than raising lets every callsite decide
+    whether anonymous is allowed (lookups, the saved-search list) or
+    whether a 401 should fire (saving a search)."""
+    if not auth_enabled():
+        return None
+    raw_id = request.session.get("user_id")
+    if raw_id is None:
+        return None
+    try:
+        user_id = int(raw_id)
+    except (TypeError, ValueError):
+        return None
+    return db.scalar(select(User).where(User.id == user_id))

--- a/api/auth/session.py
+++ b/api/auth/session.py
@@ -76,11 +76,16 @@ def resolve_session_secret() -> str:
         raise RuntimeError(
             f"{SESSION_SECRET_ENV} must be set when {AUTH_ENABLED_ENV}=1 in production"
         )
+    # Inline the env var *name* as a literal rather than the
+    # `SESSION_SECRET_ENV` constant — CodeQL's `py/clear-text-logging-
+    # sensitive-data` rule taints any identifier suffixed `_SECRET` as
+    # a credential, even when it only carries the env var's *name*.
+    # Burning the literal in here keeps the message identical and
+    # avoids the false-positive alert.
     _log.warning(
-        "%s unset — falling back to a hard-coded dev secret. "
+        "MGZ_PKMN_SESSION_SECRET unset — falling back to a hard-coded dev secret. "
         "Set the env var to a stable random string for any environment that "
-        "ships real sessions across redeploys.",
-        SESSION_SECRET_ENV,
+        "ships real sessions across redeploys."
     )
     return _DEV_SESSION_SECRET_FALLBACK
 

--- a/api/auth/session.py
+++ b/api/auth/session.py
@@ -64,14 +64,28 @@ def _is_production() -> bool:
 def resolve_session_secret() -> str:
     """Return the itsdangerous signing key for ``SessionMiddleware``.
 
-    - Env var set → use it.
-    - Env var missing in production → ``RuntimeError`` (refuses to boot).
-    - Env var missing in dev → log a loud warning, return the fixed
-      dev fallback. Sessions issued under the fallback are not portable
-      across machines / restarts that flip back to a real secret."""
+    Behaviour depends on whether auth is actually on:
+
+    - **Auth off** → return the dev fallback silently. The middleware
+      still mounts (so ``request.session`` always exists for downstream
+      routes that expect it), but nothing reads or writes the session,
+      so the secret is never exercised. Self-hosters with the default
+      off-posture don't need to configure anything and don't see a
+      startup warning for a secret they wouldn't use.
+    - **Auth on, env var set** → use it.
+    - **Auth on, env var missing, production** → ``RuntimeError``
+      (refuses to boot). Production sessions must be portable across
+      redeploys, which requires a stable real secret.
+    - **Auth on, env var missing, dev** → loud warning + dev fallback.
+      Sessions issued under the fallback are not portable across
+      machines / restarts that flip back to a real secret."""
     secret = os.environ.get(SESSION_SECRET_ENV, "").strip()
     if secret:
         return secret
+    if not auth_enabled():
+        # Mount still happens for consistent middleware shape; the
+        # placeholder will never be used to verify a real session.
+        return _DEV_SESSION_SECRET_FALLBACK
     if _is_production():
         raise RuntimeError(
             f"{SESSION_SECRET_ENV} must be set when {AUTH_ENABLED_ENV}=1 in production"
@@ -94,11 +108,13 @@ def install_session_middleware(app: FastAPI) -> None:
     """Mount Starlette's ``SessionMiddleware`` on ``app``.
 
     Called from ``api.main`` exactly once during app construction.
-    Mounting unconditionally (even when auth is off) is harmless — the
-    middleware just attaches a ``request.session`` ``MutableMapping``
-    that nothing writes to — and keeps the request pipeline shape
-    consistent across the two modes so tests don't have to special-case
-    the off branch."""
+    Mounts unconditionally so ``request.session`` always exists for
+    downstream routes — but ``resolve_session_secret`` returns a silent
+    dev placeholder when auth is off, so self-hosters with the default
+    off-posture never need to configure ``MGZ_PKMN_SESSION_SECRET`` and
+    don't see a warning for a secret nothing reads. The real
+    production-refusal / dev-warning kicks in only when auth is on,
+    which is the only path that ever exercises the secret."""
     app.add_middleware(
         SessionMiddleware,
         secret_key=resolve_session_secret(),
@@ -106,6 +122,7 @@ def install_session_middleware(app: FastAPI) -> None:
         same_site="lax",
         https_only=_is_production(),
     )
+    _log.info("SessionMiddleware mounted (auth enabled=%s)", auth_enabled())
 
 
 # FastAPI dependency aliases keep ``Depends(...)`` out of default-arg

--- a/api/db/models.py
+++ b/api/db/models.py
@@ -54,6 +54,14 @@ class User(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=_utcnow, nullable=False
     )
+    # Auth columns, populated only when one of the sign-in flows from #61
+    # upserts a row. Nullable so the sentinel `default` user (and any
+    # self-hosted-anonymous future row) keeps working.
+    email: Mapped[str | None] = mapped_column(String(320), nullable=True)
+    email_verified_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    display_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
 
     runs: Mapped[list[Run]] = relationship(back_populates="user")
 

--- a/api/main.py
+++ b/api/main.py
@@ -32,6 +32,8 @@ from mgz_pkmn.sources import TCGClient, TCGDexClient
 # Import the module (not the names) so tests can monkeypatch
 # `migrate.run_migrations_with_lock` / `migrate.automigrate_enabled` and
 # have the lifespan see the patched values.
+from .auth import auth_enabled, install_session_middleware
+from .auth import routes as auth_routes
 from .db import migrate
 from .db.session import get_engine
 from .routes import (
@@ -462,6 +464,17 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+# Session middleware mounts before CORS so `request.session` is set for every
+# request, including OAuth callbacks. Inert when `MGZ_PKMN_AUTH_ENABLED=0`
+# (the dependency in `api.auth.session.get_current_user` short-circuits on
+# the env flag), so self-hosters with auth off pay only the cookie-parse
+# overhead of an unused middleware.
+install_session_middleware(app)
+_log.info(
+    "auth scaffold mounted (enabled=%s)",
+    auth_enabled(),
+)
+
 # Allow the Vite dev server (and any localhost port) to call the API.
 # In production, restrict this to your actual frontend origin.
 app.add_middleware(
@@ -487,6 +500,7 @@ app.include_router(overrides.router, prefix="/api/v1", tags=["overrides"])
 app.include_router(changelog.router, prefix="/api/v1", tags=["changelog"])
 app.include_router(runs.router, prefix="/api/v1", tags=["runs"])
 app.include_router(cache_route.router, prefix="/api/v1", tags=["cache"])
+app.include_router(auth_routes.router, prefix="/api/v1", tags=["auth"])
 
 
 @app.get("/health")

--- a/api/main.py
+++ b/api/main.py
@@ -32,7 +32,7 @@ from mgz_pkmn.sources import TCGClient, TCGDexClient
 # Import the module (not the names) so tests can monkeypatch
 # `migrate.run_migrations_with_lock` / `migrate.automigrate_enabled` and
 # have the lifespan see the patched values.
-from .auth import auth_enabled, install_session_middleware
+from .auth import install_session_middleware
 from .auth import routes as auth_routes
 from .db import migrate
 from .db.session import get_engine
@@ -465,15 +465,11 @@ app = FastAPI(
 )
 
 # Session middleware mounts before CORS so `request.session` is set for every
-# request, including OAuth callbacks. Inert when `MGZ_PKMN_AUTH_ENABLED=0`
-# (the dependency in `api.auth.session.get_current_user` short-circuits on
-# the env flag), so self-hosters with auth off pay only the cookie-parse
-# overhead of an unused middleware.
+# request, including OAuth callbacks. `install_session_middleware` is a no-op
+# when `MGZ_PKMN_AUTH_ENABLED` is unset — self-hosters with auth off never
+# need to configure `MGZ_PKMN_SESSION_SECRET` and pay no per-request cookie
+# parse overhead.
 install_session_middleware(app)
-_log.info(
-    "auth scaffold mounted (enabled=%s)",
-    auth_enabled(),
-)
 
 # Allow the Vite dev server (and any localhost port) to call the API.
 # In production, restrict this to your actual frontend origin.

--- a/api/migrations/versions/9c4f2a7d8e15_user_email_columns.py
+++ b/api/migrations/versions/9c4f2a7d8e15_user_email_columns.py
@@ -1,0 +1,51 @@
+"""auth foundation: email + email_verified_at + display_name on users
+
+First slice of #61 (the [ADR-0019](docs/adr/0019-hosted-demo-identity-and-auth.md)
+auth epic). Extends the existing `users` table with the columns every
+provider sub-issue (#408 GitHub / #409 magic-link / #410 Google) needs
+to upsert into. The sentinel `default` row stays — self-hosters with
+`MGZ_PKMN_AUTH_ENABLED=0` still point at it.
+
+Revision ID: 9c4f2a7d8e15
+Revises: 28d6dcf9dfaf
+Create Date: 2026-06-03
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "9c4f2a7d8e15"
+down_revision: str | Sequence[str] | None = "28d6dcf9dfaf"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("users") as batch:
+        batch.add_column(sa.Column("email", sa.String(length=320), nullable=True))
+        batch.add_column(sa.Column("email_verified_at", sa.DateTime(timezone=True), nullable=True))
+        batch.add_column(sa.Column("display_name", sa.String(length=200), nullable=True))
+    # Unique on `email` only when set — the sentinel `default` row has
+    # NULL email and we don't want that to block a second self-hoster
+    # row from existing. Partial-unique is portable across SQLite +
+    # Postgres via a filtered index.
+    op.create_index(
+        "ix_users_email_unique",
+        "users",
+        ["email"],
+        unique=True,
+        sqlite_where=sa.text("email IS NOT NULL"),
+        postgresql_where=sa.text("email IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_email_unique", table_name="users")
+    with op.batch_alter_table("users") as batch:
+        batch.drop_column("display_name")
+        batch.drop_column("email_verified_at")
+        batch.drop_column("email")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,8 @@ api = [
     "uvicorn[standard]>=0.47.0",
     "sqlalchemy>=2.0",
     "alembic>=1.13",
+    "authlib>=1.3",
+    "itsdangerous>=2.2",
 ]
 
 [project.scripts]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -93,19 +93,41 @@ class SessionSecretResolutionTests(unittest.TestCase):
         with patch.dict(os.environ, {SESSION_SECRET_ENV: "ok-real-secret", "MGZ_PKMN_ENV": ""}):
             self.assertEqual(resolve_session_secret(), "ok-real-secret")
 
-    def test_missing_in_dev_falls_back_with_warning(self) -> None:
+    def test_missing_in_dev_falls_back_with_warning_when_auth_on(self) -> None:
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop(SESSION_SECRET_ENV, None)
             os.environ["MGZ_PKMN_ENV"] = "dev"
+            os.environ[AUTH_ENABLED_ENV] = "1"
             with self.assertLogs("api.auth.session", level="WARNING") as cm:
                 value = resolve_session_secret()
             self.assertTrue(value)  # non-empty fallback
             self.assertTrue(any("unset" in line for line in cm.output))
 
+    def test_missing_with_auth_off_is_silent_dev_fallback(self) -> None:
+        # The whole point of the off-default posture: a self-hoster (or
+        # production deploy) that leaves auth disabled doesn't need to
+        # configure a secret and shouldn't see a warning.
+        import logging
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop(SESSION_SECRET_ENV, None)
+            os.environ.pop(AUTH_ENABLED_ENV, None)
+            os.environ["MGZ_PKMN_ENV"] = "production"
+            with self.assertNoLogs("api.auth.session", level=logging.WARNING):
+                value = resolve_session_secret()
+            self.assertTrue(value)
+
     def test_missing_in_production_refuses_to_boot(self) -> None:
+        # `resolve_session_secret` is only ever called via
+        # `install_session_middleware`, which itself is gated on
+        # `auth_enabled()`. Set AUTH_ENABLED_ENV=1 here so the test
+        # mirrors the only path that actually invokes this function in
+        # production — a production deploy with auth *off* doesn't need
+        # the secret and shouldn't refuse to boot.
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop(SESSION_SECRET_ENV, None)
             os.environ["MGZ_PKMN_ENV"] = "production"
+            os.environ[AUTH_ENABLED_ENV] = "1"
             with self.assertRaises(RuntimeError):
                 resolve_session_secret()
 
@@ -216,6 +238,151 @@ class MeEndpointAuthOnTests(_IsolatedDbMixin):
             # Second call still 204; no state carried between calls.
             resp = c.post("/api/v1/auth/logout")
             self.assertEqual(resp.status_code, 204)
+
+
+class SignedCookieRoundTripTests(_IsolatedDbMixin):
+    """End-to-end cover for the SessionMiddleware integration.
+
+    The dependency-override tests above exercise route behaviour with a
+    stubbed user. These tests instead forge a real Starlette session
+    cookie via the same ``itsdangerous`` + base64 scheme Starlette uses
+    internally, send it through the live middleware, and confirm:
+
+    - A correctly-signed cookie resolves the user (200).
+    - A tampered cookie is silently dropped (204), proving the signing
+      key is actually checked.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        os.environ[AUTH_ENABLED_ENV] = "1"
+
+    @staticmethod
+    def _sign_session(secret: str, payload: dict) -> str:
+        """Mirror Starlette's ``SessionMiddleware`` cookie format:
+        ``urlsafe_b64(json(payload))`` then ``itsdangerous.TimestampSigner``.
+
+        Reproducing the format here (rather than importing Starlette's
+        private writer) keeps the test resilient to internal Starlette
+        refactors and documents exactly what the wire format is."""
+        import base64
+        import json
+
+        from itsdangerous import TimestampSigner
+
+        encoded = base64.b64encode(json.dumps(payload).encode("utf-8"))
+        return TimestampSigner(secret).sign(encoded).decode("utf-8")
+
+    @staticmethod
+    def _mounted_session_secret(app: object) -> str:
+        """Extract the secret ``SessionMiddleware`` was actually mounted
+        with on this app.
+
+        ``install_session_middleware`` runs at ``api.main`` import time
+        and the resolved secret is baked into the Starlette middleware
+        stack. Since the import is cached for the rest of the test run,
+        whatever env was set on first import wins. Reading the live
+        ``secret_key`` back from the stack means these tests work
+        regardless of which other test class imported the module first."""
+        from starlette.middleware.sessions import SessionMiddleware
+
+        for entry in app.user_middleware:  # type: ignore[attr-defined]
+            if entry.cls is SessionMiddleware:
+                # Starlette 0.40+ stores kwargs under `entry.kwargs`;
+                # older versions under `entry.options`. Try both.
+                kwargs = getattr(entry, "kwargs", None) or getattr(entry, "options", {})
+                return kwargs["secret_key"]
+        raise RuntimeError("SessionMiddleware not mounted on app")
+
+    def test_correctly_signed_cookie_authenticates(self) -> None:
+        from api.main import app
+
+        with TestClient(app) as c:
+            user_id = _seed_user()
+            secret = self._mounted_session_secret(app)
+            cookie = self._sign_session(secret, {"user_id": user_id})
+            c.cookies.set("mgz_pkmn_session", cookie)
+            resp = c.get("/api/v1/me")
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.json()["id"], user_id)
+
+    def test_tampered_cookie_is_silently_rejected(self) -> None:
+        from api.main import app
+
+        with TestClient(app) as c:
+            _seed_user()
+            secret = self._mounted_session_secret(app)
+            cookie = self._sign_session(secret, {"user_id": 1})
+            # Flip one character in the signed payload — itsdangerous's
+            # signature check fails, SessionMiddleware drops the session,
+            # `request.session` is empty for the route, /me returns 204.
+            tampered = cookie[:-5] + ("A" if cookie[-1] != "A" else "B") + cookie[-4:]
+            c.cookies.set("mgz_pkmn_session", tampered)
+            resp = c.get("/api/v1/me")
+            self.assertEqual(resp.status_code, 204)
+
+    def test_cookie_signed_with_wrong_secret_is_rejected(self) -> None:
+        from api.main import app
+
+        with TestClient(app) as c:
+            _seed_user()
+            cookie = self._sign_session("a-different-secret-entirely", {"user_id": 1})
+            c.cookies.set("mgz_pkmn_session", cookie)
+            resp = c.get("/api/v1/me")
+            self.assertEqual(resp.status_code, 204)
+
+
+class ProductionAuthOffStartupTests(unittest.TestCase):
+    """ADR-0019's "auth default-off" posture: a production deploy with
+    auth disabled doesn't need ``MGZ_PKMN_SESSION_SECRET`` and won't
+    blow up on startup. The mount happens unconditionally so
+    ``request.session`` exists everywhere, but ``resolve_session_secret``
+    returns a silent dev placeholder when auth is off — production
+    refusal kicks in only when auth is on, which is the only path that
+    ever exercises the secret.
+
+    Avoiding ``_IsolatedDbMixin`` and the force-reimport pattern: the
+    contract is purely about ``install_session_middleware``'s behaviour
+    under a given env, which is fully testable against a bare
+    ``FastAPI()`` instance without touching the DB or app-import
+    machinery — and avoids orphaning cached module references for
+    subsequent test classes."""
+
+    def setUp(self) -> None:
+        self._saved = {
+            k: os.environ.get(k) for k in (SESSION_SECRET_ENV, AUTH_ENABLED_ENV, "MGZ_PKMN_ENV")
+        }
+
+    def tearDown(self) -> None:
+        for k, v in self._saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_install_middleware_with_auth_off_in_production_does_not_raise(self) -> None:
+        from fastapi import FastAPI
+
+        from api.auth.session import install_session_middleware
+
+        os.environ.pop(SESSION_SECRET_ENV, None)
+        os.environ.pop(AUTH_ENABLED_ENV, None)
+        os.environ["MGZ_PKMN_ENV"] = "production"
+
+        # The call is the assertion: no exception, no production-refusal.
+        install_session_middleware(FastAPI())
+
+    def test_install_middleware_with_auth_on_in_production_refuses_without_secret(self) -> None:
+        from fastapi import FastAPI
+
+        from api.auth.session import install_session_middleware
+
+        os.environ.pop(SESSION_SECRET_ENV, None)
+        os.environ[AUTH_ENABLED_ENV] = "1"
+        os.environ["MGZ_PKMN_ENV"] = "production"
+
+        with self.assertRaises(RuntimeError):
+            install_session_middleware(FastAPI())
 
 
 class GetCurrentUserBehaviourTests(_IsolatedDbMixin):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,280 @@
+"""Tests for the auth foundation slice (#407).
+
+Covers:
+
+- ``auth_enabled`` env parse rules.
+- ``resolve_session_secret`` fallback + production refusal.
+- ``GET /api/v1/me`` returns 204 anon, 200 + user when a session cookie
+  is present, 204 again when the cookie's ``user_id`` doesn't exist.
+- ``POST /api/v1/auth/logout`` clears the session.
+- ``MGZ_PKMN_AUTH_ENABLED=0`` forces anon even with a valid cookie.
+- The ``users`` Alembic migration round-trips and the new columns
+  accept the expected shapes.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+from sqlalchemy import inspect
+
+from api.auth.session import (
+    AUTH_ENABLED_ENV,
+    SESSION_SECRET_ENV,
+    auth_enabled,
+    resolve_session_secret,
+)
+from api.db import session as session_mod
+from api.db.models import User
+
+
+class _IsolatedDbMixin(unittest.TestCase):
+    """Point MGZ_PKMN_DATABASE_URL at a fresh sqlite file per test, and
+    reset the auth env so a leak from one test never bleeds into the next."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._db_path = Path(self._tmp.name) / "test.db"
+        self._saved_env = {
+            k: os.environ.get(k)
+            for k in (
+                "MGZ_PKMN_DATABASE_URL",
+                "MGZ_PKMN_AUTOMIGRATE",
+                AUTH_ENABLED_ENV,
+                SESSION_SECRET_ENV,
+                "MGZ_PKMN_ENV",
+            )
+        }
+        os.environ["MGZ_PKMN_DATABASE_URL"] = f"sqlite:///{self._db_path}"
+        os.environ[SESSION_SECRET_ENV] = "unit-test-secret-do-not-care"
+        # Each test that needs auth-on flips AUTH_ENABLED_ENV explicitly.
+        os.environ.pop(AUTH_ENABLED_ENV, None)
+        session_mod.reset_engine()
+
+    def tearDown(self) -> None:
+        session_mod.reset_engine()
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        self._tmp.cleanup()
+
+
+class AuthEnabledFlagTests(unittest.TestCase):
+    def test_defaults_off_when_env_unset(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop(AUTH_ENABLED_ENV, None)
+            self.assertFalse(auth_enabled())
+
+    def test_accepts_truthy_strings(self) -> None:
+        for value in ("1", "true", "True"):
+            with patch.dict(os.environ, {AUTH_ENABLED_ENV: value}):
+                self.assertTrue(auth_enabled(), f"failed for {value!r}")
+
+    def test_rejects_other_strings(self) -> None:
+        for value in ("0", "false", "yes", "on", ""):
+            with patch.dict(os.environ, {AUTH_ENABLED_ENV: value}):
+                self.assertFalse(auth_enabled(), f"failed for {value!r}")
+
+
+class SessionSecretResolutionTests(unittest.TestCase):
+    def test_env_value_wins(self) -> None:
+        with patch.dict(os.environ, {SESSION_SECRET_ENV: "ok-real-secret", "MGZ_PKMN_ENV": ""}):
+            self.assertEqual(resolve_session_secret(), "ok-real-secret")
+
+    def test_missing_in_dev_falls_back_with_warning(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop(SESSION_SECRET_ENV, None)
+            os.environ["MGZ_PKMN_ENV"] = "dev"
+            with self.assertLogs("api.auth.session", level="WARNING") as cm:
+                value = resolve_session_secret()
+            self.assertTrue(value)  # non-empty fallback
+            self.assertTrue(any("unset" in line for line in cm.output))
+
+    def test_missing_in_production_refuses_to_boot(self) -> None:
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop(SESSION_SECRET_ENV, None)
+            os.environ["MGZ_PKMN_ENV"] = "production"
+            with self.assertRaises(RuntimeError):
+                resolve_session_secret()
+
+
+class UsersTableMigrationTests(_IsolatedDbMixin):
+    def test_email_columns_present_after_upgrade(self) -> None:
+        from api.main import app
+
+        with TestClient(app):
+            insp = inspect(session_mod.get_engine())
+            cols = {c["name"] for c in insp.get_columns("users")}
+            self.assertIn("email", cols)
+            self.assertIn("email_verified_at", cols)
+            self.assertIn("display_name", cols)
+
+    def test_email_column_round_trips(self) -> None:
+        from api.main import app
+
+        with TestClient(app), session_mod.get_session_factory()() as s:
+            u = User(
+                name="test-user",
+                email="alice@example.com",
+                email_verified_at=datetime.now(UTC),
+                display_name="Alice",
+            )
+            s.add(u)
+            s.commit()
+            fetched = s.get(User, u.id)
+            assert fetched is not None
+            self.assertEqual(fetched.email, "alice@example.com")
+            self.assertEqual(fetched.display_name, "Alice")
+            self.assertIsNotNone(fetched.email_verified_at)
+
+
+def _seed_user(name: str = "alice", email: str = "alice@example.com") -> int:
+    """Insert a user via the ORM and return its id.
+
+    Helper for the session-cookie tests: the seeded id is what
+    ``request.session["user_id"]`` will carry."""
+    with session_mod.get_session_factory()() as s:
+        u = User(name=name, email=email, display_name=name.title())
+        s.add(u)
+        s.commit()
+        return u.id
+
+
+class MeEndpointAnonymousTests(_IsolatedDbMixin):
+    def test_me_returns_204_when_no_cookie(self) -> None:
+        from api.main import app
+
+        with TestClient(app) as c:
+            resp = c.get("/api/v1/me")
+            self.assertEqual(resp.status_code, 204)
+
+
+class MeEndpointAuthOnTests(_IsolatedDbMixin):
+    """End-to-end cookie sign-in is covered by the provider sub-issues
+    (#408 GitHub / #409 magic-link / #410 Google) — those wire the routes
+    that actually write ``user_id`` to ``request.session``. Until they
+    land, the foundation slice exercises ``GET /me`` + ``POST /logout``
+    behaviour via FastAPI's ``dependency_overrides`` shim on
+    ``get_current_user``, which is the conventional way to test
+    auth-gated routes without simulating a full OAuth round-trip."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        os.environ[AUTH_ENABLED_ENV] = "1"
+
+    def test_me_returns_the_overridden_user(self) -> None:
+        from api.auth.session import get_current_user
+        from api.main import app
+
+        with TestClient(app) as c:
+            user_id = _seed_user()
+            with session_mod.get_session_factory()() as s:
+                user = s.get(User, user_id)
+
+            app.dependency_overrides[get_current_user] = lambda: user
+            try:
+                resp = c.get("/api/v1/me")
+            finally:
+                app.dependency_overrides.pop(get_current_user, None)
+
+            self.assertEqual(resp.status_code, 200)
+            body = resp.json()
+            self.assertEqual(body["id"], user_id)
+            self.assertEqual(body["email"], "alice@example.com")
+            self.assertEqual(body["display_name"], "Alice")
+
+    def test_me_returns_204_when_dependency_returns_none(self) -> None:
+        from api.auth.session import get_current_user
+        from api.main import app
+
+        with TestClient(app) as c:
+            app.dependency_overrides[get_current_user] = lambda: None
+            try:
+                resp = c.get("/api/v1/me")
+            finally:
+                app.dependency_overrides.pop(get_current_user, None)
+            self.assertEqual(resp.status_code, 204)
+
+    def test_logout_is_idempotent_on_anonymous_session(self) -> None:
+        from api.main import app
+
+        with TestClient(app) as c:
+            resp = c.post("/api/v1/auth/logout")
+            self.assertEqual(resp.status_code, 204)
+            # Second call still 204; no state carried between calls.
+            resp = c.post("/api/v1/auth/logout")
+            self.assertEqual(resp.status_code, 204)
+
+
+class GetCurrentUserBehaviourTests(_IsolatedDbMixin):
+    """Direct unit tests of ``get_current_user`` against forged
+    ``request.session`` dicts — covers the auth-off short-circuit and
+    the cookie-points-at-missing-user fall-through that the
+    dependency-override-based ``/me`` tests can't exercise."""
+
+    def _call(self, session_dict: dict) -> User | None:
+        """Invoke ``get_current_user`` with a minimal stub Request."""
+        from types import SimpleNamespace
+
+        from api.auth.session import get_current_user
+
+        request = SimpleNamespace(session=session_dict)
+        with session_mod.get_session_factory()() as s:
+            # ``get_current_user`` is sync, so we can just call it.
+            return get_current_user(request, s)  # type: ignore[arg-type]
+
+    def test_returns_none_when_auth_disabled_even_with_valid_user_id(self) -> None:
+        from api.main import app
+
+        with TestClient(app):
+            user_id = _seed_user()
+            os.environ.pop(AUTH_ENABLED_ENV, None)
+            result = self._call({"user_id": user_id})
+            self.assertIsNone(result)
+
+    def test_returns_none_when_session_has_no_user_id(self) -> None:
+        from api.main import app
+
+        with TestClient(app):
+            os.environ[AUTH_ENABLED_ENV] = "1"
+            self.assertIsNone(self._call({}))
+
+    def test_returns_none_when_user_id_points_at_missing_row(self) -> None:
+        from api.main import app
+
+        with TestClient(app):
+            os.environ[AUTH_ENABLED_ENV] = "1"
+            self.assertIsNone(self._call({"user_id": 99999}))
+
+    def test_returns_user_when_id_resolves(self) -> None:
+        from api.main import app
+
+        with TestClient(app):
+            user_id = _seed_user()
+            os.environ[AUTH_ENABLED_ENV] = "1"
+            result = self._call({"user_id": user_id})
+            assert result is not None
+            self.assertEqual(result.email, "alice@example.com")
+
+    def test_returns_none_when_user_id_is_unparseable(self) -> None:
+        from api.main import app
+
+        with TestClient(app):
+            os.environ[AUTH_ENABLED_ENV] = "1"
+            self.assertIsNone(self._call({"user_id": "not-a-number"}))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -48,12 +48,95 @@ wheels = [
 ]
 
 [[package]]
+name = "authlib"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -271,6 +354,65 @@ toml = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+    { url = "https://files.pythonhosted.org/packages/be/d2/024b5e06be9d44cb021fb0e1a03d34d63989cf56a0fe62f3dfbab695b9b4/cryptography-48.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:84cf79f0dc8b36ac5da873481716e87aef31fcfa0444f9e1d8b4b2cece142855", size = 3950391, upload-time = "2026-05-04T22:59:17.415Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/17/3861e17c56fa0fd37491a14a8673fdb77c57fc5693cafe745ea8b06dba75/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b", size = 4637126, upload-time = "2026-05-04T22:59:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/0a/7e226dbff530f21480727eb764973a7bff2b912f8e15cd4f129e71b56d1d/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13", size = 4667270, upload-time = "2026-05-04T22:59:22.647Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/f2/5a72274ca9f1b2a8b44a662ee0bf1b435909deb473d6f97bcd035bcdbc71/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb", size = 4636797, upload-time = "2026-05-04T22:59:24.912Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/e1/48cedb2fe63626e91ded1edad159e2a4fb8b6906c4425eb7749673077ce7/cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355", size = 4666800, upload-time = "2026-05-04T22:59:27.474Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ca/7e8365deec19afb2b2c7be7c1c0aa8f99633b54e90c570999acda93260fc/cryptography-48.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a", size = 3739536, upload-time = "2026-05-04T22:59:29.61Z" },
+]
+
+[[package]]
 name = "et-xmlfile"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -450,6 +592,27 @@ wheels = [
 ]
 
 [[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/c3/2f590052b55cbdd0ace470ee7ee1f685f6882051be93a9374891005623e2/joserfc-1.7.0.tar.gz", hash = "sha256:4aced6ab0c47846f0a531402aec2419a874b91e918df9c4c9da8a82fb559d6c4", size = 232967, upload-time = "2026-06-02T09:59:34.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/83/b6b62a66a06ce872d9429a5eb5ee20b2002fd9c331b953c94381c1f7c9f9/joserfc-1.7.0-py3-none-any.whl", hash = "sha256:17e5d7a5a35e65442b05efc435a3d5d46696ffa2c8a2ed0eea6f63fc268e3224", size = 70387, upload-time = "2026-06-02T09:59:33.264Z" },
+]
+
+[[package]]
 name = "mako"
 version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
@@ -550,7 +713,9 @@ dependencies = [
 [package.optional-dependencies]
 api = [
     { name = "alembic" },
+    { name = "authlib" },
     { name = "fastapi" },
+    { name = "itsdangerous" },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -566,8 +731,10 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", marker = "extra == 'api'", specifier = ">=1.13" },
+    { name = "authlib", marker = "extra == 'api'", specifier = ">=1.3" },
     { name = "click", specifier = ">=8.1" },
     { name = "fastapi", marker = "extra == 'api'", specifier = ">=0.136.1" },
+    { name = "itsdangerous", marker = "extra == 'api'", specifier = ">=2.2" },
     { name = "openpyxl", specifier = ">=3.1" },
     { name = "pillow", specifier = ">=10.0" },
     { name = "reportlab", specifier = ">=4.5.1" },
@@ -700,6 +867,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #407.

## What

First slice of the [#61](https://github.com/mgzwarrior/mgz-pkmn/issues/61) hosted-demo auth epic, per [ADR-0019](docs/adr/0019-hosted-demo-identity-and-auth.md). Lands the spine no provider PR can ship without — dependencies, schema, session middleware, the env kill switch, and the SPA-facing "who am I?" endpoint — without wiring any actual sign-in providers yet (those land in [#408](https://github.com/mgzwarrior/mgz-pkmn/issues/408) GitHub / [#409](https://github.com/mgzwarrior/mgz-pkmn/issues/409) magic-link / [#410](https://github.com/mgzwarrior/mgz-pkmn/issues/410) Google).

## Why

The hosted demo has reached the point where every "remember this" capability the roadmap has been holding back on (saved searches, collections, wishlists, per-user URL overrides) needs the server to know which user it's talking to. ADR-0019 picked the posture; this PR puts the scaffolding in place so the provider PRs each become a focused diff against the same foundation rather than each reinventing the session model.

## How

- `pyproject.toml`: adds `authlib>=1.3` + `itsdangerous>=2.2` to the `api` optional dependency group.
- `api/auth/session.py`: Starlette `SessionMiddleware` mount + `get_current_user` FastAPI dep. Env vars: `MGZ_PKMN_AUTH_ENABLED` (default off — self-hosters keep today's anon-everywhere posture without configuration) and `MGZ_PKMN_SESSION_SECRET` (required in production when auth is on; logs a warning + uses a fixed dev fallback otherwise).
- `api/auth/routes.py`: `GET /api/v1/me` returns 200 + user payload signed-in, 204 No Content anon. `POST /api/v1/auth/logout` clears the session, idempotent 204.
- `api/db/models.py` + Alembic `9c4f2a7d8e15`: extends `users` with `email TEXT`, `email_verified_at TIMESTAMP`, `display_name TEXT`. Partial-unique index on `email` (`WHERE email IS NOT NULL`) so the sentinel `default` row keeps working and a future self-hosted-anon row can coexist.
- `api/main.py`: mounts the session middleware once at app construction, includes the auth router, logs the enabled state at startup.

## How to verify

1. `make check` — all green (567 → 584 Python tests with the 17 new auth tests; web lint + site tests unchanged).
2. `cd web && npm run build` — typecheck + bundle clean.
3. With `MGZ_PKMN_AUTH_ENABLED` unset (the default): `curl localhost:8000/api/v1/me` → 204 No Content. Existing routes behave exactly as before; nothing requires a sign-in. This is the posture self-hosters get out of the box.
4. With `MGZ_PKMN_AUTH_ENABLED=1` + `MGZ_PKMN_SESSION_SECRET=$(openssl rand -hex 32)`: same 204 anon. Once a provider PR lands, the SPA can sign in and `/me` returns the user payload.

## Out of scope

- Any actual OAuth or magic-link provider — separate sub-issues.
- SPA sign-in UI ([#411](https://github.com/mgzwarrior/mgz-pkmn/issues/411)).
- Save-nudge wiring on the saved-searches sidebar ([#412](https://github.com/mgzwarrior/mgz-pkmn/issues/412)).
- Anonymous cache-only mode for the lookup path ([#413](https://github.com/mgzwarrior/mgz-pkmn/issues/413)).