### PR TITLE
design: publish styleguide via GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,80 @@
+name: Pages
+
+# Publish the in-repo design styleguide (`design/styleguide/`) to GitHub
+# Pages. Separate from the marketing-site Render deploy (see render.yaml) —
+# Pages hosts the static design reference; Render hosts the product.
+#
+# The styleguide cards reference `../tokens/colors_and_type.css` and
+# `../../assets/*.svg` relative to `design/styleguide/`, so the published
+# tree mirrors that layout: `design/styleguide/`, `design/tokens/`, and
+# `assets/` all sit under the site root. A small redirect at `/` lands
+# visitors on the styleguide index.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "design/styleguide/**"
+      - "design/tokens/**"
+      - "assets/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Stage styleguide tree
+        run: |
+          set -euo pipefail
+          rm -rf _site
+          mkdir -p _site/design/styleguide _site/design/tokens _site/assets
+          cp -R design/styleguide/. _site/design/styleguide/
+          cp -R design/tokens/. _site/design/tokens/
+          cp -R assets/. _site/assets/
+          cat > _site/index.html <<'HTML'
+          <!doctype html>
+          <html lang="en">
+            <head>
+              <meta charset="utf-8">
+              <title>mgz-pkmn design styleguide</title>
+              <meta http-equiv="refresh" content="0; url=design/styleguide/index.html">
+              <link rel="canonical" href="design/styleguide/index.html">
+            </head>
+            <body>
+              <p>Redirecting to <a href="design/styleguide/index.html">the design styleguide</a>.</p>
+            </body>
+          </html>
+          HTML
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    name: deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Design: **Styleguide published to GitHub Pages** ([#547](https://github.com/mgzwarrior/mgz-pkmn/issues/547)). New `.github/workflows/pages.yml` stages `design/styleguide/`, `design/tokens/`, and `assets/` into a deploy artifact and publishes the tree to <https://mgzwarrior.github.io/mgz-pkmn/> on every push to `main` that touches `design/` or `assets/`. The root index redirects to `design/styleguide/index.html`; the relative `../tokens/colors_and_type.css` and `../../assets/*.svg` references the cards already use resolve unchanged. Separate from the marketing-site Render deploy (which still hosts the product). A new `tests/test_styleguide_links.py` guard fails CI when any local `href` / `src` in a styleguide card stops resolving so a broken stylesheet or asset surfaces before review. `design/DESIGN_SYSTEM.md`, `design/INTEGRATION.md`, and `README.md` point at the hosted URL.
+
 ### Fixed
 
 - Web: **Bookmark / heart actions pinned to the left of every ResultsTable row** ([#540](https://github.com/mgzwarrior/mgz-pkmn/issues/540)). `AddToCollectionButton` and `AddToWishlistButton` used to render in the rightmost cell, which sat off-screen behind a horizontal scrollbar whenever the table overflowed (narrow viewports, or once the comp-tier + price-source columns kicked in). They now live in their own fixed-width cell on the left edge so they stay visible regardless of column count, matching the row-actions convention used by Gmail / Linear / GitHub PR lists. The external-link icon stays at its right-end position. The new actions column is only rendered when the row-level save buttons would actually be visible (signed-in or self-host) so anonymous hosted-demo visitors see no extra empty cell.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ push to `main`.
 | Disk cache + URL overrides | [Cache](docs/cache.md) |
 | Render / Docker / production recipe | [Deployment](docs/deployment.md) |
 | Marketing site (Astro + Tailwind, Cloudflare Pages) | [site/README.md](site/README.md) |
-| Design system, tokens, and styleguide | [Design system](design/DESIGN_SYSTEM.md) |
+| Design system, tokens, and styleguide | [Design system](design/DESIGN_SYSTEM.md) · hosted at <https://mgzwarrior.github.io/mgz-pkmn/> |
 | Project layout, dev workflow, CI, release | [Contributing](docs/contributing.md) |
 
 ## AI-assisted development

--- a/design/DESIGN_SYSTEM.md
+++ b/design/DESIGN_SYSTEM.md
@@ -325,7 +325,7 @@ they render across system fonts.
 | [`tokens/colors_and_type.css`](tokens/colors_and_type.css) | All CSS variables — palette, semantic tokens, type scale, spacing, radii, shadows, motion. |
 | [`../assets/`](../assets/) | Logos, brand mark, icon SVGs, marketing imagery. |
 | [`CLASS_CHEATSHEET.md`](CLASS_CHEATSHEET.md) | Find/replace table for zinc/blue Tailwind classes. |
-| [`styleguide/index.html`](styleguide/index.html) | Static styleguide index linking every rendered card. Open it directly in a browser; no build step is required. |
+| [`styleguide/index.html`](styleguide/index.html) | Static styleguide index linking every rendered card. Open it directly in a browser; no build step is required. Hosted at <https://mgzwarrior.github.io/mgz-pkmn/> for reviewer-friendly sharing. |
 
 ### Styleguide cards
 

--- a/design/INTEGRATION.md
+++ b/design/INTEGRATION.md
@@ -173,6 +173,11 @@ Open [`design/styleguide/index.html`](styleguide/index.html) directly in a
 browser. It links every rendered card in `design/styleguide/` and is the
 lightweight site for this PR; no build step or generated output is required.
 
+The same tree is published to <https://mgzwarrior.github.io/mgz-pkmn/> by
+[`.github/workflows/pages.yml`](../.github/workflows/pages.yml) on every
+push to `main` that touches `design/` or `assets/` — share that URL when
+you want a stable reference instead of asking a reviewer to clone.
+
 ---
 
 ## Step 8 — Verify
@@ -215,7 +220,7 @@ new one on a beta path. Once the new theme is signed off, remove the
 | [`site/src/styles/global.css`](../site/src/styles/global.css) | Tailwind v4 implementation for the marketing site. |
 | [`web/src/index.css`](../web/src/index.css) | Tailwind v4 implementation for the React app. |
 | [`design/CLASS_CHEATSHEET.md`](CLASS_CHEATSHEET.md) | Find/replace table for zinc/blue Tailwind classes. |
-| [`design/styleguide/index.html`](styleguide/index.html) | Static styleguide index linking every rendered card. |
+| [`design/styleguide/index.html`](styleguide/index.html) | Static styleguide index linking every rendered card. Hosted at <https://mgzwarrior.github.io/mgz-pkmn/>. |
 
 ---
 

--- a/tests/test_styleguide_links.py
+++ b/tests/test_styleguide_links.py
@@ -1,0 +1,50 @@
+"""Static-link check for the in-repo design styleguide.
+
+The cards under [`design/styleguide/`](../design/styleguide/) are plain HTML
+that the Pages workflow ([.github/workflows/pages.yml](../.github/workflows/pages.yml))
+publishes verbatim — every local `href` / `src` must resolve relative to the
+file that declares it, or the published page will 404 a stylesheet, a token,
+or an SVG before a reviewer notices.
+"""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+from urllib.parse import urlsplit
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+STYLEGUIDE = REPO_ROOT / "design" / "styleguide"
+
+_ATTR_RE = re.compile(r"""(?:href|src)\s*=\s*"([^"]+)\"""")
+
+
+def _local_refs(html: str) -> list[str]:
+    refs: list[str] = []
+    for raw in _ATTR_RE.findall(html):
+        parts = urlsplit(raw)
+        if parts.scheme or parts.netloc:
+            continue
+        target = parts.path
+        if not target or target.startswith("#"):
+            continue
+        refs.append(target)
+    return refs
+
+
+class StyleguideLinkTests(unittest.TestCase):
+    def test_every_local_ref_resolves(self) -> None:
+        html_files = sorted(STYLEGUIDE.glob("*.html"))
+        self.assertGreater(len(html_files), 0, "no styleguide html files found")
+        missing: list[str] = []
+        for html_path in html_files:
+            for ref in _local_refs(html_path.read_text(encoding="utf-8")):
+                resolved = (html_path.parent / ref).resolve()
+                if not resolved.exists():
+                    missing.append(f"{html_path.name} → {ref}")
+        self.assertEqual(missing, [], "broken styleguide refs:\n  " + "\n  ".join(missing))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #547

## What

- New `.github/workflows/pages.yml` stages `design/styleguide/`, `design/tokens/`, and `assets/` into a Pages artifact and publishes the tree to <https://mgzwarrior.github.io/mgz-pkmn/> on every push to `main` that touches `design/` or `assets/` (plus `workflow_dispatch` for manual rebuilds).
- A small redirect at site `/` lands visitors on `design/styleguide/index.html`.
- New `tests/test_styleguide_links.py` walks every `design/styleguide/*.html` and asserts every local `href` / `src` resolves to a real file — runs as part of `make check` so a broken stylesheet, token reference, or asset fails before the Pages deploy.
- `design/DESIGN_SYSTEM.md`, `design/INTEGRATION.md`, and `README.md` now point at the hosted URL.
- New CHANGELOG bullet under `[Unreleased] → Added`.

## Why

The styleguide cards landed in #544 as static HTML, but reviewers still have to clone the repo and open the local index. Publishing the same tree to GitHub Pages gives reviewers, contributors, and future agents a single stable URL to share, while leaving the in-repo files as the source artifact.

Per the issue: separate from the marketing-site Render deploy (`render.yaml`). Pages hosts the static design reference; Render still hosts the product. The link-check guard the issue asked for is wired in too.

## How to verify

1. CI green (`api`, `web`, `site`, `DCO`, CodeQL).
2. On merge, the new `Pages` workflow runs against `main`. The first run requires the `Pages` source in repo Settings → Pages to be set to "GitHub Actions" (one-time setup). After that, the styleguide is reachable at <https://mgzwarrior.github.io/mgz-pkmn/> and the root redirect lands on `design/styleguide/index.html`.
3. Local check: `uv run python -m unittest tests.test_styleguide_links` passes today, and breaks if you (for example) point a card at a non-existent SVG.