### PR TITLE
ci: bump release-please to node 24

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,7 +29,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           # PAT (same secret as the existing tag-push flow) so the
           # opened PR can be edited by subsequent agent / human


### PR DESCRIPTION
Closes #592

## What

Bumps `.github/workflows/release-please.yml` from `googleapis/release-please-action@v4` to `@v5`.

## Why

GitHub Actions now warns that Node.js 20 JavaScript actions are deprecated. Upstream `release-please-action@v4` still declares `runs.using: node20`, while `v5.0.0` is the Node 24 upgrade. This removes the release-please annotation ahead of GitHub forcing Node 24 by default on June 16, 2026.

## How to verify

- `rg -n "googleapis/release-please-action@" .github/workflows release-please-config.json`
- `make fix`
- `make check`

## Notes

Release behavior is unchanged: the existing PAT, config file, manifest file, and `skip-github-release: true` setting are untouched.