### PR TITLE
fix(deploy): enable uvicorn --proxy-headers so OAuth callback resolves as https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Deploy: **Production OAuth callbacks now resolve as `https://`** ([#487](https://github.com/mgzwarrior/mgz-pkmn/issues/487)). The Dockerfile launched uvicorn without `--proxy-headers`, so behind Render's TLS-terminating proxy FastAPI saw the request as `http`. `request.url_for("github_callback")` (and the Google equivalent) then produced an `http://` redirect_uri that didn't match the `https://` URL registered on the OAuth apps — GitHub returned its "redirect_uri is not associated with this application" page, and Google would have failed the same way on first use. Adds `--proxy-headers --forwarded-allow-ips=*` so uvicorn trusts Render's `X-Forwarded-Proto: https` header and `url_for` resolves the scheme correctly.
+
 - Docs: **BMC button image now renders in the README** ([#472](https://github.com/mgzwarrior/mgz-pkmn/issues/472)). The Buy Me a Coffee button-api img src added in [#471](https://github.com/mgzwarrior/mgz-pkmn/pull/471) contained raw spaces (`text=Buy me some pizza`) and a raw multibyte emoji (`emoji=🍕`); GitHub's image proxy (camo) silently refuses URLs with those characters and the button rendered as a broken image. URL-encodes `text` (`Buy%20me%20some%20pizza`) and `emoji` (`%F0%9F%8D%95`), and switches the `&` query separators to `&amp;` so the HTML stays well-formed. `curl -sI` on the encoded URL returns `HTTP/2 200` with `content-type: image/svg+xml`.
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,4 +56,8 @@ COPY --from=web-builder /app/web/dist ./web/dist
 # Render injects $PORT; default to 8000 for local docker run.
 ENV PORT=8000
 EXPOSE 8000
-CMD ["sh", "-c", "uvicorn api.main:app --host 0.0.0.0 --port ${PORT}"]
+# `--proxy-headers --forwarded-allow-ips=*` trusts Render's TLS-terminating
+# proxy so `request.url_for(...)` builds https:// URLs from X-Forwarded-Proto.
+# Without this, OAuth `redirect_uri` is generated as http:// and providers
+# (GitHub / Google) reject the callback as not matching the registered URL.
+CMD ["sh", "-c", "uvicorn api.main:app --host 0.0.0.0 --port ${PORT} --proxy-headers --forwarded-allow-ips=*"]


### PR DESCRIPTION
Closes #487

## What

Add `--proxy-headers --forwarded-allow-ips=*` to the uvicorn command in the Dockerfile.

## Why

Render terminates TLS at the edge and forwards plain HTTP internally with `X-Forwarded-Proto: https`. Without `--proxy-headers`, uvicorn's default `forwarded_allow_ips=127.0.0.1` ignores Render's proxy IP, FastAPI sees `request.url.scheme == "http"`, and `api/auth/github.py:171`'s `request.url_for("github_callback")` builds an `http://` redirect URL. GitHub's OAuth app is registered with the `https://` callback URL and rejects the mismatch with the "Be careful! The `redirect_uri` is not associated with this application." page. Google OAuth has the same shape and would fail the same way on first use.

## How to verify

After redeploy, click *Sign in with GitHub* on the production header chip. Expected: GitHub's consent screen renders instead of the "Be careful!" page, granting access lands back on `/` with the chip flipped to the signed-in shape. In the Network panel, the outgoing authorize URL's `redirect_uri` query parameter is `https://mgz-pkmn.onrender.com/api/v1/auth/github/callback`.