### PR TITLE
chore: release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-06-08
+
 ### Added
 
 - Design: **Tropical design system landed as a durable, machine-checkable package** ([#543](https://github.com/mgzwarrior/mgz-pkmn/issues/543)). Adds a new `design/` folder with the canonical token source (`design/tokens/colors_and_type.css` — the `@theme` blocks in `site/src/styles/global.css` and `web/src/index.css` derive from this) plus the supporting docs (`INTEGRATION.md` cutover playbook, `CLASS_CHEATSHEET.md` find-and-replace table, `DESIGN_SYSTEM.md` voice + component guide) and `design/styleguide/*.html` rendered reference cards (publishable via GitHub Pages later). Wires `.oxlintrc.json` into `make check` via a new `lint-design` target and a CI step in the `web` job — `oxlint` enforces `no-restricted-imports` (no deep imports from `ui_kits/web/**`); the dropin's `no-restricted-syntax` regex rules for raw hex / raw px / off-system fonts are documented as a known TODO in `CLAUDE.md` since `oxlint` doesn't implement that selector yet (likely landing as an `eslint` preset with an allowlist for brand-mark SVGs and Tailwind arbitrary values). Appends a "Design system" section to `CLAUDE.md` covering the source-of-truth rule, the hard rules + exceptions, the voice pillars, and the visual-reference pointer so every agent reads the same brief.
@@ -1019,7 +1021,8 @@ UI, multi-source card lookup, all output formats, and release infrastructure.
 - Incomplete URL substring sanitization (CodeQL alerts).
 - Workflow permissions hardening (CodeQL alerts).
 
-[Unreleased]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.3.1...HEAD
+[Unreleased]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.3.1...v1.4.0
 [1.3.1]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/mgzwarrior/mgz-pkmn/compare/v1.1.1...v1.2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,5 +8,5 @@ authors:
 url: "https://mgz-pkmn.com"
 repository-code: "https://github.com/mgzwarrior/mgz-pkmn"
 license: "MIT"
-version: "1.3.1"
-date-released: "2026-06-02"
+version: "1.4.0"
+date-released: "2026-06-08"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mgz-pkmn-api"
-version = "1.3.1"
+version = "1.4.0"
 description = "FastAPI service for the mgz-pkmn card lookup tool."
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mgz-pkmn"
-version = "1.3.1"
+version = "1.4.0"
 description = "CLI and web app to look up Pokemon cards across open data sources, fetch images and prices, and emit an .xlsx, PDF binder, set-completion checklist, and JSON report for card-show prep."
 readme = "README.md"
 license = "MIT"

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mgz-pkmn-site",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mgz-pkmn-site",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.0.0",
         "astro": "^5.18.2",

--- a/site/package.json
+++ b/site/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mgz-pkmn-site",
   "type": "module",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "private": true,
   "scripts": {
     "dev": "astro dev",

--- a/src/mgz_pkmn/__init__.py
+++ b/src/mgz_pkmn/__init__.py
@@ -1,6 +1,6 @@
 """Pokemon card list -> spreadsheet for card shows."""
 
-__version__ = "1.3.1"
+__version__ = "1.4.0"
 
 from mgz_pkmn.parser import CardQuery, parse_lines
 

--- a/uv.lock
+++ b/uv.lock
@@ -712,7 +712,7 @@ wheels = [
 
 [[package]]
 name = "mgz-pkmn"
-version = "1.3.1"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "web",
   "private": true,
-  "version": "1.3.1",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
Closes #561

## What

Cuts the **v1.4.0** release. Aligns every surface on the same version in one PR:

| Surface | File(s) | Was → Now |
|---|---|---|
| CLI | `pyproject.toml`, `src/mgz_pkmn/__init__.py`, `uv.lock` | 1.3.1 → 1.4.0 |
| API | `api/pyproject.toml` | 1.3.1 → 1.4.0 |
| Web SPA | `web/package.json`, `web/package-lock.json` | 1.3.1 → 1.4.0 |
| Marketing site | `site/package.json`, `site/package-lock.json` | 1.3.1 → 1.4.0 |
| Citation | `CITATION.cff` (`version` + `date-released`) | 1.3.1 / 2026-06-02 → 1.4.0 / 2026-06-08 |

Rotates `CHANGELOG.md`: renames the long `[Unreleased]` section to `[1.4.0] - 2026-06-08`, inserts a fresh empty `[Unreleased]` block above it, and updates the compare-links footer.

## Why

The version bump PR **is** the release. Once this merges to `main`, the auto-release flow tags `v1.4.0`, publishes to PyPI with PEP 740 attestation, and cuts a GitHub Release.

## How to verify

- [x] `make check` is green.
- [x] `cd web && npm run build` is green.
- [x] `cd site && npm run build` is green.
- [x] `uv run pkmn --version` reports `pkmn, version 1.4.0`.
- [x] `curl http://localhost:8000/version` returns `{"version": "1.4.0"}`.
- [x] `GET /api/v1/changelog` parses `[1.4.0] - 2026-06-08` as the latest shipped release.
- [x] After merge: `release-on-version-bump` workflow tags `v1.4.0`, `release.yml` publishes to PyPI, GitHub Release appears.

## Out of scope

- Backport release notes to the Wiki (`sync-wiki.yml` handles this).