### PR TITLE
feat(web): browse pokedex-# view toggle across all sets

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -69,6 +69,7 @@ without CORS gymnastics. CORS is also pre-allowed for `localhost:5173` and
 | `POST` | `/api/v1/bulk` | Resolve many lines, streaming each row as SSE |
 | `POST` | `/api/v1/export` | Build an `.xlsx` or PDF binder from rows |
 | `GET`  | `/api/v1/sets` | Cached list of Pokémon TCG sets (weekly TTL) |
+| `GET`  | `/api/v1/pokedex/{number}/cards` | Every printing of one species (national dex #), newest-first |
 | `POST` | `/api/v1/overrides` | Record a sticky PriceCharting URL override |
 | `GET`  | `/api/v1/overrides` | List all recorded URL overrides |
 | `GET`  | `/api/v1/set-cards.pdf` | Printable set identification cards PDF (no input needed) |

--- a/api/main.py
+++ b/api/main.py
@@ -53,6 +53,7 @@ from .routes import (
     lookup,
     overrides,
     parse,
+    pokedex,
     runs,
     set_cards,
     sets,
@@ -531,6 +532,7 @@ app.include_router(lookup.router, prefix="/api/v1", tags=["lookup"])
 app.include_router(export.router, prefix="/api/v1", tags=["export"])
 app.include_router(sets.router, prefix="/api/v1", tags=["sets"])
 app.include_router(set_cards.router, prefix="/api/v1", tags=["set-cards"])
+app.include_router(pokedex.router, prefix="/api/v1", tags=["pokedex"])
 app.include_router(cards.router, prefix="/api/v1", tags=["cards"])
 app.include_router(overrides.router, prefix="/api/v1", tags=["overrides"])
 app.include_router(changelog.router, prefix="/api/v1", tags=["changelog"])

--- a/api/routes/pokedex.py
+++ b/api/routes/pokedex.py
@@ -1,0 +1,104 @@
+"""Pokédex-organised card surface — every printing of one species across every set.
+
+`GET /api/v1/pokedex/{number}/cards` returns a **trimmed** list of every
+card whose `nationalPokedexNumbers` includes `{number}` — the data behind
+Browse's pokedex-# view, where the organisation flips from "cards in a
+set" to "every Charizard ever printed" (issue #577).
+
+The payload reuses the slim set-card trim (`sets._trim_card`) and adds the
+per-card set context — id, name, release date — that set view leaves
+implicit in its single-set grid. Because printings span sets, each row
+needs to know which set it came from to label and sort itself.
+
+Rows arrive pre-sorted newest-first: release date desc, then set name,
+then collector number. A 1-day `Cache-Control` matches `/sets/{id}/cards`
+— a species' printing list is stable within a prep session; only market
+prices drift."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, HTTPException, Response
+from fastapi import Path as PathParam
+from fastapi.concurrency import run_in_threadpool
+
+from mgz_pkmn.sources import TCGClient
+
+from .sets import _SET_CARDS_BROWSER_TTL, _trim_card
+
+router = APIRouter()
+
+# National dex numbers are positive integers; the catalog tops out at 1025
+# today. `le` is generous headroom for future generations while bounding
+# pathological inputs — FastAPI 422s anything out of range before the
+# handler runs.
+_DEX_NUMBER_PATH = PathParam(ge=1, le=20000)
+
+
+def _collector_sort_key(number: str) -> tuple[int, str]:
+    """Sort collector numbers numerically when possible, else lexically.
+
+    Numbers like `6` sort ahead of `25`; promo/trainer-gallery numbers
+    like `TG12` or `SV107` fall back to a string compare in a second
+    bucket so they don't crash the int parse and cluster together."""
+    head = (number or "").split("/")[0]
+    try:
+        return (0, f"{int(head):08d}")
+    except ValueError:
+        return (1, head)
+
+
+def _trim_pokedex_card(card: dict[str, Any]) -> dict[str, Any]:
+    """Slim set-card shape plus the set context a cross-set row needs."""
+    set_obj = card.get("set") or {}
+    trimmed = _trim_card(card)
+    trimmed.update(
+        {
+            "setId": set_obj.get("id"),
+            "setName": set_obj.get("name"),
+            "releaseDate": set_obj.get("releaseDate"),
+        }
+    )
+    return trimmed
+
+
+def _fetch_pokedex_cards(number: int, api_key: str | None) -> list[dict[str, Any]]:
+    """Fetch every printing of a species via pokemontcg.io, newest first.
+
+    `q=nationalPokedexNumbers:{n}` is the canonical filter for "every card
+    of this Pokémon". Flows through `search_all` so the request shares the
+    on-disk API cache with the rest of the app. Sorted server-side so the
+    SPA renders the response verbatim."""
+    client = TCGClient(api_key=api_key)
+    cards, _status = client.search_all(f"nationalPokedexNumbers:{number}")
+    trimmed = [_trim_pokedex_card(c) for c in cards]
+    # Two stable passes: the secondary keys (set name, then collector
+    # number) ascending, then release date descending on top. Python's
+    # stable sort preserves the ascending tie-break within each release
+    # date — so the order is newest set first, ties broken set A→Z, number low→high.
+    trimmed.sort(key=lambda c: (c.get("setName") or "", _collector_sort_key(c.get("number") or "")))
+    trimmed.sort(key=lambda c: c.get("releaseDate") or "", reverse=True)
+    return trimmed
+
+
+@router.get("/pokedex/{number}/cards")
+async def get_pokedex_cards(
+    response: Response,
+    number: Annotated[int, _DEX_NUMBER_PATH],
+    api_key: str | None = None,
+) -> dict:
+    """Return every printing of one species, trimmed and newest-first.
+
+    Each entry carries the Browse-grid fields plus `setId` / `setName` /
+    `releaseDate`. 404 when no card carries that national dex number —
+    either an out-of-range species or one the TCG has never printed. The
+    SPA surfaces the detail message as an empty state."""
+    cards = await run_in_threadpool(_fetch_pokedex_cards, number, api_key)
+    if not cards:
+        raise HTTPException(
+            status_code=404,
+            detail=f"no printings found for national dex #{number}",
+        )
+    response.headers["Cache-Control"] = f"public, max-age={_SET_CARDS_BROWSER_TTL}"
+    return {"number": number, "cards": cards}

--- a/tests/test_pokedex_api.py
+++ b/tests/test_pokedex_api.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+
+from api.main import app
+
+client = TestClient(app)
+
+
+class PokedexRouteTests(unittest.TestCase):
+    """`GET /api/v1/pokedex/{number}/cards` — every printing of one species."""
+
+    def test_returns_cards_with_set_context(self) -> None:
+        with patch(
+            "api.routes.pokedex._fetch_pokedex_cards",
+            return_value=[
+                {
+                    "id": "base1-4",
+                    "name": "Charizard",
+                    "number": "4",
+                    "rarity": "Rare Holo",
+                    "supertype": "Pokémon",
+                    "subtypes": ["Stage 2"],
+                    "thumb": None,
+                    "market": 250.0,
+                    "setId": "base1",
+                    "setName": "Base",
+                    "releaseDate": "1999/01/09",
+                }
+            ],
+        ) as fetch_mock:
+            resp = client.get("/api/v1/pokedex/6/cards")
+
+        self.assertEqual(resp.status_code, 200)
+        body = resp.json()
+        self.assertEqual(body["number"], 6)
+        self.assertEqual(len(body["cards"]), 1)
+        card = body["cards"][0]
+        # The per-card set context that set view leaves implicit.
+        for field in ("setId", "setName", "releaseDate"):
+            self.assertIn(field, card)
+        self.assertEqual(card["setName"], "Base")
+        fetch_mock.assert_called_once_with(6, None)
+
+    def test_404_when_species_has_no_printings(self) -> None:
+        with patch("api.routes.pokedex._fetch_pokedex_cards", return_value=[]):
+            resp = client.get("/api/v1/pokedex/9999/cards")
+        self.assertEqual(resp.status_code, 404)
+        self.assertIn("9999", resp.json()["detail"])
+
+    def test_browser_cache_control_header(self) -> None:
+        with patch(
+            "api.routes.pokedex._fetch_pokedex_cards",
+            return_value=[
+                {
+                    "id": "base1-4",
+                    "name": "Charizard",
+                    "number": "4",
+                    "rarity": None,
+                    "supertype": None,
+                    "subtypes": [],
+                    "thumb": None,
+                    "market": None,
+                    "setId": "base1",
+                    "setName": "Base",
+                    "releaseDate": "1999/01/09",
+                }
+            ],
+        ):
+            resp = client.get("/api/v1/pokedex/6/cards")
+        self.assertEqual(resp.status_code, 200)
+        cache_control = resp.headers.get("cache-control", "")
+        self.assertIn("public", cache_control)
+        self.assertIn("max-age=", cache_control)
+
+    def test_rejects_non_integer_and_out_of_range(self) -> None:
+        for bad in ("abc", "0", "-3", "999999"):
+            with self.subTest(number=bad):
+                resp = client.get(f"/api/v1/pokedex/{bad}/cards")
+                self.assertEqual(resp.status_code, 422)
+
+    def test_number_and_api_key_passed_through(self) -> None:
+        with patch(
+            "api.routes.pokedex._fetch_pokedex_cards",
+            return_value=[
+                {
+                    "id": "x",
+                    "name": "x",
+                    "number": "1",
+                    "rarity": None,
+                    "supertype": None,
+                    "subtypes": [],
+                    "thumb": None,
+                    "market": None,
+                    "setId": "s",
+                    "setName": "S",
+                    "releaseDate": "2000/01/01",
+                }
+            ],
+        ) as fetch_mock:
+            client.get("/api/v1/pokedex/25/cards?api_key=abc")
+        fetch_mock.assert_called_once_with(25, "abc")
+
+
+class PokedexHelperTests(unittest.TestCase):
+    def test_fetch_queries_national_dex_filter(self) -> None:
+        # The Lucene query keys the disk cache; it MUST stay
+        # `nationalPokedexNumbers:<n>` — see api/routes/pokedex.py.
+        from api.routes.pokedex import _fetch_pokedex_cards
+
+        captured: list[str] = []
+
+        def _capture(self_, query):
+            del self_
+            captured.append(query)
+            return [], "MISS"
+
+        with patch("mgz_pkmn.sources.pokemontcg.TCGClient.search_all", _capture):
+            _fetch_pokedex_cards(6, api_key=None)
+
+        self.assertEqual(captured, ["nationalPokedexNumbers:6"])
+
+    def test_trim_adds_set_context(self) -> None:
+        from api.routes.pokedex import _trim_pokedex_card
+
+        slim = _trim_pokedex_card(
+            {
+                "id": "base1-4",
+                "name": "Charizard",
+                "number": "4",
+                "set": {"id": "base1", "name": "Base", "releaseDate": "1999/01/09"},
+            }
+        )
+        self.assertEqual(slim["setId"], "base1")
+        self.assertEqual(slim["setName"], "Base")
+        self.assertEqual(slim["releaseDate"], "1999/01/09")
+        # Still carries the slim set-card fields.
+        self.assertEqual(slim["name"], "Charizard")
+        self.assertNotIn("set", slim)
+
+    def test_sorts_release_desc_then_set_then_number(self) -> None:
+        # Unsorted upstream → newest set first; ties broken set A→Z, number
+        # low→high (the contract the SPA renders verbatim).
+        from api.routes.pokedex import _fetch_pokedex_cards
+
+        raw = [
+            {
+                "id": "a",
+                "name": "P",
+                "number": "25",
+                "set": {"id": "s1", "name": "Alpha", "releaseDate": "2020/01/01"},
+            },
+            {
+                "id": "b",
+                "name": "P",
+                "number": "4",
+                "set": {"id": "s1", "name": "Alpha", "releaseDate": "2020/01/01"},
+            },
+            {
+                "id": "c",
+                "name": "P",
+                "number": "1",
+                "set": {"id": "s2", "name": "Zephyr", "releaseDate": "2024/01/01"},
+            },
+            {
+                "id": "d",
+                "name": "P",
+                "number": "1",
+                "set": {"id": "s3", "name": "Beta", "releaseDate": "2020/01/01"},
+            },
+        ]
+
+        def _stub(self_, query):
+            del self_, query
+            return raw, "HIT"
+
+        with patch("mgz_pkmn.sources.pokemontcg.TCGClient.search_all", _stub):
+            out = _fetch_pokedex_cards(25, api_key=None)
+
+        # Newest release first (c), then the 2020 sets ordered by set name
+        # Alpha (#4 before #25) then Beta.
+        self.assertEqual([c["id"] for c in out], ["c", "b", "a", "d"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run",
-    "refresh-sets": "node scripts/refresh-sets.mjs"
+    "refresh-sets": "node scripts/refresh-sets.mjs",
+    "refresh-pokedex": "node scripts/refresh-pokedex.mjs"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"

--- a/web/scripts/refresh-pokedex.mjs
+++ b/web/scripts/refresh-pokedex.mjs
@@ -64,6 +64,13 @@ const NAME_OVERRIDES = {
   flabebe: 'Flabébé',
   sirfetchd: "Sirfetch'd",
   'mr-rime': 'Mr. Rime',
+  // Treasures of Ruin (Gen IX) — official names keep the hyphen, which the
+  // PokéAPI slug also carries; `titleCase` would otherwise space them out
+  // and break a search for the hyphenated name.
+  'wo-chien': 'Wo-Chien',
+  'chien-pao': 'Chien-Pao',
+  'ting-lu': 'Ting-Lu',
+  'chi-yu': 'Chi-Yu',
 }
 
 function log(msg) {

--- a/web/scripts/refresh-pokedex.mjs
+++ b/web/scripts/refresh-pokedex.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * refresh-pokedex.mjs — pull the national Pokédex (species number → name)
+ * from PokéAPI and write it to `web/src/data/pokedex.json`, the static
+ * species index Browse's pokedex-# view renders.
+ *
+ * Why this exists
+ * ---------------
+ * Browse's pokedex view (issue #577) organises printings by national dex
+ * number — "show me every Charizard ever printed" — so the SPA needs the
+ * full species list (#1 Bulbasaur … #1025 Pecharunt) to render the picker
+ * with zero round-trips, exactly like the baked set catalog (`sets.json`).
+ * Card printings are still fetched on demand per species; only the species
+ * *index* is baked. The list is canonical reference data that only grows
+ * when a new generation ships, so a manual bake-refresh-commit cadence is
+ * plenty.
+ *
+ * Source
+ * ------
+ * PokéAPI's national Pokédex (`/api/v2/pokedex/1`) returns every species
+ * with its `entry_number` (= national dex #) and a lowercase slug. We map
+ * the slug to a display name with `displayName` below — a plain
+ * title-case for the common case, plus a small override table for the
+ * handful of names PokéAPI slugifies lossily (Farfetch'd, Mr. Mime,
+ * Nidoran♀/♂, Type: Null, …).
+ *
+ * When to run
+ * -----------
+ * - **Manually**: `npm run refresh-pokedex` from `web/`. Run it when a new
+ *   generation lands upstream; otherwise the baked file is stable.
+ *
+ * On error
+ * --------
+ * If PokéAPI is unreachable, the script logs a warning and exits **0** as
+ * long as the existing `pokedex.json` is present — a transient upstream
+ * outage must never fail the build. A missing file is a hard error.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const ROOT = resolve(dirname(__filename), '..')
+const OUT_PATH = join(ROOT, 'src', 'data', 'pokedex.json')
+
+const ENDPOINT = 'https://pokeapi.co/api/v2/pokedex/1'
+
+// PokéAPI slugs strip punctuation and accents that the display name keeps.
+// Only the lossy cases need an override; everything else round-trips fine
+// through `titleCase`.
+const NAME_OVERRIDES = {
+  'nidoran-f': 'Nidoran♀',
+  'nidoran-m': 'Nidoran♂',
+  farfetchd: "Farfetch'd",
+  'mr-mime': 'Mr. Mime',
+  'mime-jr': 'Mime Jr.',
+  'ho-oh': 'Ho-Oh',
+  'porygon-z': 'Porygon-Z',
+  'type-null': 'Type: Null',
+  'jangmo-o': 'Jangmo-o',
+  'hakamo-o': 'Hakamo-o',
+  'kommo-o': 'Kommo-o',
+  flabebe: 'Flabébé',
+  sirfetchd: "Sirfetch'd",
+  'mr-rime': 'Mr. Rime',
+}
+
+function log(msg) {
+  process.stdout.write(`[refresh-pokedex] ${msg}\n`)
+}
+
+function warn(msg) {
+  process.stderr.write(`[refresh-pokedex] WARN ${msg}\n`)
+}
+
+function titleCase(slug) {
+  return slug
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+}
+
+function displayName(slug) {
+  return NAME_OVERRIDES[slug] ?? titleCase(slug)
+}
+
+async function fetchPokedex() {
+  const headers = { 'User-Agent': 'mgz-pkmn/refresh-pokedex' }
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 30_000)
+  try {
+    const res = await fetch(ENDPOINT, { headers, signal: controller.signal })
+    if (!res.ok) {
+      throw new Error(`HTTP ${res.status} ${res.statusText}`)
+    }
+    const body = await res.json()
+    return Array.isArray(body?.pokemon_entries) ? body.pokemon_entries : []
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function trim(entries) {
+  // Match the SPA's `PokedexEntry` shape: a national dex number and a
+  // display name. The fetch URL for a species' printings keys off the
+  // number, so the name is purely cosmetic — formatting drift never
+  // affects which cards load.
+  return entries
+    .map((e) => ({
+      number: e.entry_number,
+      name: displayName(e.pokemon_species?.name ?? ''),
+    }))
+    .sort((a, b) => a.number - b.number)
+}
+
+async function main() {
+  let trimmed
+  try {
+    log(`fetching ${ENDPOINT}`)
+    const entries = await fetchPokedex()
+    if (entries.length === 0) {
+      throw new Error('upstream returned 0 species')
+    }
+    trimmed = trim(entries)
+    log(`fetched ${trimmed.length} species`)
+  } catch (err) {
+    warn(`fetch failed: ${err.message}`)
+    if (existsSync(OUT_PATH)) {
+      log(`keeping existing ${OUT_PATH}`)
+      return
+    }
+    warn('no existing pokedex.json to fall back to — bailing out')
+    process.exit(1)
+  }
+
+  mkdirSync(dirname(OUT_PATH), { recursive: true })
+
+  const next = JSON.stringify(trimmed, null, 2) + '\n'
+  if (existsSync(OUT_PATH)) {
+    const current = readFileSync(OUT_PATH, 'utf-8')
+    if (current === next) {
+      log('no changes — pokedex.json is already up to date')
+      return
+    }
+  }
+
+  writeFileSync(OUT_PATH, next, 'utf-8')
+  log(`wrote ${OUT_PATH}`)
+}
+
+main().catch((err) => {
+  warn(`unexpected error: ${err.stack || err.message}`)
+  process.exit(1)
+})

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -262,6 +262,19 @@ export function setLogoUrl(setId: string): string {
   return `${BASE}/sets/${encodeURIComponent(setId)}/logo`
 }
 
+// PokéAPI's sprite CDN keys the standard front sprite off the same national
+// dex number we already bake into the species index, so the URL derives
+// directly — no extra data, no backend round-trip. Lazy-loaded per tile with
+// a soft fallback, mirroring how set logos degrade on a miss.
+const _POKEMON_SPRITE_BASE =
+  'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon'
+
+/** Standard front sprite for a species, by national dex number (Browse's
+ *  pokedex-# view). */
+export function pokemonSpriteUrl(number: number): string {
+  return `${_POKEMON_SPRITE_BASE}/${number}.png`
+}
+
 // ---------------------------------------------------------------------------
 // sets
 // ---------------------------------------------------------------------------

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -12,6 +12,7 @@ import type {
   CardQuery,
   ChangelogRelease,
   ExportFormat,
+  PokedexCard,
   Row,
   RunDetail,
   RunSummary,
@@ -293,6 +294,33 @@ export async function fetchSetCards(setId: string, apiKey?: string): Promise<Set
   }
   const data = await res.json()
   return data.cards as SetCard[]
+}
+
+/**
+ * Fetch every printing of one species across all sets, newest-first, for
+ * Browse's pokedex-# view. The backend keys off the national dex `number`
+ * and returns rows pre-sorted (release date desc, set, collector number)
+ * with per-card set context. Browser-cacheable for a day like
+ * `fetchSetCards`.
+ */
+export async function fetchPokedexCards(
+  number: number,
+  apiKey?: string,
+): Promise<PokedexCard[]> {
+  const params = apiKey ? `?api_key=${encodeURIComponent(apiKey)}` : ''
+  const res = await fetch(`${BASE}/pokedex/${number}/cards${params}`)
+  if (!res.ok) {
+    let detail = `pokedex cards failed: ${res.status}`
+    try {
+      const body = await res.json()
+      if (body?.detail) detail = body.detail
+    } catch {
+      /* fall through */
+    }
+    throw new Error(detail)
+  }
+  const data = await res.json()
+  return data.cards as PokedexCard[]
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/components/BrowsePanel.test.tsx
+++ b/web/src/components/BrowsePanel.test.tsx
@@ -46,6 +46,10 @@ describe('BrowsePanel — pokedex view (#577)', () => {
     // The baked national dex seeds the picker with zero round-trips.
     expect(await screen.findByText('Bulbasaur')).toBeInTheDocument()
     expect(screen.getByText('Generation I')).toBeInTheDocument()
+    // Each species tile shows its standard sprite, derived from the dex #.
+    const bulbasaurTile = screen.getByText('Bulbasaur').closest('button')!
+    const sprite = bulbasaurTile.querySelector('img')
+    expect(sprite?.getAttribute('src')).toContain('/pokemon/1.png')
   })
 
   it('filters the species list by name', async () => {

--- a/web/src/components/BrowsePanel.test.tsx
+++ b/web/src/components/BrowsePanel.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { BrowsePanel } from './BrowsePanel'
+import { useBrowseController } from './useBrowseController'
+import { useAppStore } from '../store'
+import * as client from '../api/client'
+import type { PokedexCard } from '../types'
+
+function Harness() {
+  const controller = useBrowseController(true)
+  return <BrowsePanel controller={controller} />
+}
+
+const CHARIZARD_PRINTINGS: PokedexCard[] = [
+  {
+    id: 'base1-4',
+    name: 'Charizard',
+    number: '4',
+    rarity: 'Rare Holo',
+    supertype: 'Pokémon',
+    subtypes: ['Stage 2'],
+    thumb: null,
+    market: 250,
+    setId: 'base1',
+    setName: 'Base',
+    releaseDate: '1999/01/09',
+  },
+]
+
+describe('BrowsePanel — pokedex view (#577)', () => {
+  beforeEach(() => {
+    useAppStore.setState({ inputText: '' })
+    vi.restoreAllMocks()
+    // The set-catalog revalidation fires on mount; keep it inert so the
+    // baked catalog stays on screen and no real network is hit.
+    vi.spyOn(client, 'fetchSets').mockResolvedValue([])
+    vi.spyOn(client, 'fetchSetCards').mockResolvedValue([])
+  })
+
+  it('toggles to pokedex view and lists species from the national dex', async () => {
+    render(<Harness />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'By Pokédex #' }))
+
+    expect(screen.getByText('Browse by Pokédex #')).toBeInTheDocument()
+    // The baked national dex seeds the picker with zero round-trips.
+    expect(await screen.findByText('Bulbasaur')).toBeInTheDocument()
+    expect(screen.getByText('Generation I')).toBeInTheDocument()
+  })
+
+  it('filters the species list by name', async () => {
+    render(<Harness />)
+    fireEvent.click(screen.getByRole('button', { name: 'By Pokédex #' }))
+
+    fireEvent.change(screen.getByLabelText('Find a Pokémon'), {
+      target: { value: 'charizard' },
+    })
+
+    expect(await screen.findByText('Charizard')).toBeInTheDocument()
+    expect(screen.queryByText('Bulbasaur')).not.toBeInTheDocument()
+  })
+
+  it('drills into a species, fetches every printing, and adds one to the list', async () => {
+    const fetchPokedex = vi
+      .spyOn(client, 'fetchPokedexCards')
+      .mockResolvedValue(CHARIZARD_PRINTINGS)
+
+    render(<Harness />)
+    fireEvent.click(screen.getByRole('button', { name: 'By Pokédex #' }))
+    fireEvent.change(screen.getByLabelText('Find a Pokémon'), {
+      target: { value: 'charizard' },
+    })
+    fireEvent.click(await screen.findByText('Charizard'))
+
+    // Charizard is national dex #6 — the fetch keys off the number.
+    await waitFor(() => expect(fetchPokedex).toHaveBeenCalledWith(6, undefined))
+
+    // The printing renders its own set context (set name + year).
+    expect(await screen.findByText('Base')).toBeInTheDocument()
+    expect(screen.getByText('1 printing')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /Add Charizard from Base to list/ }))
+
+    expect(useAppStore.getState().inputText).toContain('Charizard | Base | 4')
+  })
+})

--- a/web/src/components/BrowsePanel.tsx
+++ b/web/src/components/BrowsePanel.tsx
@@ -1,16 +1,21 @@
 /**
- * BrowsePanel — the inline "browse cards by set" view rendered by the
- * Browse discovery-mode tab in App.tsx. State + effects live in
+ * BrowsePanel — the inline "browse cards" view rendered by the Browse
+ * discovery-mode tab in App.tsx. A view-mode toggle flips the whole panel
+ * between two organisations (#577): **set view** (series → set → cards in
+ * that set) and **pokedex view** (national dex # → every printing of one
+ * Pokémon across every set). State + effects live in
  * [useBrowseController](./useBrowseController.ts).
  */
 import { ArrowLeft, ImageOff, Library, Loader2, Plus, Search } from 'lucide-react'
 import { useState } from 'react'
 import type { ReactNode } from 'react'
 import { setLogoUrl } from '../api/client'
-import type { SetCard, SetInfo } from '../types'
+import type { PokedexCard, PokedexEntry, SetCard, SetInfo } from '../types'
 import type {
   BrowseController,
+  BrowseViewMode,
   CardSort,
+  PokedexGroup,
   RarityBucket,
   SeriesGroup,
 } from './useBrowseController'
@@ -26,6 +31,8 @@ interface BrowsePanelProps {
 
 export function BrowsePanel({ controller }: BrowsePanelProps) {
   const {
+    viewMode,
+    setViewMode,
     groups,
     activeSet,
     setActiveSet,
@@ -44,32 +51,57 @@ export function BrowsePanel({ controller }: BrowsePanelProps) {
     addAll,
     addHolos,
     addRares,
+    pokedexGroups,
+    pokedexFilter,
+    setPokedexFilter,
+    activePokemon,
+    setActivePokemon,
+    pokedexCards,
+    pokedexCardsLoading,
+    pokedexCardsError,
+    addPokedexCards,
+    addAllPrintings,
   } = controller
 
-  const headerTitle = activeSet ? activeSet.name : 'Browse sets'
-  const description = activeSet
-    ? 'Click a card to add it to your input list, or use the bulk actions below.'
-    : 'Pick a set to see every card with its market price, sortable and filterable.'
+  const drilledIn = viewMode === 'set' ? !!activeSet : !!activePokemon
+  const onBack = () =>
+    viewMode === 'set' ? setActiveSet(null) : setActivePokemon(null)
+
+  let headerTitle: string
+  let description: string
+  if (viewMode === 'set') {
+    headerTitle = activeSet ? activeSet.name : 'Browse sets'
+    description = activeSet
+      ? 'Click a card to add it to your input list, or use the bulk actions below.'
+      : 'Pick a set to see every card with its market price, sortable and filterable.'
+  } else {
+    headerTitle = activePokemon
+      ? `#${activePokemon.number} ${activePokemon.name}`
+      : 'Browse by Pokédex #'
+    description = activePokemon
+      ? 'Every printing we found, newest first. Click a card to add it to your input list.'
+      : 'Pick a Pokémon to see every printing across every set, newest first.'
+  }
 
   return (
     <div className="flex flex-col overflow-hidden rounded-lg border border-sand-300 dark:border-husk-50 bg-sand-50 dark:bg-husk-200 shadow-sm">
       <header className="flex items-center justify-between gap-3 border-b border-sand-200 dark:border-husk-100 px-5 py-4">
-        <div className="flex items-center gap-2">
-          {activeSet && (
+        <div className="flex min-w-0 items-center gap-2">
+          {drilledIn && (
             <button
               type="button"
-              onClick={() => setActiveSet(null)}
-              aria-label="Back to set list"
+              onClick={onBack}
+              aria-label={viewMode === 'set' ? 'Back to set list' : 'Back to Pokédex list'}
               className="rounded p-1 text-coconut-400 dark:text-sand-300 hover:bg-sand-200 dark:hover:bg-husk-100 hover:text-coconut-700 dark:hover:text-sand-50"
             >
               <ArrowLeft size={16} />
             </button>
           )}
           <Library size={18} className="text-coconut-600 dark:text-sand-200" />
-          <h2 className="text-lg font-semibold text-coconut-700 dark:text-sand-50">
+          <h2 className="truncate text-lg font-semibold text-coconut-700 dark:text-sand-50">
             {headerTitle}
           </h2>
-          {activeSet && (
+          {viewMode === 'set' && activeSet && (
             <span className="text-xs text-coconut-400 dark:text-sand-400">
               {activeSet.series}
               {releaseYear(activeSet.releaseDate)
@@ -78,33 +110,92 @@ export function BrowsePanel({ controller }: BrowsePanelProps) {
             </span>
           )}
         </div>
+        <ViewModeToggle value={viewMode} onChange={setViewMode} />
       </header>
 
       <p className="px-5 pt-3 text-sm text-coconut-400 dark:text-sand-300">
         {description}
       </p>
 
-      {activeSet ? (
-        <SetDetailView
-          cards={filteredCards}
-          total={cards?.length ?? 0}
-          loading={cardsLoading}
-          error={cardsError}
-          search={search}
-          onSearch={setSearch}
-          bucket={bucket}
-          onBucket={setBucket}
-          sort={sort}
-          onSort={setSort}
+      {viewMode === 'set' ? (
+        activeSet ? (
+          <SetDetailView
+            cards={filteredCards}
+            total={cards?.length ?? 0}
+            loading={cardsLoading}
+            error={cardsError}
+            search={search}
+            onSearch={setSearch}
+            bucket={bucket}
+            onBucket={setBucket}
+            sort={sort}
+            onSort={setSort}
+            addedCount={addedCount}
+            onAddCards={addCards}
+            onAddAll={addAll}
+            onAddHolos={addHolos}
+            onAddRares={addRares}
+          />
+        ) : (
+          <SetListView groups={groups} onPick={(s) => setActiveSet(s)} />
+        )
+      ) : activePokemon ? (
+        <PokedexDetailView
+          cards={pokedexCards}
+          loading={pokedexCardsLoading}
+          error={pokedexCardsError}
           addedCount={addedCount}
-          onAddCards={addCards}
-          onAddAll={addAll}
-          onAddHolos={addHolos}
-          onAddRares={addRares}
+          onAddCards={addPokedexCards}
+          onAddAll={addAllPrintings}
         />
       ) : (
-        <SetListView groups={groups} onPick={(s) => setActiveSet(s)} />
+        <PokedexListView
+          groups={pokedexGroups}
+          filter={pokedexFilter}
+          onFilter={setPokedexFilter}
+          onPick={(p) => setActivePokemon(p)}
+        />
       )}
+    </div>
+  )
+}
+
+const VIEW_MODES: { value: BrowseViewMode; label: string }[] = [
+  { value: 'set', label: 'By set' },
+  { value: 'pokedex', label: 'By Pokédex #' },
+]
+
+function ViewModeToggle({
+  value,
+  onChange,
+}: {
+  value: BrowseViewMode
+  onChange: (m: BrowseViewMode) => void
+}) {
+  return (
+    <div
+      className="flex flex-none items-center gap-1 rounded-md border border-sand-300 dark:border-husk-50 bg-sand-200 dark:bg-husk-100 p-0.5"
+      role="group"
+      aria-label="Browse organisation"
+    >
+      {VIEW_MODES.map((m) => {
+        const active = value === m.value
+        return (
+          <button
+            key={m.value}
+            type="button"
+            onClick={() => onChange(m.value)}
+            aria-pressed={active}
+            className={`rounded px-2.5 py-1 text-xs transition-colors ${
+              active
+                ? 'bg-sand-50 dark:bg-husk-400 text-coconut-700 dark:text-sand-50 shadow-sm'
+                : 'text-coconut-600 dark:text-sand-300 hover:text-coconut-700 dark:hover:text-sand-50'
+            }`}
+          >
+            {m.label}
+          </button>
+        )
+      })}
     </div>
   )
 }
@@ -306,6 +397,151 @@ function SetDetailView({
   )
 }
 
+interface PokedexListProps {
+  groups: PokedexGroup[]
+  filter: string
+  onFilter: (v: string) => void
+  onPick: (species: PokedexEntry) => void
+}
+
+function PokedexListView({ groups, filter, onFilter, onPick }: PokedexListProps) {
+  return (
+    <>
+      <div className="flex flex-wrap items-center gap-2 border-b border-sand-200 dark:border-husk-100 px-5 py-3">
+        <label className="relative flex-1 min-w-[180px]">
+          <Search
+            size={14}
+            className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-coconut-400 dark:text-sand-400"
+            aria-hidden
+          />
+          <input
+            type="search"
+            placeholder="Find a Pokémon by name or dex #…"
+            value={filter}
+            onChange={(e) => onFilter(e.target.value)}
+            className="w-full rounded-md border border-sand-300 dark:border-husk-50 bg-sand-50 dark:bg-husk-400 py-1.5 pl-8 pr-2 text-sm text-coconut-700 dark:text-sand-50 placeholder:text-coconut-400 dark:placeholder:text-sand-400 focus:border-sand-400 dark:focus:border-coconut-400 focus:outline-none"
+            aria-label="Find a Pokémon"
+          />
+        </label>
+      </div>
+      <div className="flex-1 overflow-y-auto px-5 py-3">
+        {groups.length === 0 ? (
+          <p className="text-sm text-coconut-400 dark:text-sand-400">
+            No Pokémon match “{filter}”.
+          </p>
+        ) : (
+          <ul className="space-y-4">
+            {groups.map((group) => (
+              <li key={group.label}>
+                <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-coconut-600 dark:text-sand-200">
+                  {group.label}
+                  <span className="ml-1 font-normal normal-case tracking-normal text-coconut-400 dark:text-sand-400">
+                    ({group.species.length})
+                  </span>
+                </div>
+                <ul className="grid grid-cols-2 gap-1 sm:grid-cols-3 lg:grid-cols-4">
+                  {group.species.map((s) => (
+                    <SpeciesTile key={s.number} species={s} onPick={() => onPick(s)} />
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </>
+  )
+}
+
+function SpeciesTile({
+  species,
+  onPick,
+}: {
+  species: PokedexEntry
+  onPick: () => void
+}) {
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onPick}
+        className="flex w-full items-center gap-2 rounded-md border border-sand-200 dark:border-husk-100 bg-sand-50 dark:bg-husk-400/40 px-3 py-2 text-left hover:border-sand-300 dark:hover:border-husk-50 hover:bg-sand-50 dark:hover:bg-husk-200 focus:outline-none focus:ring-2 focus:ring-sand-300 dark:ring-husk-50"
+      >
+        <span className="w-10 flex-none font-mono text-xs text-coconut-400 dark:text-sand-400">
+          #{species.number}
+        </span>
+        <span className="truncate text-sm font-medium text-coconut-700 dark:text-sand-50">
+          {species.name}
+        </span>
+      </button>
+    </li>
+  )
+}
+
+interface PokedexDetailProps {
+  cards: PokedexCard[] | null
+  loading: boolean
+  error: string | null
+  addedCount: number | null
+  onAddCards: (cards: PokedexCard[]) => void
+  onAddAll: () => void
+}
+
+function PokedexDetailView({
+  cards,
+  loading,
+  error,
+  addedCount,
+  onAddCards,
+  onAddAll,
+}: PokedexDetailProps) {
+  const count = cards?.length ?? 0
+  return (
+    <>
+      <div className="flex flex-wrap items-center gap-2 border-b border-sand-200 dark:border-husk-100 px-5 py-2 text-xs text-coconut-400 dark:text-sand-300">
+        <span>
+          {count} printing{count === 1 ? '' : 's'}
+        </span>
+        {count > 0 && (
+          <>
+            <span className="text-coconut-300 dark:text-sand-500">·</span>
+            <BulkButton onClick={onAddAll}>Add all printings</BulkButton>
+          </>
+        )}
+        {addedCount != null && (
+          <span className="ml-auto text-palm-500 dark:text-palm-200" role="status">
+            Added {addedCount} line{addedCount === 1 ? '' : 's'} to your list
+          </span>
+        )}
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-5 py-3">
+        {error && (
+          <p className="rounded border border-ember-500/40 dark:border-ember-500/50 bg-ember-500/10 dark:bg-ember-500/30 px-3 py-2 text-sm text-ember-400 dark:text-ember-300">
+            Couldn’t load printings: {error}
+          </p>
+        )}
+        {loading && !error && (
+          <p className="flex items-center gap-2 text-sm text-coconut-400 dark:text-sand-300">
+            <Loader2 size={14} className="animate-spin" />
+            Loading printings…
+          </p>
+        )}
+        {!loading && !error && count === 0 && (
+          <p className="text-sm text-coconut-400 dark:text-sand-400">No printings found.</p>
+        )}
+        {!loading && !error && cards && count > 0 && (
+          <ul className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+            {cards.map((c) => (
+              <PokedexCardTile key={c.id} card={c} onAdd={() => onAddCards([c])} />
+            ))}
+          </ul>
+        )}
+      </div>
+    </>
+  )
+}
+
 function CardTile({ card, onAdd }: { card: SetCard; onAdd: () => void }) {
   const [thumbFailed, setThumbFailed] = useState(false)
   return (
@@ -339,16 +575,64 @@ function CardTile({ card, onAdd }: { card: SetCard; onAdd: () => void }) {
           <div className="truncate text-[11px] text-coconut-400 dark:text-sand-400">{card.rarity}</div>
         )}
       </div>
-      <button
-        type="button"
-        onClick={onAdd}
-        className="mt-2 flex items-center justify-center gap-1 rounded-md border border-sand-300 dark:border-husk-50 bg-sand-200 dark:bg-husk-100 px-2 py-1 text-xs text-coconut-600 dark:text-sand-200 hover:border-palm-400 dark:hover:border-palm-500 hover:bg-palm-100 dark:hover:bg-palm-500/30 hover:text-palm-400 dark:hover:text-palm-100"
-        aria-label={`Add ${card.name} to list`}
-      >
-        <Plus size={12} />
-        Add to list
-      </button>
+      <AddToListButton label={card.name} onClick={onAdd} />
     </li>
+  )
+}
+
+function PokedexCardTile({ card, onAdd }: { card: PokedexCard; onAdd: () => void }) {
+  const [thumbFailed, setThumbFailed] = useState(false)
+  const year = releaseYear(card.releaseDate)
+  return (
+    <li className="group flex flex-col rounded-md border border-sand-200 dark:border-husk-100 bg-sand-50 dark:bg-husk-400/40 p-2 text-left hover:border-sand-300 dark:hover:border-husk-50 hover:bg-sand-50 dark:hover:bg-husk-200">
+      <div className="relative aspect-[245/342] w-full overflow-hidden rounded bg-sand-50 dark:bg-husk-400">
+        {card.thumb && !thumbFailed ? (
+          <img
+            src={card.thumb}
+            alt={card.name}
+            className="h-full w-full object-contain"
+            loading="lazy"
+            onError={() => setThumbFailed(true)}
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-coconut-700 dark:text-sand-200">
+            <ImageOff size={28} aria-hidden />
+          </div>
+        )}
+      </div>
+      <div className="mt-2 min-w-0 flex-1">
+        <div className="truncate text-sm font-medium text-coconut-700 dark:text-sand-50" title={card.setName}>
+          {card.setName}
+        </div>
+        <div className="flex items-center justify-between text-xs text-coconut-400 dark:text-sand-400">
+          <span>
+            #{card.number}
+            {year ? ` · ${year}` : ''}
+          </span>
+          {card.market != null && (
+            <span className="text-palm-500 dark:text-palm-200">${card.market.toFixed(2)}</span>
+          )}
+        </div>
+        {card.rarity && (
+          <div className="truncate text-[11px] text-coconut-400 dark:text-sand-400">{card.rarity}</div>
+        )}
+      </div>
+      <AddToListButton label={`${card.name} from ${card.setName}`} onClick={onAdd} />
+    </li>
+  )
+}
+
+function AddToListButton({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="mt-2 flex items-center justify-center gap-1 rounded-md border border-sand-300 dark:border-husk-50 bg-sand-200 dark:bg-husk-100 px-2 py-1 text-xs text-coconut-600 dark:text-sand-200 hover:border-palm-400 dark:hover:border-palm-500 hover:bg-palm-100 dark:hover:bg-palm-500/30 hover:text-palm-400 dark:hover:text-palm-100"
+      aria-label={`Add ${label} to list`}
+    >
+      <Plus size={12} />
+      Add to list
+    </button>
   )
 }
 

--- a/web/src/components/BrowsePanel.tsx
+++ b/web/src/components/BrowsePanel.tsx
@@ -9,7 +9,7 @@
 import { ArrowLeft, ImageOff, Library, Loader2, Plus, Search } from 'lucide-react'
 import { useState } from 'react'
 import type { ReactNode } from 'react'
-import { setLogoUrl } from '../api/client'
+import { pokemonSpriteUrl, setLogoUrl } from '../api/client'
 import type { PokedexCard, PokedexEntry, SetCard, SetInfo } from '../types'
 import type {
   BrowseController,
@@ -460,6 +460,7 @@ function SpeciesTile({
   species: PokedexEntry
   onPick: () => void
 }) {
+  const [spriteFailed, setSpriteFailed] = useState(false)
   return (
     <li>
       <button
@@ -467,7 +468,20 @@ function SpeciesTile({
         onClick={onPick}
         className="flex w-full items-center gap-2 rounded-md border border-sand-200 dark:border-husk-100 bg-sand-50 dark:bg-husk-400/40 px-3 py-2 text-left hover:border-sand-300 dark:hover:border-husk-50 hover:bg-sand-50 dark:hover:bg-husk-200 focus:outline-none focus:ring-2 focus:ring-sand-300 dark:ring-husk-50"
       >
-        <span className="w-10 flex-none font-mono text-xs text-coconut-400 dark:text-sand-400">
+        <span className="flex h-9 w-9 flex-none items-center justify-center rounded bg-sand-50 dark:bg-husk-400">
+          {spriteFailed ? (
+            <ImageOff size={14} className="text-coconut-300 dark:text-sand-500" aria-hidden />
+          ) : (
+            <img
+              src={pokemonSpriteUrl(species.number)}
+              alt=""
+              className="h-9 w-9 object-contain"
+              loading="lazy"
+              onError={() => setSpriteFailed(true)}
+            />
+          )}
+        </span>
+        <span className="w-9 flex-none font-mono text-xs text-coconut-400 dark:text-sand-400">
           #{species.number}
         </span>
         <span className="truncate text-sm font-medium text-coconut-700 dark:text-sand-50">

--- a/web/src/components/useBrowseController.ts
+++ b/web/src/components/useBrowseController.ts
@@ -10,15 +10,29 @@
  * lands on the set list, not whatever they were browsing last time.
  */
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { fetchSetCards, fetchSets } from '../api/client'
+import { fetchPokedexCards, fetchSetCards, fetchSets } from '../api/client'
+import { BAKED_POKEDEX, POKEDEX_GENERATIONS } from '../data/pokedex'
 import { BAKED_SETS } from '../data/sets'
 import { useAppStore } from '../store'
-import type { SetCard, SetInfo } from '../types'
+import type { PokedexCard, PokedexEntry, SetCard, SetInfo } from '../types'
 
 export interface SeriesGroup {
   series: string
   sets: SetInfo[]
 }
+
+/** One generation section of the national dex species index. */
+export interface PokedexGroup {
+  label: string
+  species: PokedexEntry[]
+}
+
+/**
+ * Which organisation Browse is showing: `set` walks series → set → cards;
+ * `pokedex` walks national dex # → every printing of that species across
+ * every set (issue #577).
+ */
+export type BrowseViewMode = 'set' | 'pokedex'
 
 const OTHER_SERIES = 'Other'
 
@@ -39,6 +53,13 @@ function groupBySeries(sets: SetInfo[]): SeriesGroup[] {
     buckets.get(key)!.push(s)
   }
   return order.map((series) => ({ series, sets: buckets.get(series)! }))
+}
+
+function groupByGeneration(species: PokedexEntry[]): PokedexGroup[] {
+  return POKEDEX_GENERATIONS.map((gen) => ({
+    label: gen.label,
+    species: species.filter((s) => s.number >= gen.start && s.number <= gen.end),
+  })).filter((group) => group.species.length > 0)
 }
 
 export type RarityBucket = 'all' | 'holo' | 'rare' | 'ultra'
@@ -75,11 +96,13 @@ function compareCards(a: SetCard, b: SetCard, sort: CardSort): number {
   return (a.number || '').localeCompare(b.number || '')
 }
 
-function toInputLine(card: SetCard, set: SetInfo): string {
-  return `${card.name} | ${set.name} | ${card.number}`
+function toInputLine(card: SetCard, setName: string): string {
+  return `${card.name} | ${setName} | ${card.number}`
 }
 
 export interface BrowseController {
+  viewMode: BrowseViewMode
+  setViewMode: (m: BrowseViewMode) => void
   groups: SeriesGroup[]
   activeSet: SetInfo | null
   setActiveSet: (s: SetInfo | null) => void
@@ -98,6 +121,17 @@ export interface BrowseController {
   addAll: () => void
   addHolos: () => void
   addRares: () => void
+  // Pokedex view (#577) — national dex # → every printing across all sets.
+  pokedexGroups: PokedexGroup[]
+  pokedexFilter: string
+  setPokedexFilter: (v: string) => void
+  activePokemon: PokedexEntry | null
+  setActivePokemon: (p: PokedexEntry | null) => void
+  pokedexCards: PokedexCard[] | null
+  pokedexCardsLoading: boolean
+  pokedexCardsError: string | null
+  addPokedexCards: (toAdd: PokedexCard[]) => void
+  addAllPrintings: () => void
 }
 
 export function useBrowseController(active: boolean): BrowseController {
@@ -115,11 +149,20 @@ export function useBrowseController(active: boolean): BrowseController {
   const [sort, setSort] = useState<CardSort>('number')
   const [addedCount, setAddedCount] = useState<number | null>(null)
 
+  const [viewMode, setViewModeState] = useState<BrowseViewMode>('set')
+  const [pokedexFilter, setPokedexFilter] = useState('')
+  const [activePokemon, setActivePokemon] = useState<PokedexEntry | null>(null)
+  const [pokedexCards, setPokedexCards] = useState<PokedexCard[] | null>(null)
+  const [pokedexCardsError, setPokedexCardsError] = useState<string | null>(null)
+  const [pokedexCardsLoading, setPokedexCardsLoading] = useState(false)
+
   const cardCacheRef = useRef<Map<string, SetCard[]>>(new Map())
+  const pokedexCacheRef = useRef<Map<number, PokedexCard[]>>(new Map())
 
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     if (!active) return
+    setViewModeState('set')
     setActiveSet(null)
     setCards(null)
     setCardsError(null)
@@ -127,8 +170,23 @@ export function useBrowseController(active: boolean): BrowseController {
     setBucket('all')
     setSort('number')
     setAddedCount(null)
+    setActivePokemon(null)
+    setPokedexCards(null)
+    setPokedexCardsError(null)
+    setPokedexFilter('')
   }, [active])
   /* eslint-enable react-hooks/set-state-in-effect */
+
+  // Switching organisation always lands on that view's top-level list:
+  // set view → the set grid, pokedex view → the species index. Clears the
+  // drill-in state on both sides and the shared "added N lines" status so
+  // the toggle is a clean reset, not a half-remembered prior position.
+  function setViewMode(mode: BrowseViewMode) {
+    setViewModeState(mode)
+    setActiveSet(null)
+    setActivePokemon(null)
+    setAddedCount(null)
+  }
 
   useEffect(() => {
     if (!active || revalidatedSets) return
@@ -182,7 +240,51 @@ export function useBrowseController(active: boolean): BrowseController {
     }
   }, [activeSet, settings.apiKey])
 
+  useEffect(() => {
+    if (!activePokemon) return
+    let cancelled = false
+    const load = async () => {
+      setAddedCount(null)
+      setPokedexCardsError(null)
+
+      const cached = pokedexCacheRef.current.get(activePokemon.number)
+      if (cached) {
+        setPokedexCards(cached)
+        setPokedexCardsLoading(false)
+        return
+      }
+
+      setPokedexCardsLoading(true)
+      setPokedexCards(null)
+      try {
+        const data = await fetchPokedexCards(activePokemon.number, settings.apiKey || undefined)
+        if (!cancelled) {
+          pokedexCacheRef.current.set(activePokemon.number, data)
+          setPokedexCards(data)
+        }
+      } catch (err) {
+        if (!cancelled) setPokedexCardsError(err instanceof Error ? err.message : String(err))
+      } finally {
+        if (!cancelled) setPokedexCardsLoading(false)
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [activePokemon, settings.apiKey])
+
   const groups = useMemo(() => groupBySeries(sets), [sets])
+
+  const pokedexGroups = useMemo(() => {
+    const term = pokedexFilter.trim().toLowerCase()
+    const species = term
+      ? BAKED_POKEDEX.filter(
+          (s) => s.name.toLowerCase().includes(term) || String(s.number) === term,
+        )
+      : BAKED_POKEDEX
+    return groupByGeneration(species)
+  }, [pokedexFilter])
 
   const filteredCards = useMemo(() => {
     if (!cards) return []
@@ -202,7 +304,7 @@ export function useBrowseController(active: boolean): BrowseController {
 
   function addCards(toAdd: SetCard[]) {
     if (!activeSet || toAdd.length === 0) return
-    const added = appendInputLines(toAdd.map((c) => toInputLine(c, activeSet)))
+    const added = appendInputLines(toAdd.map((c) => toInputLine(c, activeSet.name)))
     setAddedCount(added)
   }
 
@@ -218,7 +320,19 @@ export function useBrowseController(active: boolean): BrowseController {
     addCards((cards ?? []).filter((c) => inBucket(c, 'rare')))
   }
 
+  function addPokedexCards(toAdd: PokedexCard[]) {
+    if (toAdd.length === 0) return
+    const added = appendInputLines(toAdd.map((c) => toInputLine(c, c.setName)))
+    setAddedCount(added)
+  }
+
+  function addAllPrintings() {
+    addPokedexCards(pokedexCards ?? [])
+  }
+
   return {
+    viewMode,
+    setViewMode,
     groups,
     activeSet,
     setActiveSet,
@@ -237,5 +351,15 @@ export function useBrowseController(active: boolean): BrowseController {
     addAll,
     addHolos,
     addRares,
+    pokedexGroups,
+    pokedexFilter,
+    setPokedexFilter,
+    activePokemon,
+    setActivePokemon,
+    pokedexCards,
+    pokedexCardsLoading,
+    pokedexCardsError,
+    addPokedexCards,
+    addAllPrintings,
   }
 }

--- a/web/src/data/pokedex.json
+++ b/web/src/data/pokedex.json
@@ -4001,19 +4001,19 @@
   },
   {
     "number": 1001,
-    "name": "Wo Chien"
+    "name": "Wo-Chien"
   },
   {
     "number": 1002,
-    "name": "Chien Pao"
+    "name": "Chien-Pao"
   },
   {
     "number": 1003,
-    "name": "Ting Lu"
+    "name": "Ting-Lu"
   },
   {
     "number": 1004,
-    "name": "Chi Yu"
+    "name": "Chi-Yu"
   },
   {
     "number": 1005,

--- a/web/src/data/pokedex.json
+++ b/web/src/data/pokedex.json
@@ -1,0 +1,4102 @@
+[
+  {
+    "number": 1,
+    "name": "Bulbasaur"
+  },
+  {
+    "number": 2,
+    "name": "Ivysaur"
+  },
+  {
+    "number": 3,
+    "name": "Venusaur"
+  },
+  {
+    "number": 4,
+    "name": "Charmander"
+  },
+  {
+    "number": 5,
+    "name": "Charmeleon"
+  },
+  {
+    "number": 6,
+    "name": "Charizard"
+  },
+  {
+    "number": 7,
+    "name": "Squirtle"
+  },
+  {
+    "number": 8,
+    "name": "Wartortle"
+  },
+  {
+    "number": 9,
+    "name": "Blastoise"
+  },
+  {
+    "number": 10,
+    "name": "Caterpie"
+  },
+  {
+    "number": 11,
+    "name": "Metapod"
+  },
+  {
+    "number": 12,
+    "name": "Butterfree"
+  },
+  {
+    "number": 13,
+    "name": "Weedle"
+  },
+  {
+    "number": 14,
+    "name": "Kakuna"
+  },
+  {
+    "number": 15,
+    "name": "Beedrill"
+  },
+  {
+    "number": 16,
+    "name": "Pidgey"
+  },
+  {
+    "number": 17,
+    "name": "Pidgeotto"
+  },
+  {
+    "number": 18,
+    "name": "Pidgeot"
+  },
+  {
+    "number": 19,
+    "name": "Rattata"
+  },
+  {
+    "number": 20,
+    "name": "Raticate"
+  },
+  {
+    "number": 21,
+    "name": "Spearow"
+  },
+  {
+    "number": 22,
+    "name": "Fearow"
+  },
+  {
+    "number": 23,
+    "name": "Ekans"
+  },
+  {
+    "number": 24,
+    "name": "Arbok"
+  },
+  {
+    "number": 25,
+    "name": "Pikachu"
+  },
+  {
+    "number": 26,
+    "name": "Raichu"
+  },
+  {
+    "number": 27,
+    "name": "Sandshrew"
+  },
+  {
+    "number": 28,
+    "name": "Sandslash"
+  },
+  {
+    "number": 29,
+    "name": "Nidoran♀"
+  },
+  {
+    "number": 30,
+    "name": "Nidorina"
+  },
+  {
+    "number": 31,
+    "name": "Nidoqueen"
+  },
+  {
+    "number": 32,
+    "name": "Nidoran♂"
+  },
+  {
+    "number": 33,
+    "name": "Nidorino"
+  },
+  {
+    "number": 34,
+    "name": "Nidoking"
+  },
+  {
+    "number": 35,
+    "name": "Clefairy"
+  },
+  {
+    "number": 36,
+    "name": "Clefable"
+  },
+  {
+    "number": 37,
+    "name": "Vulpix"
+  },
+  {
+    "number": 38,
+    "name": "Ninetales"
+  },
+  {
+    "number": 39,
+    "name": "Jigglypuff"
+  },
+  {
+    "number": 40,
+    "name": "Wigglytuff"
+  },
+  {
+    "number": 41,
+    "name": "Zubat"
+  },
+  {
+    "number": 42,
+    "name": "Golbat"
+  },
+  {
+    "number": 43,
+    "name": "Oddish"
+  },
+  {
+    "number": 44,
+    "name": "Gloom"
+  },
+  {
+    "number": 45,
+    "name": "Vileplume"
+  },
+  {
+    "number": 46,
+    "name": "Paras"
+  },
+  {
+    "number": 47,
+    "name": "Parasect"
+  },
+  {
+    "number": 48,
+    "name": "Venonat"
+  },
+  {
+    "number": 49,
+    "name": "Venomoth"
+  },
+  {
+    "number": 50,
+    "name": "Diglett"
+  },
+  {
+    "number": 51,
+    "name": "Dugtrio"
+  },
+  {
+    "number": 52,
+    "name": "Meowth"
+  },
+  {
+    "number": 53,
+    "name": "Persian"
+  },
+  {
+    "number": 54,
+    "name": "Psyduck"
+  },
+  {
+    "number": 55,
+    "name": "Golduck"
+  },
+  {
+    "number": 56,
+    "name": "Mankey"
+  },
+  {
+    "number": 57,
+    "name": "Primeape"
+  },
+  {
+    "number": 58,
+    "name": "Growlithe"
+  },
+  {
+    "number": 59,
+    "name": "Arcanine"
+  },
+  {
+    "number": 60,
+    "name": "Poliwag"
+  },
+  {
+    "number": 61,
+    "name": "Poliwhirl"
+  },
+  {
+    "number": 62,
+    "name": "Poliwrath"
+  },
+  {
+    "number": 63,
+    "name": "Abra"
+  },
+  {
+    "number": 64,
+    "name": "Kadabra"
+  },
+  {
+    "number": 65,
+    "name": "Alakazam"
+  },
+  {
+    "number": 66,
+    "name": "Machop"
+  },
+  {
+    "number": 67,
+    "name": "Machoke"
+  },
+  {
+    "number": 68,
+    "name": "Machamp"
+  },
+  {
+    "number": 69,
+    "name": "Bellsprout"
+  },
+  {
+    "number": 70,
+    "name": "Weepinbell"
+  },
+  {
+    "number": 71,
+    "name": "Victreebel"
+  },
+  {
+    "number": 72,
+    "name": "Tentacool"
+  },
+  {
+    "number": 73,
+    "name": "Tentacruel"
+  },
+  {
+    "number": 74,
+    "name": "Geodude"
+  },
+  {
+    "number": 75,
+    "name": "Graveler"
+  },
+  {
+    "number": 76,
+    "name": "Golem"
+  },
+  {
+    "number": 77,
+    "name": "Ponyta"
+  },
+  {
+    "number": 78,
+    "name": "Rapidash"
+  },
+  {
+    "number": 79,
+    "name": "Slowpoke"
+  },
+  {
+    "number": 80,
+    "name": "Slowbro"
+  },
+  {
+    "number": 81,
+    "name": "Magnemite"
+  },
+  {
+    "number": 82,
+    "name": "Magneton"
+  },
+  {
+    "number": 83,
+    "name": "Farfetch'd"
+  },
+  {
+    "number": 84,
+    "name": "Doduo"
+  },
+  {
+    "number": 85,
+    "name": "Dodrio"
+  },
+  {
+    "number": 86,
+    "name": "Seel"
+  },
+  {
+    "number": 87,
+    "name": "Dewgong"
+  },
+  {
+    "number": 88,
+    "name": "Grimer"
+  },
+  {
+    "number": 89,
+    "name": "Muk"
+  },
+  {
+    "number": 90,
+    "name": "Shellder"
+  },
+  {
+    "number": 91,
+    "name": "Cloyster"
+  },
+  {
+    "number": 92,
+    "name": "Gastly"
+  },
+  {
+    "number": 93,
+    "name": "Haunter"
+  },
+  {
+    "number": 94,
+    "name": "Gengar"
+  },
+  {
+    "number": 95,
+    "name": "Onix"
+  },
+  {
+    "number": 96,
+    "name": "Drowzee"
+  },
+  {
+    "number": 97,
+    "name": "Hypno"
+  },
+  {
+    "number": 98,
+    "name": "Krabby"
+  },
+  {
+    "number": 99,
+    "name": "Kingler"
+  },
+  {
+    "number": 100,
+    "name": "Voltorb"
+  },
+  {
+    "number": 101,
+    "name": "Electrode"
+  },
+  {
+    "number": 102,
+    "name": "Exeggcute"
+  },
+  {
+    "number": 103,
+    "name": "Exeggutor"
+  },
+  {
+    "number": 104,
+    "name": "Cubone"
+  },
+  {
+    "number": 105,
+    "name": "Marowak"
+  },
+  {
+    "number": 106,
+    "name": "Hitmonlee"
+  },
+  {
+    "number": 107,
+    "name": "Hitmonchan"
+  },
+  {
+    "number": 108,
+    "name": "Lickitung"
+  },
+  {
+    "number": 109,
+    "name": "Koffing"
+  },
+  {
+    "number": 110,
+    "name": "Weezing"
+  },
+  {
+    "number": 111,
+    "name": "Rhyhorn"
+  },
+  {
+    "number": 112,
+    "name": "Rhydon"
+  },
+  {
+    "number": 113,
+    "name": "Chansey"
+  },
+  {
+    "number": 114,
+    "name": "Tangela"
+  },
+  {
+    "number": 115,
+    "name": "Kangaskhan"
+  },
+  {
+    "number": 116,
+    "name": "Horsea"
+  },
+  {
+    "number": 117,
+    "name": "Seadra"
+  },
+  {
+    "number": 118,
+    "name": "Goldeen"
+  },
+  {
+    "number": 119,
+    "name": "Seaking"
+  },
+  {
+    "number": 120,
+    "name": "Staryu"
+  },
+  {
+    "number": 121,
+    "name": "Starmie"
+  },
+  {
+    "number": 122,
+    "name": "Mr. Mime"
+  },
+  {
+    "number": 123,
+    "name": "Scyther"
+  },
+  {
+    "number": 124,
+    "name": "Jynx"
+  },
+  {
+    "number": 125,
+    "name": "Electabuzz"
+  },
+  {
+    "number": 126,
+    "name": "Magmar"
+  },
+  {
+    "number": 127,
+    "name": "Pinsir"
+  },
+  {
+    "number": 128,
+    "name": "Tauros"
+  },
+  {
+    "number": 129,
+    "name": "Magikarp"
+  },
+  {
+    "number": 130,
+    "name": "Gyarados"
+  },
+  {
+    "number": 131,
+    "name": "Lapras"
+  },
+  {
+    "number": 132,
+    "name": "Ditto"
+  },
+  {
+    "number": 133,
+    "name": "Eevee"
+  },
+  {
+    "number": 134,
+    "name": "Vaporeon"
+  },
+  {
+    "number": 135,
+    "name": "Jolteon"
+  },
+  {
+    "number": 136,
+    "name": "Flareon"
+  },
+  {
+    "number": 137,
+    "name": "Porygon"
+  },
+  {
+    "number": 138,
+    "name": "Omanyte"
+  },
+  {
+    "number": 139,
+    "name": "Omastar"
+  },
+  {
+    "number": 140,
+    "name": "Kabuto"
+  },
+  {
+    "number": 141,
+    "name": "Kabutops"
+  },
+  {
+    "number": 142,
+    "name": "Aerodactyl"
+  },
+  {
+    "number": 143,
+    "name": "Snorlax"
+  },
+  {
+    "number": 144,
+    "name": "Articuno"
+  },
+  {
+    "number": 145,
+    "name": "Zapdos"
+  },
+  {
+    "number": 146,
+    "name": "Moltres"
+  },
+  {
+    "number": 147,
+    "name": "Dratini"
+  },
+  {
+    "number": 148,
+    "name": "Dragonair"
+  },
+  {
+    "number": 149,
+    "name": "Dragonite"
+  },
+  {
+    "number": 150,
+    "name": "Mewtwo"
+  },
+  {
+    "number": 151,
+    "name": "Mew"
+  },
+  {
+    "number": 152,
+    "name": "Chikorita"
+  },
+  {
+    "number": 153,
+    "name": "Bayleef"
+  },
+  {
+    "number": 154,
+    "name": "Meganium"
+  },
+  {
+    "number": 155,
+    "name": "Cyndaquil"
+  },
+  {
+    "number": 156,
+    "name": "Quilava"
+  },
+  {
+    "number": 157,
+    "name": "Typhlosion"
+  },
+  {
+    "number": 158,
+    "name": "Totodile"
+  },
+  {
+    "number": 159,
+    "name": "Croconaw"
+  },
+  {
+    "number": 160,
+    "name": "Feraligatr"
+  },
+  {
+    "number": 161,
+    "name": "Sentret"
+  },
+  {
+    "number": 162,
+    "name": "Furret"
+  },
+  {
+    "number": 163,
+    "name": "Hoothoot"
+  },
+  {
+    "number": 164,
+    "name": "Noctowl"
+  },
+  {
+    "number": 165,
+    "name": "Ledyba"
+  },
+  {
+    "number": 166,
+    "name": "Ledian"
+  },
+  {
+    "number": 167,
+    "name": "Spinarak"
+  },
+  {
+    "number": 168,
+    "name": "Ariados"
+  },
+  {
+    "number": 169,
+    "name": "Crobat"
+  },
+  {
+    "number": 170,
+    "name": "Chinchou"
+  },
+  {
+    "number": 171,
+    "name": "Lanturn"
+  },
+  {
+    "number": 172,
+    "name": "Pichu"
+  },
+  {
+    "number": 173,
+    "name": "Cleffa"
+  },
+  {
+    "number": 174,
+    "name": "Igglybuff"
+  },
+  {
+    "number": 175,
+    "name": "Togepi"
+  },
+  {
+    "number": 176,
+    "name": "Togetic"
+  },
+  {
+    "number": 177,
+    "name": "Natu"
+  },
+  {
+    "number": 178,
+    "name": "Xatu"
+  },
+  {
+    "number": 179,
+    "name": "Mareep"
+  },
+  {
+    "number": 180,
+    "name": "Flaaffy"
+  },
+  {
+    "number": 181,
+    "name": "Ampharos"
+  },
+  {
+    "number": 182,
+    "name": "Bellossom"
+  },
+  {
+    "number": 183,
+    "name": "Marill"
+  },
+  {
+    "number": 184,
+    "name": "Azumarill"
+  },
+  {
+    "number": 185,
+    "name": "Sudowoodo"
+  },
+  {
+    "number": 186,
+    "name": "Politoed"
+  },
+  {
+    "number": 187,
+    "name": "Hoppip"
+  },
+  {
+    "number": 188,
+    "name": "Skiploom"
+  },
+  {
+    "number": 189,
+    "name": "Jumpluff"
+  },
+  {
+    "number": 190,
+    "name": "Aipom"
+  },
+  {
+    "number": 191,
+    "name": "Sunkern"
+  },
+  {
+    "number": 192,
+    "name": "Sunflora"
+  },
+  {
+    "number": 193,
+    "name": "Yanma"
+  },
+  {
+    "number": 194,
+    "name": "Wooper"
+  },
+  {
+    "number": 195,
+    "name": "Quagsire"
+  },
+  {
+    "number": 196,
+    "name": "Espeon"
+  },
+  {
+    "number": 197,
+    "name": "Umbreon"
+  },
+  {
+    "number": 198,
+    "name": "Murkrow"
+  },
+  {
+    "number": 199,
+    "name": "Slowking"
+  },
+  {
+    "number": 200,
+    "name": "Misdreavus"
+  },
+  {
+    "number": 201,
+    "name": "Unown"
+  },
+  {
+    "number": 202,
+    "name": "Wobbuffet"
+  },
+  {
+    "number": 203,
+    "name": "Girafarig"
+  },
+  {
+    "number": 204,
+    "name": "Pineco"
+  },
+  {
+    "number": 205,
+    "name": "Forretress"
+  },
+  {
+    "number": 206,
+    "name": "Dunsparce"
+  },
+  {
+    "number": 207,
+    "name": "Gligar"
+  },
+  {
+    "number": 208,
+    "name": "Steelix"
+  },
+  {
+    "number": 209,
+    "name": "Snubbull"
+  },
+  {
+    "number": 210,
+    "name": "Granbull"
+  },
+  {
+    "number": 211,
+    "name": "Qwilfish"
+  },
+  {
+    "number": 212,
+    "name": "Scizor"
+  },
+  {
+    "number": 213,
+    "name": "Shuckle"
+  },
+  {
+    "number": 214,
+    "name": "Heracross"
+  },
+  {
+    "number": 215,
+    "name": "Sneasel"
+  },
+  {
+    "number": 216,
+    "name": "Teddiursa"
+  },
+  {
+    "number": 217,
+    "name": "Ursaring"
+  },
+  {
+    "number": 218,
+    "name": "Slugma"
+  },
+  {
+    "number": 219,
+    "name": "Magcargo"
+  },
+  {
+    "number": 220,
+    "name": "Swinub"
+  },
+  {
+    "number": 221,
+    "name": "Piloswine"
+  },
+  {
+    "number": 222,
+    "name": "Corsola"
+  },
+  {
+    "number": 223,
+    "name": "Remoraid"
+  },
+  {
+    "number": 224,
+    "name": "Octillery"
+  },
+  {
+    "number": 225,
+    "name": "Delibird"
+  },
+  {
+    "number": 226,
+    "name": "Mantine"
+  },
+  {
+    "number": 227,
+    "name": "Skarmory"
+  },
+  {
+    "number": 228,
+    "name": "Houndour"
+  },
+  {
+    "number": 229,
+    "name": "Houndoom"
+  },
+  {
+    "number": 230,
+    "name": "Kingdra"
+  },
+  {
+    "number": 231,
+    "name": "Phanpy"
+  },
+  {
+    "number": 232,
+    "name": "Donphan"
+  },
+  {
+    "number": 233,
+    "name": "Porygon2"
+  },
+  {
+    "number": 234,
+    "name": "Stantler"
+  },
+  {
+    "number": 235,
+    "name": "Smeargle"
+  },
+  {
+    "number": 236,
+    "name": "Tyrogue"
+  },
+  {
+    "number": 237,
+    "name": "Hitmontop"
+  },
+  {
+    "number": 238,
+    "name": "Smoochum"
+  },
+  {
+    "number": 239,
+    "name": "Elekid"
+  },
+  {
+    "number": 240,
+    "name": "Magby"
+  },
+  {
+    "number": 241,
+    "name": "Miltank"
+  },
+  {
+    "number": 242,
+    "name": "Blissey"
+  },
+  {
+    "number": 243,
+    "name": "Raikou"
+  },
+  {
+    "number": 244,
+    "name": "Entei"
+  },
+  {
+    "number": 245,
+    "name": "Suicune"
+  },
+  {
+    "number": 246,
+    "name": "Larvitar"
+  },
+  {
+    "number": 247,
+    "name": "Pupitar"
+  },
+  {
+    "number": 248,
+    "name": "Tyranitar"
+  },
+  {
+    "number": 249,
+    "name": "Lugia"
+  },
+  {
+    "number": 250,
+    "name": "Ho-Oh"
+  },
+  {
+    "number": 251,
+    "name": "Celebi"
+  },
+  {
+    "number": 252,
+    "name": "Treecko"
+  },
+  {
+    "number": 253,
+    "name": "Grovyle"
+  },
+  {
+    "number": 254,
+    "name": "Sceptile"
+  },
+  {
+    "number": 255,
+    "name": "Torchic"
+  },
+  {
+    "number": 256,
+    "name": "Combusken"
+  },
+  {
+    "number": 257,
+    "name": "Blaziken"
+  },
+  {
+    "number": 258,
+    "name": "Mudkip"
+  },
+  {
+    "number": 259,
+    "name": "Marshtomp"
+  },
+  {
+    "number": 260,
+    "name": "Swampert"
+  },
+  {
+    "number": 261,
+    "name": "Poochyena"
+  },
+  {
+    "number": 262,
+    "name": "Mightyena"
+  },
+  {
+    "number": 263,
+    "name": "Zigzagoon"
+  },
+  {
+    "number": 264,
+    "name": "Linoone"
+  },
+  {
+    "number": 265,
+    "name": "Wurmple"
+  },
+  {
+    "number": 266,
+    "name": "Silcoon"
+  },
+  {
+    "number": 267,
+    "name": "Beautifly"
+  },
+  {
+    "number": 268,
+    "name": "Cascoon"
+  },
+  {
+    "number": 269,
+    "name": "Dustox"
+  },
+  {
+    "number": 270,
+    "name": "Lotad"
+  },
+  {
+    "number": 271,
+    "name": "Lombre"
+  },
+  {
+    "number": 272,
+    "name": "Ludicolo"
+  },
+  {
+    "number": 273,
+    "name": "Seedot"
+  },
+  {
+    "number": 274,
+    "name": "Nuzleaf"
+  },
+  {
+    "number": 275,
+    "name": "Shiftry"
+  },
+  {
+    "number": 276,
+    "name": "Taillow"
+  },
+  {
+    "number": 277,
+    "name": "Swellow"
+  },
+  {
+    "number": 278,
+    "name": "Wingull"
+  },
+  {
+    "number": 279,
+    "name": "Pelipper"
+  },
+  {
+    "number": 280,
+    "name": "Ralts"
+  },
+  {
+    "number": 281,
+    "name": "Kirlia"
+  },
+  {
+    "number": 282,
+    "name": "Gardevoir"
+  },
+  {
+    "number": 283,
+    "name": "Surskit"
+  },
+  {
+    "number": 284,
+    "name": "Masquerain"
+  },
+  {
+    "number": 285,
+    "name": "Shroomish"
+  },
+  {
+    "number": 286,
+    "name": "Breloom"
+  },
+  {
+    "number": 287,
+    "name": "Slakoth"
+  },
+  {
+    "number": 288,
+    "name": "Vigoroth"
+  },
+  {
+    "number": 289,
+    "name": "Slaking"
+  },
+  {
+    "number": 290,
+    "name": "Nincada"
+  },
+  {
+    "number": 291,
+    "name": "Ninjask"
+  },
+  {
+    "number": 292,
+    "name": "Shedinja"
+  },
+  {
+    "number": 293,
+    "name": "Whismur"
+  },
+  {
+    "number": 294,
+    "name": "Loudred"
+  },
+  {
+    "number": 295,
+    "name": "Exploud"
+  },
+  {
+    "number": 296,
+    "name": "Makuhita"
+  },
+  {
+    "number": 297,
+    "name": "Hariyama"
+  },
+  {
+    "number": 298,
+    "name": "Azurill"
+  },
+  {
+    "number": 299,
+    "name": "Nosepass"
+  },
+  {
+    "number": 300,
+    "name": "Skitty"
+  },
+  {
+    "number": 301,
+    "name": "Delcatty"
+  },
+  {
+    "number": 302,
+    "name": "Sableye"
+  },
+  {
+    "number": 303,
+    "name": "Mawile"
+  },
+  {
+    "number": 304,
+    "name": "Aron"
+  },
+  {
+    "number": 305,
+    "name": "Lairon"
+  },
+  {
+    "number": 306,
+    "name": "Aggron"
+  },
+  {
+    "number": 307,
+    "name": "Meditite"
+  },
+  {
+    "number": 308,
+    "name": "Medicham"
+  },
+  {
+    "number": 309,
+    "name": "Electrike"
+  },
+  {
+    "number": 310,
+    "name": "Manectric"
+  },
+  {
+    "number": 311,
+    "name": "Plusle"
+  },
+  {
+    "number": 312,
+    "name": "Minun"
+  },
+  {
+    "number": 313,
+    "name": "Volbeat"
+  },
+  {
+    "number": 314,
+    "name": "Illumise"
+  },
+  {
+    "number": 315,
+    "name": "Roselia"
+  },
+  {
+    "number": 316,
+    "name": "Gulpin"
+  },
+  {
+    "number": 317,
+    "name": "Swalot"
+  },
+  {
+    "number": 318,
+    "name": "Carvanha"
+  },
+  {
+    "number": 319,
+    "name": "Sharpedo"
+  },
+  {
+    "number": 320,
+    "name": "Wailmer"
+  },
+  {
+    "number": 321,
+    "name": "Wailord"
+  },
+  {
+    "number": 322,
+    "name": "Numel"
+  },
+  {
+    "number": 323,
+    "name": "Camerupt"
+  },
+  {
+    "number": 324,
+    "name": "Torkoal"
+  },
+  {
+    "number": 325,
+    "name": "Spoink"
+  },
+  {
+    "number": 326,
+    "name": "Grumpig"
+  },
+  {
+    "number": 327,
+    "name": "Spinda"
+  },
+  {
+    "number": 328,
+    "name": "Trapinch"
+  },
+  {
+    "number": 329,
+    "name": "Vibrava"
+  },
+  {
+    "number": 330,
+    "name": "Flygon"
+  },
+  {
+    "number": 331,
+    "name": "Cacnea"
+  },
+  {
+    "number": 332,
+    "name": "Cacturne"
+  },
+  {
+    "number": 333,
+    "name": "Swablu"
+  },
+  {
+    "number": 334,
+    "name": "Altaria"
+  },
+  {
+    "number": 335,
+    "name": "Zangoose"
+  },
+  {
+    "number": 336,
+    "name": "Seviper"
+  },
+  {
+    "number": 337,
+    "name": "Lunatone"
+  },
+  {
+    "number": 338,
+    "name": "Solrock"
+  },
+  {
+    "number": 339,
+    "name": "Barboach"
+  },
+  {
+    "number": 340,
+    "name": "Whiscash"
+  },
+  {
+    "number": 341,
+    "name": "Corphish"
+  },
+  {
+    "number": 342,
+    "name": "Crawdaunt"
+  },
+  {
+    "number": 343,
+    "name": "Baltoy"
+  },
+  {
+    "number": 344,
+    "name": "Claydol"
+  },
+  {
+    "number": 345,
+    "name": "Lileep"
+  },
+  {
+    "number": 346,
+    "name": "Cradily"
+  },
+  {
+    "number": 347,
+    "name": "Anorith"
+  },
+  {
+    "number": 348,
+    "name": "Armaldo"
+  },
+  {
+    "number": 349,
+    "name": "Feebas"
+  },
+  {
+    "number": 350,
+    "name": "Milotic"
+  },
+  {
+    "number": 351,
+    "name": "Castform"
+  },
+  {
+    "number": 352,
+    "name": "Kecleon"
+  },
+  {
+    "number": 353,
+    "name": "Shuppet"
+  },
+  {
+    "number": 354,
+    "name": "Banette"
+  },
+  {
+    "number": 355,
+    "name": "Duskull"
+  },
+  {
+    "number": 356,
+    "name": "Dusclops"
+  },
+  {
+    "number": 357,
+    "name": "Tropius"
+  },
+  {
+    "number": 358,
+    "name": "Chimecho"
+  },
+  {
+    "number": 359,
+    "name": "Absol"
+  },
+  {
+    "number": 360,
+    "name": "Wynaut"
+  },
+  {
+    "number": 361,
+    "name": "Snorunt"
+  },
+  {
+    "number": 362,
+    "name": "Glalie"
+  },
+  {
+    "number": 363,
+    "name": "Spheal"
+  },
+  {
+    "number": 364,
+    "name": "Sealeo"
+  },
+  {
+    "number": 365,
+    "name": "Walrein"
+  },
+  {
+    "number": 366,
+    "name": "Clamperl"
+  },
+  {
+    "number": 367,
+    "name": "Huntail"
+  },
+  {
+    "number": 368,
+    "name": "Gorebyss"
+  },
+  {
+    "number": 369,
+    "name": "Relicanth"
+  },
+  {
+    "number": 370,
+    "name": "Luvdisc"
+  },
+  {
+    "number": 371,
+    "name": "Bagon"
+  },
+  {
+    "number": 372,
+    "name": "Shelgon"
+  },
+  {
+    "number": 373,
+    "name": "Salamence"
+  },
+  {
+    "number": 374,
+    "name": "Beldum"
+  },
+  {
+    "number": 375,
+    "name": "Metang"
+  },
+  {
+    "number": 376,
+    "name": "Metagross"
+  },
+  {
+    "number": 377,
+    "name": "Regirock"
+  },
+  {
+    "number": 378,
+    "name": "Regice"
+  },
+  {
+    "number": 379,
+    "name": "Registeel"
+  },
+  {
+    "number": 380,
+    "name": "Latias"
+  },
+  {
+    "number": 381,
+    "name": "Latios"
+  },
+  {
+    "number": 382,
+    "name": "Kyogre"
+  },
+  {
+    "number": 383,
+    "name": "Groudon"
+  },
+  {
+    "number": 384,
+    "name": "Rayquaza"
+  },
+  {
+    "number": 385,
+    "name": "Jirachi"
+  },
+  {
+    "number": 386,
+    "name": "Deoxys"
+  },
+  {
+    "number": 387,
+    "name": "Turtwig"
+  },
+  {
+    "number": 388,
+    "name": "Grotle"
+  },
+  {
+    "number": 389,
+    "name": "Torterra"
+  },
+  {
+    "number": 390,
+    "name": "Chimchar"
+  },
+  {
+    "number": 391,
+    "name": "Monferno"
+  },
+  {
+    "number": 392,
+    "name": "Infernape"
+  },
+  {
+    "number": 393,
+    "name": "Piplup"
+  },
+  {
+    "number": 394,
+    "name": "Prinplup"
+  },
+  {
+    "number": 395,
+    "name": "Empoleon"
+  },
+  {
+    "number": 396,
+    "name": "Starly"
+  },
+  {
+    "number": 397,
+    "name": "Staravia"
+  },
+  {
+    "number": 398,
+    "name": "Staraptor"
+  },
+  {
+    "number": 399,
+    "name": "Bidoof"
+  },
+  {
+    "number": 400,
+    "name": "Bibarel"
+  },
+  {
+    "number": 401,
+    "name": "Kricketot"
+  },
+  {
+    "number": 402,
+    "name": "Kricketune"
+  },
+  {
+    "number": 403,
+    "name": "Shinx"
+  },
+  {
+    "number": 404,
+    "name": "Luxio"
+  },
+  {
+    "number": 405,
+    "name": "Luxray"
+  },
+  {
+    "number": 406,
+    "name": "Budew"
+  },
+  {
+    "number": 407,
+    "name": "Roserade"
+  },
+  {
+    "number": 408,
+    "name": "Cranidos"
+  },
+  {
+    "number": 409,
+    "name": "Rampardos"
+  },
+  {
+    "number": 410,
+    "name": "Shieldon"
+  },
+  {
+    "number": 411,
+    "name": "Bastiodon"
+  },
+  {
+    "number": 412,
+    "name": "Burmy"
+  },
+  {
+    "number": 413,
+    "name": "Wormadam"
+  },
+  {
+    "number": 414,
+    "name": "Mothim"
+  },
+  {
+    "number": 415,
+    "name": "Combee"
+  },
+  {
+    "number": 416,
+    "name": "Vespiquen"
+  },
+  {
+    "number": 417,
+    "name": "Pachirisu"
+  },
+  {
+    "number": 418,
+    "name": "Buizel"
+  },
+  {
+    "number": 419,
+    "name": "Floatzel"
+  },
+  {
+    "number": 420,
+    "name": "Cherubi"
+  },
+  {
+    "number": 421,
+    "name": "Cherrim"
+  },
+  {
+    "number": 422,
+    "name": "Shellos"
+  },
+  {
+    "number": 423,
+    "name": "Gastrodon"
+  },
+  {
+    "number": 424,
+    "name": "Ambipom"
+  },
+  {
+    "number": 425,
+    "name": "Drifloon"
+  },
+  {
+    "number": 426,
+    "name": "Drifblim"
+  },
+  {
+    "number": 427,
+    "name": "Buneary"
+  },
+  {
+    "number": 428,
+    "name": "Lopunny"
+  },
+  {
+    "number": 429,
+    "name": "Mismagius"
+  },
+  {
+    "number": 430,
+    "name": "Honchkrow"
+  },
+  {
+    "number": 431,
+    "name": "Glameow"
+  },
+  {
+    "number": 432,
+    "name": "Purugly"
+  },
+  {
+    "number": 433,
+    "name": "Chingling"
+  },
+  {
+    "number": 434,
+    "name": "Stunky"
+  },
+  {
+    "number": 435,
+    "name": "Skuntank"
+  },
+  {
+    "number": 436,
+    "name": "Bronzor"
+  },
+  {
+    "number": 437,
+    "name": "Bronzong"
+  },
+  {
+    "number": 438,
+    "name": "Bonsly"
+  },
+  {
+    "number": 439,
+    "name": "Mime Jr."
+  },
+  {
+    "number": 440,
+    "name": "Happiny"
+  },
+  {
+    "number": 441,
+    "name": "Chatot"
+  },
+  {
+    "number": 442,
+    "name": "Spiritomb"
+  },
+  {
+    "number": 443,
+    "name": "Gible"
+  },
+  {
+    "number": 444,
+    "name": "Gabite"
+  },
+  {
+    "number": 445,
+    "name": "Garchomp"
+  },
+  {
+    "number": 446,
+    "name": "Munchlax"
+  },
+  {
+    "number": 447,
+    "name": "Riolu"
+  },
+  {
+    "number": 448,
+    "name": "Lucario"
+  },
+  {
+    "number": 449,
+    "name": "Hippopotas"
+  },
+  {
+    "number": 450,
+    "name": "Hippowdon"
+  },
+  {
+    "number": 451,
+    "name": "Skorupi"
+  },
+  {
+    "number": 452,
+    "name": "Drapion"
+  },
+  {
+    "number": 453,
+    "name": "Croagunk"
+  },
+  {
+    "number": 454,
+    "name": "Toxicroak"
+  },
+  {
+    "number": 455,
+    "name": "Carnivine"
+  },
+  {
+    "number": 456,
+    "name": "Finneon"
+  },
+  {
+    "number": 457,
+    "name": "Lumineon"
+  },
+  {
+    "number": 458,
+    "name": "Mantyke"
+  },
+  {
+    "number": 459,
+    "name": "Snover"
+  },
+  {
+    "number": 460,
+    "name": "Abomasnow"
+  },
+  {
+    "number": 461,
+    "name": "Weavile"
+  },
+  {
+    "number": 462,
+    "name": "Magnezone"
+  },
+  {
+    "number": 463,
+    "name": "Lickilicky"
+  },
+  {
+    "number": 464,
+    "name": "Rhyperior"
+  },
+  {
+    "number": 465,
+    "name": "Tangrowth"
+  },
+  {
+    "number": 466,
+    "name": "Electivire"
+  },
+  {
+    "number": 467,
+    "name": "Magmortar"
+  },
+  {
+    "number": 468,
+    "name": "Togekiss"
+  },
+  {
+    "number": 469,
+    "name": "Yanmega"
+  },
+  {
+    "number": 470,
+    "name": "Leafeon"
+  },
+  {
+    "number": 471,
+    "name": "Glaceon"
+  },
+  {
+    "number": 472,
+    "name": "Gliscor"
+  },
+  {
+    "number": 473,
+    "name": "Mamoswine"
+  },
+  {
+    "number": 474,
+    "name": "Porygon-Z"
+  },
+  {
+    "number": 475,
+    "name": "Gallade"
+  },
+  {
+    "number": 476,
+    "name": "Probopass"
+  },
+  {
+    "number": 477,
+    "name": "Dusknoir"
+  },
+  {
+    "number": 478,
+    "name": "Froslass"
+  },
+  {
+    "number": 479,
+    "name": "Rotom"
+  },
+  {
+    "number": 480,
+    "name": "Uxie"
+  },
+  {
+    "number": 481,
+    "name": "Mesprit"
+  },
+  {
+    "number": 482,
+    "name": "Azelf"
+  },
+  {
+    "number": 483,
+    "name": "Dialga"
+  },
+  {
+    "number": 484,
+    "name": "Palkia"
+  },
+  {
+    "number": 485,
+    "name": "Heatran"
+  },
+  {
+    "number": 486,
+    "name": "Regigigas"
+  },
+  {
+    "number": 487,
+    "name": "Giratina"
+  },
+  {
+    "number": 488,
+    "name": "Cresselia"
+  },
+  {
+    "number": 489,
+    "name": "Phione"
+  },
+  {
+    "number": 490,
+    "name": "Manaphy"
+  },
+  {
+    "number": 491,
+    "name": "Darkrai"
+  },
+  {
+    "number": 492,
+    "name": "Shaymin"
+  },
+  {
+    "number": 493,
+    "name": "Arceus"
+  },
+  {
+    "number": 494,
+    "name": "Victini"
+  },
+  {
+    "number": 495,
+    "name": "Snivy"
+  },
+  {
+    "number": 496,
+    "name": "Servine"
+  },
+  {
+    "number": 497,
+    "name": "Serperior"
+  },
+  {
+    "number": 498,
+    "name": "Tepig"
+  },
+  {
+    "number": 499,
+    "name": "Pignite"
+  },
+  {
+    "number": 500,
+    "name": "Emboar"
+  },
+  {
+    "number": 501,
+    "name": "Oshawott"
+  },
+  {
+    "number": 502,
+    "name": "Dewott"
+  },
+  {
+    "number": 503,
+    "name": "Samurott"
+  },
+  {
+    "number": 504,
+    "name": "Patrat"
+  },
+  {
+    "number": 505,
+    "name": "Watchog"
+  },
+  {
+    "number": 506,
+    "name": "Lillipup"
+  },
+  {
+    "number": 507,
+    "name": "Herdier"
+  },
+  {
+    "number": 508,
+    "name": "Stoutland"
+  },
+  {
+    "number": 509,
+    "name": "Purrloin"
+  },
+  {
+    "number": 510,
+    "name": "Liepard"
+  },
+  {
+    "number": 511,
+    "name": "Pansage"
+  },
+  {
+    "number": 512,
+    "name": "Simisage"
+  },
+  {
+    "number": 513,
+    "name": "Pansear"
+  },
+  {
+    "number": 514,
+    "name": "Simisear"
+  },
+  {
+    "number": 515,
+    "name": "Panpour"
+  },
+  {
+    "number": 516,
+    "name": "Simipour"
+  },
+  {
+    "number": 517,
+    "name": "Munna"
+  },
+  {
+    "number": 518,
+    "name": "Musharna"
+  },
+  {
+    "number": 519,
+    "name": "Pidove"
+  },
+  {
+    "number": 520,
+    "name": "Tranquill"
+  },
+  {
+    "number": 521,
+    "name": "Unfezant"
+  },
+  {
+    "number": 522,
+    "name": "Blitzle"
+  },
+  {
+    "number": 523,
+    "name": "Zebstrika"
+  },
+  {
+    "number": 524,
+    "name": "Roggenrola"
+  },
+  {
+    "number": 525,
+    "name": "Boldore"
+  },
+  {
+    "number": 526,
+    "name": "Gigalith"
+  },
+  {
+    "number": 527,
+    "name": "Woobat"
+  },
+  {
+    "number": 528,
+    "name": "Swoobat"
+  },
+  {
+    "number": 529,
+    "name": "Drilbur"
+  },
+  {
+    "number": 530,
+    "name": "Excadrill"
+  },
+  {
+    "number": 531,
+    "name": "Audino"
+  },
+  {
+    "number": 532,
+    "name": "Timburr"
+  },
+  {
+    "number": 533,
+    "name": "Gurdurr"
+  },
+  {
+    "number": 534,
+    "name": "Conkeldurr"
+  },
+  {
+    "number": 535,
+    "name": "Tympole"
+  },
+  {
+    "number": 536,
+    "name": "Palpitoad"
+  },
+  {
+    "number": 537,
+    "name": "Seismitoad"
+  },
+  {
+    "number": 538,
+    "name": "Throh"
+  },
+  {
+    "number": 539,
+    "name": "Sawk"
+  },
+  {
+    "number": 540,
+    "name": "Sewaddle"
+  },
+  {
+    "number": 541,
+    "name": "Swadloon"
+  },
+  {
+    "number": 542,
+    "name": "Leavanny"
+  },
+  {
+    "number": 543,
+    "name": "Venipede"
+  },
+  {
+    "number": 544,
+    "name": "Whirlipede"
+  },
+  {
+    "number": 545,
+    "name": "Scolipede"
+  },
+  {
+    "number": 546,
+    "name": "Cottonee"
+  },
+  {
+    "number": 547,
+    "name": "Whimsicott"
+  },
+  {
+    "number": 548,
+    "name": "Petilil"
+  },
+  {
+    "number": 549,
+    "name": "Lilligant"
+  },
+  {
+    "number": 550,
+    "name": "Basculin"
+  },
+  {
+    "number": 551,
+    "name": "Sandile"
+  },
+  {
+    "number": 552,
+    "name": "Krokorok"
+  },
+  {
+    "number": 553,
+    "name": "Krookodile"
+  },
+  {
+    "number": 554,
+    "name": "Darumaka"
+  },
+  {
+    "number": 555,
+    "name": "Darmanitan"
+  },
+  {
+    "number": 556,
+    "name": "Maractus"
+  },
+  {
+    "number": 557,
+    "name": "Dwebble"
+  },
+  {
+    "number": 558,
+    "name": "Crustle"
+  },
+  {
+    "number": 559,
+    "name": "Scraggy"
+  },
+  {
+    "number": 560,
+    "name": "Scrafty"
+  },
+  {
+    "number": 561,
+    "name": "Sigilyph"
+  },
+  {
+    "number": 562,
+    "name": "Yamask"
+  },
+  {
+    "number": 563,
+    "name": "Cofagrigus"
+  },
+  {
+    "number": 564,
+    "name": "Tirtouga"
+  },
+  {
+    "number": 565,
+    "name": "Carracosta"
+  },
+  {
+    "number": 566,
+    "name": "Archen"
+  },
+  {
+    "number": 567,
+    "name": "Archeops"
+  },
+  {
+    "number": 568,
+    "name": "Trubbish"
+  },
+  {
+    "number": 569,
+    "name": "Garbodor"
+  },
+  {
+    "number": 570,
+    "name": "Zorua"
+  },
+  {
+    "number": 571,
+    "name": "Zoroark"
+  },
+  {
+    "number": 572,
+    "name": "Minccino"
+  },
+  {
+    "number": 573,
+    "name": "Cinccino"
+  },
+  {
+    "number": 574,
+    "name": "Gothita"
+  },
+  {
+    "number": 575,
+    "name": "Gothorita"
+  },
+  {
+    "number": 576,
+    "name": "Gothitelle"
+  },
+  {
+    "number": 577,
+    "name": "Solosis"
+  },
+  {
+    "number": 578,
+    "name": "Duosion"
+  },
+  {
+    "number": 579,
+    "name": "Reuniclus"
+  },
+  {
+    "number": 580,
+    "name": "Ducklett"
+  },
+  {
+    "number": 581,
+    "name": "Swanna"
+  },
+  {
+    "number": 582,
+    "name": "Vanillite"
+  },
+  {
+    "number": 583,
+    "name": "Vanillish"
+  },
+  {
+    "number": 584,
+    "name": "Vanilluxe"
+  },
+  {
+    "number": 585,
+    "name": "Deerling"
+  },
+  {
+    "number": 586,
+    "name": "Sawsbuck"
+  },
+  {
+    "number": 587,
+    "name": "Emolga"
+  },
+  {
+    "number": 588,
+    "name": "Karrablast"
+  },
+  {
+    "number": 589,
+    "name": "Escavalier"
+  },
+  {
+    "number": 590,
+    "name": "Foongus"
+  },
+  {
+    "number": 591,
+    "name": "Amoonguss"
+  },
+  {
+    "number": 592,
+    "name": "Frillish"
+  },
+  {
+    "number": 593,
+    "name": "Jellicent"
+  },
+  {
+    "number": 594,
+    "name": "Alomomola"
+  },
+  {
+    "number": 595,
+    "name": "Joltik"
+  },
+  {
+    "number": 596,
+    "name": "Galvantula"
+  },
+  {
+    "number": 597,
+    "name": "Ferroseed"
+  },
+  {
+    "number": 598,
+    "name": "Ferrothorn"
+  },
+  {
+    "number": 599,
+    "name": "Klink"
+  },
+  {
+    "number": 600,
+    "name": "Klang"
+  },
+  {
+    "number": 601,
+    "name": "Klinklang"
+  },
+  {
+    "number": 602,
+    "name": "Tynamo"
+  },
+  {
+    "number": 603,
+    "name": "Eelektrik"
+  },
+  {
+    "number": 604,
+    "name": "Eelektross"
+  },
+  {
+    "number": 605,
+    "name": "Elgyem"
+  },
+  {
+    "number": 606,
+    "name": "Beheeyem"
+  },
+  {
+    "number": 607,
+    "name": "Litwick"
+  },
+  {
+    "number": 608,
+    "name": "Lampent"
+  },
+  {
+    "number": 609,
+    "name": "Chandelure"
+  },
+  {
+    "number": 610,
+    "name": "Axew"
+  },
+  {
+    "number": 611,
+    "name": "Fraxure"
+  },
+  {
+    "number": 612,
+    "name": "Haxorus"
+  },
+  {
+    "number": 613,
+    "name": "Cubchoo"
+  },
+  {
+    "number": 614,
+    "name": "Beartic"
+  },
+  {
+    "number": 615,
+    "name": "Cryogonal"
+  },
+  {
+    "number": 616,
+    "name": "Shelmet"
+  },
+  {
+    "number": 617,
+    "name": "Accelgor"
+  },
+  {
+    "number": 618,
+    "name": "Stunfisk"
+  },
+  {
+    "number": 619,
+    "name": "Mienfoo"
+  },
+  {
+    "number": 620,
+    "name": "Mienshao"
+  },
+  {
+    "number": 621,
+    "name": "Druddigon"
+  },
+  {
+    "number": 622,
+    "name": "Golett"
+  },
+  {
+    "number": 623,
+    "name": "Golurk"
+  },
+  {
+    "number": 624,
+    "name": "Pawniard"
+  },
+  {
+    "number": 625,
+    "name": "Bisharp"
+  },
+  {
+    "number": 626,
+    "name": "Bouffalant"
+  },
+  {
+    "number": 627,
+    "name": "Rufflet"
+  },
+  {
+    "number": 628,
+    "name": "Braviary"
+  },
+  {
+    "number": 629,
+    "name": "Vullaby"
+  },
+  {
+    "number": 630,
+    "name": "Mandibuzz"
+  },
+  {
+    "number": 631,
+    "name": "Heatmor"
+  },
+  {
+    "number": 632,
+    "name": "Durant"
+  },
+  {
+    "number": 633,
+    "name": "Deino"
+  },
+  {
+    "number": 634,
+    "name": "Zweilous"
+  },
+  {
+    "number": 635,
+    "name": "Hydreigon"
+  },
+  {
+    "number": 636,
+    "name": "Larvesta"
+  },
+  {
+    "number": 637,
+    "name": "Volcarona"
+  },
+  {
+    "number": 638,
+    "name": "Cobalion"
+  },
+  {
+    "number": 639,
+    "name": "Terrakion"
+  },
+  {
+    "number": 640,
+    "name": "Virizion"
+  },
+  {
+    "number": 641,
+    "name": "Tornadus"
+  },
+  {
+    "number": 642,
+    "name": "Thundurus"
+  },
+  {
+    "number": 643,
+    "name": "Reshiram"
+  },
+  {
+    "number": 644,
+    "name": "Zekrom"
+  },
+  {
+    "number": 645,
+    "name": "Landorus"
+  },
+  {
+    "number": 646,
+    "name": "Kyurem"
+  },
+  {
+    "number": 647,
+    "name": "Keldeo"
+  },
+  {
+    "number": 648,
+    "name": "Meloetta"
+  },
+  {
+    "number": 649,
+    "name": "Genesect"
+  },
+  {
+    "number": 650,
+    "name": "Chespin"
+  },
+  {
+    "number": 651,
+    "name": "Quilladin"
+  },
+  {
+    "number": 652,
+    "name": "Chesnaught"
+  },
+  {
+    "number": 653,
+    "name": "Fennekin"
+  },
+  {
+    "number": 654,
+    "name": "Braixen"
+  },
+  {
+    "number": 655,
+    "name": "Delphox"
+  },
+  {
+    "number": 656,
+    "name": "Froakie"
+  },
+  {
+    "number": 657,
+    "name": "Frogadier"
+  },
+  {
+    "number": 658,
+    "name": "Greninja"
+  },
+  {
+    "number": 659,
+    "name": "Bunnelby"
+  },
+  {
+    "number": 660,
+    "name": "Diggersby"
+  },
+  {
+    "number": 661,
+    "name": "Fletchling"
+  },
+  {
+    "number": 662,
+    "name": "Fletchinder"
+  },
+  {
+    "number": 663,
+    "name": "Talonflame"
+  },
+  {
+    "number": 664,
+    "name": "Scatterbug"
+  },
+  {
+    "number": 665,
+    "name": "Spewpa"
+  },
+  {
+    "number": 666,
+    "name": "Vivillon"
+  },
+  {
+    "number": 667,
+    "name": "Litleo"
+  },
+  {
+    "number": 668,
+    "name": "Pyroar"
+  },
+  {
+    "number": 669,
+    "name": "Flabébé"
+  },
+  {
+    "number": 670,
+    "name": "Floette"
+  },
+  {
+    "number": 671,
+    "name": "Florges"
+  },
+  {
+    "number": 672,
+    "name": "Skiddo"
+  },
+  {
+    "number": 673,
+    "name": "Gogoat"
+  },
+  {
+    "number": 674,
+    "name": "Pancham"
+  },
+  {
+    "number": 675,
+    "name": "Pangoro"
+  },
+  {
+    "number": 676,
+    "name": "Furfrou"
+  },
+  {
+    "number": 677,
+    "name": "Espurr"
+  },
+  {
+    "number": 678,
+    "name": "Meowstic"
+  },
+  {
+    "number": 679,
+    "name": "Honedge"
+  },
+  {
+    "number": 680,
+    "name": "Doublade"
+  },
+  {
+    "number": 681,
+    "name": "Aegislash"
+  },
+  {
+    "number": 682,
+    "name": "Spritzee"
+  },
+  {
+    "number": 683,
+    "name": "Aromatisse"
+  },
+  {
+    "number": 684,
+    "name": "Swirlix"
+  },
+  {
+    "number": 685,
+    "name": "Slurpuff"
+  },
+  {
+    "number": 686,
+    "name": "Inkay"
+  },
+  {
+    "number": 687,
+    "name": "Malamar"
+  },
+  {
+    "number": 688,
+    "name": "Binacle"
+  },
+  {
+    "number": 689,
+    "name": "Barbaracle"
+  },
+  {
+    "number": 690,
+    "name": "Skrelp"
+  },
+  {
+    "number": 691,
+    "name": "Dragalge"
+  },
+  {
+    "number": 692,
+    "name": "Clauncher"
+  },
+  {
+    "number": 693,
+    "name": "Clawitzer"
+  },
+  {
+    "number": 694,
+    "name": "Helioptile"
+  },
+  {
+    "number": 695,
+    "name": "Heliolisk"
+  },
+  {
+    "number": 696,
+    "name": "Tyrunt"
+  },
+  {
+    "number": 697,
+    "name": "Tyrantrum"
+  },
+  {
+    "number": 698,
+    "name": "Amaura"
+  },
+  {
+    "number": 699,
+    "name": "Aurorus"
+  },
+  {
+    "number": 700,
+    "name": "Sylveon"
+  },
+  {
+    "number": 701,
+    "name": "Hawlucha"
+  },
+  {
+    "number": 702,
+    "name": "Dedenne"
+  },
+  {
+    "number": 703,
+    "name": "Carbink"
+  },
+  {
+    "number": 704,
+    "name": "Goomy"
+  },
+  {
+    "number": 705,
+    "name": "Sliggoo"
+  },
+  {
+    "number": 706,
+    "name": "Goodra"
+  },
+  {
+    "number": 707,
+    "name": "Klefki"
+  },
+  {
+    "number": 708,
+    "name": "Phantump"
+  },
+  {
+    "number": 709,
+    "name": "Trevenant"
+  },
+  {
+    "number": 710,
+    "name": "Pumpkaboo"
+  },
+  {
+    "number": 711,
+    "name": "Gourgeist"
+  },
+  {
+    "number": 712,
+    "name": "Bergmite"
+  },
+  {
+    "number": 713,
+    "name": "Avalugg"
+  },
+  {
+    "number": 714,
+    "name": "Noibat"
+  },
+  {
+    "number": 715,
+    "name": "Noivern"
+  },
+  {
+    "number": 716,
+    "name": "Xerneas"
+  },
+  {
+    "number": 717,
+    "name": "Yveltal"
+  },
+  {
+    "number": 718,
+    "name": "Zygarde"
+  },
+  {
+    "number": 719,
+    "name": "Diancie"
+  },
+  {
+    "number": 720,
+    "name": "Hoopa"
+  },
+  {
+    "number": 721,
+    "name": "Volcanion"
+  },
+  {
+    "number": 722,
+    "name": "Rowlet"
+  },
+  {
+    "number": 723,
+    "name": "Dartrix"
+  },
+  {
+    "number": 724,
+    "name": "Decidueye"
+  },
+  {
+    "number": 725,
+    "name": "Litten"
+  },
+  {
+    "number": 726,
+    "name": "Torracat"
+  },
+  {
+    "number": 727,
+    "name": "Incineroar"
+  },
+  {
+    "number": 728,
+    "name": "Popplio"
+  },
+  {
+    "number": 729,
+    "name": "Brionne"
+  },
+  {
+    "number": 730,
+    "name": "Primarina"
+  },
+  {
+    "number": 731,
+    "name": "Pikipek"
+  },
+  {
+    "number": 732,
+    "name": "Trumbeak"
+  },
+  {
+    "number": 733,
+    "name": "Toucannon"
+  },
+  {
+    "number": 734,
+    "name": "Yungoos"
+  },
+  {
+    "number": 735,
+    "name": "Gumshoos"
+  },
+  {
+    "number": 736,
+    "name": "Grubbin"
+  },
+  {
+    "number": 737,
+    "name": "Charjabug"
+  },
+  {
+    "number": 738,
+    "name": "Vikavolt"
+  },
+  {
+    "number": 739,
+    "name": "Crabrawler"
+  },
+  {
+    "number": 740,
+    "name": "Crabominable"
+  },
+  {
+    "number": 741,
+    "name": "Oricorio"
+  },
+  {
+    "number": 742,
+    "name": "Cutiefly"
+  },
+  {
+    "number": 743,
+    "name": "Ribombee"
+  },
+  {
+    "number": 744,
+    "name": "Rockruff"
+  },
+  {
+    "number": 745,
+    "name": "Lycanroc"
+  },
+  {
+    "number": 746,
+    "name": "Wishiwashi"
+  },
+  {
+    "number": 747,
+    "name": "Mareanie"
+  },
+  {
+    "number": 748,
+    "name": "Toxapex"
+  },
+  {
+    "number": 749,
+    "name": "Mudbray"
+  },
+  {
+    "number": 750,
+    "name": "Mudsdale"
+  },
+  {
+    "number": 751,
+    "name": "Dewpider"
+  },
+  {
+    "number": 752,
+    "name": "Araquanid"
+  },
+  {
+    "number": 753,
+    "name": "Fomantis"
+  },
+  {
+    "number": 754,
+    "name": "Lurantis"
+  },
+  {
+    "number": 755,
+    "name": "Morelull"
+  },
+  {
+    "number": 756,
+    "name": "Shiinotic"
+  },
+  {
+    "number": 757,
+    "name": "Salandit"
+  },
+  {
+    "number": 758,
+    "name": "Salazzle"
+  },
+  {
+    "number": 759,
+    "name": "Stufful"
+  },
+  {
+    "number": 760,
+    "name": "Bewear"
+  },
+  {
+    "number": 761,
+    "name": "Bounsweet"
+  },
+  {
+    "number": 762,
+    "name": "Steenee"
+  },
+  {
+    "number": 763,
+    "name": "Tsareena"
+  },
+  {
+    "number": 764,
+    "name": "Comfey"
+  },
+  {
+    "number": 765,
+    "name": "Oranguru"
+  },
+  {
+    "number": 766,
+    "name": "Passimian"
+  },
+  {
+    "number": 767,
+    "name": "Wimpod"
+  },
+  {
+    "number": 768,
+    "name": "Golisopod"
+  },
+  {
+    "number": 769,
+    "name": "Sandygast"
+  },
+  {
+    "number": 770,
+    "name": "Palossand"
+  },
+  {
+    "number": 771,
+    "name": "Pyukumuku"
+  },
+  {
+    "number": 772,
+    "name": "Type: Null"
+  },
+  {
+    "number": 773,
+    "name": "Silvally"
+  },
+  {
+    "number": 774,
+    "name": "Minior"
+  },
+  {
+    "number": 775,
+    "name": "Komala"
+  },
+  {
+    "number": 776,
+    "name": "Turtonator"
+  },
+  {
+    "number": 777,
+    "name": "Togedemaru"
+  },
+  {
+    "number": 778,
+    "name": "Mimikyu"
+  },
+  {
+    "number": 779,
+    "name": "Bruxish"
+  },
+  {
+    "number": 780,
+    "name": "Drampa"
+  },
+  {
+    "number": 781,
+    "name": "Dhelmise"
+  },
+  {
+    "number": 782,
+    "name": "Jangmo-o"
+  },
+  {
+    "number": 783,
+    "name": "Hakamo-o"
+  },
+  {
+    "number": 784,
+    "name": "Kommo-o"
+  },
+  {
+    "number": 785,
+    "name": "Tapu Koko"
+  },
+  {
+    "number": 786,
+    "name": "Tapu Lele"
+  },
+  {
+    "number": 787,
+    "name": "Tapu Bulu"
+  },
+  {
+    "number": 788,
+    "name": "Tapu Fini"
+  },
+  {
+    "number": 789,
+    "name": "Cosmog"
+  },
+  {
+    "number": 790,
+    "name": "Cosmoem"
+  },
+  {
+    "number": 791,
+    "name": "Solgaleo"
+  },
+  {
+    "number": 792,
+    "name": "Lunala"
+  },
+  {
+    "number": 793,
+    "name": "Nihilego"
+  },
+  {
+    "number": 794,
+    "name": "Buzzwole"
+  },
+  {
+    "number": 795,
+    "name": "Pheromosa"
+  },
+  {
+    "number": 796,
+    "name": "Xurkitree"
+  },
+  {
+    "number": 797,
+    "name": "Celesteela"
+  },
+  {
+    "number": 798,
+    "name": "Kartana"
+  },
+  {
+    "number": 799,
+    "name": "Guzzlord"
+  },
+  {
+    "number": 800,
+    "name": "Necrozma"
+  },
+  {
+    "number": 801,
+    "name": "Magearna"
+  },
+  {
+    "number": 802,
+    "name": "Marshadow"
+  },
+  {
+    "number": 803,
+    "name": "Poipole"
+  },
+  {
+    "number": 804,
+    "name": "Naganadel"
+  },
+  {
+    "number": 805,
+    "name": "Stakataka"
+  },
+  {
+    "number": 806,
+    "name": "Blacephalon"
+  },
+  {
+    "number": 807,
+    "name": "Zeraora"
+  },
+  {
+    "number": 808,
+    "name": "Meltan"
+  },
+  {
+    "number": 809,
+    "name": "Melmetal"
+  },
+  {
+    "number": 810,
+    "name": "Grookey"
+  },
+  {
+    "number": 811,
+    "name": "Thwackey"
+  },
+  {
+    "number": 812,
+    "name": "Rillaboom"
+  },
+  {
+    "number": 813,
+    "name": "Scorbunny"
+  },
+  {
+    "number": 814,
+    "name": "Raboot"
+  },
+  {
+    "number": 815,
+    "name": "Cinderace"
+  },
+  {
+    "number": 816,
+    "name": "Sobble"
+  },
+  {
+    "number": 817,
+    "name": "Drizzile"
+  },
+  {
+    "number": 818,
+    "name": "Inteleon"
+  },
+  {
+    "number": 819,
+    "name": "Skwovet"
+  },
+  {
+    "number": 820,
+    "name": "Greedent"
+  },
+  {
+    "number": 821,
+    "name": "Rookidee"
+  },
+  {
+    "number": 822,
+    "name": "Corvisquire"
+  },
+  {
+    "number": 823,
+    "name": "Corviknight"
+  },
+  {
+    "number": 824,
+    "name": "Blipbug"
+  },
+  {
+    "number": 825,
+    "name": "Dottler"
+  },
+  {
+    "number": 826,
+    "name": "Orbeetle"
+  },
+  {
+    "number": 827,
+    "name": "Nickit"
+  },
+  {
+    "number": 828,
+    "name": "Thievul"
+  },
+  {
+    "number": 829,
+    "name": "Gossifleur"
+  },
+  {
+    "number": 830,
+    "name": "Eldegoss"
+  },
+  {
+    "number": 831,
+    "name": "Wooloo"
+  },
+  {
+    "number": 832,
+    "name": "Dubwool"
+  },
+  {
+    "number": 833,
+    "name": "Chewtle"
+  },
+  {
+    "number": 834,
+    "name": "Drednaw"
+  },
+  {
+    "number": 835,
+    "name": "Yamper"
+  },
+  {
+    "number": 836,
+    "name": "Boltund"
+  },
+  {
+    "number": 837,
+    "name": "Rolycoly"
+  },
+  {
+    "number": 838,
+    "name": "Carkol"
+  },
+  {
+    "number": 839,
+    "name": "Coalossal"
+  },
+  {
+    "number": 840,
+    "name": "Applin"
+  },
+  {
+    "number": 841,
+    "name": "Flapple"
+  },
+  {
+    "number": 842,
+    "name": "Appletun"
+  },
+  {
+    "number": 843,
+    "name": "Silicobra"
+  },
+  {
+    "number": 844,
+    "name": "Sandaconda"
+  },
+  {
+    "number": 845,
+    "name": "Cramorant"
+  },
+  {
+    "number": 846,
+    "name": "Arrokuda"
+  },
+  {
+    "number": 847,
+    "name": "Barraskewda"
+  },
+  {
+    "number": 848,
+    "name": "Toxel"
+  },
+  {
+    "number": 849,
+    "name": "Toxtricity"
+  },
+  {
+    "number": 850,
+    "name": "Sizzlipede"
+  },
+  {
+    "number": 851,
+    "name": "Centiskorch"
+  },
+  {
+    "number": 852,
+    "name": "Clobbopus"
+  },
+  {
+    "number": 853,
+    "name": "Grapploct"
+  },
+  {
+    "number": 854,
+    "name": "Sinistea"
+  },
+  {
+    "number": 855,
+    "name": "Polteageist"
+  },
+  {
+    "number": 856,
+    "name": "Hatenna"
+  },
+  {
+    "number": 857,
+    "name": "Hattrem"
+  },
+  {
+    "number": 858,
+    "name": "Hatterene"
+  },
+  {
+    "number": 859,
+    "name": "Impidimp"
+  },
+  {
+    "number": 860,
+    "name": "Morgrem"
+  },
+  {
+    "number": 861,
+    "name": "Grimmsnarl"
+  },
+  {
+    "number": 862,
+    "name": "Obstagoon"
+  },
+  {
+    "number": 863,
+    "name": "Perrserker"
+  },
+  {
+    "number": 864,
+    "name": "Cursola"
+  },
+  {
+    "number": 865,
+    "name": "Sirfetch'd"
+  },
+  {
+    "number": 866,
+    "name": "Mr. Rime"
+  },
+  {
+    "number": 867,
+    "name": "Runerigus"
+  },
+  {
+    "number": 868,
+    "name": "Milcery"
+  },
+  {
+    "number": 869,
+    "name": "Alcremie"
+  },
+  {
+    "number": 870,
+    "name": "Falinks"
+  },
+  {
+    "number": 871,
+    "name": "Pincurchin"
+  },
+  {
+    "number": 872,
+    "name": "Snom"
+  },
+  {
+    "number": 873,
+    "name": "Frosmoth"
+  },
+  {
+    "number": 874,
+    "name": "Stonjourner"
+  },
+  {
+    "number": 875,
+    "name": "Eiscue"
+  },
+  {
+    "number": 876,
+    "name": "Indeedee"
+  },
+  {
+    "number": 877,
+    "name": "Morpeko"
+  },
+  {
+    "number": 878,
+    "name": "Cufant"
+  },
+  {
+    "number": 879,
+    "name": "Copperajah"
+  },
+  {
+    "number": 880,
+    "name": "Dracozolt"
+  },
+  {
+    "number": 881,
+    "name": "Arctozolt"
+  },
+  {
+    "number": 882,
+    "name": "Dracovish"
+  },
+  {
+    "number": 883,
+    "name": "Arctovish"
+  },
+  {
+    "number": 884,
+    "name": "Duraludon"
+  },
+  {
+    "number": 885,
+    "name": "Dreepy"
+  },
+  {
+    "number": 886,
+    "name": "Drakloak"
+  },
+  {
+    "number": 887,
+    "name": "Dragapult"
+  },
+  {
+    "number": 888,
+    "name": "Zacian"
+  },
+  {
+    "number": 889,
+    "name": "Zamazenta"
+  },
+  {
+    "number": 890,
+    "name": "Eternatus"
+  },
+  {
+    "number": 891,
+    "name": "Kubfu"
+  },
+  {
+    "number": 892,
+    "name": "Urshifu"
+  },
+  {
+    "number": 893,
+    "name": "Zarude"
+  },
+  {
+    "number": 894,
+    "name": "Regieleki"
+  },
+  {
+    "number": 895,
+    "name": "Regidrago"
+  },
+  {
+    "number": 896,
+    "name": "Glastrier"
+  },
+  {
+    "number": 897,
+    "name": "Spectrier"
+  },
+  {
+    "number": 898,
+    "name": "Calyrex"
+  },
+  {
+    "number": 899,
+    "name": "Wyrdeer"
+  },
+  {
+    "number": 900,
+    "name": "Kleavor"
+  },
+  {
+    "number": 901,
+    "name": "Ursaluna"
+  },
+  {
+    "number": 902,
+    "name": "Basculegion"
+  },
+  {
+    "number": 903,
+    "name": "Sneasler"
+  },
+  {
+    "number": 904,
+    "name": "Overqwil"
+  },
+  {
+    "number": 905,
+    "name": "Enamorus"
+  },
+  {
+    "number": 906,
+    "name": "Sprigatito"
+  },
+  {
+    "number": 907,
+    "name": "Floragato"
+  },
+  {
+    "number": 908,
+    "name": "Meowscarada"
+  },
+  {
+    "number": 909,
+    "name": "Fuecoco"
+  },
+  {
+    "number": 910,
+    "name": "Crocalor"
+  },
+  {
+    "number": 911,
+    "name": "Skeledirge"
+  },
+  {
+    "number": 912,
+    "name": "Quaxly"
+  },
+  {
+    "number": 913,
+    "name": "Quaxwell"
+  },
+  {
+    "number": 914,
+    "name": "Quaquaval"
+  },
+  {
+    "number": 915,
+    "name": "Lechonk"
+  },
+  {
+    "number": 916,
+    "name": "Oinkologne"
+  },
+  {
+    "number": 917,
+    "name": "Tarountula"
+  },
+  {
+    "number": 918,
+    "name": "Spidops"
+  },
+  {
+    "number": 919,
+    "name": "Nymble"
+  },
+  {
+    "number": 920,
+    "name": "Lokix"
+  },
+  {
+    "number": 921,
+    "name": "Pawmi"
+  },
+  {
+    "number": 922,
+    "name": "Pawmo"
+  },
+  {
+    "number": 923,
+    "name": "Pawmot"
+  },
+  {
+    "number": 924,
+    "name": "Tandemaus"
+  },
+  {
+    "number": 925,
+    "name": "Maushold"
+  },
+  {
+    "number": 926,
+    "name": "Fidough"
+  },
+  {
+    "number": 927,
+    "name": "Dachsbun"
+  },
+  {
+    "number": 928,
+    "name": "Smoliv"
+  },
+  {
+    "number": 929,
+    "name": "Dolliv"
+  },
+  {
+    "number": 930,
+    "name": "Arboliva"
+  },
+  {
+    "number": 931,
+    "name": "Squawkabilly"
+  },
+  {
+    "number": 932,
+    "name": "Nacli"
+  },
+  {
+    "number": 933,
+    "name": "Naclstack"
+  },
+  {
+    "number": 934,
+    "name": "Garganacl"
+  },
+  {
+    "number": 935,
+    "name": "Charcadet"
+  },
+  {
+    "number": 936,
+    "name": "Armarouge"
+  },
+  {
+    "number": 937,
+    "name": "Ceruledge"
+  },
+  {
+    "number": 938,
+    "name": "Tadbulb"
+  },
+  {
+    "number": 939,
+    "name": "Bellibolt"
+  },
+  {
+    "number": 940,
+    "name": "Wattrel"
+  },
+  {
+    "number": 941,
+    "name": "Kilowattrel"
+  },
+  {
+    "number": 942,
+    "name": "Maschiff"
+  },
+  {
+    "number": 943,
+    "name": "Mabosstiff"
+  },
+  {
+    "number": 944,
+    "name": "Shroodle"
+  },
+  {
+    "number": 945,
+    "name": "Grafaiai"
+  },
+  {
+    "number": 946,
+    "name": "Bramblin"
+  },
+  {
+    "number": 947,
+    "name": "Brambleghast"
+  },
+  {
+    "number": 948,
+    "name": "Toedscool"
+  },
+  {
+    "number": 949,
+    "name": "Toedscruel"
+  },
+  {
+    "number": 950,
+    "name": "Klawf"
+  },
+  {
+    "number": 951,
+    "name": "Capsakid"
+  },
+  {
+    "number": 952,
+    "name": "Scovillain"
+  },
+  {
+    "number": 953,
+    "name": "Rellor"
+  },
+  {
+    "number": 954,
+    "name": "Rabsca"
+  },
+  {
+    "number": 955,
+    "name": "Flittle"
+  },
+  {
+    "number": 956,
+    "name": "Espathra"
+  },
+  {
+    "number": 957,
+    "name": "Tinkatink"
+  },
+  {
+    "number": 958,
+    "name": "Tinkatuff"
+  },
+  {
+    "number": 959,
+    "name": "Tinkaton"
+  },
+  {
+    "number": 960,
+    "name": "Wiglett"
+  },
+  {
+    "number": 961,
+    "name": "Wugtrio"
+  },
+  {
+    "number": 962,
+    "name": "Bombirdier"
+  },
+  {
+    "number": 963,
+    "name": "Finizen"
+  },
+  {
+    "number": 964,
+    "name": "Palafin"
+  },
+  {
+    "number": 965,
+    "name": "Varoom"
+  },
+  {
+    "number": 966,
+    "name": "Revavroom"
+  },
+  {
+    "number": 967,
+    "name": "Cyclizar"
+  },
+  {
+    "number": 968,
+    "name": "Orthworm"
+  },
+  {
+    "number": 969,
+    "name": "Glimmet"
+  },
+  {
+    "number": 970,
+    "name": "Glimmora"
+  },
+  {
+    "number": 971,
+    "name": "Greavard"
+  },
+  {
+    "number": 972,
+    "name": "Houndstone"
+  },
+  {
+    "number": 973,
+    "name": "Flamigo"
+  },
+  {
+    "number": 974,
+    "name": "Cetoddle"
+  },
+  {
+    "number": 975,
+    "name": "Cetitan"
+  },
+  {
+    "number": 976,
+    "name": "Veluza"
+  },
+  {
+    "number": 977,
+    "name": "Dondozo"
+  },
+  {
+    "number": 978,
+    "name": "Tatsugiri"
+  },
+  {
+    "number": 979,
+    "name": "Annihilape"
+  },
+  {
+    "number": 980,
+    "name": "Clodsire"
+  },
+  {
+    "number": 981,
+    "name": "Farigiraf"
+  },
+  {
+    "number": 982,
+    "name": "Dudunsparce"
+  },
+  {
+    "number": 983,
+    "name": "Kingambit"
+  },
+  {
+    "number": 984,
+    "name": "Great Tusk"
+  },
+  {
+    "number": 985,
+    "name": "Scream Tail"
+  },
+  {
+    "number": 986,
+    "name": "Brute Bonnet"
+  },
+  {
+    "number": 987,
+    "name": "Flutter Mane"
+  },
+  {
+    "number": 988,
+    "name": "Slither Wing"
+  },
+  {
+    "number": 989,
+    "name": "Sandy Shocks"
+  },
+  {
+    "number": 990,
+    "name": "Iron Treads"
+  },
+  {
+    "number": 991,
+    "name": "Iron Bundle"
+  },
+  {
+    "number": 992,
+    "name": "Iron Hands"
+  },
+  {
+    "number": 993,
+    "name": "Iron Jugulis"
+  },
+  {
+    "number": 994,
+    "name": "Iron Moth"
+  },
+  {
+    "number": 995,
+    "name": "Iron Thorns"
+  },
+  {
+    "number": 996,
+    "name": "Frigibax"
+  },
+  {
+    "number": 997,
+    "name": "Arctibax"
+  },
+  {
+    "number": 998,
+    "name": "Baxcalibur"
+  },
+  {
+    "number": 999,
+    "name": "Gimmighoul"
+  },
+  {
+    "number": 1000,
+    "name": "Gholdengo"
+  },
+  {
+    "number": 1001,
+    "name": "Wo Chien"
+  },
+  {
+    "number": 1002,
+    "name": "Chien Pao"
+  },
+  {
+    "number": 1003,
+    "name": "Ting Lu"
+  },
+  {
+    "number": 1004,
+    "name": "Chi Yu"
+  },
+  {
+    "number": 1005,
+    "name": "Roaring Moon"
+  },
+  {
+    "number": 1006,
+    "name": "Iron Valiant"
+  },
+  {
+    "number": 1007,
+    "name": "Koraidon"
+  },
+  {
+    "number": 1008,
+    "name": "Miraidon"
+  },
+  {
+    "number": 1009,
+    "name": "Walking Wake"
+  },
+  {
+    "number": 1010,
+    "name": "Iron Leaves"
+  },
+  {
+    "number": 1011,
+    "name": "Dipplin"
+  },
+  {
+    "number": 1012,
+    "name": "Poltchageist"
+  },
+  {
+    "number": 1013,
+    "name": "Sinistcha"
+  },
+  {
+    "number": 1014,
+    "name": "Okidogi"
+  },
+  {
+    "number": 1015,
+    "name": "Munkidori"
+  },
+  {
+    "number": 1016,
+    "name": "Fezandipiti"
+  },
+  {
+    "number": 1017,
+    "name": "Ogerpon"
+  },
+  {
+    "number": 1018,
+    "name": "Archaludon"
+  },
+  {
+    "number": 1019,
+    "name": "Hydrapple"
+  },
+  {
+    "number": 1020,
+    "name": "Gouging Fire"
+  },
+  {
+    "number": 1021,
+    "name": "Raging Bolt"
+  },
+  {
+    "number": 1022,
+    "name": "Iron Boulder"
+  },
+  {
+    "number": 1023,
+    "name": "Iron Crown"
+  },
+  {
+    "number": 1024,
+    "name": "Terapagos"
+  },
+  {
+    "number": 1025,
+    "name": "Pecharunt"
+  }
+]

--- a/web/src/data/pokedex.ts
+++ b/web/src/data/pokedex.ts
@@ -1,0 +1,32 @@
+/**
+ * Baked-in national Pokédex (species number → display name) — the SPA's
+ * zero-round-trip species index for Browse's pokedex-# view, where the
+ * organisation flips from "cards in a set" to "every printing of one
+ * Pokémon across every set" (issue #577).
+ *
+ * The JSON file is refreshed by `npm run refresh-pokedex`, which pulls the
+ * national dex from PokéAPI. Unlike the set catalog there's no live
+ * background revalidation: the species list is canonical reference data
+ * that only grows when a new generation ships, so the baked file is the
+ * single source of truth. Card printings for a chosen species are still
+ * fetched on demand from `GET /api/v1/pokedex/{number}/cards`.
+ */
+import type { PokedexEntry } from '../types'
+import bakedPokedex from './pokedex.json'
+
+export const BAKED_POKEDEX = bakedPokedex as PokedexEntry[]
+
+/** National dex generation boundaries (inclusive). Used to group the
+ *  species index into the same kind of labelled sections Browse's set
+ *  view gets from `series`. */
+export const POKEDEX_GENERATIONS: { label: string; start: number; end: number }[] = [
+  { label: 'Generation I', start: 1, end: 151 },
+  { label: 'Generation II', start: 152, end: 251 },
+  { label: 'Generation III', start: 252, end: 386 },
+  { label: 'Generation IV', start: 387, end: 493 },
+  { label: 'Generation V', start: 494, end: 649 },
+  { label: 'Generation VI', start: 650, end: 721 },
+  { label: 'Generation VII', start: 722, end: 809 },
+  { label: 'Generation VIII', start: 810, end: 905 },
+  { label: 'Generation IX', start: 906, end: 1025 },
+]

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -185,6 +185,31 @@ export interface SetCard {
 }
 
 /**
+ * One species in the national Pokédex, as baked into `data/pokedex.json`
+ * and rendered by Browse's pokedex-# view. `number` is the national dex
+ * number Browse keys the printings fetch off of.
+ */
+export interface PokedexEntry {
+  number: number
+  name: string
+}
+
+/**
+ * One printing returned by `GET /api/v1/pokedex/{number}/cards` — every
+ * card of a given species across every set.
+ *
+ * A superset of `SetCard`: because printings span sets, each row carries
+ * its own set id / name / release date (the set context that's implicit
+ * in set view's single-set grid) so the pokedex grid can label and sort
+ * by set, and synthesise an "add to list" line without an active set.
+ */
+export interface PokedexCard extends SetCard {
+  setId: string
+  setName: string
+  releaseDate: string
+}
+
+/**
  * One section within a release (Added / Changed / Fixed / …) as returned
  * by `GET /api/v1/changelog`. Bullet `entries` are raw Markdown — the
  * renderer formats inline links and code spans.


### PR DESCRIPTION
Closes #577

## What

Adds a view-mode toggle to the Browse panel that flips the organisation between two modes:

- **By set** (unchanged): series → set → cards in that set.
- **By Pokédex #** (new): national dex # → every printing of one Pokémon across every set ("show me every Charizard ever printed").

Pokedex view mirrors set view's two-level shape. The top level is a baked national-dex species index (1025 species, grouped by generation, filterable by name or dex #). Picking a species drills into every printing, fetched on demand, sorted newest-first.

## Why

Set view answers "what's in this set." Pokedex view answers "every printing of this Pokémon" — the mode serious collectors and one-Pokémon chasers think in at least as often. Groundwork for the library epic (#501) and one-Pokémon collections.

## How

- **`GET /api/v1/pokedex/{number}/cards`** (`api/routes/pokedex.py`) — queries pokemontcg.io with `nationalPokedexNumbers:{n}` via the shared `search_all` (so it rides the existing on-disk API cache). Reuses the slim set-card trim and adds per-card set context (`setId` / `setName` / `releaseDate`) that set view leaves implicit in its single-set grid. Rows arrive pre-sorted: release date desc, then set name, then collector number (a stable two-pass sort). 1-day `Cache-Control`, matching `/sets/{id}/cards`. 404 when a species has no printings.
- **Baked species index** (`web/src/data/pokedex.json` + `pokedex.ts`) — the zero-round-trip picker, mirroring the baked set catalog. Generated by `npm run refresh-pokedex` (`web/scripts/refresh-pokedex.mjs`) from PokéAPI's national dex, with a small override table for the names PokéAPI slugifies lossily (Farfetch'd, Mr. Mime, Nidoran♀/♂, Type: Null, …). Generation boundaries are computed from the dex number, no extra data.
- **Species sprites** (`web/src/components/BrowsePanel.tsx`, `pokemonSpriteUrl`) — each species tile shows its standard front sprite, derived from the national dex number via PokéAPI's sprite CDN (no extra baked data, no backend round-trip). Lazy-loaded with a soft icon fallback.
- **Controller** (`useBrowseController.ts`) — adds `viewMode`, the generation-grouped species index, a filter, and an on-demand printings fetch with its own per-number cache. Toggling organisation lands on that view's top-level list.
- **Panel** (`BrowsePanel.tsx`) — the segmented toggle plus the two new pokedex views. Each printing exposes the same add-to-list action as set view; the input line uses each printing's own set name.

No new env vars / disk / health-check, so `render.yaml` is unchanged.

## How to verify

1. `cd web && npm run dev`, open Browse, click **By Pokédex #**. The species index renders instantly from the baked dex (Generation I … IX); filter by "charizard" or "6".
2. Pick a species → it fetches every printing across all sets, newest-first, each row labelled with its set + year. "Add to list" / "Add all printings" feed the input list.
3. Backend, live upstream: `GET /api/v1/pokedex/6/cards` returns 107 Charizard printings, newest-first (Ascended Heroes → … → Base), each carrying `setName` / `releaseDate`.
4. `make check` green (778 Python tests incl. `tests/test_pokedex_api.py`, web ESLint, design lint); `cd web && npm run build` green (incl. `BrowsePanel.test.tsx`).

Species-index screenshot captured during verification (the live Browse panel rendering the generation-grouped national dex); to be dragged into this PR.