### PR TITLE
site: load Google Fonts via <link> for parallel fetch

### DIFF
--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -49,6 +49,10 @@ const ogImage = new URL("/social-preview-tropical.png", Astro.site).toString();
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,600;12..96,700;12..96,800&family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=JetBrains+Mono:wght@400;500;700&display=swap"
+    />
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={title} />

--- a/site/src/styles/global.css
+++ b/site/src/styles/global.css
@@ -12,9 +12,9 @@
  * ============================================================ */
 @import "tailwindcss";
 
-/* If you self-host the fonts, replace this with @font-face rules pointing
-   at site/public/fonts/*.woff2. */
-@import url("https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,600;12..96,700;12..96,800&family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=JetBrains+Mono:wght@400;500;700&display=swap");
+/* Fonts ship via the <link rel="stylesheet"> in BaseLayout.astro so they
+   parallel-load with the rest of the page. Self-hosting: drop woff2 files
+   in site/public/fonts/ and replace the <link> with @font-face rules. */
 
 /* Dark mode is class-driven (`.dark` on <html>), not the default
    prefers-color-scheme media query — an inline script in BaseLayout sets the


### PR DESCRIPTION
Closes part of #543.

## What

Move the Bricolage Grotesque / DM Sans / JetBrains Mono Google Fonts fetch out of the `@import url(...)` inside [site/src/styles/global.css](site/src/styles/global.css) and into a `<link rel="stylesheet">` in [BaseLayout.astro](site/src/layouts/BaseLayout.astro), alongside the existing preconnects.

## Why

Per `design/INTEGRATION.md` Step 6 (landing on `main` via [#544](https://github.com/mgzwarrior/mgz-pkmn/pull/544)): a `<link>` lets the font stylesheet download in parallel with the rest of the page; the `@import` inside `global.css` serializes the request behind the CSS download. The site Tailwind v4 build was also emitting a warning that I can now retire — `@import url(...)` was sitting after `@custom-variant`, which Tailwind v4 doesn't allow: *"`@import` rules must precede all rules aside from `@charset` and `@layer` statements"*.

The rest of `INTEGRATION.md`'s site steps (Step 2 `@theme` replacement, Step 3 zinc/blue → tropical sweep, Step 7 README badge rename) are already done in the repo. Step 2 in particular: `global.css` is already on the tropical token set, and it carries class-driven dark mode + the asciinema player tropical theme that the dropin version doesn't have — there's nothing to "replace" there.

## How to verify

- `cd site && npm run build` — clean, no `@import url` ordering warning.
- `make check` — clean.
- DevTools Network on the built page: the Google Fonts stylesheet request fires in parallel with `_astro/*.css` instead of after it.