### PR TITLE
web: pin row save actions to the left of ResultsTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Web: **Bookmark / heart actions pinned to the left of every ResultsTable row** ([#540](https://github.com/mgzwarrior/mgz-pkmn/issues/540)). `AddToCollectionButton` and `AddToWishlistButton` used to render in the rightmost cell, which sat off-screen behind a horizontal scrollbar whenever the table overflowed (narrow viewports, or once the comp-tier + price-source columns kicked in). They now live in their own fixed-width cell on the left edge so they stay visible regardless of column count, matching the row-actions convention used by Gmail / Linear / GitHub PR lists. The external-link icon stays at its right-end position. The new actions column is only rendered when the row-level save buttons would actually be visible (signed-in or self-host) so anonymous hosted-demo visitors see no extra empty cell.
+
 ## [1.4.0] - 2026-06-08
 
 ### Added

--- a/web/src/components/ResultsTable.test.tsx
+++ b/web/src/components/ResultsTable.test.tsx
@@ -240,6 +240,45 @@ describe('ResultsTable', () => {
     useAppStore.setState({ rows: [] })
   })
 
+  it('renders the row-level save buttons in a cell to the left of the Name column (#540)', async () => {
+    useAppStore.setState({
+      rows: [
+        makeRow({
+          card: {
+            id: 'base1-4',
+            name: 'Charizard',
+            number: '4',
+            rarity: 'Rare Holo',
+            set: { name: 'Base Set' },
+          },
+          pricing: { market: 250, currency: 'USD', variant: null, source: 'TCGPlayer', url: null },
+        }),
+      ],
+      isRunning: false,
+      progress: null,
+    })
+    const { container } = render(<ResultsTable />)
+    // useAuth resolves async — wait for the row-level save buttons to mount.
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /save to collection/i }),
+      ).toBeInTheDocument()
+    })
+    const bodyRow = container.querySelector('tbody tr')!
+    const cells = bodyRow.querySelectorAll(':scope > td')
+    const firstCell = cells[0]
+    expect(firstCell.querySelector('button[aria-label="Save to collection"]')).not.toBeNull()
+    expect(firstCell.querySelector('button[aria-label="Save to wishlist"]')).not.toBeNull()
+    const nameCell = Array.from(cells).find((td) =>
+      td.textContent?.includes('Charizard'),
+    )
+    expect(nameCell).toBeTruthy()
+    expect(
+      firstCell.compareDocumentPosition(nameCell!) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+    useAppStore.setState({ rows: [] })
+  })
+
   it('hides the row-level save buttons for an anonymous (auth-on) user', async () => {
     // Anonymous on a hosted deploy → the collections / wishlists chips
     // can't fire without a user, so the row buttons hide.

--- a/web/src/components/ResultsTable.tsx
+++ b/web/src/components/ResultsTable.tsx
@@ -161,6 +161,11 @@ export function ResultsTable({ onRerunLine }: Props) {
         <table className="w-full text-sm border-collapse">
           <thead>
             <tr className="border-b border-sand-300 dark:border-husk-50 bg-sand-100 dark:bg-husk-200 text-left">
+              {showSavedActions && (
+                <th className="px-3 py-2 text-xs font-medium text-coconut-400 dark:text-sand-300 w-20">
+                  <span className="sr-only">Save actions</span>
+                </th>
+              )}
               {!settings.noImages && (
                 <th className="px-3 py-2 text-xs font-medium text-coconut-400 dark:text-sand-300 w-16">Img</th>
               )}
@@ -208,11 +213,16 @@ export function ResultsTable({ onRerunLine }: Props) {
                 className="hidden sm:table-cell"
               />
               <th className="px-3 py-2 text-xs font-medium text-coconut-400 dark:text-sand-300 w-8">
-                <span className="sr-only">Actions</span>
+                <span className="sr-only">Listing link</span>
               </th>
             </tr>
             {showFilters && (
               <tr className="border-b border-sand-300 dark:border-husk-50 bg-sand-50 dark:bg-husk-200">
+                {showSavedActions && (
+                  <th>
+                    <span className="sr-only">Save actions (no filter)</span>
+                  </th>
+                )}
                 {!settings.noImages && (
                   <th>
                     <span className="sr-only">Image (no filter)</span>
@@ -283,7 +293,7 @@ export function ResultsTable({ onRerunLine }: Props) {
                   />
                 </FilterCell>
                 <th>
-                  <span className="sr-only">Actions (no filter)</span>
+                  <span className="sr-only">Listing link (no filter)</span>
                 </th>
               </tr>
             )}
@@ -480,6 +490,21 @@ function ResultRow({
             : undefined
         }
       >
+        {/* Row actions — pinned left so they stay visible on narrow
+            viewports where the table overflows horizontally. */}
+        {showSavedActions && (
+          <td className="px-3 py-1.5 w-20">
+            <div className="flex items-center gap-1">
+              {row.matched && card && (
+                <>
+                  <AddToCollectionButton card={card as Record<string, unknown>} />
+                  <AddToWishlistButton card={card as Record<string, unknown>} />
+                </>
+              )}
+            </div>
+          </td>
+        )}
+
         {/* Thumbnail */}
         {showImage && (
           <td className="px-3 py-1.5 w-16">
@@ -562,27 +587,19 @@ function ResultRow({
           {p.source ?? '—'}
         </td>
 
-        {/* Link + collection / wishlist actions */}
-        <td className="px-3 py-2 w-20">
-          <div className="flex items-center justify-end gap-1">
-            {row.matched && card && showSavedActions && (
-              <>
-                <AddToCollectionButton card={card as Record<string, unknown>} />
-                <AddToWishlistButton card={card as Record<string, unknown>} />
-              </>
-            )}
-            {p.url && (
-              <a
-                href={p.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-coconut-400 hover:text-palm-500 dark:text-sand-300 dark:hover:text-sun-300 transition-colors"
-                title="Open listing"
-              >
-                <ExternalLink size={13} />
-              </a>
-            )}
-          </div>
+        {/* Listing link */}
+        <td className="px-3 py-2 w-8">
+          {p.url && (
+            <a
+              href={p.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-coconut-400 hover:text-palm-500 dark:text-sand-300 dark:hover:text-sun-300 transition-colors"
+              title="Open listing"
+            >
+              <ExternalLink size={13} />
+            </a>
+          )}
         </td>
       </tr>
 


### PR DESCRIPTION
Closes #540

## What

`AddToCollectionButton` and `AddToWishlistButton` move out of the rightmost cell (where they shared space with the external-link icon) into a new fixed-width actions cell pinned to the left edge of every row. The external-link icon stays at its right-end position.

The new actions column is only rendered when `showSavedActions` is true (signed-in or self-host), so anonymous hosted-demo visitors continue to see no save surface — no extra empty cell either. Header + filter row + body cells were all updated together so column alignment stays consistent.

## Why

Once enough columns are visible — narrow viewport, or comp tiers (xl+) + Source (sm+) + Set (md+) kicking in — the table overflowed horizontally and the save actions sat off-screen behind the scrollbar. They're the call-to-action of the row, and hiding them defeats the feature for anyone who doesn't realize there's more table to the right. Pinning row actions to the left edge is the convention Gmail, Linear, and the GitHub PR list all use.

## How to verify

1. Run a lookup (e.g. `Charizard | Base Set | 4/102`).
2. At any viewport width, the bookmark + heart icons sit in the leftmost cell of every matched row, before the Name column. The external-link icon stays at the far right of the row.
3. Sign out (or open in a hosted-demo session without auth): both the leftmost actions column and the right-end save buttons stay hidden — no empty cell or layout shift.
4. New regression test in `web/src/components/ResultsTable.test.tsx` (`renders the row-level save buttons in a cell to the left of the Name column (#540)`) asserts the cell ordering directly. All 22 ResultsTable tests pass; `make check` and `cd web && npm run build` are green.

### Verified locally

DOM inspection at the tablet preset (768×1024) confirmed the new row layout:

| index | cell | width | contents |
|------:|------|------:|----------|
| 0 | actions (new) | 80px | Save to collection + Save to wishlist |
| 1 | Name | 258px | Charizard / query echo |
| 2 | Set | 121px | Base Set 2 #4 |
| 3 | Rarity | auto | Rare Holo |
| 4 | Market | 122px | \$427.38 |
| 5–8 | 80/85/90/95% | auto | comp tiers |
| 9 | Source | 116px | tcgplayer |
| 10 | Listing link | 37px | external-link icon |

At a 500px viewport the breakpoints collapse Set/Rarity/comps/Source out, and the actions still sit at the row's left edge — visible without horizontal scrolling.