### PR TITLE
web: parallel Google Fonts <link>, sweep amber warn stat

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -5,6 +5,12 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>mgz-pkmn — card lookup</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,600;12..96,700;12..96,800&family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=JetBrains+Mono:wght@400;500;700&display=swap"
+    />
     <script>
       // Resolve the theme before first paint to avoid a flash. A saved
       // choice wins; otherwise follow OS preference, defaulting to light

--- a/web/src/components/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer.tsx
@@ -329,7 +329,7 @@ function StatRow({ label, value, warn = false }: { label: string; value: string;
       <dd
         className={`text-right tabular-nums ${
           warn
-            ? 'text-amber-700 dark:text-amber-400'
+            ? 'text-sun-700 dark:text-sun-300'
             : 'text-coconut-700 dark:text-sand-50'
         }`}
       >

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -13,7 +13,9 @@
  * ============================================================ */
 @import "tailwindcss";
 
-@import url("https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,600;12..96,700;12..96,800&family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=JetBrains+Mono:wght@400;500;700&display=swap");
+/* Fonts ship via the <link rel="stylesheet"> in web/index.html so they
+   parallel-load with the SPA bundle. Self-hosting: drop woff2 files in
+   web/src/assets/fonts/ and replace the <link> with @font-face rules. */
 
 @custom-variant dark (&:where(.dark, .dark *));
 


### PR DESCRIPTION
Closes part of #543.

## What

Two design-system stragglers in the SPA, per `design/INTEGRATION.md` Steps 4-6:

1. **Google Fonts → `<link>` in `web/index.html`.** Move the Bricolage Grotesque / DM Sans / JetBrains Mono fetch out of the `@import url(...)` inside [web/src/index.css](web/src/index.css) into a `<link rel="stylesheet">` in [web/index.html](web/index.html), alongside preconnects to `googleapis` + `gstatic`. Mirrors the change [#545](https://github.com/mgzwarrior/mgz-pkmn/pull/545) makes for the marketing site.

2. **`StatRow` warn variant swept off `amber-*` in [SettingsDrawer.tsx:332](web/src/components/SettingsDrawer.tsx:332).** Amber sits outside the tropical palette; `sun-700 dark:sun-300` is the documented warning hue in `design/CLASS_CHEATSHEET.md` and visually matches the rest of the panel.

## Why

The font stylesheet now downloads in parallel with the SPA bundle instead of serializing behind the CSS download. The Tailwind v4 build warning about `@import url(...)` ordering — *"`@import` rules must precede all rules aside from `@charset` and `@layer` statements"* — goes away. And the lone amber warning swatch was the last drift from the design system in `web/src/components/`.

The rest of `INTEGRATION.md`'s web steps are already done in the repo:

- **Step 4** (`@theme` replacement): [web/src/index.css](web/src/index.css) is already on the tropical token set + carries class-driven dark mode via `@custom-variant dark`, which the dropin version lacks.
- **Step 5** (component sweep): a repo-wide grep across `web/src/components/*.tsx` for `zinc-*` / `blue-*` / `brand-*` / `text-white` / `text-green-[34]00` / `text-amber-400` / `bg-red-*` returns no hits after this PR except the intentional Apple SSO button — Apple's HIG mandates strict black-on-white / white-on-black pairing for the Sign in with Apple anchor (and `CLAUDE.md`'s design-system block from [#544](https://github.com/mgzwarrior/mgz-pkmn/pull/544) calls out the brand-mark hex exception for the same reason). The 🌴 Easter-egg emoji in `App.tsx` also stays as the documented one-emoji exception.
- **Logo import** in `App.tsx`: already on `logo.svg` (matches the README badge, which uses a `<picture>` tag with the light/dark variants for prefers-color-scheme).

## How to verify

- `cd web && npm run build` — clean, no `@import url` ordering warning.
- `cd web && npx vitest run` — all 300 tests pass, including the `SettingsDrawer.test.tsx` warn-variant cases.
- `make check` — clean.
- DevTools Network on the running SPA: the Google Fonts stylesheet request fires in parallel with `/src/main.tsx` instead of after `/src/index.css` loads.