### PR TITLE
Fix BMC button image not rendering in README (URL-encode spaces + emoji)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Docs: **BMC button image now renders in the README** ([#472](https://github.com/mgzwarrior/mgz-pkmn/issues/472)). The Buy Me a Coffee button-api img src added in [#471](https://github.com/mgzwarrior/mgz-pkmn/pull/471) contained raw spaces (`text=Buy me some pizza`) and a raw multibyte emoji (`emoji=🍕`); GitHub's image proxy (camo) silently refuses URLs with those characters and the button rendered as a broken image. URL-encodes `text` (`Buy%20me%20some%20pizza`) and `emoji` (`%F0%9F%8D%95`), and switches the `&` query separators to `&amp;` so the HTML stays well-formed. `curl -sI` on the encoded URL returns `HTTP/2 200` with `content-type: image/svg+xml`.
+
 ### Added
 
 - Docs: **Buy Me a Coffee as the sole user-facing funding CTA** ([#469](https://github.com/mgzwarrior/mgz-pkmn/issues/469)). New "Support the project" section in `README.md` embeds the official BMC button image ([🍕 Buy me some pizza](https://www.buymeacoffee.com/mgz.pkmn)) and names the three recurring membership tiers (Common / Uncommon / Holo Rare) with a short summary of perks (early-release peeks, monthly roadmap votes, members-only Discussions, supporters-strip placement at Holo Rare). `.github/FUNDING.yml` gains a `buy_me_a_coffee: mgz.pkmn` entry so the repo sidebar's Sponsor button surfaces alongside the existing GitHub Sponsors entry. The marketing-site footer (`site/src/components/Footer.astro`) adds a Support column linking "Buy me a pizza", the marketing-site `BaseLayout` (`site/src/layouts/BaseLayout.astro`) loads the BMC floating widget on every page (palm-300 brand color, bottom-right, with the "Thanks for stopping by 🌴" message), and the web SPA footer (`web/src/App.tsx`) gains a "Buy me a pizza" entry next to the existing GitHub link. GitHub Sponsors stays configured in `FUNDING.yml` but is no longer surfaced as its own CTA on the README, marketing site, or web app — funnels into the single BMC ask instead. All in-product BMC URLs canonicalize on `https://www.buymeacoffee.com/mgz.pkmn` (the BMC slug had to use `.` instead of `-` since BMC slugs disallow hyphens).

--- a/README.md
+++ b/README.md
@@ -152,6 +152,6 @@ Questions, ideas, or want to share what you built? Open a thread in [GitHub Disc
 
 mgz-pkmn is free and MIT-licensed. If it's saved you time at a card show and you'd like to chip in:
 
-<a href="https://www.buymeacoffee.com/mgz.pkmn"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me some pizza&emoji=🍕&slug=mgz.pkmn&button_colour=6bac55&font_colour=000000&font_family=Lato&outline_colour=000000&coffee_colour=FFDD00" alt="Buy me a pizza on Buy Me a Coffee" /></a>
+<a href="https://www.buymeacoffee.com/mgz.pkmn"><img src="https://img.buymeacoffee.com/button-api/?text=Buy%20me%20some%20pizza&amp;emoji=%F0%9F%8D%95&amp;slug=mgz.pkmn&amp;button_colour=6bac55&amp;font_colour=000000&amp;font_family=Lato&amp;outline_colour=000000&amp;coffee_colour=FFDD00" alt="Buy me a pizza on Buy Me a Coffee" /></a>
 
 The same page runs three recurring membership tiers — **Common**, **Uncommon**, and **Holo Rare** — with perks for early-release peeks, monthly roadmap votes, a members-only Discussions category, and (at Holo Rare) a name or logo on the supporters strip.


### PR DESCRIPTION
Closes #472

## What

URL-encodes the Buy Me a Coffee button-api img src added in #471 so GitHub's image proxy (camo) actually serves the image. Two characters needed encoding:

- Spaces in `text=Buy me some pizza` → `text=Buy%20me%20some%20pizza`
- Raw pizza emoji in `emoji=🍕` → `emoji=%F0%9F%8D%95`

Also flips the `&` query separators to `&amp;` to keep the HTML well-formed.

## Why

After #471 merged the button rendered as a broken image on github.com. Camo proxies all README images and silently refuses URLs with raw spaces / unencoded high-codepoint characters. Verified with `curl -sI`:

- Raw URL (with spaces + emoji): no response from BMC's edge.
- Encoded URL: `HTTP/2 200`, `content-type: image/svg+xml`.

## How to verify

- Open the README on github.com (web view, not raw).
- The 🍕 Buy me some pizza button image renders inside the "Support the project" section in the palm-green BMC button style.
- Clicking still routes to `https://www.buymeacoffee.com/mgz.pkmn`.