### PR TITLE
Adopt AI Pit Crew workflow layer

### DIFF
--- a/.agent-workflow.md
+++ b/.agent-workflow.md
@@ -1,0 +1,148 @@
+# Agent Workflow Reference
+
+Quick reference for AI-assisted work in mgz-pkmn.
+
+The repository uses the AI Pit Crew pattern as a coordination layer:
+
+```text
+Human sets direction -> One agent implements -> A different agent reviews -> Human approves
+```
+
+The human owns product direction, prioritization, architecture decisions, merge
+approval, and release timing. Agents contribute focused implementation, tests,
+verification notes, and cross-review.
+
+## Source Of Truth
+
+- GitHub issues, milestones, and projects own the backlog and prioritization.
+- [docs/roadmap.md](docs/roadmap.md) is the roadmap navigator.
+- [TASKS.md](TASKS.md) is only the active work board.
+- [AGENTS.md](AGENTS.md) owns project invariants and code conventions.
+- [CLAUDE.md](CLAUDE.md) and [docs/contributing.md](docs/contributing.md) own the branch,
+  PR, CI, and DCO workflow.
+
+## The Loop
+
+```text
+Select -> Claim -> Implement -> Verify -> Review -> Human approval -> Merge
+```
+
+## 1. Select
+
+Use a human assignment or a GitHub issue. If selecting work yourself, follow
+[CLAUDE.md](CLAUDE.md): prefer bugs, small well-scoped changes, and issues aligned
+with the current milestone. Skip issues labelled `wip`, `blocked`, or
+`needs-discussion`.
+
+Every code change should be traceable to a GitHub issue unless the human
+explicitly scopes a docs-only or workflow-only change.
+
+## 2. Claim
+
+Before starting:
+
+1. Re-read [TASKS.md](TASKS.md).
+2. Add or move the task to **In Progress** with your agent name.
+3. Note the GitHub issue, branch, or human-provided task description.
+
+`TASKS.md` is shared mutable state. Re-read it immediately before deciding task
+status and immediately before editing it.
+
+## 3. Implement
+
+Follow [AGENTS.md](AGENTS.md):
+
+- Preserve dataclass-driven data shapes across module boundaries.
+- Use `spreadsheet.Row` as the canonical pipeline unit.
+- Keep pure modules pure and I/O at the edges.
+- Match existing source, API, web, and docs patterns.
+- Keep changes small and reviewable.
+- Add tests before or alongside behavior changes.
+- Update docs and changelog entries when public behavior changes.
+
+## 4. Verify
+
+Run the narrowest useful checks while iterating, then the project gate before a
+PR when the change warrants it:
+
+```bash
+make fix
+make check
+```
+
+If the change touches `web/`, also run:
+
+```bash
+cd web && npm run build
+```
+
+Docs-only workflow changes do not require the full test suite unless they affect
+generated docs, examples, or commands.
+
+## 5. Mark Ready For Review
+
+Before updating the board:
+
+1. Re-read [TASKS.md](TASKS.md).
+2. Move the task to **Ready For Review**.
+3. Add implementation notes with what changed, tests run, and any skipped checks.
+4. Assign review to a different agent where possible.
+
+Suggested review pairings:
+
+| Author | Reviewer |
+| --- | --- |
+| Claude | Codex or Copilot |
+| Codex | Claude or Copilot |
+| Copilot | Claude or Codex |
+| Gemini | Codex or Claude |
+
+## 6. Review
+
+The reviewing agent should check:
+
+- Correctness against the issue or human request.
+- Alignment with [AGENTS.md](AGENTS.md) invariants.
+- Edge cases, error handling, and security implications.
+- Test coverage and verification notes.
+- Documentation and changelog updates where applicable.
+
+If review finds required fixes, move the task back to **In Progress** with
+specific notes.
+
+## 7. Human Approval
+
+The human makes the final call. Agents do not merge their own work.
+
+For PRs, follow the PR verification artifact rules in [AGENTS.md](AGENTS.md):
+agents leave the placeholder and local verification notes; the developer attaches
+screenshots, Jam clips, or external artifacts when required.
+
+## TASKS.md Format
+
+```md
+## In Progress
+
+- [Agent]: Task description
+  - Issue: #123
+  - Branch: 123-short-description
+
+## Ready For Review
+
+- [Agent]: Task description
+  - Review assigned to: Different agent
+  - Implementation notes:
+    - Summary of changes
+    - Tests or checks run
+    - Skipped checks and why
+
+## Blocked
+
+- [Agent]: Task description
+  - Blocked by: Specific decision, dependency, or failure
+  - Owner: Human, maintainer, or external service
+
+## Done
+
+- Task description - completed YYYY-MM-DD
+```

