### PR TITLE
fix(ci): document RELEASE_PAT scopes required by release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,11 +31,18 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          # PAT (same secret as the existing tag-push flow) so the
-          # opened PR can be edited by subsequent agent / human
-          # extensions without triggering the "GITHUB_TOKEN-authored
-          # commits don't fire downstream workflows" footgun.
-          token: ${{ secrets.RELEASE_PAT }}
+          # Default GITHUB_TOKEN (no `token:` input) is intentional. The
+          # block-level `permissions:` above grants the three scopes
+          # release-please needs (contents, pull-requests, issues).
+          #
+          # The "GITHUB_TOKEN-authored commits don't trigger downstream
+          # workflows" footgun that drives the PAT use in
+          # `release-on-version-bump.yml` doesn't apply here: that
+          # constraint is about direct `push` events. release-please
+          # opens a PR, and when the PR merges, the merge push to
+          # `main` is attributed to the merging actor (human or agent),
+          # not to GITHUB_TOKEN — so `release-on-version-bump.yml`
+          # fires regardless of who authored the PR commits.
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           # PR-only: when the release PR merges, the existing

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,18 +31,25 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          # Default GITHUB_TOKEN (no `token:` input) is intentional. The
-          # block-level `permissions:` above grants the three scopes
-          # release-please needs (contents, pull-requests, issues).
+          # PAT (not GITHUB_TOKEN) is load-bearing here. Per GitHub's
+          # docs, events triggered by GITHUB_TOKEN do not create new
+          # workflow runs — so a release PR opened with GITHUB_TOKEN
+          # would not fire `pull_request` workflows (CI, DCO,
+          # Conventional Commits check), leaving the bot's PR without
+          # the required validation runs until someone pushes another
+          # commit with a different credential.
           #
-          # The "GITHUB_TOKEN-authored commits don't trigger downstream
-          # workflows" footgun that drives the PAT use in
-          # `release-on-version-bump.yml` doesn't apply here: that
-          # constraint is about direct `push` events. release-please
-          # opens a PR, and when the PR merges, the merge push to
-          # `main` is attributed to the merging actor (human or agent),
-          # not to GITHUB_TOKEN — so `release-on-version-bump.yml`
-          # fires regardless of who authored the PR commits.
+          # RELEASE_PAT must carry these fine-grained scopes (or the
+          # classic `repo` scope):
+          #   - contents: write
+          #   - pull-requests: write   ← required by the action below;
+          #                              the workflow's permissions:
+          #                              block only applies to
+          #                              GITHUB_TOKEN
+          #   - issues: write          ← release-please manages its
+          #                              own autorelease:* labels
+          #                              through the Issues API
+          token: ${{ secrets.RELEASE_PAT }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           # PR-only: when the release PR merges, the existing

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,24 +31,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          # PAT (not GITHUB_TOKEN) is load-bearing here. Per GitHub's
-          # docs, events triggered by GITHUB_TOKEN do not create new
-          # workflow runs — so a release PR opened with GITHUB_TOKEN
-          # would not fire `pull_request` workflows (CI, DCO,
-          # Conventional Commits check), leaving the bot's PR without
-          # the required validation runs until someone pushes another
-          # commit with a different credential.
-          #
-          # RELEASE_PAT must carry these fine-grained scopes (or the
-          # classic `repo` scope):
-          #   - contents: write
-          #   - pull-requests: write   ← required by the action below;
-          #                              the workflow's permissions:
-          #                              block only applies to
-          #                              GITHUB_TOKEN
-          #   - issues: write          ← release-please manages its
-          #                              own autorelease:* labels
-          #                              through the Issues API
           token: ${{ secrets.RELEASE_PAT }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -697,16 +697,20 @@ that OIDC trusted-publisher auth uses.
 
 ### `RELEASE_PAT` secret
 
-`release-on-version-bump.yml` pushes the release tag with a
-fine-grained Personal Access Token stored as the repo secret
-`RELEASE_PAT`. A PAT is required because tags pushed with the
-default `GITHUB_TOKEN` do not trigger downstream workflows, and
-`release.yml` needs to fire on the tag push.
+Two workflows authenticate with the repo secret `RELEASE_PAT` (a fine-grained Personal Access Token), each for a different reason:
 
-Scope the PAT to this repository with **Contents: read and write**.
-Rotate it on the standard cadence and update the
-`RELEASE_PAT` secret under repo Settings → Secrets and variables →
-Actions.
+- **`release-on-version-bump.yml`** pushes the release tag. Tags pushed with the default `GITHUB_TOKEN` don't trigger downstream workflows, and `release.yml` needs to fire on the tag push.
+- **`release-please.yml`** opens the version-bump PR. PRs opened with `GITHUB_TOKEN` don't trigger `pull_request` workflows (CI, DCO, Conventional Commits check), so the bot's PR would sit there with no validation runs until someone pushed another commit.
+
+The PAT needs three scopes (fine-grained) — or `repo` on a classic PAT:
+
+| Scope | Why |
+|---|---|
+| **Contents: read and write** | Tag pushes (`release-on-version-bump.yml`) + release branch commits (`release-please.yml`) |
+| **Pull requests: read and write** | Open + maintain the release PR (`release-please.yml`). The workflow's block-level `permissions:` doesn't help PATs — only `GITHUB_TOKEN`. |
+| **Issues: read and write** | release-please manages its own `autorelease: pending` / `autorelease: tagged` labels through the Issues API |
+
+Rotate on the standard cadence and update the `RELEASE_PAT` secret under repo Settings → Secrets and variables → Actions.
 
 ### Cloudflare Pages deploy hook
 


### PR DESCRIPTION
Closes #587

## What

The release-please workflow's `RELEASE_PAT` needs `pull-requests: write` + `issues: write` in addition to the `contents: write` scope it was originally provisioned with for `release-on-version-bump.yml`. The workflow's `permissions:` block doesn't help PATs — it only applies to `GITHUB_TOKEN`.

Documents the required scopes in:

- `.github/workflows/release-please.yml` — comment on the `token:` input listing all three scopes with one-liners on why each is needed.
- `docs/contributing.md` → "RELEASE_PAT secret" — rewrites the section to cover both workflows that share the secret, with a scope table.

## Why

Codex P1 caught the failure mode of my first pass (switching to GITHUB_TOKEN): per [GitHub Actions docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow), events triggered by `GITHUB_TOKEN` do not create new workflow runs. A release-please PR opened with `GITHUB_TOKEN` would not fire CI, DCO, or the Conventional Commits check — leaving the bot's PR with no validation runs until someone pushed another commit with a different credential.

So PAT is the right call. The original `release-on-version-bump.yml` PAT was scoped only for tag pushes (`contents: write`). release-please needs two more scopes; the existing secret needs to be re-issued or edited.

## How to verify

- [x] CI passes on this PR (pure docs + comment change).
- [x] Maintainer updates `RELEASE_PAT` with `pull-requests: write` and `issues: write` (fine-grained) or `repo` (classic) under repo Settings → Secrets and variables → Actions.
- [x] After the scope update, the next release-please workflow run reuses the dangling `release-please--branches--main--components--mgz-pkmn` branch (commit `492ab89` from the failed run) and opens the version-bump PR successfully.

## Out of scope

- The streamline-to-release-please-owned-end-to-end plan ([#586](https://github.com/mgzwarrior/mgz-pkmn/issues/586)).
- Switching to a GitHub App token (a cleaner long-term alternative to PATs, but requires installing + configuring an app). Not in scope; #586 is a better forum for that conversation.