### PR TITLE
ci(release): auto-close milestone matching the just-cut tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v8
@@ -86,6 +87,23 @@ jobs:
             ```bash
             pip install mgz-pkmn==${{ steps.pypi.outputs.version }}
             ```
+
+      - name: Close matching milestone
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          number=$(gh api \
+            "/repos/${GITHUB_REPOSITORY}/milestones?state=open&per_page=100" \
+            --jq ".[] | select(.title == \"${TAG}\") | .number")
+          if [ -z "$number" ]; then
+            echo "::notice::No open milestone named '${TAG}'; nothing to close."
+            exit 0
+          fi
+          echo "Closing milestone '${TAG}' (#${number})…"
+          gh api --method PATCH \
+            "/repos/${GITHUB_REPOSITORY}/milestones/${number}" \
+            -f state=closed >/dev/null
 
   rebuild-site:
     name: Rebuild marketing site

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,7 +93,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ github.ref_name }}
         run: |
-          number=$(gh api \
+          number=$(gh api --paginate \
             "/repos/${GITHUB_REPOSITORY}/milestones?state=open&per_page=100" \
             --jq ".[] | select(.title == \"${TAG}\") | .number")
           if [ -z "$number" ]; then

--- a/TASKS.md
+++ b/TASKS.md
@@ -13,7 +13,9 @@ See [.agent-workflow.md](.agent-workflow.md) for the full workflow.
 
 ## In Progress
 
-_No tasks in progress._
+- [Claude]: Auto-close milestone after GitHub Release tag is cut
+  - Issue: #404
+  - Branch: 404-close-milestone-on-release
 
 ## Ready For Review
 

--- a/TASKS.md
+++ b/TASKS.md
@@ -13,11 +13,18 @@ See [.agent-workflow.md](.agent-workflow.md) for the full workflow.
 
 ## In Progress
 
+_No tasks in progress._
+
+## Ready For Review
+
 - [Claude]: Auto-close milestone after GitHub Release tag is cut
   - Issue: #404
   - Branch: 404-close-milestone-on-release
-
-## Ready For Review
+  - Review assigned to: Codex or Copilot
+  - Implementation notes:
+    - Added a `Close matching milestone` step at the end of `github-release` in `.github/workflows/release.yml`. Looks up an open milestone whose title equals the pushed tag (`vX.Y.Z`) via `gh api`, then PATCHes it to `state=closed`. Emits a `::notice::` and exits 0 when no matching open milestone exists, so re-runs (and tags without a milestone) are safe.
+    - Granted the job `issues: write` (milestones live under the issues API); kept the existing `contents: write` for the release publish step.
+    - Checks run: `make check` (green). Skipped: end-to-end release run — only verifiable on a real tag push.
 
 - [Claude]: Account panel — SPA UI for #491 slice 3
   - Issue: #491


### PR DESCRIPTION
Closes #404

## What

Adds a final `Close matching milestone` step to the `github-release` job in `.github/workflows/release.yml`. After the GitHub Release is published, the step looks up an open milestone whose title equals the pushed tag (`vX.Y.Z`) and PATCHes it to `state=closed` via the GitHub API.

## Why

Until now the milestone has to be closed by hand after every tag. Stale open milestones make the milestones page noisy and confuse the issue-triage workflow described in `CLAUDE.md`, where milestone is used as a priority signal.

## How

- `gh api` lists open milestones, filtered by `title == tag`. If no match, the step emits a `::notice::` and exits 0, so tags without a matching milestone (and re-runs after a manual close) are no-ops.
- Granted the job `issues: write`; milestones live under the issues API. Existing `contents: write` is retained for the release publish step.

## How to verify

End-to-end verification only happens on a real tag push, but the step is structured so it can be inspected without running:

- Tag pushed → workflow runs → `Close matching milestone` finds the open milestone of the same name and closes it.
- Re-running the workflow after the milestone has been manually re-opened closes it again.
- Re-running with no matching open milestone logs a notice and succeeds (no error).