--- a/.agent-workflow.md
+++ b/.agent-workflow.md
@@ -2,7 +2,9 @@
 
 Quick reference for AI-assisted work in mgz-pkmn.
 
-The repository uses the AI Pit Crew pattern as a coordination layer:
+The repository uses an AI Pit Crew pattern as a coordination layer, inspired by
+[@bobbylough](https://github.com/bobbylough)'s
+[ai-pit-crew](https://github.com/bobbylough/ai-pit-crew) project:
 
 ```text
 Human sets direction -> One agent implements -> A different agent reviews -> Human approves

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,6 +21,14 @@
 - `src/mgz_pkmn/sources/`: source-specific clients (pokemontcg, tcgdex, pricecharting)
 - `tests/`: unit tests (`unittest` style)
 
+## Shared agent workflow
+- Read `AGENTS.md` first for mgz-pkmn architecture invariants and PR verification rules.
+- Read `.agent-workflow.md` for the AI Pit Crew development loop.
+- Read `TASKS.md` fresh before relying on task status or editing it.
+- Treat GitHub issues, milestones, projects, and `docs/roadmap.md` as the backlog.
+- Treat `TASKS.md` as the active board only: in progress, ready for review, blocked, done.
+- Prefer cross-agent review: code authored by Copilot should be reviewed by Claude or Codex when practical.
+
 ## Setup and run
 From repo root:
 
@@ -36,12 +44,21 @@ python -m uv run pkmn input/ -o output/cards.xlsx --pdf output/binder.pdf --repo
 ```
 
 ## Validation commands
-Use existing project tooling only:
+Use existing project tooling only. For normal PR work, prefer:
 
 ```bash
-python -m uv run ruff check src/
-python -m uv run python -m unittest discover -s tests
+make fix
+make check
 ```
+
+If the change touches `web/`, also run:
+
+```bash
+cd web && npm run build
+```
+
+For narrow iteration, targeted `python -m uv run pytest ...` or
+`python -m uv run ruff check ...` commands are fine.
 
 ## Working conventions for agents
 - Keep changes targeted; avoid broad refactors unless requested.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,12 @@ process, see [CLAUDE.md](CLAUDE.md) (Claude Code) or
 
 ## AI Pit Crew operating model
 
-mgz-pkmn uses AI Pit Crew as a lightweight coordination layer, not as a runtime
-framework or dependency. The repository is the shared workspace: every agent
-works from the same docs, issue tracker, task board, tests, and PR process.
+mgz-pkmn uses an AI Pit Crew workflow as a lightweight coordination layer, not
+as a runtime framework or dependency. This workflow is inspired by
+[@bobbylough](https://github.com/bobbylough)'s
+[ai-pit-crew](https://github.com/bobbylough/ai-pit-crew) project. The
+repository is the shared workspace: every agent works from the same docs, issue
+tracker, task board, tests, and PR process.
 
 - The human developer owns product direction, prioritization, architecture
   decisions, merge approval, and release timing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,9 +3,29 @@
 This file documents the code conventions and invariants that AI coding agents
 (GitHub Copilot, Cursor, etc.) must follow when working in this repo.
 
-**Workflow** — for issue selection, branching, and PR process, see
-[CLAUDE.md](CLAUDE.md) (Claude Code) or [docs/contributing.md](docs/contributing.md)
-(all contributors).
+**Workflow** — for the shared AI-assisted development loop, see
+[.agent-workflow.md](.agent-workflow.md). For issue selection, branching, and PR
+process, see [CLAUDE.md](CLAUDE.md) (Claude Code) or
+[docs/contributing.md](docs/contributing.md) (all contributors).
+
+---
+
+## AI Pit Crew operating model
+
+mgz-pkmn uses AI Pit Crew as a lightweight coordination layer, not as a runtime
+framework or dependency. The repository is the shared workspace: every agent
+works from the same docs, issue tracker, task board, tests, and PR process.
+
+- The human developer owns product direction, prioritization, architecture
+  decisions, merge approval, and release timing.
+- GitHub issues, milestones, projects, and [docs/roadmap.md](docs/roadmap.md)
+  own planned work and sequencing.
+- [TASKS.md](TASKS.md) is only the active work board for work in progress,
+  ready for review, blocked, or recently done.
+- Agents should re-read [TASKS.md](TASKS.md) immediately before relying on task
+  status or editing it.
+- Prefer cross-agent review: code written by one AI tool should be reviewed by a
+  different AI tool when practical, then approved by the human.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,22 @@ If an issue is ambiguous and intent can't be inferred from context, **leave a cl
 comment and move to the next best issue**. Every change must be traceable to an issue — if
 no issue exists, open one first.
 
+## Step 1.5 — Claim active work
+
+mgz-pkmn uses [TASKS.md](TASKS.md) as an active-work board for AI-assisted
+contributors. GitHub issues and [docs/roadmap.md](docs/roadmap.md) remain the
+backlog and planning source of truth.
+
+Before implementing:
+
+1. Re-read [TASKS.md](TASKS.md).
+2. Move or add the selected task under **In Progress** with your agent name.
+3. Include the issue number or human-provided task description.
+
+Re-read [TASKS.md](TASKS.md) immediately before relying on task status or editing
+the file. See [.agent-workflow.md](.agent-workflow.md) for the shared AI Pit Crew
+loop.
+
 ## Step 2 — Understand the codebase before touching it
 
 ```bash
@@ -60,6 +76,8 @@ No other format is acceptable. Keep the description short (2–4 words, kebab-ca
 
 - Match existing patterns and style. Don't introduce new dependencies without a strong reason.
 - Keep the change **focused**: one issue, one PR.
+- Prefer cross-agent review: implementation by one AI tool should be reviewed by
+  a different AI tool when practical, then approved by the human.
 - For **user-facing** changes (features, fixes, behavior changes, deprecations,
   removals), add a bullet under the matching subsection of `[Unreleased]` in
   [CHANGELOG.md](CHANGELOG.md). Skip it for dependency bumps, CI tweaks,
@@ -99,6 +117,10 @@ cd web && npm run build
 All CI checks must be green before opening the PR.
 
 ## Step 5 — Open the PR
+
+Before opening the PR, re-read [TASKS.md](TASKS.md), move the task to
+**Ready For Review**, and add concise implementation notes with checks run,
+skipped checks, and the requested reviewer agent.
 
 First, pull the issue's labels, milestone, and project assignment:
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,19 @@ push to `main`.
 | Marketing site (Astro + Tailwind, Cloudflare Pages) | [site/README.md](site/README.md) |
 | Project layout, dev workflow, CI, release | [Contributing](docs/contributing.md) |
 
+## AI-assisted development
+
+mgz-pkmn uses a lightweight multi-agent workflow inspired by
+[@bobbylough](https://github.com/bobbylough)'s
+[ai-pit-crew](https://github.com/bobbylough/ai-pit-crew) project. The
+repo keeps GitHub issues, milestones, and [docs/roadmap.md](docs/roadmap.md)
+as the planning source of truth, while [TASKS.md](TASKS.md) tracks only
+active AI-assisted work.
+
+Agents should start with [AGENTS.md](AGENTS.md), follow the shared loop in
+[.agent-workflow.md](.agent-workflow.md), and expect cross-agent review before
+human approval.
+
 ## Community
 
 Questions, ideas, or want to share what you built? Open a thread in [GitHub Discussions](https://github.com/mgzwarrior/mgz-pkmn/discussions).

--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,35 @@
+# Tasks
+
+Active work board for mgz-pkmn.
+
+GitHub issues, milestones, and [docs/roadmap.md](docs/roadmap.md) own planned work.
+This file only tracks work that is actively being implemented, reviewed, blocked, or
+recently completed by an AI-assisted contributor.
+
+Always re-read this file immediately before relying on task status or editing it.
+See [.agent-workflow.md](.agent-workflow.md) for the full workflow.
+
+---
+
+## In Progress
+
+_No tasks in progress._
+
+## Ready For Review
+
+- [Codex]: Add AI Pit Crew workflow layer
+  - Issue: #495
+  - Branch: 495-ai-pit-crew-workflow
+  - Review assigned to: Claude or Copilot
+  - Implementation notes:
+    - Added `TASKS.md` as an active-work board while keeping GitHub issues and `docs/roadmap.md` as the backlog.
+    - Added `.agent-workflow.md` as the shared AI-assisted development loop.
+    - Updated agent instructions to point contributors at the new workflow without replacing mgz-pkmn's existing architecture invariants.
+
+## Blocked
+
+_No blocked tasks._
+
+## Done
+
+_No completed tasks yet._

--- a/TASKS.md
+++ b/TASKS.md
@@ -25,6 +25,7 @@ _No tasks in progress._
     - Added `TASKS.md` as an active-work board while keeping GitHub issues and `docs/roadmap.md` as the backlog.
     - Added `.agent-workflow.md` as the shared AI-assisted development loop.
     - Updated agent instructions to point contributors at the new workflow without replacing mgz-pkmn's existing architecture invariants.
+    - Added README and contributor-doc attribution to @bobbylough's `ai-pit-crew` project as the workflow inspiration.
 
 ## Blocked
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -4,7 +4,9 @@ Developer-facing setup, workflow, and release notes for `mgz-pkmn`. For
 end-user installation and usage, see the [README](../README.md).
 
 > **AI agents** — see [AGENTS.md](../AGENTS.md) for the code conventions,
-> invariants, and commit rules that agents must follow.
+> invariants, and commit rules that agents must follow. See
+> [.agent-workflow.md](../.agent-workflow.md) for the shared AI-assisted
+> development loop.
 
 ## Getting started
 
@@ -34,7 +36,9 @@ The fastest way in:
 2. **Skim [AGENTS.md](../AGENTS.md)** for the project's invariants
    (single `Row` shape, pure-function writers, dataclass-driven
    layouts).
-3. **Open a PR** following the [branch naming](#branch-naming) and
+3. **For AI-assisted work**, use [TASKS.md](../TASKS.md) as the active
+   work board and keep GitHub issues as the backlog.
+4. **Open a PR** following the [branch naming](#branch-naming) and
    [opening a PR](#opening-a-pr) sections below.
 
 Stuck on scope or design? Open a [GitHub

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -45,6 +45,27 @@ Stuck on scope or design? Open a [GitHub
 Discussion](https://github.com/mgzwarrior/mgz-pkmn/discussions/new?category=general)
 before writing code — it's cheaper to align early than to redo a PR.
 
+## AI-assisted workflow
+
+mgz-pkmn's AI-assisted workflow is inspired by
+[@bobbylough](https://github.com/bobbylough)'s
+[ai-pit-crew](https://github.com/bobbylough/ai-pit-crew) project: the
+human sets direction, one agent implements, a different agent reviews,
+and the human makes the final approval decision.
+
+Expect the following when AI agents contribute:
+
+- GitHub issues, milestones, projects, and [docs/roadmap.md](roadmap.md)
+  remain the backlog and planning source of truth.
+- [TASKS.md](../TASKS.md) tracks active AI-assisted work only. Agents
+  re-read it immediately before relying on task state or editing it.
+- [AGENTS.md](../AGENTS.md) remains the canonical source for code
+  invariants, PR verification artifacts, and repository-specific rules.
+- [.agent-workflow.md](../.agent-workflow.md) provides the short shared
+  loop for claiming, implementing, verifying, and cross-reviewing work.
+- When practical, code written by one AI tool should be reviewed by a
+  different AI tool before maintainer approval.
+
 ## Opening an issue
 
 Blank issues are disabled — the "New Issue" button shows structured templates


### PR DESCRIPTION
Closes #495

## What

- Add TASKS.md as an active-work board for AI-assisted contributors.
- Add .agent-workflow.md as the shared AI Pit Crew development loop.
- Link the workflow from AGENTS.md, CLAUDE.md, Copilot instructions, README.md, and docs/contributing.md.
- Attribute the workflow inspiration to [@bobbylough](https://github.com/bobbylough)'s [ai-pit-crew](https://github.com/bobbylough/ai-pit-crew) project.

## Why

This gives multi-agent work a lightweight shared process while keeping GitHub issues, milestones, projects, and docs/roadmap.md as the planning source of truth. It avoids adding runtime dependencies or replacing mgz-pkmn's existing architecture invariants.

## Contributor expectations

The human sets direction, one agent implements, a different agent reviews when practical, and the human makes the final approval decision. TASKS.md is for active work only; GitHub remains the backlog.

## How to verify

- Review the workflow docs for consistency with the existing contributor process.
- Confirm git diff --check passes.

Docs-only workflow change; no runtime tests were run.