### PR TITLE
docs: project grooming pass — roadmap, ADRs, cache doc cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Docs: **Q3 2026 grooming pass — second-pass refinements**
+  ([#415](https://github.com/mgzwarrior/mgz-pkmn/issues/415)). Acts on
+  reviewer feedback against the initial grooming PR:
+  - `docs/roadmap.md` — drops the V1.0/V1.1/V1.2 shipped sections from
+    the body (now one-line summaries in the Versioning policy); badges
+    refreshed to in-flight milestones only; V2 entry reframed around
+    the strict-semver trigger ("plugin contract goes live" or
+    "hosted-demo identity becomes required"), naming the current v2.0
+    milestone as a staging area for breakpoint-adjacent epics.
+  - `docs/contributing.md` — Project layout section extended beyond
+    `src/mgz_pkmn/` to cover `api/`, `web/`, `site/`, `tests/`, plus
+    the newer mgz_pkmn modules (`card_images.py`, `set_cards.py`,
+    `branding.py`, `changelog.py`).
+  - `docs/cli.md` — `pkmn cache` is documented as a group with all
+    eight subcommands (path, stats, clear, warm-concepts, warm-sets,
+    warm-set-cards, warm-cards, warm-card-images), not just `stats`.
+  - `docs/cache.md` — new "Entries vs. API calls" section showing why
+    a 20k-entry cache typically represents under 1k catalog API
+    calls (per-card structural fan-out from a handful of paginated
+    search fetches).
+  - `docs/deployment.md` — Cache warming table extended to five
+    passes (was three) with their separate env-var opt-ins.
+  - Two new ADRs as Proposed:
+    [ADR-0023](docs/adr/0023-source-ensemble-pricing.md) (source
+    ensemble for pricing display, partially superseding ADR-0002) and
+    new content in ADR-0020 / ADR-0021 reflecting the ensemble model
+    and the "TCGPlayer may become default if pokemontcg.io is sunset"
+    forward note.
+  - ADR-0002 amended with a Status note pointing to ADR-0023 for the
+    pricing-priority aspect.
+
 - Docs: **Q3 2026 grooming pass — roadmap, ADRs, cache doc cleanup**
   ([#415](https://github.com/mgzwarrior/mgz-pkmn/issues/415)).
   `docs/roadmap.md` gains a "How to read this roadmap" intro naming the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Docs: **Q3 2026 grooming pass — roadmap, ADRs, cache doc cleanup**
+  ([#415](https://github.com/mgzwarrior/mgz-pkmn/issues/415)).
+  `docs/roadmap.md` gains a "How to read this roadmap" intro naming the
+  new `epic:*` and `specialty:*` label families, plus committed
+  sections for **V1.5** (eBay integration), **V1.6** (TCGPlayer
+  integration), and **V2.1** (persistence-at-growth). The V2 entry for
+  [#39](https://github.com/mgzwarrior/mgz-pkmn/issues/39) is re-framed
+  as dual-mode + smart auto-detect, and the V3 *Vendor / power-user
+  portal* section now names the vendor scanner explicitly and links to
+  [ADR-0012](docs/adr/0012-open-core-architecture.md). Three new ADRs
+  land as Proposed: [ADR-0020](docs/adr/0020-ebay-pricing-source.md)
+  (eBay pricing source),
+  [ADR-0021](docs/adr/0021-tcgplayer-first-class-pricing.md) (TCGPlayer
+  first-class pricing), [ADR-0022](docs/adr/0022-query-dsl.md) (query
+  DSL with dual-mode); ADR-0012 is amended to name the bulk
+  card-recognition scanner as the first architectural vendor surface.
+- Docs: **`docs/cache.md` TTL vs. freshness-window cleanup**
+  ([#415](https://github.com/mgzwarrior/mgz-pkmn/issues/415)). The page
+  previously conflated *entry-level TTLs* (structural: none, pricing:
+  24 h SWR) with *per-warm-pass freshness windows* (e.g. 7 d for the
+  catalog warms), which read as if the structural cache had a TTL it
+  doesn't have. A new "Two kinds of 'expiry'" glossary distinguishes
+  the two, the legacy `api/<sha1>.json` row's behaviour after lazy
+  migration is spelled out, and the warm-passes table is re-labelled
+  *Freshness window* with a paragraph explaining why concepts is 24 h
+  while the catalog warms are 7 d.
+
 ### Added
 
 - API: **Auth scaffold foundation** ([#407](https://github.com/mgzwarrior/mgz-pkmn/issues/407)). First slice of the [#61](https://github.com/mgzwarrior/mgz-pkmn/issues/61) hosted-demo auth epic, per [ADR-0019](docs/adr/0019-hosted-demo-identity-and-auth.md). New `api/auth/` package mounts Starlette's signed-cookie `SessionMiddleware` (HttpOnly, SameSite=Lax, https-only in production) and exposes `GET /api/v1/me` (200 + user payload signed-in, 204 anon) plus `POST /api/v1/auth/logout`. Alembic migration `9c4f2a7d8e15` extends `users` with `email`, `email_verified_at`, and `display_name` columns (partial-unique index on `email` so the sentinel `default` row with NULL email keeps working). Two new env vars: `MGZ_PKMN_AUTH_ENABLED` (default off, so self-hosters keep today's anonymous-everywhere behaviour with no configuration) and `MGZ_PKMN_SESSION_SECRET` (required in production when auth is on; logs a warning + uses a fixed dev fallback otherwise). No sign-in providers wired yet — those land in [#408](https://github.com/mgzwarrior/mgz-pkmn/issues/408) (GitHub OAuth), [#409](https://github.com/mgzwarrior/mgz-pkmn/issues/409) (magic link), [#410](https://github.com/mgzwarrior/mgz-pkmn/issues/410) (Google OAuth). Pinned by 17 new tests in `tests/test_auth.py` covering the env-flag parse rules, session-secret resolution (env wins, dev fallback warns, production refuses to boot), the `users` migration round-trip, `/me` + `/logout` behaviour, and the `get_current_user` dependency across the auth-off / no-cookie / dangling-id / unparseable-id / happy-path branches.

--- a/docs/adr/0002-multi-source-lookup-priority.md
+++ b/docs/adr/0002-multi-source-lookup-priority.md
@@ -1,8 +1,16 @@
 # ADR 0002: Layer three open data sources with explicit priority order
 
-- **Status:** Accepted
+- **Status:** Accepted (pricing-priority aspect partially superseded by [ADR-0023](0023-source-ensemble-pricing.md))
 - **Date:** 2026-05-09
 - **Tags:** lookup, sources, data
+
+> **Amendment (2026-06-03):** The *pricing display* part of this ADR —
+> "the first source that produces a usable match wins" — is superseded
+> by [ADR-0023](0023-source-ensemble-pricing.md), which switches
+> pricing to a multi-source ensemble with user-selectable preferences.
+> This ADR continues to govern **card-object resolution** (which
+> source's metadata is authoritative for structural fields like name,
+> set, number, art) and the failure-message contract.
 
 ## Context
 

--- a/docs/adr/0012-open-core-architecture.md
+++ b/docs/adr/0012-open-core-architecture.md
@@ -115,9 +115,9 @@ the roadmap, extending the
 prototype. Naming it here pins down which side of the open-core line
 the first non-trivial vendor capability sits on: implementation lives
 in `mgz-pkmn-vendor`; the OSS repo gains no scanner code, only the
-plugin-surface hooks the scanner registers against (e.g. a `pkmn vendor
-scan` entry point and an output-writer hook for the bulk-resolved
-results). An `epic:vendor-vision` placeholder issue exists in the OSS
+plugin-surface hooks the scanner registers against (e.g. a
+`pkmn vendor scan` entry point and an output-writer hook for the
+bulk-resolved results). An `epic:vendor-vision` placeholder issue exists in the OSS
 repo for visibility only; substantive issues live in the vendor repo.
 
 **Explicitly out of scope of this ADR**: specific paid-tier names,

--- a/docs/adr/0012-open-core-architecture.md
+++ b/docs/adr/0012-open-core-architecture.md
@@ -107,11 +107,24 @@ when it reuses OSS code. Distinct from cryptographic commit signing
 (intentionally dropped in #153 / [ADR-0010 era](0010-unified-project-with-area-views.md));
 DCO solves a different problem.
 
+**First concrete vendor-track surface** (named for architectural
+clarity, not as a commercial commitment): the **bulk card-recognition
+scanner** described in the V3 *Vendor / power-user portal* section of
+the roadmap, extending the
+[breakwater-tcg-scanner](https://github.com/mgzwarrior/breakwater-tcg-scanner)
+prototype. Naming it here pins down which side of the open-core line
+the first non-trivial vendor capability sits on: implementation lives
+in `mgz-pkmn-vendor`; the OSS repo gains no scanner code, only the
+plugin-surface hooks the scanner registers against (e.g. a `pkmn vendor
+scan` entry point and an output-writer hook for the bulk-resolved
+results). An `epic:vendor-vision` placeholder issue exists in the OSS
+repo for visibility only; substantive issues live in the vendor repo.
+
 **Explicitly out of scope of this ADR**: specific paid-tier names,
-pricing, feature lists, hosted-vs-local SKU packaging, support
-policies. Those are commercial decisions that change frequently
-before launch and don't belong in a public architectural record
-until they're real.
+pricing, feature lists *beyond* the architectural example above,
+hosted-vs-local SKU packaging, support policies. Those are commercial
+decisions that change frequently before launch and don't belong in a
+public architectural record until they're real.
 
 ## Consequences
 

--- a/docs/adr/0020-ebay-pricing-source.md
+++ b/docs/adr/0020-ebay-pricing-source.md
@@ -1,0 +1,100 @@
+# ADR 0020: eBay as a first-class pricing source
+
+- **Status:** Proposed
+- **Date:** 2026-06-03
+- **Tags:** sources, pricing, auth, epic-ebay
+
+## Context
+
+mgz-pkmn currently resolves pricing from three sources, layered in the
+order defined by [ADR-0002](0002-multi-source-lookup-priority.md):
+pokemontcg.io (embedded `tcgplayer` and `cardmarket` blocks), TCGdex
+(structural only — no pricing), and PriceCharting (when a user pastes
+a URL). The hosted demo will shortly cut over to Scrydex
+([#351](https://github.com/mgzwarrior/mgz-pkmn/issues/351)) for the
+pokemontcg.io path, but none of these surfaces give us **sold-listings
+distribution**, which is the single most useful signal for setting a
+realistic asking price at a card show.
+
+eBay's Developer API exposes both `findCompletedItems` (sold) and
+`findItemsAdvanced` (active) endpoints, with OAuth client credentials
+and rate limits that are workable for our scale (one listing-set
+fetched per resolved card, cached aggressively).
+
+The `epic:ebay` umbrella tracks the implementation; this ADR records
+the source-layering decision and the contract.
+
+## Decision
+
+Add **eBay** as a fourth source in the lookup pipeline, layered
+**after PriceCharting** in the priority order:
+
+1. Explicit URL paste (PriceCharting) — highest, user intent is
+   unambiguous.
+2. pokemontcg.io / Scrydex (embedded `tcgplayer` + `cardmarket`).
+3. PriceCharting fallback (URL overrides).
+4. **eBay sold + active** (new).
+5. TCGdex (structural only).
+
+The eBay source contributes two new `Pricing.source` enum values:
+`"ebay_sold"` and `"ebay_active"`. Both flow through the existing
+`Pricing` dataclass; consumers (spreadsheet, JSON report, web UI) treat
+them as additional price tiers rather than replacing existing values.
+
+Authentication uses the eBay Developer **OAuth client-credentials
+flow** for application-level reads. The token is stored as an env var
+(`MGZ_PKMN_EBAY_TOKEN`) on the hosted demo and refreshed via a
+background task; no per-user OAuth (no per-user eBay account is
+required to consume public listing data). User-scoped eBay flows
+(e.g. "list this card to my eBay") are out of scope here and would
+require a separate ADR.
+
+Caching policy: eBay results live under
+`api_pricing/<sha1>.json` like all other pricing data, with a
+**source-specific TTL**: sold listings carry a **7-day TTL** (sales
+data is more stable; backfill comps from the past week are equally
+useful day-to-day), active listings carry a **6-hour TTL** (more
+volatile, more sensitive to user expectations of freshness). This
+extends [ADR-0018](0018-structural-vs-volatile-cache-with-swr.md)'s
+single-TTL pricing model.
+
+## Consequences
+
+Positive:
+
+- Sold-listings comps give a real price-discovery signal, complementing
+  TCGPlayer's spread-based market price.
+- The source-layering pattern in ADR-0002 generalizes cleanly to a
+  fourth source; no architectural change.
+- Per-source TTL paves the way for the same treatment in
+  [ADR-0021](0021-tcgplayer-first-class-pricing.md) (TCGPlayer market
+  price is intermediate-volatility).
+
+Negative:
+
+- eBay's API has rate limits (5000 calls/day on the default tier)
+  that will eventually bound how many cards we can comp per warm pass.
+  Mitigated by the 7-day sold TTL.
+- A new third-party service to monitor (token rotation, ToS changes,
+  API deprecations).
+- Sold-listing data includes outliers (mis-listings, condition
+  mismatches) that need filtering before display. Median-of-N comps
+  rather than raw last-sale.
+
+Neutral:
+
+- Adds an opt-in `--ebay` CLI flag for parity with the existing
+  `--no-cache` / `--clear-cache` style. Default is on for the hosted
+  demo, off for the CLI when no token is configured.
+
+## Alternatives considered
+
+- **Skip eBay; rely on TCGPlayer market price as the comp signal.**
+  Loses the sold-distribution signal, which is qualitatively different
+  from market price. Rejected — see #40.
+- **Use only sold listings, skip active.** Active listings are useful
+  as a "what's the floor right now" signal at a show. Cheap to fetch;
+  worth including.
+- **Run the eBay fetch entirely client-side from the SPA.** Would
+  eliminate the server-side rate limit but exposes the API key and
+  prevents caching. Rejected.

--- a/docs/adr/0020-ebay-pricing-source.md
+++ b/docs/adr/0020-ebay-pricing-source.md
@@ -26,13 +26,19 @@ the source-layering decision and the contract.
 
 ## Decision
 
-Add **eBay** as a fourth source in the lookup pipeline, layered
-**after PriceCharting** in the priority order:
+Add **eBay** as a fourth source in the lookup pipeline, slotted **after
+the PriceCharting paths** (explicit URL + saved URL overrides) and
+**after the primary pokemontcg.io / Scrydex catalog**, but before the
+TCGdex multilingual fallback. The full ordering, aligned with
+[ADR-0002](0002-multi-source-lookup-priority.md) and the existing
+behaviour described in [`docs/cache.md`](../cache.md):
 
 1. Explicit URL paste (PriceCharting) — highest, user intent is
    unambiguous.
-2. pokemontcg.io / Scrydex (embedded `tcgplayer` + `cardmarket`).
-3. PriceCharting fallback (URL overrides).
+2. Saved URL overrides (PriceCharting via `url_overrides.json`) —
+   behaves "exactly like a re-pasted URL would" per ADR-0004, so it
+   sits with the explicit-URL path and ahead of pokemontcg.io.
+3. pokemontcg.io / Scrydex (embedded `tcgplayer` + `cardmarket`).
 4. **eBay sold + active** (new).
 5. TCGdex (structural only).
 

--- a/docs/adr/0020-ebay-pricing-source.md
+++ b/docs/adr/0020-ebay-pricing-source.md
@@ -26,21 +26,17 @@ the source-layering decision and the contract.
 
 ## Decision
 
-Add **eBay** as a fourth source in the lookup pipeline, slotted **after
-the PriceCharting paths** (explicit URL + saved URL overrides) and
-**after the primary pokemontcg.io / Scrydex catalog**, but before the
-TCGdex multilingual fallback. The full ordering, aligned with
-[ADR-0002](0002-multi-source-lookup-priority.md) and the existing
-behaviour described in [`docs/cache.md`](../cache.md):
+Add **eBay** as a new source in the lookup pipeline, contributing
+**sold-listings median + active-listings floor** as independent
+pricing data points. Per
+[ADR-0023](0023-source-ensemble-pricing.md), pricing is computed as an
+ensemble across all configured sources rather than first-source-wins;
+this ADR records the eBay-specific contract (auth, caching, display)
+that the ensemble layer consumes.
 
-1. Explicit URL paste (PriceCharting) — highest, user intent is
-   unambiguous.
-2. Saved URL overrides (PriceCharting via `url_overrides.json`) —
-   behaves "exactly like a re-pasted URL would" per ADR-0004, so it
-   sits with the explicit-URL path and ahead of pokemontcg.io.
-3. pokemontcg.io / Scrydex (embedded `tcgplayer` + `cardmarket`).
-4. **eBay sold + active** (new).
-5. TCGdex (structural only).
+For **card-object resolution** (structural fields), eBay is *not* a
+source — listing titles are too unreliable for structural data. eBay
+only contributes to the pricing ensemble.
 
 The eBay source contributes two new `Pricing.source` enum values:
 `"ebay_sold"` and `"ebay_active"`. Both flow through the existing
@@ -70,8 +66,10 @@ Positive:
 
 - Sold-listings comps give a real price-discovery signal, complementing
   TCGPlayer's spread-based market price.
-- The source-layering pattern in ADR-0002 generalizes cleanly to a
-  fourth source; no architectural change.
+- Plugs into the ensemble model from
+  [ADR-0023](0023-source-ensemble-pricing.md) — sold and active are
+  separate `Pricing.source` enum values so users can toggle them
+  independently in the Settings drawer.
 - Per-source TTL paves the way for the same treatment in
   [ADR-0021](0021-tcgplayer-first-class-pricing.md) (TCGPlayer market
   price is intermediate-volatility).
@@ -97,7 +95,9 @@ Neutral:
 
 - **Skip eBay; rely on TCGPlayer market price as the comp signal.**
   Loses the sold-distribution signal, which is qualitatively different
-  from market price. Rejected — see #40.
+  from market price. Rejected — see the original framing in #40 (now
+  closed in favor of the [`epic:ebay`](https://github.com/mgzwarrior/mgz-pkmn/labels/epic%3Aebay)
+  umbrella).
 - **Use only sold listings, skip active.** Active listings are useful
   as a "what's the floor right now" signal at a show. Cheap to fetch;
   worth including.

--- a/docs/adr/0021-tcgplayer-first-class-pricing.md
+++ b/docs/adr/0021-tcgplayer-first-class-pricing.md
@@ -1,0 +1,100 @@
+# ADR 0021: First-class TCGPlayer pricing via the TCGPlayer API
+
+- **Status:** Proposed
+- **Date:** 2026-06-03
+- **Tags:** sources, pricing, auth, epic-tcgplayer
+
+## Context
+
+Today, every pokemontcg.io card response embeds a `tcgplayer` block
+with market, low, mid, and high prices that pokemontcg.io has scraped
+or licensed from TCGPlayer. That block has been the de facto
+"canonical" market price in mgz-pkmn since v1, but it has three
+limitations:
+
+1. **Lag.** Refresh cadence is whatever pokemontcg.io chooses; we have
+   no contract for it.
+2. **Opacity.** We can't ask follow-up questions of the data (sales
+   history, sealed-product prices, condition spread).
+3. **No write path.** We can't link out to or auto-list against a
+   specific TCGPlayer SKU.
+
+TCGPlayer's developer API
+([docs](https://docs.tcgplayer.com/reference/app_authorizeapplication))
+exposes per-SKU pricing, market history, and (via the seller endpoints)
+a per-user authorize-application flow that lets sellers connect their
+TCGPlayer account to a third-party app for listing and inventory
+operations. The `epic:tcgplayer` umbrella tracks the implementation;
+this ADR records the **direct-source** decision and the **token
+storage** contract.
+
+## Decision
+
+Treat TCGPlayer as a **first-class pricing source** when credentials
+are present:
+
+- A new `TCGPlayerClient` adapter in `src/mgz_pkmn/sources/` implements
+  the existing source contract, returning a `Pricing` entry with
+  `source="tcgplayer_api"`.
+- When the client is configured, the embedded `tcgplayer` block from
+  pokemontcg.io is **superseded** for display purposes: the live API
+  data wins. The embedded block is still kept in the structural cache
+  for offline fallback and remains the default when no credentials are
+  configured.
+- Per-user **OAuth tokens** (TCGPlayer `app/authorizeApplication`) are
+  stored in the new persistence layer
+  ([ADR-0013](0013-sqlite-persistence-for-runs-collections-wishlists.md)).
+  Tokens are scoped per `user_id` in a new `tcgplayer_tokens` table,
+  encrypted at rest with the same session-secret key used by
+  [ADR-0019](0019-hosted-demo-identity-and-auth.md).
+- App-level (no user) reads use a **single shared application token**
+  configured via `MGZ_PKMN_TCGPLAYER_APP_TOKEN`. Sufficient for the
+  read-only "what's the market price" path; required for the
+  write-path features (out of scope for this ADR — captured under V3
+  vendor track).
+
+Caching: per ADR-0020's pattern, TCGPlayer market price carries an
+**intermediate TTL of 12 hours**, between the 6-hour active-listings
+window and the 7-day sold-listings window. The split-cache structural
+slice (ADR-0018) is unaffected.
+
+## Consequences
+
+Positive:
+
+- Real-time market price unhitched from pokemontcg.io's refresh
+  cadence.
+- Foundation for the V3 vendor write path (auto-list, inventory sync).
+- Per-user tokens land cleanly on the new persistence layer; no
+  separate keystore needed.
+
+Negative:
+
+- TCGPlayer's OAuth flow requires app review and approval. The hosted
+  demo will need a published privacy policy + ToS page; reflect in the
+  v1.6 launch checklist.
+- Token encryption requires the persistence layer (ADR-0013) to be
+  live. Pairs the v1.6 ship with V2 timing.
+- Two source-of-truth blocks for the same data (embedded
+  pokemontcg.io's `tcgplayer` block + the live API) creates a
+  divergence-monitoring question. We mitigate by logging when they
+  drift past a configurable threshold and surfacing it as an
+  observability signal, not a user-facing one.
+
+Neutral:
+
+- A `Connect TCGPlayer` settings panel in the SPA (see the epic's
+  frontend task) introduces a new auth-status UX pattern that the eBay
+  user-OAuth path (deferred to V3) will reuse.
+
+## Alternatives considered
+
+- **Keep the embedded `tcgplayer` block; skip the API.** Cheapest path,
+  but forecloses the write-path features the V3 vendor track depends
+  on. Rejected.
+- **Use the API only for sealed product, leave singles on
+  pokemontcg.io.** Plausible but inverts the priority — singles are
+  what users want freshest. Rejected.
+- **Anonymous (no-OAuth) read access only.** Available via the public
+  catalog endpoints but the SKU-level pricing requires authentication.
+  Would limit us to coarse data.

--- a/docs/adr/0021-tcgplayer-first-class-pricing.md
+++ b/docs/adr/0021-tcgplayer-first-class-pricing.md
@@ -68,6 +68,20 @@ Positive:
 - Per-user tokens land cleanly on the new persistence layer; no
   separate keystore needed.
 
+Forward-looking note:
+
+- **TCGPlayer may become the *default* pricing path** if pokemontcg.io
+  is sunset or the [Scrydex cutover (#351)](https://github.com/mgzwarrior/mgz-pkmn/issues/351)
+  turns out cost-prohibitive after Phase 4 lands. Under
+  [ADR-0023](0023-source-ensemble-pricing.md) the ensemble model is
+  source-agnostic, so the "default" change is just a re-weight of the
+  user-preference defaults rather than an architectural shift. The
+  TCGPlayer adapter is built with that downstream reuse in mind:
+  per-SKU pricing, sealed-product support, and condition-aware
+  pricing are all on the API surface even when we don't show them
+  in v1.6's MVP, so an upgrade to "TCGPlayer + cardmarket only" later
+  doesn't require new adapter work.
+
 Negative:
 
 - TCGPlayer's OAuth flow requires app review and approval. The hosted

--- a/docs/adr/0022-query-dsl.md
+++ b/docs/adr/0022-query-dsl.md
@@ -1,0 +1,100 @@
+# ADR 0022: Structured query DSL with dual-mode + smart auto-detect
+
+- **Status:** Proposed
+- **Date:** 2026-06-03
+- **Tags:** parser, lookup, web, epic-query-dsl
+
+## Context
+
+mgz-pkmn's input parser today is a **flavor-text** parser: it tokenizes
+free-form lines like `top 5 Charizard from Surging Sparks under $50`
+into a `CardQuery` dataclass by recognizing keywords (`top`, `from`,
+`under`, `over`), bracketed variants (`[holo]`), URLs, and a few
+shorthand markers. It's friendly for first-time users and matches the
+"talking about cards out loud" cadence.
+
+[Issue #39](https://github.com/mgzwarrior/mgz-pkmn/issues/39) proposed
+replacing this with a **structured DSL** like
+`top:N subtype:V,VMAX in "Surging Sparks" rarity:rare>=$50` to enable
+precise, composable queries (boolean combinations, range predicates,
+multi-field intersection) that the flavor parser can't express
+reliably.
+
+The maintainer's read after live use: **both modes have a real
+audience**. The flavor parser stays welcoming for casual users; the
+DSL unlocks power-user workflows (filtering wishlists, vendor pulls,
+analytics). Forcing one or the other regresses one population.
+
+## Decision
+
+Ship **both modes**, with a frontend toggle and a smart auto-detect
+default:
+
+1. **`QueryMode` strategy interface.** A small interface in the parser
+   layer that accepts a raw line and returns a `CardQuery`. Two
+   implementations: `FlavorMode` (the current parser, unchanged
+   behavior) and `DslMode` (the new Lark/PEG grammar).
+
+2. **DSL grammar.** Documented in `docs/query-dsl.md`. Key tokens:
+   - `key:value` predicates (`subtype:VMAX`, `rarity:rare`,
+     `type:Fire`, `set:"Surging Sparks"`).
+   - Range predicates with comparators (`price>=50`, `hp<100`).
+   - Boolean combinators (`AND`, `OR`, `NOT`; `AND` is implicit).
+   - Top-N selector (`top:N`) as a query-level modifier.
+   - Quoted strings for multi-word values (`set:"Surging Sparks"`).
+   - Backwards-compatible: an input that parses cleanly under
+     `FlavorMode` continues to work in flavor mode without change.
+
+3. **Frontend toggle.** A mode switch in the SPA (in Settings + an
+   inline switcher above the query box) sets the per-user default mode.
+   Persists in the user record when signed in; in localStorage when
+   anonymous.
+
+4. **Smart auto-detect.** Regardless of the toggle, if input contains
+   any **unambiguous DSL token** (e.g. `key:value` where `key` is a
+   known DSL key, or a `>=$` / `<=$` comparator), the line is parsed
+   as DSL. The toggle only resolves the ambiguous middle. An inline
+   hint ("interpreted as DSL — switch?") surfaces the auto-detect so
+   users can learn the mode boundary.
+
+5. **Lookup planner.** A new planner in `src/mgz_pkmn/lookup/` walks
+   the DSL AST and pushes predicates to the appropriate source API
+   (e.g. `subtype:` and `type:` become pokemontcg.io `types:` /
+   `subtypes:` filters; `price>=` is applied client-side after the
+   fetch since no source exposes a server-side price filter).
+
+## Consequences
+
+Positive:
+
+- Casual users keep the input shape they already know.
+- Power users get composable predicates and Top-N over filtered sets.
+- Auto-detect lets users learn the DSL by typing one token at a time,
+  without flipping a setting first.
+
+Negative:
+
+- Two grammars to maintain. Mitigated by sharing the post-parse
+  `CardQuery` shape — only the parsing stage differs.
+- "Interpreted as DSL" surprise on flavor-mode input that happens to
+  contain a `:`. Mitigated by restricting auto-detect to *known* DSL
+  keys (`subtype:`, `rarity:`, etc.), not any token with a colon.
+- Documentation effort: `docs/query-dsl.md` with worked examples and a
+  cheat sheet drawer in the SPA. Worth the cost.
+
+Neutral:
+
+- Closes #39 once the dual-mode contract ships. The original "DSL
+  replaces flavor" framing is explicitly rejected in favor of this
+  dual approach.
+
+## Alternatives considered
+
+- **DSL only; deprecate flavor.** Cleaner maintenance but regresses
+  the casual audience that the project was designed for.
+- **Single auto-detect, no toggle.** Simpler UX but harder to teach;
+  users can't see the rules. Rejected — we keep auto-detect *and* a
+  visible mode setting so the system is legible.
+- **Server-side query planner only (no DSL on the CLI).** Forecloses
+  power-user CLI workflows (`pkmn lookup -e 'top:5 subtype:VMAX'`).
+  Rejected.

--- a/docs/adr/0023-source-ensemble-pricing.md
+++ b/docs/adr/0023-source-ensemble-pricing.md
@@ -1,0 +1,131 @@
+# ADR 0023: Source ensemble for pricing display (with user-selectable preferences)
+
+- **Status:** Proposed
+- **Date:** 2026-06-03
+- **Tags:** sources, pricing, web, supersedes-aspects-of-0002
+
+## Context
+
+[ADR-0002](0002-multi-source-lookup-priority.md) established a strict
+**priority order** across three sources: pokemontcg.io → TCGdex →
+PriceCharting. Each row's pricing was set by the first source that
+returned a usable value. That contract was right for v1, when the
+project had one source per data shape (catalog from pokemontcg.io,
+multilingual fallback from TCGdex, explicit URL paste from
+PriceCharting), and it kept the lookup pipeline simple.
+
+The picture is changing as we add eBay (ADR-0020) and a first-class
+TCGPlayer client (ADR-0021):
+
+1. **Several sources will overlap meaningfully on the same data
+   shape.** TCGPlayer market price, eBay last-sold median, pokemontcg.io's
+   embedded `tcgplayer` block, and PriceCharting's "loose" price are all
+   plausible candidates for "the Market Price" of a given card.
+2. **Ordering by source hides useful signal.** A strict
+   first-source-wins resolution treats the also-rans as wasted work; a
+   user looking at the row never sees that two sources agreed within
+   $2 and a third was an outlier, which is exactly the read a vendor or
+   collector wants.
+3. **User preference varies.** A vendor pricing a binder for a card
+   show wants eBay sold-listings as the primary anchor. A collector
+   checking value before sealing a wishlist wants TCGPlayer market.
+   A casual user wants whatever's reasonable without configuring
+   anything. One ordering can't serve all three.
+
+## Decision
+
+Replace the **pricing display** aspect of ADR-0002 with a **source
+ensemble model**. ADR-0002 still governs which source's **card object**
+wins for structural fields (name, set, number, art) — that resolution
+problem is unchanged. What changes is how pricing values are surfaced.
+
+**The model:**
+
+1. **Every configured source contributes its pricing as an independent
+   data point.** The lookup pipeline calls every applicable source for
+   each card, in parallel, and collects whichever values come back.
+2. **The displayed Market Price is an aggregate** — by default a
+   **trimmed mean** (drop the highest and lowest if ≥4 values, plain
+   mean otherwise) across the user-enabled pricing sources. Less
+   sensitive to a single outlier than a plain mean, lighter to compute
+   than a full distribution.
+3. **The card detail drawer shows the breakdown** — per-source value,
+   freshness, and any drift flag.
+4. **Per-user source preferences live in the SPA Settings drawer** as a
+   feature-flag-style toggle per source. Anonymous users get a sensible
+   default set (TCGPlayer + pokemontcg.io's embedded block); signed-in
+   users persist their choices to the new persistence layer (ADR-0013).
+5. **A "primary anchor" preference** lets users tag one source as the
+   one they want to see as the headline Market Price; the aggregate
+   still computes, but the displayed value can favor the anchor when
+   it disagrees with the aggregate by more than a configurable
+   threshold (logged but not auto-resolved).
+6. **The CLI keeps a default deterministic ordering** for non-interactive
+   use — the same default the SPA shows for anonymous users — so
+   `pkmn lookup` runs are reproducible without a settings layer.
+
+**What ADR-0002 still owns:**
+
+- Card-object resolution: which source's card metadata is the
+  authoritative shape (name, set, number, attacks, art URLs). The
+  priority order there is preserved unchanged.
+- Fallback chain when *no* pricing comes back from the enabled
+  sources: TCGdex's structural-only fallback continues to mean "no
+  price available," not "use TCGdex's $0".
+
+**Out of scope:**
+
+- Time-series pricing or historical comps. Each source provides a
+  current snapshot; trends are a v3 concern.
+- Per-condition pricing (NM / LP / MP / HP). Tracked separately in
+  #270; the ensemble model is condition-agnostic at the contract
+  level.
+
+## Consequences
+
+Positive:
+
+- A pricing row now reflects market consensus across multiple sources,
+  not a single source's read. Outlier sources show up in the breakdown
+  rather than silently winning.
+- The user-preference layer lets vendor and collector audiences each
+  configure the tool for their own primary signal without the
+  defaults arguing about who's right.
+- Ensemble computation is independent of source layering, so adding a
+  sixth or seventh source later (CardMarket direct, Scrydex, …) is a
+  config change, not a re-ranking exercise.
+
+Negative:
+
+- N sources called per card vs. 1-2 today. The cache (ADR-0018 split,
+  per-source TTLs from ADR-0020) absorbs most of the cost on warm
+  runs, but cold-cache performance degrades linearly with sources
+  enabled. Mitigation: parallel fetches; a budget that caps
+  concurrent upstream calls.
+- Aggregate-display means the user can't always point at a single
+  source as "where this number came from." The drawer breakdown
+  mitigates the trust hit; users who want a single source can pin
+  one as primary anchor.
+- ADR-0002 is partially superseded — the load-bearing
+  *priority-for-pricing* claim no longer holds. The ADR file gets a
+  Status amendment pointing here.
+
+Neutral:
+
+- The ensemble lives behind a feature flag (`MGZ_PKMN_PRICING_ENSEMBLE`)
+  during rollout. Default `0` initially; flips to `1` once the SPA
+  Settings drawer ships the source-selection UI. Old behavior
+  (first-source-wins) remains available via the flag for a
+  deprecation window.
+
+## Alternatives considered
+
+- **Keep strict priority ordering; add a "show breakdown" toggle.**
+  Cheapest implementation but loses the consensus benefit — users
+  see one number as canonical and the breakdown as decoration.
+- **Auto-detect "primary source" per card based on confidence.** Too
+  much magic; freshness and rate-limit considerations vary by source
+  in ways the planner can't reliably score.
+- **Pure user choice (no default aggregate).** Forces every user to
+  configure preferences before getting useful output. Bad casual-user
+  experience.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,6 +30,9 @@ not just the shape.
 | [0017](0017-tropical-design-system.md) | Tropical design system — sun + palm + coconut, paired light/dark tokens | Accepted | 2026-05-31 |
 | [0018](0018-structural-vs-volatile-cache-with-swr.md) | Structural / volatile cache split with stale-while-revalidate on pricing | Accepted | 2026-06-01 |
 | [0019](0019-hosted-demo-identity-and-auth.md) | Hosted-demo identity and auth — cache-only anon, sign-in gates persistence, GitHub + magic-link + Google | Accepted | 2026-06-02 |
+| [0020](0020-ebay-pricing-source.md) | eBay as a first-class pricing source (sold + active listings, per-source TTL) | Proposed | 2026-06-03 |
+| [0021](0021-tcgplayer-first-class-pricing.md) | First-class TCGPlayer pricing via the TCGPlayer API, with per-user OAuth tokens | Proposed | 2026-06-03 |
+| [0022](0022-query-dsl.md) | Structured query DSL with dual-mode + smart auto-detect (closes #39) | Proposed | 2026-06-03 |
 
 ## Adding a new ADR
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -33,6 +33,7 @@ not just the shape.
 | [0020](0020-ebay-pricing-source.md) | eBay as a first-class pricing source (sold + active listings, per-source TTL) | Proposed | 2026-06-03 |
 | [0021](0021-tcgplayer-first-class-pricing.md) | First-class TCGPlayer pricing via the TCGPlayer API, with per-user OAuth tokens | Proposed | 2026-06-03 |
 | [0022](0022-query-dsl.md) | Structured query DSL with dual-mode + smart auto-detect (closes #39) | Proposed | 2026-06-03 |
+| [0023](0023-source-ensemble-pricing.md) | Source ensemble for pricing display, with user-selectable preferences (partially supersedes ADR-0002) | Proposed | 2026-06-03 |
 
 ## Adding a new ADR
 

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -205,7 +205,7 @@ bootstrap in [`api/main.py`](../api/main.py) fires the first three when
 pass writes one cache entry per card across the full English catalog.
 The per-card *image* warm has yet another opt-in
 (`MGZ_PKMN_WARM_CARD_IMAGES_ON_STARTUP=1`) because it's the heaviest of
-the four — a completed pass on the deployed instance reports
+the five — a completed pass on the deployed instance reports
 `card-images warm complete: 40088 images warmed (17904440414 bytes)
 across 173 sets`, so plan disk size and first-deploy duration
 accordingly. Subsequent boots within the 7-day

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -108,6 +108,29 @@ rules above.
   to silence the warning entirely. The check is stat-only (no payload
   reads) so it adds negligible startup cost.
 
+### Entries vs. API calls
+
+`pkmn cache stats` reports **entries**, not HTTP calls — the two
+diverge because the lookup pipeline writes one
+`api_structural/<sha1>.json` per resolved card (so the planner can
+re-resolve directly by card id) on top of the paginated search-URL
+entries. A single page-of-250 catalog response → ~251 entries (1 page
++ 250 per-card structural).
+
+Rough HTTP-call accounting for a full warm:
+
+| Pass | HTTP calls (catalog) | Entries written |
+|---|---|---|
+| `warm-concepts` | ~200 | ~200 page entries + a few thousand per-card entries depending on uniqueness |
+| `warm-sets` | ~170 | ~170 set-info + image entries |
+| `warm-set-cards` / `warm-cards` | ~170–340 (one or two pages per set) | ~18,000 (one per English card) |
+| `warm-card-images` | ~40,000 *image* GETs (separate quota; not catalog API) | ~40,000 image files |
+
+So a cache showing **~20k entries on disk** typically represents
+**well under 1,000 catalog API calls** — most of the count is per-card
+structural fan-out from a handful of page fetches plus user lookups
+since the last warm.
+
 ## Inspecting the cache
 
 `pkmn cache path` prints the cache root as a single bare line for shell

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -2,13 +2,33 @@
 
 The CLI keeps a small disk cache under `$XDG_CACHE_HOME/mgz-pkmn`
 (`~/.cache/mgz-pkmn` by default) so consecutive runs over the same card
-list don't keep re-spending API quota. Two stores live there:
+list don't keep re-spending API quota.
 
-| Path | What it holds | TTL |
+## Two kinds of "expiry" used in this doc
+
+The cache doc talks about two different things that both look like time
+windows. Keep them separate when reading:
+
+- **Entry TTL** — how old a *single cached entry* can be before reads
+  treat it as stale. Applies per-file under `api_structural/`,
+  `api_pricing/`, etc.
+- **Warm-pass freshness window** — how recently the last *batch warm
+  pass* must have completed for the next boot/run to skip re-walking
+  it. Applies per-manifest (`concept_warm.json`, `card_warm.json`, …)
+  and never expires individual entries — those keep whatever TTL their
+  store assigns. See [Warm passes](#warm-passes).
+
+So a warm pass with a 7-day freshness window can populate
+`api_structural/` entries that themselves have no TTL — the 7 days
+governs when to *re-warm*, not when entries go stale.
+
+## Stores on disk
+
+| Path | What it holds | Entry TTL |
 |---|---|---|
 | `api_structural/<sha1>.json` | Structural fields per cached request URL — name, set, number, rarity, attacks, images, etc. Anything that doesn't change once a card is printed. | None — indefinite. |
 | `api_pricing/<sha1>.json` | Volatile pricing fields per cached request URL — `tcgplayer.prices`, `cardmarket.prices`, `_pc_prices`, `_pc_url`. | 24 h (mtime-based). Stale reads return the cached value while a background refresh runs. |
-| `api/<sha1>.json` | **Legacy** — pre-#372 combined payload. Migrated to the split form lazily on first read; new writes go directly to `api_structural/` + `api_pricing/`. | 7 days (mtime-based). |
+| `api/<sha1>.json` | **Legacy** — pre-#372 combined payload. New writes never land here; existing entries are migrated to the split form lazily on first read. | No standalone TTL. On read the legacy file is split, the pricing slice's mtime is preserved, and the legacy file is unlinked — so a pre-existing 9-day-old legacy entry comes out STALE on the pricing side immediately after migration. |
 | `url_overrides.json` | `(name, set_hint)` → PriceCharting URL, recorded whenever you paste a PC URL on a line. | None — sticky until you overwrite or delete. |
 
 ## Freshness model
@@ -47,9 +67,13 @@ and the worst-case cost is 2× upstream for an affected key.
 Legacy `api/<sha1>.json` entries from before the split are migrated
 **lazily** on first read: the legacy file is parsed, split into both
 new locations atomically, the pricing file's mtime is preserved via
-`os.utime` (so a 9 d-old legacy entry is correctly STALE after
-migration), and the legacy file is unlinked. After migration the
-entry behaves identically to a fresh split write.
+`os.utime`, and the legacy file is unlinked. The preserved mtime means
+the pricing slice carries forward whatever age the legacy entry had —
+a 9-day-old legacy file produces a freshly-migrated pricing entry that
+is already STALE under the 24 h pricing TTL and triggers a background
+refresh on first read. After migration, the entry behaves identically
+to a fresh split write; subsequent reads follow the per-slice TTL
+rules above.
 
 ## Behavior
 
@@ -145,10 +169,16 @@ same snapshot with snake_case keys:
 
 ## Warm passes
 
-Four CLI commands pre-populate slices of the cache so first-use lookups
-land on a warm disk instead of paying upstream latency:
+Five CLI commands pre-populate slices of the cache so first-use lookups
+land on a warm disk instead of paying upstream latency. Each command
+writes entries into the normal stores (`api_structural/`, `images/`,
+etc.) — those entries follow the **entry TTL** rules from the table
+above (structural: indefinite; pricing: 24 h SWR). What the warm
+commands add on top is a **freshness window**: a per-manifest skip
+threshold so the next boot/run doesn't re-walk a warm that was
+recently completed.
 
-| Command | What it warms | Manifest | Stale window |
+| Command | What it warms | Manifest | Freshness window |
 |---|---|---|---|
 | `pkmn cache warm-concepts` | Concept-name → card-id lookups (~200 names) | `concept_warm.json` | 24 h |
 | `pkmn cache warm-set-cards` | Per-set card-list JSON for every set | `set_cards_warm.json` | 7 d |
@@ -156,9 +186,19 @@ land on a warm disk instead of paying upstream latency:
 | `pkmn cache warm-cards` | Full per-card structural payload (~18,000 cards) | `card_warm.json` | 7 d |
 | `pkmn cache warm-card-images` | `large` + `small` image bytes for every English card (~40,000 files / ~17 GB) | `card_images_warm.json` | 7 d |
 
+Why concepts is 24 h while the catalog warms are 7 d: the concept walk
+is cheap (a couple hundred lookups) and the underlying set of concept
+names changes more often than the catalog does, so a tighter
+re-walk window is worth the cost. The catalog warms are expensive
+(thousands of HTTP calls or tens of GB of images) but the cards
+themselves don't change once printed — a week between re-walks is a
+good fit for the structural data they populate.
+
 Each manifest records `timestamp` + a count of what was warmed; the
 freshness gate (`*_warm_is_fresh()`) reads it to skip a re-walk when a
-recent pass is still within the staleness window. The on-startup
+recent pass is still within the freshness window. Re-walks do **not**
+touch entries that are already on disk except to refresh them; the
+underlying entries keep their own TTL semantics. The on-startup
 bootstrap in [`api/main.py`](../api/main.py) fires the first three when
 `MGZ_PKMN_WARM_ON_STARTUP=1`. The per-card warm has its own opt-in
 (`MGZ_PKMN_WARM_CARDS_ON_STARTUP=1`) because it's heavier — a fresh
@@ -168,8 +208,9 @@ The per-card *image* warm has yet another opt-in
 the four — a completed pass on the deployed instance reports
 `card-images warm complete: 40088 images warmed (17904440414 bytes)
 across 173 sets`, so plan disk size and first-deploy duration
-accordingly. Subsequent boots within the 1-week freshness window skip
-the re-walk.
+accordingly. Subsequent boots within the 7-day
+`card_images_warm.json` freshness window skip the re-walk; entries
+already on disk remain valid regardless (images carry no TTL).
 
 `warm-cards` is Phase 1 of the pre-Scrydex catalog-warm epic
 ([#368](https://github.com/mgzwarrior/mgz-pkmn/issues/368)). Reuses the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,15 +1,30 @@
 # CLI reference
 
-`pkmn` is a Click group exposing three subcommands:
+`pkmn` is a Click group with three subcommands:
 
 - **`pkmn lookup INPUTS...`** — the original card-lookup pipeline (xlsx,
   binder PDFs, checklist, JSON report). Documented below.
 - **`pkmn set-cards`** — generate printable set identification cutouts
   for binder section dividers; takes no positional arguments. See
   [PDF binder → Set identification cards](binder-pdf.md#set-identification-cards-pkmn-set-cards).
-- **`pkmn cache stats`** — print on-disk cache health (total size,
-  oldest API entry, URL-override count). See
-  [Cache → Inspecting the cache](cache.md#inspecting-the-cache).
+- **`pkmn cache`** — disk-cache management group. Subcommands:
+  - `pkmn cache path` — print the cache root (single bare line).
+  - `pkmn cache stats` — on-disk cache health (size, entry count,
+    oldest API entry). `--json` for scripted use.
+  - `pkmn cache clear` — wipe the API response cache (overrides + image
+    cache preserved).
+  - `pkmn cache warm-concepts` — pre-populate concept-name lookups (~200
+    names).
+  - `pkmn cache warm-sets` — pre-populate set logo + symbol images.
+  - `pkmn cache warm-set-cards` — pre-populate per-set card-list JSON.
+  - `pkmn cache warm-cards` — pre-populate full per-card structural
+    payload (~18,000 cards). Phase 1 of [#368](https://github.com/mgzwarrior/mgz-pkmn/issues/368).
+  - `pkmn cache warm-card-images` — pre-populate large + small image
+    bytes for every English card (~40,000 files / ~17 GB).
+    Phase 2 of [#368](https://github.com/mgzwarrior/mgz-pkmn/issues/368).
+
+  See [Cache → Inspecting the cache](cache.md#inspecting-the-cache) and
+  [Cache → Warm passes](cache.md#warm-passes) for details.
 
 For backward compatibility, **invoking `pkmn` with input paths and no
 subcommand is forwarded to `lookup`** — `./pkmn cards.txt` and

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -109,20 +109,43 @@ modules — those benefit from a design discussion first.
 
 ## Project layout
 
+The repo carries four production surfaces (CLI + API + SPA + marketing
+site) plus the usual test / doc / output dirs.
+
+```
+mgz-pkmn/
+├── src/mgz_pkmn/    # Python CLI and lookup pipeline
+├── api/             # FastAPI service + SSE streaming + auth + persistence
+├── web/             # React 19 + Vite SPA (served by api/ in production)
+├── site/            # Astro static marketing site (mgz-pkmn.com)
+├── tests/           # pytest suite for src/ and api/
+├── docs/            # reference + ADRs (canonical; the wiki is a mirror)
+├── input/           # sample input files used by the docs and examples
+├── output/          # tracked example artifacts; refreshed by `make refresh-examples`
+└── assets/          # logos and shared static assets
+```
+
+### `src/mgz_pkmn/` — the CLI and lookup pipeline
+
 ```
 src/mgz_pkmn/
 ├── __init__.py
 ├── __main__.py        # python -m mgz_pkmn
 ├── cli.py             # Click command, top-level orchestration
 ├── parser.py          # parse_line, CardQuery, language + bulk-phrase detection
-├── lookup.py          # find_card + find_top_cards (pokemontcg → URL hint → tcgdex)
+├── lookup.py          # find_card / find_top_cards, plus warm_concepts / warm_set_cards / warm_cards
 ├── pricing.py         # extract_pricing, Pricing, COMP_PERCENTS
-├── images.py          # download + thumbnail
+├── images.py          # download + thumbnail (per-card art)
+├── card_images.py     # batch warm-cache for card images across warmed sets
+├── set_cards.py       # set-cards PDF + warm_set_images
 ├── spreadsheet.py     # write_spreadsheet, HEADERS, Row
 ├── binder.py          # PDF binder layouts (standard 3×3 + condensed 6×4)
 ├── checklist.py       # printable per-tag checklist PDF
 ├── report.py          # JSON report builder (pure)
 ├── sorting.py         # row ordering applied before any output is written
+├── cache.py           # disk cache (split structural / pricing, ADR-0018) + warm manifests
+├── branding.py        # logo + footer rendered into exports
+├── changelog.py       # parses CHANGELOG.md for the /version endpoint
 └── sources/
     ├── __init__.py
     ├── base.py            # MatchResult, scoring, set-overlap
@@ -131,9 +154,33 @@ src/mgz_pkmn/
     └── pricecharting.py   # URL-based scraper for region-exclusive cards
 ```
 
-Adding a new source is a matter of dropping a module under `sources/`
-that returns the normalized card shape, then adding it to
-`lookup.find_card`.
+### `api/` — the FastAPI backend
+
+```
+api/
+├── main.py            # app factory, lifespan, warm bootstrap, static mount
+├── routes/            # /lookup, /bulk (SSE), /parse, /sets, /cards, /runs, /me
+├── auth/              # signed-cookie sessions, /me, env kill switch (ADR-0019)
+├── db/                # SQLAlchemy session + URL resolution
+├── models/            # ORM models (users, runs, run_rows)
+└── migrations/        # Alembic migrations under versions/
+```
+
+### `web/` — the React SPA
+
+Vite + React 19 + TypeScript, TailwindCSS 4, Radix UI primitives,
+Zustand for state, TanStack Query for data fetching. Build output is
+served as a static SPA from the FastAPI app in production.
+
+### `site/` — the marketing site
+
+Astro static site at <https://mgz-pkmn.com>. Deployed to Cloudflare
+Pages on every push to `main` (see [ADR-0016](adr/0016-deployment-topology.md)).
+
+Adding a new lookup source is a matter of dropping a module under
+`src/mgz_pkmn/sources/` that returns the normalized card shape, then
+wiring it into `lookup.find_card` (or, post-ADR-0023, registering it
+with the source ensemble).
 
 ## Branch naming
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -179,8 +179,11 @@ Pages on every push to `main` (see [ADR-0016](adr/0016-deployment-topology.md)).
 
 Adding a new lookup source is a matter of dropping a module under
 `src/mgz_pkmn/sources/` that returns the normalized card shape, then
-wiring it into `lookup.find_card` (or, post-ADR-0023, registering it
-with the source ensemble).
+wiring it into `lookup.find_card`. If the new source also contributes
+pricing data, see [ADR-0023](adr/0023-source-ensemble-pricing.md) for
+the ensemble-display contract — registration of the source itself
+doesn't change, but the ensemble determines how its prices appear
+alongside other sources'.
 
 ## Branch naming
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -164,20 +164,33 @@ point the env var at the *parent* directory; pointing it at
 
 ### Cache warming
 
-Three runtime warm passes fire on startup when `MGZ_PKMN_WARM_ON_STARTUP=1`
-(set by default in `render.yaml`). Each writes its own freshness manifest
-so container restarts within the staleness window skip the re-walk:
+Five runtime warm passes can fire on startup, gated by three env vars
+so the lighter passes can run independently of the two heaviest. Each
+writes its own freshness manifest so container restarts within the
+freshness window skip the re-walk:
 
-| Pass | Manifest | Stale window | Walks |
-|---|---|---|---|
-| Concepts | `concept_warm.json` | 24 h | ~200 concept-name → card-id lookups |
-| Set cards | `set_cards_warm.json` | 7 d | Per-set card-list JSON (~170 sets) |
-| Sets (images) | `sets_warm.json` | 7 d | Set logo + symbol images (~200 × 2) |
+| Pass | Env var | Manifest | Freshness window | Walks |
+|---|---|---|---|---|
+| Concepts | `MGZ_PKMN_WARM_ON_STARTUP=1` | `concept_warm.json` | 24 h | ~200 concept-name → card-id lookups |
+| Set cards | `MGZ_PKMN_WARM_ON_STARTUP=1` | `set_cards_warm.json` | 7 d | Per-set card-list JSON (~170 sets) |
+| Sets (images) | `MGZ_PKMN_WARM_ON_STARTUP=1` | `sets_warm.json` | 7 d | Set logo + symbol images (~200 × 2) |
+| Per-card structural | `MGZ_PKMN_WARM_CARDS_ON_STARTUP=1` | `card_warm.json` | 7 d | Full per-card structural payload (~18,000 cards) |
+| Per-card images | `MGZ_PKMN_WARM_CARD_IMAGES_ON_STARTUP=1` | `card_images_warm.json` | 7 d | `large` + `small` image bytes per card (~40,000 files / ~17 GB) |
+
+The two per-card passes get their own opt-in env vars (separate from
+the umbrella `MGZ_PKMN_WARM_ON_STARTUP`) because they're heavyweight —
+the image warm in particular needs ~17 GB of persistent disk. All three
+env vars are set in `render.yaml` by default.
 
 The set-image warm previously lived as a Dockerfile build-time step.
-With the persistent disk in place it runs at runtime onto durable
-storage — a single warm after the first deploy serves every subsequent
-deploy until the manifest TTL expires.
+With the persistent disk in place all five passes run at runtime onto
+durable storage — a single warm after the first deploy serves every
+subsequent deploy until the relevant manifest's freshness window
+expires.
+
+See [Cache → Warm passes](cache.md#warm-passes) for the per-pass
+mechanics, and [Cache → Entries vs. API calls](cache.md#entries-vs-api-calls)
+for why a 20k-entry cache typically represents well under 1k API calls.
 
 ## Inspecting deployed cache state
 
@@ -190,9 +203,10 @@ curl -s https://mgz-pkmn.onrender.com/api/v1/cache/stats | jq
 ```
 
 Same field names as `pkmn cache stats --json`, so the two surfaces are
-pipe-compatible. Use it to confirm `MGZ_PKMN_WARM_ON_STARTUP` actually
-landed (`concept_warm_timestamp` / `set_cards_warm_timestamp` /
-`sets_warm_timestamp` are non-null after a successful warm pass) and to
-spot drift between the entry counts you expected and what's actually on
-disk. The response is served with `Cache-Control: no-store` because the
+pipe-compatible. Use it to confirm the warm
+env vars actually landed (`concept_warm_timestamp` /
+`set_cards_warm_timestamp` / `sets_warm_timestamp` /
+`card_warm_timestamp` / `card_images_warm_timestamp` are non-null after
+a successful warm pass) and to spot drift between the entry counts you
+expected and what's actually on disk. The response is served with `Cache-Control: no-store` because the
 underlying state changes on every warm pass and cache write.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -179,8 +179,10 @@ freshness window skip the re-walk:
 
 The two per-card passes get their own opt-in env vars (separate from
 the umbrella `MGZ_PKMN_WARM_ON_STARTUP`) because they're heavyweight —
-the image warm in particular needs ~17 GB of persistent disk. All three
-env vars are set in `render.yaml` by default.
+the image warm in particular needs the disk size declared in
+`render.yaml`'s `disk` block (the table above gives the order of
+magnitude; check `render.yaml` for the current size and bump as the
+catalog grows). All three env vars are set in `render.yaml` by default.
 
 The set-image warm previously lived as a Dockerfile build-time step.
 With the persistent disk in place all five passes run at runtime onto

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,25 +25,81 @@ live demo), see <https://mgz-pkmn.com>.
   marketing site at <https://mgz-pkmn.com>, mobile + a11y pass on
   the SPA. Released 2026-05-25; see the
   [v1.1 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/2).
-- **V1.2** — **committed**. Marketing-site polish + the web UX
+- **V1.2** — **shipped**. Marketing-site polish + the web UX
   enhancements that landed late in the v1.1 cycle but didn't gate
-  the cut. Tracked on the
+  the cut. See the
   [v1.2 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/4).
-- **V2** — **committed**. Deeper development per area, including
-  the persistence layer (Alembic + SQLAlchemy + `/runs` endpoints)
-  that opens the door to sidebars, collections, and wishlists.
+- **V1.3** — **shipped**. Pre-Scrydex catalog-warm epic
+  ([#368](https://github.com/mgzwarrior/mgz-pkmn/issues/368)) plus the
+  auth foundation (signed-cookie sessions, `/me`, env kill switch —
+  [#414](https://github.com/mgzwarrior/mgz-pkmn/pull/414)). See the
+  [v1.3 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/5)
+  and [v1.3.1 patch](https://github.com/mgzwarrior/mgz-pkmn/milestone/7).
+- **V1.4** — **committed**. Hosted-demo auth UX (provider sign-in,
+  Save-Search nudge, anonymous cache-only mode), CLI maintainability
+  refactor, marketing polish. Tracked on the
+  [v1.4 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/6).
+- **V1.5** — **committed**. **eBay integration epic** — additive sold +
+  active listings as a fourth pricing source via OAuth. Tracked on the
+  [v1.5 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/8)
+  under [`epic:ebay`](https://github.com/mgzwarrior/mgz-pkmn/labels/epic%3Aebay).
+- **V1.6** — **committed**. **TCGPlayer integration epic** —
+  first-class TCGPlayer API replacing the embedded `tcgplayer` block
+  from pokemontcg.io. Tracked on the
+  [v1.6 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/9)
+  under [`epic:tcgplayer`](https://github.com/mgzwarrior/mgz-pkmn/labels/epic%3Atcgplayer).
+- **V2** — **committed**. Structured query DSL (dual-mode, see #39
+  re-scope below) + persistence layer (Alembic + SQLAlchemy +
+  `/runs` / `/collections` / `/wishlists`) + hosted-demo identity
+  sign-off. The v2 thesis is *structured + persistent + identity*.
   Tracked per-area on the unified
   [`mgz-pkmn`](https://github.com/users/mgzwarrior/projects/11)
   project (per-area views linked below) and the
   [v2.0 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/3).
+- **V2.1** — **committed**. **Persistence-at-growth epic** — post-MVP
+  collections/wishlists scaling (Postgres / D1 / Turso spike, retention,
+  per-user export, ops runbooks). Tracked on the
+  [v2.1 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/10)
+  under [`epic:persistence-growth`](https://github.com/mgzwarrior/mgz-pkmn/labels/epic%3Apersistence-growth).
 - **V2.x / Post-V2** — **committed but later**. Currently themed around
   the **free / paid separation and monetization work** — once V2 is
   shipped, the project is mature enough to consider sustainable funding
   models. Free features stay free forever; paid features expand the
-  vendor / power-user surface.
+  vendor / power-user surface. See [ADR-0012](adr/0012-open-core-architecture.md)
+  for the open-core split.
 - **V3 and beyond** — **proposed**. Big ideas (vendor portal,
   marketplace integrations, multi-TCG expansion) that need community
-  input before any commitment. Subject to redirection.
+  input before any commitment. The **vendor card-scanner** (see
+  `epic:vendor-vision` placeholder) lives in this band, in the private
+  `mgz-pkmn-vendor` repo per ADR-0012. Subject to redirection.
+
+## How to read this roadmap
+
+Every committed item below is filed as a GitHub issue, and every
+issue carries the labels that let you filter the board to exactly what
+you're looking for:
+
+- **`area:*`** — which part of the codebase. One of `area:lookup`,
+  `area:web`, `area:cache`, `area:outputs`, `area:site`, `area:devops`.
+- **`type:*`** — what kind of change. One of `type:feature`,
+  `type:bug`, `type:docs`, `type:chore`, `type:test`.
+- **`version:*`** + **milestone** — when. The milestone is the source
+  of truth; the label exists as a coarse filter that survives milestone
+  renames.
+- **`epic:*`** — which epic an issue belongs to, when it's part of one
+  of the umbrella tracks (e.g. `epic:ebay`, `epic:query-dsl`,
+  `epic:persistence-growth`). Each epic has a tracking issue with the
+  full task list.
+- **`specialty:*`** — what skill is most useful for picking it up. One
+  of `specialty:frontend`, `specialty:backend`, `specialty:devops`,
+  `specialty:security`, `specialty:data`, `specialty:design`. Pick
+  whichever matches your background and filter the board to it.
+
+A frontend contributor browsing v1.5 work can run
+`is:open milestone:v1.5 label:specialty:frontend` to find their issues.
+A security-minded contributor can pull `label:specialty:security` across
+all open milestones. The combinations are meant to make self-serve
+contribution easy without anyone having to triage by hand.
 
 ## Project areas
 
@@ -292,6 +348,55 @@ in the v1.1 cycle but didn't gate the release cut. Tracked on the
 
 ---
 
+## V1.5 — committed (epic: eBay integration)
+
+Adds eBay as a fourth pricing source alongside pokemontcg.io / Scrydex
+/ PriceCharting. Slots into the existing source-plugin pattern; the
+existing CLI / API contracts don't change, hence a v1.x rather than v2
+milestone. See [ADR-0020](adr/0020-ebay-pricing-source.md) for the
+acceptance contract and the
+[`epic:ebay`](https://github.com/mgzwarrior/mgz-pkmn/labels/epic%3Aebay)
+tracking issue for the live task list.
+
+The epic spans every project area:
+
+- **Lookup engine** — `EbayClient` adapter implementing the existing
+  source contract; `Pricing.source` enum gains `"ebay_sold"` and
+  `"ebay_active"`.
+- **Cache & persistence** — per-source TTL policy (sold listings get a
+  longer freshness window than active listings).
+- **Web UI / API** — results-table column / drawer for eBay comps + a
+  last-N sold sparkline.
+- **DevOps & release** — eBay Developer OAuth client, secret rotation
+  runbook, Render env-var wiring.
+- **Security** — token storage, scope minimization, rate-limit
+  back-pressure.
+- **Tests** — cassette-based integration tests against eBay sandbox.
+
+---
+
+## V1.6 — committed (epic: TCGPlayer integration)
+
+Upgrades the embedded `tcgplayer` price block (today delivered nested
+inside pokemontcg.io responses) to live data from TCGPlayer's API,
+falling through to the embedded block when no credentials are present.
+See [ADR-0021](adr/0021-tcgplayer-first-class-pricing.md) and the
+[`epic:tcgplayer`](https://github.com/mgzwarrior/mgz-pkmn/labels/epic%3Atcgplayer)
+tracking issue.
+
+Pairs with the V2 persistence epic: per-user OAuth tokens land in the
+new persistence schema.
+
+- **Lookup engine** — `TCGPlayerClient` adapter; pricing upgrade path.
+- **Cache & persistence** — SWR window for TCGPlayer market price.
+- **Web UI / API** — "Connect TCGPlayer" settings panel with status.
+- **DevOps & release** — per-user token storage migration.
+- **Security** — OAuth `app/authorizeApplication` flow, refresh-token
+  handling.
+- **Tests** — sandbox / canned-response coverage.
+
+---
+
 ## V2 — committed
 
 Deeper development per area. The kind of work that takes more than an
@@ -300,11 +405,19 @@ its own GitHub issue + PR thread.
 
 ### Lookup engine
 
-- Structured query DSL (`top:N subtype:V,VMAX in "Surging Sparks"
-  rarity:rare>=$50`) — replace the flavor-text fallback with real
-  semantics. ([#39](https://github.com/mgzwarrior/mgz-pkmn/issues/39))
-- eBay sold-listings as a fourth price source (opt-in via `--ebay`).
-  ([#40](https://github.com/mgzwarrior/mgz-pkmn/issues/40))
+- **Structured query DSL — dual-mode + smart auto-detect.**
+  `top:N subtype:V,VMAX in "Surging Sparks" rarity:rare>=$50` runs in
+  DSL mode alongside the existing flavor-text mode. A frontend toggle
+  picks the default; smart auto-detect picks the right mode when input
+  is unambiguous (`key:value` or `>=$` tokens are always DSL even if
+  the toggle says flavor). Tracked under the `epic:query-dsl` umbrella;
+  closes [#39](https://github.com/mgzwarrior/mgz-pkmn/issues/39) when
+  the dual-mode contract ships.
+- eBay sold-listings — has graduated to its own epic in V1.5; see the
+  `epic:ebay` tracking issue and [v1.5 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/8). The
+  original opt-in framing in
+  [#40](https://github.com/mgzwarrior/mgz-pkmn/issues/40) is now a
+  child issue under that epic.
 - Cache TCGdex responses too (today only pokemontcg.io is cached).
   ([#41](https://github.com/mgzwarrior/mgz-pkmn/issues/41))
 - Surface ambiguity in the JSON report
@@ -397,6 +510,28 @@ its own GitHub issue + PR thread.
 
 ---
 
+## V2.1 — committed (epic: persistence at growth)
+
+V2 ships the persistence MVP (collections #244, wishlists #245, runs).
+V2.1 is the layer below — what we do when the single-tenant SQLite
+shape outgrows the hosted demo. Tracked under
+[`epic:persistence-growth`](https://github.com/mgzwarrior/mgz-pkmn/labels/epic%3Apersistence-growth);
+depends on the V2 persistence MVP landing first.
+
+- **Cache & persistence** — Postgres (via Hyperdrive) vs. Turso vs.
+  Cloudflare D1 spike (captured as a follow-up ADR); migration story
+  keeps Alembic and adds a Postgres dialect adapter.
+- **Web UI / API** — per-user data export (`GET /me/export` → JSON
+  dump); "Your data" page listing runs, collections, wishlists with
+  delete + export controls.
+- **DevOps & release** — backup + restore runbook for the hosted demo
+  DB.
+- **Security** — retention policy for `runs` / `run_rows` (90 days
+  anonymous, indefinite signed-in).
+- **Tests** — SQLite ↔ Postgres migration round-trip coverage.
+
+---
+
 ## V2.x — committed but post-V2
 
 Themed around **monetization**. The premise: *every end-user-facing
@@ -446,11 +581,20 @@ yet — items here graduate to issues only after community discussion.
 ### Vendor / power-user portal
 
 A separate persona from the personal-prep tool: someone who *runs* a
-booth, not just attends one.
+booth, not just attends one. Per
+[ADR-0012](adr/0012-open-core-architecture.md), the implementation
+lives in the private `mgz-pkmn-vendor` repo and is the first paid
+surface. The OSS repo carries an
+[`epic:vendor-vision`](https://github.com/mgzwarrior/mgz-pkmn/labels/epic%3Avendor-vision)
+placeholder issue for visibility; substantive work happens in the
+vendor repo.
 
-- **Bulk card recognition.** Camera or upload-based image recognition
-  to identify cards in bulk (set, number, condition hints) and
-  populate inventory. Pairs with Multi-user persistent collections.
+- **Bulk card recognition (vendor scanner).** Camera or upload-based
+  image recognition to identify cards in bulk (set, number, condition
+  hints) and populate inventory. Extends the
+  [breakwater-tcg-scanner](https://github.com/mgzwarrior/breakwater-tcg-scanner)
+  prototype. Lives in `mgz-pkmn-vendor`. Pairs with Multi-user
+  persistent collections.
 - **Booth inventory tracking.** Per-show, per-binder, per-card
   movement: what was on the table at the start of a show, what sold,
   for how much, and what came home.
@@ -510,19 +654,24 @@ lands.
 
 ## How this list becomes work
 
-Each item under V1 / V1.1 / V1.2 / V2 is filed as a GitHub issue with
-two labels: an **area** label (`area:lookup` / `area:outputs` /
-`area:cache` / `area:web` / `area:site` / `area:devops`) and a
-coarse **version** label — only three exist today: `version:v1`,
-`version:v1.x`, `version:v2`. V1.1 and V1.2 both share
-`version:v1.x`; **milestone** is what splits them apart.
-Committed items sit on the matching milestone:
+Each committed item below is filed as a GitHub issue with the labels
+listed in [How to read this roadmap](#how-to-read-this-roadmap) —
+`area:*`, `type:*`, `version:*`, plus `epic:*` and `specialty:*` where
+applicable. **Milestone** is the source of truth for *when* (the
+version label exists as a coarse filter that survives milestone
+renames). All v1.x minor releases share `version:v1.x`; the milestones
+split them apart:
 [v1.0](https://github.com/mgzwarrior/mgz-pkmn/milestone/1) (shipped),
 [v1.1](https://github.com/mgzwarrior/mgz-pkmn/milestone/2) (shipped),
-[v1.2](https://github.com/mgzwarrior/mgz-pkmn/milestone/4), and
-[v2.0](https://github.com/mgzwarrior/mgz-pkmn/milestone/3). A
-`version:v2.x` label gets created when the monetization items
-above graduate from text-only proposals to filed issues.
+[v1.2](https://github.com/mgzwarrior/mgz-pkmn/milestone/4) (shipped),
+[v1.3](https://github.com/mgzwarrior/mgz-pkmn/milestone/5) (shipped),
+[v1.4](https://github.com/mgzwarrior/mgz-pkmn/milestone/6),
+[v1.5](https://github.com/mgzwarrior/mgz-pkmn/milestone/8),
+[v1.6](https://github.com/mgzwarrior/mgz-pkmn/milestone/9),
+[v2.0](https://github.com/mgzwarrior/mgz-pkmn/milestone/3), and
+[v2.1](https://github.com/mgzwarrior/mgz-pkmn/milestone/10). A
+`version:v2.x` label gets created when the monetization items above
+graduate from text-only proposals to filed issues.
 
 V2.x and V3+ items stay in this document as text-only proposals until
 they get promoted to committed work. The "proposed" tag is

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,40 +1,38 @@
 # Roadmap
 
-[![v1.2 progress](https://img.shields.io/github/milestones/progress-percent/mgzwarrior/mgz-pkmn/4?label=v1.2)](https://github.com/mgzwarrior/mgz-pkmn/milestone/4)
+[![v1.4 progress](https://img.shields.io/github/milestones/progress-percent/mgzwarrior/mgz-pkmn/6?label=v1.4)](https://github.com/mgzwarrior/mgz-pkmn/milestone/6)
+[![v1.5 progress](https://img.shields.io/github/milestones/progress-percent/mgzwarrior/mgz-pkmn/8?label=v1.5)](https://github.com/mgzwarrior/mgz-pkmn/milestone/8)
+[![v1.6 progress](https://img.shields.io/github/milestones/progress-percent/mgzwarrior/mgz-pkmn/9?label=v1.6)](https://github.com/mgzwarrior/mgz-pkmn/milestone/9)
 [![v2.0 progress](https://img.shields.io/github/milestones/progress-percent/mgzwarrior/mgz-pkmn/3?label=v2.0)](https://github.com/mgzwarrior/mgz-pkmn/milestone/3)
+[![v2.1 progress](https://img.shields.io/github/milestones/progress-percent/mgzwarrior/mgz-pkmn/10?label=v2.1)](https://github.com/mgzwarrior/mgz-pkmn/milestone/10)
 [![open issues](https://img.shields.io/github/issues-raw/mgzwarrior/mgz-pkmn?label=open)](https://github.com/mgzwarrior/mgz-pkmn/issues)
-[![closed issues](https://img.shields.io/github/issues-closed-raw/mgzwarrior/mgz-pkmn?label=closed)](https://github.com/mgzwarrior/mgz-pkmn/issues?q=is%3Aissue+is%3Aclosed)
 
-A working backlog of what shipping a polished **V1** looks like, where the
-project goes after that, and a parking lot of bigger speculative ideas.
-Items live on GitHub as issues, labels, milestones, and projects — this
-document is the navigator. Every committed item below carries its issue
-number for one-click navigation; speculative items don't have issues yet.
+A forward-looking view of what's in flight and what's next. **Shipped
+work is no longer enumerated here** — the [CHANGELOG](../CHANGELOG.md)
+and the closed milestones own that record. The Versioning policy
+section below gives a one-line summary per shipped version with a
+link to its milestone for the full ledger; everything past V1.4 is
+open work.
+
+Items live on GitHub as issues, labels, milestones, and projects —
+this document is the navigator. Every committed item below carries
+its issue number for one-click navigation; speculative items don't
+have issues yet.
 
 For the end-user-facing project overview (features, "how it works",
 live demo), see <https://mgz-pkmn.com>.
 
 ## Versioning policy
 
-- **V1** (`1.0.0`) — **shipped**. A defensible 1.0 with no obvious
-  gaps. Polish, tests, docs, basic release engineering. Released
-  2026-05-15; see the [v1.0 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/1).
-- **V1.1** (`1.1.0`) — **shipped**. Post-1.0 polish, contributor
-  comms, devex (PyPI auto-publish, DCO, Codecov), unified image
-  cache + `pkmn cache warm-sets`, set ID cards + web set-picker,
-  marketing site at <https://mgz-pkmn.com>, mobile + a11y pass on
-  the SPA. Released 2026-05-25; see the
-  [v1.1 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/2).
-- **V1.2** — **shipped**. Marketing-site polish + the web UX
-  enhancements that landed late in the v1.1 cycle but didn't gate
-  the cut. See the
-  [v1.2 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/4).
-- **V1.3** — **shipped**. Pre-Scrydex catalog-warm epic
-  ([#368](https://github.com/mgzwarrior/mgz-pkmn/issues/368)) plus the
-  auth foundation (signed-cookie sessions, `/me`, env kill switch —
-  [#414](https://github.com/mgzwarrior/mgz-pkmn/pull/414)). See the
-  [v1.3 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/5)
-  and [v1.3.1 patch](https://github.com/mgzwarrior/mgz-pkmn/milestone/7).
+**Shipped (history; see [CHANGELOG](../CHANGELOG.md) for details):**
+
+- **V1** (`1.0.0`) — 2026-05-15. Defensible 1.0; polish, tests, docs, release engineering. [v1.0 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/1).
+- **V1.1** (`1.1.0`) — 2026-05-25. Set ID cards + web set-picker, marketing site, devex (PyPI, DCO, Codecov), a11y pass. [v1.1 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/2).
+- **V1.2** — Marketing-site polish + late v1.1-cycle web UX. [v1.2 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/4).
+- **V1.3** — Pre-Scrydex catalog-warm epic ([#368](https://github.com/mgzwarrior/mgz-pkmn/issues/368)) + auth foundation ([#414](https://github.com/mgzwarrior/mgz-pkmn/pull/414)). [v1.3 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/5) · [v1.3.1 patch](https://github.com/mgzwarrior/mgz-pkmn/milestone/7).
+
+**In flight / planned:**
+
 - **V1.4** — **committed**. Hosted-demo auth UX (provider sign-in,
   Save-Search nudge, anonymous cache-only mode), CLI maintainability
   refactor, marketing polish. Tracked on the
@@ -48,14 +46,26 @@ live demo), see <https://mgz-pkmn.com>.
   from pokemontcg.io. Tracked on the
   [v1.6 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/9)
   under [`epic:tcgplayer`](https://github.com/mgzwarrior/mgz-pkmn/labels/epic%3Atcgplayer).
-- **V2** — **committed**. Structured query DSL (dual-mode, see #39
-  re-scope below) + persistence layer (Alembic + SQLAlchemy +
-  `/runs` / `/collections` / `/wishlists`) + hosted-demo identity
-  sign-off. The v2 thesis is *structured + persistent + identity*.
-  Tracked per-area on the unified
-  [`mgz-pkmn`](https://github.com/users/mgzwarrior/projects/11)
-  project (per-area views linked below) and the
-  [v2.0 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/3).
+- **V2** — **committed (currently staging area)**. The v2.0 milestone
+  on GitHub today aggregates structured query DSL, persistence MVP,
+  identity sign-on, and assorted lookup/web/output improvements. Under
+  strict semver — the trigger we've settled on — most of these are
+  **additive** (new commands, new endpoints, new fields, new UI
+  toggles) and could ship in the v1.x cadence without breaking
+  existing users. The real **v2 cut trigger** is one of:
+  1. **The plugin contract goes live** — the entry-point surface that
+     [ADR-0012](adr/0012-open-core-architecture.md) requires for
+     `mgz-pkmn-vendor` to register `pkmn vendor <subcommand>` becomes
+     a public API. Adding it doesn't break existing users; promising
+     compat on it does.
+  2. **Hosted-demo identity becomes required** — anonymous lookups stop
+     working on the demo. Doesn't affect the CLI, but materially
+     changes the demo's product shape.
+
+  The current [v2.0 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/3)
+  serves as the staging area for the breakpoint-adjacent epics. Some
+  of its items will likely ship earlier as v1.7/v1.8 minor releases
+  once the cut criterion is firmer.
 - **V2.1** — **committed**. **Persistence-at-growth epic** — post-MVP
   collections/wishlists scaling (Postgres / D1 / Turso spike, retention,
   per-user export, ops runbooks). Tracked on the
@@ -132,219 +142,6 @@ and
 [`help wanted`](https://github.com/mgzwarrior/mgz-pkmn/labels/help%20wanted)
 label filters. AI-assisted PRs welcome — see
 [AGENTS.md](../AGENTS.md).
-
----
-
-## V1 — complete
-
-All items shipped in **1.0.0** (2026-05-15). See the
-[CHANGELOG](../CHANGELOG.md) for the full list.
-
-### Lookup engine
-
-- Apply inline price filters to single-card lookups, or warn when
-  ignored. ([#6](https://github.com/mgzwarrior/mgz-pkmn/issues/6))
-- Distinguish `>` from `>=` (and `<` from `<=`) in the comparator
-  parser. ([#7](https://github.com/mgzwarrior/mgz-pkmn/issues/7))
-- Currency-aware price filtering — at minimum loud documentation of
-  the existing currency-blind behavior; ideally gating by currency.
-  ([#8](https://github.com/mgzwarrior/mgz-pkmn/issues/8))
-- Wrap PriceCharting scrape failures in a structured `MatchResult`
-  rather than letting the `requests.HTTPError` surface raw.
-  ([#9](https://github.com/mgzwarrior/mgz-pkmn/issues/9))
-- Regression test covering the word-boundary post-filter so `top 4
-  Mew` never re-introduces Mewtwo.
-  ([#10](https://github.com/mgzwarrior/mgz-pkmn/issues/10))
-
-### Output artifacts
-
-- Add `summary.sort_mode` to the JSON report so consumers know the
-  ordering used. ([#11](https://github.com/mgzwarrior/mgz-pkmn/issues/11))
-- Document (or fix) the `--no-images` divergence between CLI exports
-  and Web-UI-driven exports.
-  ([#12](https://github.com/mgzwarrior/mgz-pkmn/issues/12))
-- Tighten checklist truncation tests with a long-name fixture.
-  ([#13](https://github.com/mgzwarrior/mgz-pkmn/issues/13))
-- New `--print-summary-only` CLI mode for input iteration.
-  ([#14](https://github.com/mgzwarrior/mgz-pkmn/issues/14))
-- `make refresh-examples` target to keep the tracked
-  [`output/`](../output/) artifacts current.
-  ([#15](https://github.com/mgzwarrior/mgz-pkmn/issues/15))
-
-### Cache & persistence
-
-- Show cache hit rate in the CLI summary line.
-  ([#16](https://github.com/mgzwarrior/mgz-pkmn/issues/16))
-- Soft-warn when the cache directory exceeds 50 MB.
-  ([#17](https://github.com/mgzwarrior/mgz-pkmn/issues/17))
-- Versioned schema for `url_overrides.json` (`{schema_version: 1, …}`).
-  ([#18](https://github.com/mgzwarrior/mgz-pkmn/issues/18))
-- `pkmn cache stats` subcommand printing size, oldest entry, override
-  count. ([#19](https://github.com/mgzwarrior/mgz-pkmn/issues/19))
-- Document the `MGZ_PKMN_NO_CACHE` env var (exists in code, missing
-  from docs). ([#20](https://github.com/mgzwarrior/mgz-pkmn/issues/20))
-
-### Web UI / API
-
-- Add a `LICENSE` file at the repo root (cross-listed with DevOps —
-  hard blocker for any release).
-  ([#28](https://github.com/mgzwarrior/mgz-pkmn/issues/28))
-- API tests for `/parse`, `/lookup`, `/sets`, `/overrides` (currently
-  only `/export` is covered).
-  ([#21](https://github.com/mgzwarrior/mgz-pkmn/issues/21))
-- Vitest setup + smoke tests per web component.
-  ([#22](https://github.com/mgzwarrior/mgz-pkmn/issues/22))
-- Error boundary in the SPA so a render failure shows a message
-  instead of a blank page.
-  ([#23](https://github.com/mgzwarrior/mgz-pkmn/issues/23))
-- "Restore defaults" button in `SettingsDrawer` (escape hatch from a
-  weird state). ([#24](https://github.com/mgzwarrior/mgz-pkmn/issues/24))
-- Surface the `--dedupe` toggle in the UI (settings type has the
-  field; no control to flip it).
-  ([#25](https://github.com/mgzwarrior/mgz-pkmn/issues/25))
-- **Column filtering / sorting in the results table.** Click a column
-  header to sort; per-column filter inputs to narrow.
-  ([#26](https://github.com/mgzwarrior/mgz-pkmn/issues/26))
-- **Improved loading state** during a lookup so users have visible
-  proof the API is working — progress count, animated rows, or a
-  per-line status indicator.
-  ([#27](https://github.com/mgzwarrior/mgz-pkmn/issues/27))
-- **`Cache-Control: no-cache` on `index.html`.** Hashed JS/CSS keep
-  long-cache headers, but the SPA shell shouldn't be browser-cached
-  — otherwise newly-deployed builds keep pointing at old asset URLs.
-  ([#70](https://github.com/mgzwarrior/mgz-pkmn/issues/70))
-
-### DevOps & release
-
-- `LICENSE` file at the repo root (likely MIT given the project's
-  framing). Cross-listed with Web UI / API.
-  ([#28](https://github.com/mgzwarrior/mgz-pkmn/issues/28))
-- GitHub issue + PR templates under `.github/ISSUE_TEMPLATE/` (bug,
-  feature, docs, plus a generic PR template).
-  ([#29](https://github.com/mgzwarrior/mgz-pkmn/issues/29))
-- `CHANGELOG.md` seeded with entries for everything between `0.1.0`
-  and `1.0.0`. Going forward, every PR adds an `[Unreleased]` entry.
-  ([#30](https://github.com/mgzwarrior/mgz-pkmn/issues/30))
-- Polish `pyproject.toml` metadata for PyPI release (`description`,
-  `keywords`, `classifiers`, `urls` — current description doesn't
-  even mention the PDF / checklist / web UI).
-  ([#31](https://github.com/mgzwarrior/mgz-pkmn/issues/31))
-- Confirm Render + Docker recipes still work post-restructure.
-  ([#32](https://github.com/mgzwarrior/mgz-pkmn/issues/32))
-- **GitHub Sponsors button.** `.github/FUNDING.yml` with a sponsor
-  username so the "Sponsor" button appears on the repo. Last item
-  before the V1 release goes out.
-  ([#33](https://github.com/mgzwarrior/mgz-pkmn/issues/33))
-- **Logo + social preview.** A small logo for the README header and a
-  1280×640 social preview image set under repo Settings → Social
-  preview. Improves shareability when the repo gets linked.
-  ([#34](https://github.com/mgzwarrior/mgz-pkmn/issues/34))
-- **Security policy + Dependabot.** `SECURITY.md` covering disclosure
-  process, plus `.github/dependabot.yml` and the GitHub Advanced
-  Security toggles (secret scanning, code scanning, dependency
-  graph). ([#35](https://github.com/mgzwarrior/mgz-pkmn/issues/35))
-- **AI-agent scaffolding.** A top-level `AGENTS.md` (or
-  `CLAUDE.md`) plus a `.cursorrules` / similar that orients AI
-  assistants to the repo's conventions: dataclass-driven layouts,
-  pure-function writers, single `Row` shape, signed commits, doc
-  cross-link conventions, tests-first for behavior changes.
-  ([#36](https://github.com/mgzwarrior/mgz-pkmn/issues/36))
-
----
-
-## V1.1 — complete
-
-All items shipped in **1.1.0** (2026-05-25). See the
-[CHANGELOG](../CHANGELOG.md#110---2026-05-25) for the full list and
-the [v1.1 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/2)
-for the 80+ closed issues.
-
-The themes:
-
-- **Set ID cards + web set picker.** Printable cutout deck for binder
-  dividers via `pkmn set-cards`, a `/api/v1/set-cards.pdf` endpoint,
-  a multi-select **Set picker modal** in the SPA, and a unified
-  indefinite-TTL image cache (`pkmn cache warm-sets` to prefetch
-  every set logo + symbol so the first export is fully offline-served).
-  ([#71](https://github.com/mgzwarrior/mgz-pkmn/issues/71))
-- **Cache subcommands.** `pkmn cache path`, `pkmn cache stats` (with
-  `--json`), `pkmn cache clear`, `pkmn cache warm-sets`.
-- **Marketing site.** Astro + Tailwind landing site at
-  <https://mgz-pkmn.com>, deployed to Cloudflare Pages.
-- **Devex & release engineering.** Auto-publish to PyPI on
-  `pyproject.toml` version bump (Trusted Publisher + PEP 740
-  attestations), DCO sign-off, Codecov (api + web flags),
-  CODEOWNERS, Code of Conduct, issue templates with acceptance
-  criteria, `make dev` / `make uninstall` Docker convenience targets,
-  `HEALTHCHECK`, `make migrate`.
-- **Web polish.** Help modal with interactive tour, empty-state
-  example query chips, mobile-friendly header with collapsible
-  Export dropdown, full axe-core a11y pass (no critical/serious
-  violations), `/version` endpoint for footer display.
-- **Outreach.** GitHub Discussions launched, 1.0 announcement,
-  contributing-guide refresh.
-  ([#37](https://github.com/mgzwarrior/mgz-pkmn/issues/37),
-  [#38](https://github.com/mgzwarrior/mgz-pkmn/issues/38))
-
----
-
-## V1.2 — committed
-
-Marketing-site polish and the web UX enhancements that surfaced late
-in the v1.1 cycle but didn't gate the release cut. Tracked on the
-[v1.2 milestone](https://github.com/mgzwarrior/mgz-pkmn/milestone/4).
-
-### Marketing site
-
-- **Hero binder grid** — replace the abstract glow with a real sample
-  binder grid.
-  ([#164](https://github.com/mgzwarrior/mgz-pkmn/issues/164))
-- **Output gallery** — a "What you get" section showing the xlsx,
-  binder PDF, checklist, and set-cards artifacts.
-  ([#165](https://github.com/mgzwarrior/mgz-pkmn/issues/165))
-- **Live asciinema cast** in the hero replacing the static code block.
-  ([#167](https://github.com/mgzwarrior/mgz-pkmn/issues/167))
-
-### Web UI / API
-
-- **Card detail modal** — tap any results row for a larger art +
-  full card info view.
-  ([#257](https://github.com/mgzwarrior/mgz-pkmn/issues/257))
-- **Richer search progress** with color-coded per-line status and
-  finer-grained streaming events.
-  ([#260](https://github.com/mgzwarrior/mgz-pkmn/issues/260))
-- **Branded exports** — every export carries the mgz-pkmn logo,
-  footer, and link back to the project.
-  ([#261](https://github.com/mgzwarrior/mgz-pkmn/issues/261))
-- **Configurable export columns** — pick which fields each export
-  format includes.
-  ([#262](https://github.com/mgzwarrior/mgz-pkmn/issues/262))
-- **Lookup timer + published benchmarks** for visible regression
-  guardrails.
-  ([#263](https://github.com/mgzwarrior/mgz-pkmn/issues/263))
-- **Recent searches** with one-click rerun.
-  ([#264](https://github.com/mgzwarrior/mgz-pkmn/issues/264))
-- **Named binders** — save a card list under a name and reload it
-  later.
-  ([#265](https://github.com/mgzwarrior/mgz-pkmn/issues/265))
-- **Per-row manual price override** that flows through to every
-  export.
-  ([#266](https://github.com/mgzwarrior/mgz-pkmn/issues/266))
-- **Set browser** — explore cards by set without an input list.
-  ([#267](https://github.com/mgzwarrior/mgz-pkmn/issues/267))
-- **Bulk row actions** (multi-select → delete / retag / move) in the
-  results table.
-  ([#268](https://github.com/mgzwarrior/mgz-pkmn/issues/268))
-- **Condition-aware pricing** — toggle NM / LP / MP / HP and
-  recalculate comps.
-  ([#270](https://github.com/mgzwarrior/mgz-pkmn/issues/270))
-
-### Cache & persistence
-
-- **Pre-warm `_CONCEPT_KEYWORDS`** so concept lookups (e.g.
-  `top 5 Fire cards`) become cache-hit-only after the first warm
-  pass.
-  ([#272](https://github.com/mgzwarrior/mgz-pkmn/issues/272))
 
 ---
 


### PR DESCRIPTION
Refs #415. Two-round grooming pass.

## Round 1 — initial sweep

- `docs/roadmap.md` — "How to read this roadmap" intro naming the new `epic:*` / `specialty:*` label families; committed sections for V1.5 (eBay), V1.6 (TCGPlayer), V2.1 (persistence-at-growth).
- `docs/cache.md` — separated entry-level TTLs from per-warm freshness gates; rewrote the legacy `api/<sha1>.json` row's post-migration behaviour; explained the 24h-vs-7d split.
- Three new Proposed ADRs: [0020](https://github.com/mgzwarrior/mgz-pkmn/blob/415-grooming-docs/docs/adr/0020-ebay-pricing-source.md), [0021](https://github.com/mgzwarrior/mgz-pkmn/blob/415-grooming-docs/docs/adr/0021-tcgplayer-first-class-pricing.md), [0022](https://github.com/mgzwarrior/mgz-pkmn/blob/415-grooming-docs/docs/adr/0022-query-dsl.md).
- ADR-0012 amended to name the vendor scanner as the first architectural vendor surface.

## Round 2 — second-pass refinements (after maintainer review)

**Source model rework:**

- [ADR-0023](https://github.com/mgzwarrior/mgz-pkmn/blob/415-grooming-docs/docs/adr/0023-source-ensemble-pricing.md) (new, Proposed): source ensemble for pricing display with user-selectable preferences and trimmed-mean aggregation across all configured sources. Partially supersedes ADR-0002 for pricing display; ADR-0002 still governs card-object resolution.
- ADR-0020 reworked: drops priority-ordering language; now plugs into the ensemble model.
- ADR-0021 amended: forward note that TCGPlayer may become the default pricing path if pokemontcg.io is sunset or Scrydex is cost-prohibitive.
- ADR-0002 carries a Status amendment pointing at ADR-0023.

**Broader doc sweep:**

- `contributing.md` — Project layout extended beyond `src/mgz_pkmn/` to cover `api/`, `web/`, `site/`, `tests/`, plus newer mgz_pkmn modules (`card_images.py`, `set_cards.py`, `branding.py`, `changelog.py`).
- `cli.md` — `pkmn cache` documented as a group with all eight subcommands, not just `stats`.
- `cache.md` — new "Entries vs. API calls" section explaining why a 20k-entry cache typically maps to under 1k catalog API calls.
- `deployment.md` — Cache warming table extended to five passes (was three) with their separate env-var opt-ins.

**Roadmap reshape:**

- Drops V1.0/V1.1/V1.2 shipped sections from the body; the Versioning policy keeps one-line summaries with milestone links.
- Top-of-doc badges refreshed to in-flight milestones (v1.4, v1.5, v1.6, v2.0, v2.1) only.
- **V2 entry reframed around the strict-semver trigger** — plugin contract going live, or hosted-demo identity becoming required. The current v2.0 milestone is explicitly labeled as a staging area until the cut criterion is firmer.

## Paired infrastructure (live, no PR needed)

- 12 new labels: `epic:{ebay,tcgplayer,query-dsl,persistence-growth,vendor-vision,flavor-uplift}` + `specialty:{frontend,backend,devops,security,data,design}`.
- 3 new milestones: [v1.5](https://github.com/mgzwarrior/mgz-pkmn/milestone/8), [v1.6](https://github.com/mgzwarrior/mgz-pkmn/milestone/9), [v2.1](https://github.com/mgzwarrior/mgz-pkmn/milestone/10).
- **6 epic umbrellas filed:** #416 (eBay), #417 (TCGPlayer), #418 (Query DSL), #419 (Persistence growth), #420 (Vendor vision placeholder), #455 (Flavor uplift).
- **41 child issues filed** under #416–#419 + #455 with full metadata.
- Full triage sweep on the existing 82 open issues — specialty labels backfilled, version labels backfilled, #39 + #40 superseded and closed.

## How to verify

- `cat docs/roadmap.md` — confirm V2 reframe + collapsed shipped sections.
- `cat docs/cache.md` — confirm the "Entries vs. API calls" section and TTL glossary.
- `cat docs/adr/0023-source-ensemble-pricing.md` — new ensemble ADR.
- `cat docs/adr/0002-multi-source-lookup-priority.md` — confirm the Status amendment pointing to ADR-0023.
- `make check` passes locally.