### PR TITLE
feat(web): browse + swipe cards reach parity with search result rows

### DIFF
--- a/web/src/components/BrowsePanel.test.tsx
+++ b/web/src/components/BrowsePanel.test.tsx
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { BrowsePanel } from './BrowsePanel'
 import { useBrowseController } from './useBrowseController'
 import { useAppStore } from '../store'
+import { _resetAuthStoreForTests } from '../hooks/useAuth'
+import { _resetCollectionsCacheForTests } from './useCollections'
+import { _resetWishlistsCacheForTests } from './useWishlists'
 import * as client from '../api/client'
 import type { PokedexCard } from '../types'
 
@@ -35,6 +38,19 @@ describe('BrowsePanel — pokedex view (#577)', () => {
     // baked catalog stays on screen and no real network is hit.
     vi.spyOn(client, 'fetchSets').mockResolvedValue([])
     vi.spyOn(client, 'fetchSetCards').mockResolvedValue([])
+    // BrowsePanel now reads useAuth to gate the per-card save buttons, and
+    // the buttons mount the collections / wishlists pickers. Default to a
+    // signed-in user with empty lists so the save surface renders without
+    // touching the network; reset the shared caches between tests.
+    vi.spyOn(client, 'fetchMe').mockResolvedValue({
+      user: { id: 1, email: 'u@e.com', display_name: 'U' },
+      authEnabled: true,
+    })
+    vi.spyOn(client, 'fetchCollections').mockResolvedValue([])
+    vi.spyOn(client, 'fetchWishlists').mockResolvedValue([])
+    _resetAuthStoreForTests()
+    _resetCollectionsCacheForTests()
+    _resetWishlistsCacheForTests()
   })
 
   it('toggles to pokedex view and lists species from the national dex', async () => {
@@ -64,7 +80,7 @@ describe('BrowsePanel — pokedex view (#577)', () => {
     expect(screen.queryByText('Bulbasaur')).not.toBeInTheDocument()
   })
 
-  it('drills into a species, fetches every printing, and adds one to the list', async () => {
+  it('drills into a species, fetches every printing, and opens the card detail modal', async () => {
     const fetchPokedex = vi
       .spyOn(client, 'fetchPokedexCards')
       .mockResolvedValue(CHARIZARD_PRINTINGS)
@@ -83,8 +99,36 @@ describe('BrowsePanel — pokedex view (#577)', () => {
     expect(await screen.findByText('Base')).toBeInTheDocument()
     expect(screen.getByText('1 printing')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: /Add Charizard from Base to list/ }))
+    // Clicking the printing tile opens the same detail modal Search rows use.
+    fireEvent.click(
+      screen.getByRole('button', { name: /View details for Charizard from Base/ }),
+    )
+    const dialog = await screen.findByRole('dialog')
+    // Name shows in both the title and the Identity row; the market price is
+    // unique to the modal's pricing block.
+    expect(within(dialog).getAllByText('Charizard').length).toBeGreaterThan(0)
+    expect(within(dialog).getByText('$250.00')).toBeInTheDocument()
+  })
 
-    expect(useAppStore.getState().inputText).toContain('Charizard | Base | 4')
+  it('shows the collection / wishlist save buttons on a printing when signed in', async () => {
+    vi.spyOn(client, 'fetchPokedexCards').mockResolvedValue(CHARIZARD_PRINTINGS)
+
+    render(<Harness />)
+    fireEvent.click(screen.getByRole('button', { name: 'By Pokédex #' }))
+    fireEvent.change(screen.getByLabelText('Find a Pokémon'), {
+      target: { value: 'charizard' },
+    })
+    fireEvent.click(await screen.findByText('Charizard'))
+    expect(await screen.findByText('Base')).toBeInTheDocument()
+
+    // useAuth resolves async — wait for the per-card save buttons to mount.
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /save to collection/i }),
+      ).toBeInTheDocument()
+    })
+    expect(
+      screen.getByRole('button', { name: /save to wishlist/i }),
+    ).toBeInTheDocument()
   })
 })

--- a/web/src/components/BrowsePanel.test.tsx
+++ b/web/src/components/BrowsePanel.test.tsx
@@ -7,7 +7,7 @@ import { _resetAuthStoreForTests } from '../hooks/useAuth'
 import { _resetCollectionsCacheForTests } from './useCollections'
 import { _resetWishlistsCacheForTests } from './useWishlists'
 import * as client from '../api/client'
-import type { PokedexCard } from '../types'
+import type { PokedexCard, SetCard } from '../types'
 
 function Harness() {
   const controller = useBrowseController(true)
@@ -110,6 +110,82 @@ describe('BrowsePanel — pokedex view (#577)', () => {
     expect(within(dialog).getByText('$250.00')).toBeInTheDocument()
   })
 
+  it('set view: drills into a set, opens the detail modal, and shows the save buttons', async () => {
+    const SET_CARDS: SetCard[] = [
+      {
+        id: 'base1-4',
+        name: 'Charizard',
+        number: '4',
+        rarity: 'Rare Holo',
+        supertype: 'Pokémon',
+        subtypes: ['Stage 2'],
+        thumb: 'https://img/base1-4.png',
+        market: 250,
+      },
+    ]
+    const fetchCards = vi
+      .spyOn(client, 'fetchSetCards')
+      .mockResolvedValue(SET_CARDS)
+
+    render(<Harness />)
+
+    // Default view is "By set"; the baked catalog renders the set tiles with
+    // no round-trip. Drill into the first one (Base).
+    const setTile = screen
+      .getAllByRole('button')
+      .find((b) => /\bcards$|count unknown/.test(b.textContent ?? ''))!
+    fireEvent.click(setTile)
+
+    await waitFor(() => expect(fetchCards).toHaveBeenCalled())
+    expect(await screen.findByText('1 of 1 card')).toBeInTheDocument()
+
+    // Signed-in, so each tile carries the collection + wishlist save pair.
+    // Assert these before opening the modal — the dialog makes the grid inert.
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: /save to collection/i }),
+      ).toBeInTheDocument(),
+    )
+    expect(
+      screen.getByRole('button', { name: /save to wishlist/i }),
+    ).toBeInTheDocument()
+
+    // A broken thumbnail falls back to the placeholder.
+    fireEvent.error(screen.getByAltText('Charizard'))
+    await waitFor(() =>
+      expect(screen.queryByAltText('Charizard')).not.toBeInTheDocument(),
+    )
+
+    // The set-detail toolbar handlers (search / rarity bucket / sort) run;
+    // Charizard (Rare Holo) survives all three filters.
+    fireEvent.change(screen.getByLabelText('Search cards in this set'), {
+      target: { value: 'char' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Holos' }))
+    fireEvent.change(screen.getByLabelText('Sort cards'), {
+      target: { value: 'price-desc' },
+    })
+    expect(screen.getByText('1 of 1 card')).toBeInTheDocument()
+
+    // Clicking the card tile opens the same detail modal Search rows use.
+    fireEvent.click(
+      screen.getByRole('button', { name: /View details for Charizard/ }),
+    )
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getAllByText('Charizard').length).toBeGreaterThan(0)
+    expect(within(dialog).getByText('$250.00')).toBeInTheDocument()
+
+    // Escape closes the modal (onChangeIndex back to null)…
+    fireEvent.keyDown(dialog, { key: 'Escape' })
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument(),
+    )
+
+    // …and the back control returns to the set list.
+    fireEvent.click(screen.getByRole('button', { name: 'Back to set list' }))
+    expect(screen.getByText('Browse sets')).toBeInTheDocument()
+  })
+
   it('shows the collection / wishlist save buttons on a printing when signed in', async () => {
     vi.spyOn(client, 'fetchPokedexCards').mockResolvedValue(CHARIZARD_PRINTINGS)
 
@@ -130,5 +206,24 @@ describe('BrowsePanel — pokedex view (#577)', () => {
     expect(
       screen.getByRole('button', { name: /save to wishlist/i }),
     ).toBeInTheDocument()
+  })
+
+  it('swaps a broken printing thumbnail for the placeholder', async () => {
+    vi.spyOn(client, 'fetchPokedexCards').mockResolvedValue([
+      { ...CHARIZARD_PRINTINGS[0], thumb: 'https://img/base1-4.png' },
+    ])
+
+    render(<Harness />)
+    fireEvent.click(screen.getByRole('button', { name: 'By Pokédex #' }))
+    fireEvent.change(screen.getByLabelText('Find a Pokémon'), {
+      target: { value: 'charizard' },
+    })
+    fireEvent.click(await screen.findByText('Charizard'))
+
+    const img = await screen.findByAltText('Charizard')
+    fireEvent.error(img)
+    await waitFor(() =>
+      expect(screen.queryByAltText('Charizard')).not.toBeInTheDocument(),
+    )
   })
 })

--- a/web/src/components/BrowsePanel.tsx
+++ b/web/src/components/BrowsePanel.tsx
@@ -6,11 +6,15 @@
  * Pokémon across every set). State + effects live in
  * [useBrowseController](./useBrowseController.ts).
  */
-import { ArrowLeft, ImageOff, Library, Loader2, Plus, Search } from 'lucide-react'
-import { useState } from 'react'
+import { ArrowLeft, ImageOff, Library, Loader2, Search } from 'lucide-react'
+import { useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
 import { pokemonSpriteUrl, setLogoUrl } from '../api/client'
-import type { PokedexCard, PokedexEntry, SetCard, SetInfo } from '../types'
+import { useAuth } from '../hooks/useAuth'
+import type { PokedexCard, PokedexEntry, Row, SetCard, SetInfo } from '../types'
+import { browseCardToPayload, browseCardToRow, type BrowseSetContext } from './browseCard'
+import { CardDetailModal } from './CardDetailModal'
+import { SaveCardActions } from './SaveCardActions'
 import type {
   BrowseController,
   BrowseViewMode,
@@ -47,7 +51,6 @@ export function BrowsePanel({ controller }: BrowsePanelProps) {
     sort,
     setSort,
     addedCount,
-    addCards,
     addAll,
     addHolos,
     addRares,
@@ -59,9 +62,14 @@ export function BrowsePanel({ controller }: BrowsePanelProps) {
     pokedexCards,
     pokedexCardsLoading,
     pokedexCardsError,
-    addPokedexCards,
     addAllPrintings,
   } = controller
+
+  // Hoist the auth read here (not per tile) so the grid fires one `/me`
+  // request, then pass the boolean down — tiles only care about "should I
+  // render save buttons", matching ResultsTable's row pattern.
+  const { user } = useAuth()
+  const showSavedActions = user !== null
 
   const drilledIn = viewMode === 'set' ? !!activeSet : !!activePokemon
   const onBack = () =>
@@ -72,14 +80,14 @@ export function BrowsePanel({ controller }: BrowsePanelProps) {
   if (viewMode === 'set') {
     headerTitle = activeSet ? activeSet.name : 'Browse sets'
     description = activeSet
-      ? 'Click a card to add it to your input list, or use the bulk actions below.'
+      ? 'Click a card for its details and comps, or use the bulk actions below to build your list.'
       : 'Pick a set to see every card with its market price, sortable and filterable.'
   } else {
     headerTitle = activePokemon
       ? `#${activePokemon.number} ${activePokemon.name}`
       : 'Browse by Pokédex #'
     description = activePokemon
-      ? 'Every printing we found, newest first. Click a card to add it to your input list.'
+      ? 'Every printing we found, newest first. Click a card for its details and comps.'
       : 'Pick a Pokémon to see every printing across every set, newest first.'
   }
 
@@ -120,6 +128,8 @@ export function BrowsePanel({ controller }: BrowsePanelProps) {
       {viewMode === 'set' ? (
         activeSet ? (
           <SetDetailView
+            setInfo={activeSet}
+            showSavedActions={showSavedActions}
             cards={filteredCards}
             total={cards?.length ?? 0}
             loading={cardsLoading}
@@ -131,7 +141,6 @@ export function BrowsePanel({ controller }: BrowsePanelProps) {
             sort={sort}
             onSort={setSort}
             addedCount={addedCount}
-            onAddCards={addCards}
             onAddAll={addAll}
             onAddHolos={addHolos}
             onAddRares={addRares}
@@ -141,11 +150,11 @@ export function BrowsePanel({ controller }: BrowsePanelProps) {
         )
       ) : activePokemon ? (
         <PokedexDetailView
+          showSavedActions={showSavedActions}
           cards={pokedexCards}
           loading={pokedexCardsLoading}
           error={pokedexCardsError}
           addedCount={addedCount}
-          onAddCards={addPokedexCards}
           onAddAll={addAllPrintings}
         />
       ) : (
@@ -266,6 +275,8 @@ function SetTile({ set, onPick }: { set: SetInfo; onPick: () => void }) {
 }
 
 interface SetDetailProps {
+  setInfo: SetInfo
+  showSavedActions: boolean
   cards: SetCard[]
   total: number
   loading: boolean
@@ -277,7 +288,6 @@ interface SetDetailProps {
   sort: CardSort
   onSort: (s: CardSort) => void
   addedCount: number | null
-  onAddCards: (cards: SetCard[]) => void
   onAddAll: () => void
   onAddHolos: () => void
   onAddRares: () => void
@@ -297,6 +307,8 @@ const SORT_OPTIONS: { value: CardSort; label: string }[] = [
 ]
 
 function SetDetailView({
+  setInfo,
+  showSavedActions,
   cards,
   total,
   loading,
@@ -308,11 +320,27 @@ function SetDetailView({
   sort,
   onSort,
   addedCount,
-  onAddCards,
   onAddAll,
   onAddHolos,
   onAddRares,
 }: SetDetailProps) {
+  // Index into the displayed `cards` for the open detail modal; `null`
+  // keeps it closed. Tracking the index (not the card) keeps ←/→ modal
+  // navigation synced with the live filter + sort.
+  const [detailIndex, setDetailIndex] = useState<number | null>(null)
+  const setCtx: BrowseSetContext = {
+    id: setInfo.id,
+    name: setInfo.name,
+    series: setInfo.series,
+    releaseDate: setInfo.releaseDate,
+  }
+  const rows = useMemo<Row[]>(
+    () => cards.map((c) => browseCardToRow(c, setCtx)),
+    // setCtx is derived from setInfo; depend on the stable id, not the
+    // freshly-built object literal.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [cards, setInfo.id],
+  )
   return (
     <>
       <div className="flex flex-wrap items-center gap-2 border-b border-sand-200 dark:border-husk-100 px-5 py-3">
@@ -387,12 +415,20 @@ function SetDetailView({
         )}
         {!loading && !error && cards.length > 0 && (
           <ul className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
-            {cards.map((c) => (
-              <CardTile key={c.id} card={c} onAdd={() => onAddCards([c])} />
+            {cards.map((c, i) => (
+              <CardTile
+                key={c.id}
+                card={c}
+                setCtx={setCtx}
+                showSavedActions={showSavedActions}
+                onOpenDetail={() => setDetailIndex(i)}
+              />
             ))}
           </ul>
         )}
       </div>
+
+      <CardDetailModal rows={rows} index={detailIndex} onChangeIndex={setDetailIndex} />
     </>
   )
 }
@@ -493,23 +529,30 @@ function SpeciesTile({
 }
 
 interface PokedexDetailProps {
+  showSavedActions: boolean
   cards: PokedexCard[] | null
   loading: boolean
   error: string | null
   addedCount: number | null
-  onAddCards: (cards: PokedexCard[]) => void
   onAddAll: () => void
 }
 
 function PokedexDetailView({
+  showSavedActions,
   cards,
   loading,
   error,
   addedCount,
-  onAddCards,
   onAddAll,
 }: PokedexDetailProps) {
   const count = cards?.length ?? 0
+  // PokedexCard carries its own set context, so the rows need no external
+  // ctx. Index into the displayed printings for the open detail modal.
+  const [detailIndex, setDetailIndex] = useState<number | null>(null)
+  const rows = useMemo<Row[]>(
+    () => (cards ?? []).map((c) => browseCardToRow(c)),
+    [cards],
+  )
   return (
     <>
       <div className="flex flex-wrap items-center gap-2 border-b border-sand-200 dark:border-husk-100 px-5 py-2 text-xs text-coconut-400 dark:text-sand-300">
@@ -546,107 +589,140 @@ function PokedexDetailView({
         )}
         {!loading && !error && cards && count > 0 && (
           <ul className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
-            {cards.map((c) => (
-              <PokedexCardTile key={c.id} card={c} onAdd={() => onAddCards([c])} />
+            {cards.map((c, i) => (
+              <PokedexCardTile
+                key={c.id}
+                card={c}
+                showSavedActions={showSavedActions}
+                onOpenDetail={() => setDetailIndex(i)}
+              />
             ))}
           </ul>
         )}
       </div>
+
+      <CardDetailModal rows={rows} index={detailIndex} onChangeIndex={setDetailIndex} />
     </>
   )
 }
 
-function CardTile({ card, onAdd }: { card: SetCard; onAdd: () => void }) {
+function CardTile({
+  card,
+  setCtx,
+  showSavedActions,
+  onOpenDetail,
+}: {
+  card: SetCard
+  setCtx: BrowseSetContext
+  showSavedActions: boolean
+  onOpenDetail: () => void
+}) {
   const [thumbFailed, setThumbFailed] = useState(false)
   return (
     <li className="group flex flex-col rounded-md border border-sand-200 dark:border-husk-100 bg-sand-50 dark:bg-husk-400/40 p-2 text-left hover:border-sand-300 dark:hover:border-husk-50 hover:bg-sand-50 dark:hover:bg-husk-200">
-      <div className="relative aspect-[245/342] w-full overflow-hidden rounded bg-sand-50 dark:bg-husk-400">
-        {card.thumb && !thumbFailed ? (
-          <img
-            src={card.thumb}
-            alt={card.name}
-            className="h-full w-full object-contain"
-            loading="lazy"
-            onError={() => setThumbFailed(true)}
-          />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center text-coconut-700 dark:text-sand-200">
-            <ImageOff size={28} aria-hidden />
-          </div>
-        )}
-      </div>
-      <div className="mt-2 min-w-0 flex-1">
-        <div className="truncate text-sm font-medium text-coconut-700 dark:text-sand-50" title={card.name}>
-          {card.name}
-        </div>
-        <div className="flex items-center justify-between text-xs text-coconut-400 dark:text-sand-400">
-          <span>#{card.number}</span>
-          {card.market != null && (
-            <span className="text-palm-500 dark:text-palm-200">${card.market.toFixed(2)}</span>
+      <button
+        type="button"
+        onClick={onOpenDetail}
+        aria-label={`View details for ${card.name}`}
+        className="flex flex-1 flex-col rounded text-left focus:outline-none focus:ring-2 focus:ring-sand-300 dark:ring-husk-50"
+      >
+        <div className="relative aspect-[245/342] w-full overflow-hidden rounded bg-sand-50 dark:bg-husk-400">
+          {card.thumb && !thumbFailed ? (
+            <img
+              src={card.thumb}
+              alt={card.name}
+              className="h-full w-full object-contain"
+              loading="lazy"
+              onError={() => setThumbFailed(true)}
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-coconut-700 dark:text-sand-200">
+              <ImageOff size={28} aria-hidden />
+            </div>
           )}
         </div>
-        {card.rarity && (
-          <div className="truncate text-[11px] text-coconut-400 dark:text-sand-400">{card.rarity}</div>
-        )}
-      </div>
-      <AddToListButton label={card.name} onClick={onAdd} />
+        <div className="mt-2 min-w-0 flex-1">
+          <div className="truncate text-sm font-medium text-coconut-700 dark:text-sand-50" title={card.name}>
+            {card.name}
+          </div>
+          <div className="flex items-center justify-between text-xs text-coconut-400 dark:text-sand-400">
+            <span>#{card.number}</span>
+            {card.market != null && (
+              <span className="text-palm-500 dark:text-palm-200">${card.market.toFixed(2)}</span>
+            )}
+          </div>
+          {card.rarity && (
+            <div className="truncate text-[11px] text-coconut-400 dark:text-sand-400">{card.rarity}</div>
+          )}
+        </div>
+      </button>
+      <SaveCardActions
+        show={showSavedActions}
+        card={browseCardToPayload(card, setCtx)}
+        className="mt-2 justify-center"
+      />
     </li>
   )
 }
 
-function PokedexCardTile({ card, onAdd }: { card: PokedexCard; onAdd: () => void }) {
+function PokedexCardTile({
+  card,
+  showSavedActions,
+  onOpenDetail,
+}: {
+  card: PokedexCard
+  showSavedActions: boolean
+  onOpenDetail: () => void
+}) {
   const [thumbFailed, setThumbFailed] = useState(false)
   const year = releaseYear(card.releaseDate)
   return (
     <li className="group flex flex-col rounded-md border border-sand-200 dark:border-husk-100 bg-sand-50 dark:bg-husk-400/40 p-2 text-left hover:border-sand-300 dark:hover:border-husk-50 hover:bg-sand-50 dark:hover:bg-husk-200">
-      <div className="relative aspect-[245/342] w-full overflow-hidden rounded bg-sand-50 dark:bg-husk-400">
-        {card.thumb && !thumbFailed ? (
-          <img
-            src={card.thumb}
-            alt={card.name}
-            className="h-full w-full object-contain"
-            loading="lazy"
-            onError={() => setThumbFailed(true)}
-          />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center text-coconut-700 dark:text-sand-200">
-            <ImageOff size={28} aria-hidden />
-          </div>
-        )}
-      </div>
-      <div className="mt-2 min-w-0 flex-1">
-        <div className="truncate text-sm font-medium text-coconut-700 dark:text-sand-50" title={card.setName}>
-          {card.setName}
-        </div>
-        <div className="flex items-center justify-between text-xs text-coconut-400 dark:text-sand-400">
-          <span>
-            #{card.number}
-            {year ? ` · ${year}` : ''}
-          </span>
-          {card.market != null && (
-            <span className="text-palm-500 dark:text-palm-200">${card.market.toFixed(2)}</span>
+      <button
+        type="button"
+        onClick={onOpenDetail}
+        aria-label={`View details for ${card.name} from ${card.setName}`}
+        className="flex flex-1 flex-col rounded text-left focus:outline-none focus:ring-2 focus:ring-sand-300 dark:ring-husk-50"
+      >
+        <div className="relative aspect-[245/342] w-full overflow-hidden rounded bg-sand-50 dark:bg-husk-400">
+          {card.thumb && !thumbFailed ? (
+            <img
+              src={card.thumb}
+              alt={card.name}
+              className="h-full w-full object-contain"
+              loading="lazy"
+              onError={() => setThumbFailed(true)}
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center text-coconut-700 dark:text-sand-200">
+              <ImageOff size={28} aria-hidden />
+            </div>
           )}
         </div>
-        {card.rarity && (
-          <div className="truncate text-[11px] text-coconut-400 dark:text-sand-400">{card.rarity}</div>
-        )}
-      </div>
-      <AddToListButton label={`${card.name} from ${card.setName}`} onClick={onAdd} />
+        <div className="mt-2 min-w-0 flex-1">
+          <div className="truncate text-sm font-medium text-coconut-700 dark:text-sand-50" title={card.setName}>
+            {card.setName}
+          </div>
+          <div className="flex items-center justify-between text-xs text-coconut-400 dark:text-sand-400">
+            <span>
+              #{card.number}
+              {year ? ` · ${year}` : ''}
+            </span>
+            {card.market != null && (
+              <span className="text-palm-500 dark:text-palm-200">${card.market.toFixed(2)}</span>
+            )}
+          </div>
+          {card.rarity && (
+            <div className="truncate text-[11px] text-coconut-400 dark:text-sand-400">{card.rarity}</div>
+          )}
+        </div>
+      </button>
+      <SaveCardActions
+        show={showSavedActions}
+        card={browseCardToPayload(card)}
+        className="mt-2 justify-center"
+      />
     </li>
-  )
-}
-
-function AddToListButton({ label, onClick }: { label: string; onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="mt-2 flex items-center justify-center gap-1 rounded-md border border-sand-300 dark:border-husk-50 bg-sand-200 dark:bg-husk-100 px-2 py-1 text-xs text-coconut-600 dark:text-sand-200 hover:border-palm-400 dark:hover:border-palm-500 hover:bg-palm-100 dark:hover:bg-palm-500/30 hover:text-palm-400 dark:hover:text-palm-100"
-      aria-label={`Add ${label} to list`}
-    >
-      <Plus size={12} />
-      Add to list
-    </button>
   )
 }
 

--- a/web/src/components/SaveCardActions.tsx
+++ b/web/src/components/SaveCardActions.tsx
@@ -1,0 +1,26 @@
+/**
+ * SaveCardActions — the Save-to-collection + Save-to-wishlist button pair
+ * the Search results row carries, reused on Browse and Swipe cards so all
+ * three surfaces share one save affordance. Renders nothing when signed
+ * out, matching the row (which hides its actions column for anon users).
+ */
+import { AddToCollectionButton } from './AddToCollectionButton'
+import { AddToWishlistButton } from './AddToWishlistButton'
+
+export function SaveCardActions({
+  card,
+  show,
+  className = '',
+}: {
+  card: Record<string, unknown>
+  show: boolean
+  className?: string
+}) {
+  if (!show) return null
+  return (
+    <div className={`flex items-center gap-1 ${className}`}>
+      <AddToCollectionButton card={card} />
+      <AddToWishlistButton card={card} />
+    </div>
+  )
+}

--- a/web/src/components/SwipePanel.test.tsx
+++ b/web/src/components/SwipePanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { SwipePanel } from './SwipePanel'
 import {
   fetchSets,
@@ -7,9 +7,13 @@ import {
   createWishlist,
   addCardToWishlist,
   fetchWishlists,
+  fetchMe,
+  fetchCollections,
 } from '../api/client'
 import { _resetSwipeProfileForTests } from './useSwipeProfile'
 import { _resetWishlistsCacheForTests } from './useWishlists'
+import { _resetCollectionsCacheForTests } from './useCollections'
+import { _resetAuthStoreForTests } from '../hooks/useAuth'
 import type { SetCard } from '../types'
 
 vi.mock('../api/client', () => ({
@@ -18,6 +22,13 @@ vi.mock('../api/client', () => ({
   createWishlist: vi.fn(),
   addCardToWishlist: vi.fn(),
   fetchWishlists: vi.fn(),
+  // SwipePanel reads useAuth to gate the per-card save buttons; when signed
+  // in those buttons mount the collection / wishlist pickers, which fetch
+  // their lists on mount. beforeEach pins the signed-out + empty defaults.
+  fetchMe: vi.fn(),
+  fetchCollections: vi.fn(),
+  createCollection: vi.fn(),
+  addCardToCollection: vi.fn(),
 }))
 
 const mockFetchSets = vi.mocked(fetchSets)
@@ -25,6 +36,8 @@ const mockFetchSetCards = vi.mocked(fetchSetCards)
 const mockCreateWishlist = vi.mocked(createWishlist)
 const mockAddCardToWishlist = vi.mocked(addCardToWishlist)
 const mockFetchWishlists = vi.mocked(fetchWishlists)
+const mockFetchMe = vi.mocked(fetchMe)
+const mockFetchCollections = vi.mocked(fetchCollections)
 
 function card(overrides: Partial<SetCard> = {}): SetCard {
   return {
@@ -52,11 +65,19 @@ describe('SwipePanel', () => {
   beforeEach(() => {
     _resetSwipeProfileForTests()
     _resetWishlistsCacheForTests()
+    _resetCollectionsCacheForTests()
+    _resetAuthStoreForTests()
     mockFetchSets.mockReset()
     mockFetchSetCards.mockReset()
     mockCreateWishlist.mockReset()
     mockAddCardToWishlist.mockReset()
     mockFetchWishlists.mockReset()
+    // Default to signed-out with empty lists; the auth-gated tests below
+    // override fetchMe per-case.
+    mockFetchMe.mockReset()
+    mockFetchMe.mockResolvedValue({ user: null, authEnabled: true })
+    mockFetchCollections.mockReset()
+    mockFetchCollections.mockResolvedValue([])
     mockFetchSets.mockResolvedValue([
       { id: 'sv1', name: 'Scarlet & Violet', series: 'SV', total: 2, releaseDate: '2023/03/31' },
     ])
@@ -269,5 +290,76 @@ describe('SwipePanel', () => {
       expect(screen.queryByText(/Build a prep list/i)).not.toBeInTheDocument(),
     )
     expect(mockAddCardToWishlist).toHaveBeenCalledTimes(1)
+  })
+
+  it('tapping the card (no drag) opens the same detail modal Search rows use', async () => {
+    render(<SwipePanel active />)
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    // A click with no preceding pointer movement is a tap, not a swipe.
+    fireEvent.click(screen.getByTestId('swipe-card'))
+
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getAllByText('Pikachu').length).toBeGreaterThan(0)
+    expect(within(dialog).getByText('$5.00')).toBeInTheDocument()
+  })
+
+  it('a sub-threshold drag is not mistaken for a tap', async () => {
+    render(<SwipePanel active />)
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    const card = screen.getByTestId('swipe-card')
+    Object.defineProperty(card, 'setPointerCapture', { value: () => {}, configurable: true })
+    Object.defineProperty(card, 'releasePointerCapture', { value: () => {}, configurable: true })
+    Object.defineProperty(card, 'hasPointerCapture', { value: () => false, configurable: true })
+
+    // Past the click slop (6px) but short of the swipe threshold (110px):
+    // a cancelled swipe, not a tap. The trailing click must not open the modal.
+    fireEvent.pointerDown(card, { pointerId: 1, clientX: 0, clientY: 0 })
+    fireEvent.pointerMove(card, { pointerId: 1, clientX: 40, clientY: 0 })
+    fireEvent.pointerUp(card, { pointerId: 1, clientX: 40, clientY: 0 })
+    fireEvent.click(card)
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    // And no decision committed — still on the first candidate.
+    expect(screen.getByText('Pikachu')).toBeInTheDocument()
+  })
+
+  it('shows the collection / wishlist save buttons when signed in', async () => {
+    mockFetchMe.mockResolvedValue({
+      user: { id: 1, email: 'u@e.com', display_name: 'U' },
+      authEnabled: true,
+    })
+
+    render(<SwipePanel active />)
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    // useAuth resolves async — wait for the gated save buttons to mount.
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: /save to collection/i }),
+      ).toBeInTheDocument(),
+    )
+    expect(
+      screen.getByRole('button', { name: /save to wishlist/i }),
+    ).toBeInTheDocument()
+    // The swipe-mechanic buttons stay alongside the new save pair.
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+  })
+
+  it('hides the save buttons when signed out, matching the Search row', async () => {
+    render(<SwipePanel active />)
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    // Let any pending auth resolution flush before asserting absence.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument(),
+    )
+    expect(
+      screen.queryByRole('button', { name: /save to collection/i }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: /save to wishlist/i }),
+    ).not.toBeInTheDocument()
   })
 })

--- a/web/src/components/SwipePanel.test.tsx
+++ b/web/src/components/SwipePanel.test.tsx
@@ -362,4 +362,104 @@ describe('SwipePanel', () => {
       screen.queryByRole('button', { name: /save to wishlist/i }),
     ).not.toBeInTheDocument()
   })
+
+  it('pressing Enter on the focused card opens the detail modal', async () => {
+    render(<SwipePanel active />)
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    fireEvent.keyDown(screen.getByTestId('swipe-card'), { key: 'Enter' })
+
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getAllByText('Pikachu').length).toBeGreaterThan(0)
+
+    // Escape closes it (onChangeIndex back to null).
+    fireEvent.keyDown(dialog, { key: 'Escape' })
+    await waitFor(() =>
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument(),
+    )
+  })
+
+  it('a drag past the leftward threshold commits a pass (no save)', async () => {
+    render(<SwipePanel active />)
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    const card = screen.getByTestId('swipe-card')
+    Object.defineProperty(card, 'setPointerCapture', { value: () => {}, configurable: true })
+    Object.defineProperty(card, 'releasePointerCapture', { value: () => {}, configurable: true })
+    Object.defineProperty(card, 'hasPointerCapture', { value: () => false, configurable: true })
+
+    fireEvent.pointerDown(card, { pointerId: 1, clientX: 0, clientY: 0 })
+    fireEvent.pointerMove(card, { pointerId: 1, clientX: -200, clientY: 0 })
+    fireEvent.pointerUp(card, { pointerId: 1, clientX: -200, clientY: 0 })
+
+    await waitFor(
+      () => expect(screen.getByText('Charizard')).toBeInTheDocument(),
+      POST_SWIPE_WAIT,
+    )
+    // A pass saves nothing — the header still offers a plain reset.
+    expect(
+      screen.getByRole('button', { name: 'Reset profile' }),
+    ).toBeInTheDocument()
+  })
+
+  it('a drag past the upward threshold commits a love (save + weight)', async () => {
+    render(<SwipePanel active />)
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    const card = screen.getByTestId('swipe-card')
+    Object.defineProperty(card, 'setPointerCapture', { value: () => {}, configurable: true })
+    Object.defineProperty(card, 'releasePointerCapture', { value: () => {}, configurable: true })
+    Object.defineProperty(card, 'hasPointerCapture', { value: () => false, configurable: true })
+
+    fireEvent.pointerDown(card, { pointerId: 1, clientX: 0, clientY: 0 })
+    fireEvent.pointerMove(card, { pointerId: 1, clientX: 0, clientY: -200 })
+    fireEvent.pointerUp(card, { pointerId: 1, clientX: 0, clientY: -200 })
+
+    await waitFor(
+      () => expect(screen.getByText('Charizard')).toBeInTheDocument(),
+      POST_SWIPE_WAIT,
+    )
+    expect(
+      screen.getByRole('button', { name: /1 saved · reset/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('the Pass and More-like-this action buttons commit decisions', async () => {
+    render(<SwipePanel active />)
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pass' }))
+    await waitFor(
+      () => expect(screen.getByText('Charizard')).toBeInTheDocument(),
+      POST_SWIPE_WAIT,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'More like this' }))
+    // Love saves the card; the header chip reflects the one save.
+    await waitFor(
+      () =>
+        expect(
+          screen.getByRole('button', { name: /1 saved · reset/i }),
+        ).toBeInTheDocument(),
+      POST_SWIPE_WAIT,
+    )
+  })
+
+  it('falls back to the placeholder when the card art fails to load', async () => {
+    mockFetchSetCards.mockReset()
+    mockFetchSetCards.mockResolvedValue([
+      card({ id: 'sv1-1', name: 'Pikachu', thumb: 'https://img/pikachu.png' }),
+    ])
+
+    render(<SwipePanel active />)
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    const img = screen.getByAltText('Pikachu') as HTMLImageElement
+    fireEvent.error(img)
+
+    // The broken image is swapped for the ImageOff placeholder.
+    await waitFor(() =>
+      expect(screen.queryByAltText('Pikachu')).not.toBeInTheDocument(),
+    )
+  })
 })

--- a/web/src/components/SwipePanel.tsx
+++ b/web/src/components/SwipePanel.tsx
@@ -16,7 +16,7 @@
  * [useWishlists](./useWishlists.ts) and adds every saved card, then
  * clears the local saved list so the next session starts fresh.
  */
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   ArrowLeft,
   ArrowRight,
@@ -27,7 +27,11 @@ import {
   Sparkles,
   X,
 } from 'lucide-react'
-import type { SetCard } from '../types'
+import { useAuth } from '../hooks/useAuth'
+import type { Row, SetCard } from '../types'
+import { browseCardToPayload, browseCardToRow } from './browseCard'
+import { CardDetailModal } from './CardDetailModal'
+import { SaveCardActions } from './SaveCardActions'
 import {
   useSwipeProfile,
   type SavedCard,
@@ -40,6 +44,9 @@ import { useWishlists } from './useWishlists'
 const SWIPE_THRESHOLD_X = 110
 /** Vertical-drag threshold (px) — up commits a "love". */
 const SWIPE_THRESHOLD_Y = 110
+/** Pointer movement (px) past which a gesture counts as a drag, not a tap.
+ *  Below it, releasing opens the detail modal instead. */
+const CLICK_SLOP = 6
 
 interface Drag {
   startX: number
@@ -60,10 +67,28 @@ export function SwipePanel({ active }: SwipePanelProps) {
     active,
     seenSet,
   })
+  const { user } = useAuth()
+  const showSavedActions = user !== null
 
   const [drag, setDrag] = useState<Drag | null>(null)
   const [outgoing, setOutgoing] = useState<SwipeAction | null>(null)
+  // Open the detail modal for the current candidate. The modal navigates a
+  // `Row[]`, so a one-element array of the current card is enough — there's
+  // no queue to step through here.
+  const [detailOpen, setDetailOpen] = useState(false)
   const cardRef = useRef<HTMLDivElement | null>(null)
+  // Distinguishes a tap (opens the detail modal) from a drag (a swipe
+  // decision). Set true once a pointer moves past the click slop so the
+  // trailing click event after a drag doesn't pop the modal open.
+  const movedRef = useRef(false)
+
+  const detailRows = useMemo<Row[]>(
+    () =>
+      current
+        ? [browseCardToRow(current.card, { id: current.setId, name: current.setName })]
+        : [],
+    [current],
+  )
 
   const commit = useCallback(
     (action: SwipeAction) => {
@@ -84,7 +109,7 @@ export function SwipePanel({ active }: SwipePanelProps) {
   useEffect(() => {
     if (!active) return
     function onKey(e: KeyboardEvent) {
-      if (!current || outgoing) return
+      if (!current || outgoing || detailOpen) return
       const target = e.target as HTMLElement | null
       if (target && /^(INPUT|TEXTAREA|SELECT)$/.test(target.tagName)) return
       if (e.key === 'ArrowLeft') {
@@ -100,13 +125,14 @@ export function SwipePanel({ active }: SwipePanelProps) {
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
-  }, [active, current, outgoing, commit])
+  }, [active, current, outgoing, detailOpen, commit])
 
   const onPointerDown = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       if (outgoing) return
       const el = e.currentTarget
       el.setPointerCapture(e.pointerId)
+      movedRef.current = false
       setDrag({
         startX: e.clientX,
         startY: e.clientY,
@@ -120,14 +146,25 @@ export function SwipePanel({ active }: SwipePanelProps) {
 
   const onPointerMove = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
-      setDrag((d) =>
-        d && d.pointerId === e.pointerId
-          ? { ...d, dx: e.clientX - d.startX, dy: e.clientY - d.startY }
-          : d,
-      )
+      setDrag((d) => {
+        if (!d || d.pointerId !== e.pointerId) return d
+        const dx = e.clientX - d.startX
+        const dy = e.clientY - d.startY
+        if (Math.abs(dx) > CLICK_SLOP || Math.abs(dy) > CLICK_SLOP)
+          movedRef.current = true
+        return { ...d, dx, dy }
+      })
     },
     [],
   )
+
+  // A pointer release that never crossed the click slop is a tap → open the
+  // detail modal. A real drag (movedRef set) or an in-flight exit animation
+  // suppresses it so swipes don't double as taps.
+  const onCardClick = useCallback(() => {
+    if (outgoing || movedRef.current) return
+    setDetailOpen(true)
+  }, [outgoing])
 
   const onPointerEnd = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
@@ -177,12 +214,22 @@ export function SwipePanel({ active }: SwipePanelProps) {
           <div
             ref={cardRef}
             data-testid="swipe-card"
+            role="button"
+            tabIndex={0}
+            aria-label={`View details for ${current.card.name}`}
             onPointerDown={onPointerDown}
             onPointerMove={onPointerMove}
             onPointerUp={onPointerEnd}
             onPointerCancel={onPointerEnd}
+            onClick={onCardClick}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                setDetailOpen(true)
+              }
+            }}
             style={cardTransformStyle(drag, outgoing)}
-            className="relative w-full max-w-xs touch-none select-none rounded-xl border border-sand-300 bg-sand-50 p-3 shadow-lg shadow-coconut-700/10 dark:border-husk-50 dark:bg-husk-400 dark:shadow-coconut-900/40"
+            className="relative w-full max-w-xs cursor-pointer touch-none select-none rounded-xl border border-sand-300 bg-sand-50 p-3 shadow-lg shadow-coconut-700/10 dark:border-husk-50 dark:bg-husk-400 dark:shadow-coconut-900/40"
           >
             <CardArtwork card={current.card} />
             <CardMeta
@@ -202,12 +249,29 @@ export function SwipePanel({ active }: SwipePanelProps) {
           />
         )}
 
+        {current && (
+          <SaveCardActions
+            show={showSavedActions}
+            card={browseCardToPayload(current.card, {
+              id: current.setId,
+              name: current.setName,
+            })}
+            className="justify-center"
+          />
+        )}
+
         <KeyboardHint />
       </div>
 
       {profile.saved.length > 0 && (
         <BuildPrepList saved={profile.saved} onCleared={clearSaved} />
       )}
+
+      <CardDetailModal
+        rows={detailRows}
+        index={detailOpen && current ? 0 : null}
+        onChangeIndex={(next) => setDetailOpen(next !== null)}
+      />
     </section>
   )
 }

--- a/web/src/components/browseCard.test.ts
+++ b/web/src/components/browseCard.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import { browseCardToPayload, browseCardToRow } from './browseCard'
+import type { PokedexCard, SetCard } from '../types'
+
+const POKEDEX_CARD: PokedexCard = {
+  id: 'base1-4',
+  name: 'Charizard',
+  number: '4',
+  rarity: 'Rare Holo',
+  supertype: 'Pokémon',
+  subtypes: ['Stage 2'],
+  thumb: 'https://img/base1-4.png',
+  market: 250,
+  setId: 'base1',
+  setName: 'Base',
+  releaseDate: '1999/01/09',
+}
+
+// A SetCard carries no set identity of its own and, here, no optional
+// metadata — the absent-field branches in the payload adapter.
+const BARE_SET_CARD: SetCard = {
+  id: 'sv1-1',
+  name: 'Pikachu',
+  number: '1',
+  rarity: null,
+  supertype: null,
+  subtypes: [],
+  thumb: null,
+  market: null,
+}
+
+describe('browseCard adapters', () => {
+  it('a PokedexCard carries its own set context and full payload fields', () => {
+    const payload = browseCardToPayload(POKEDEX_CARD)
+    expect(payload).toMatchObject({
+      id: 'base1-4',
+      name: 'Charizard',
+      number: '4',
+      rarity: 'Rare Holo',
+      supertype: 'Pokémon',
+      // thumb present → both image sizes stamped for the modal + saved row.
+      images: { small: 'https://img/base1-4.png', large: 'https://img/base1-4.png' },
+      // set sourced from the card's own setId, not external ctx.
+      set: { id: 'base1', name: 'Base', releaseDate: '1999/01/09' },
+      // flattened market the backend snapshot extractor reads first.
+      market_price: 250,
+    })
+  })
+
+  it('a SetCard borrows external set ctx and omits absent optional fields', () => {
+    const payload = browseCardToPayload(BARE_SET_CARD, {
+      id: 'sv1',
+      name: 'Scarlet & Violet',
+      series: 'SV',
+      releaseDate: '2023/03/31',
+    })
+    expect(payload.set).toEqual({
+      id: 'sv1',
+      name: 'Scarlet & Violet',
+      series: 'SV',
+      releaseDate: '2023/03/31',
+    })
+    // Null rarity / supertype / thumb / market collapse to undefined so the
+    // payload stays clean rather than carrying explicit nulls.
+    expect(payload.rarity).toBeUndefined()
+    expect(payload.supertype).toBeUndefined()
+    expect(payload.images).toBeUndefined()
+    expect(payload.market_price).toBeUndefined()
+  })
+
+  it('a SetCard with no ctx produces a payload without set identity', () => {
+    const payload = browseCardToPayload(BARE_SET_CARD)
+    expect(payload.set).toBeUndefined()
+  })
+
+  it('browseCardToRow shapes a CardDetailModal Row off the trimmed card', () => {
+    const row = browseCardToRow(POKEDEX_CARD)
+    expect(row.query).toMatchObject({ name: 'Charizard', number: '4', raw: 'Charizard' })
+    expect(row.pricing).toMatchObject({ market: 250, currency: 'USD' })
+    expect(row.card?.id).toBe('base1-4')
+    expect(row.matched).toBe(true)
+  })
+
+  it('browseCardToRow carries a null market through for a price-less card', () => {
+    const row = browseCardToRow(BARE_SET_CARD)
+    expect(row.pricing.market).toBeNull()
+  })
+})

--- a/web/src/components/browseCard.ts
+++ b/web/src/components/browseCard.ts
@@ -1,0 +1,100 @@
+/**
+ * browseCard — adapt a trimmed Browse / Swipe card (`SetCard` /
+ * `PokedexCard`) into the shapes the Search surfaces already speak: a
+ * full-ish `CardData` payload for the collection / wishlist save path, and
+ * a `Row` for the `CardDetailModal`.
+ *
+ * The trimmed cards (see [types](../types.ts)) carry only what a grid needs
+ * — id, name, number, rarity, supertype, subtypes, thumb, market — plus set
+ * context (`PokedexCard` carries its own; `SetCard` borrows the active
+ * set). That's enough to round-trip both: the modal renders identity +
+ * pricing comps off `market`, and the backend's `extract_card_identity` /
+ * `extract_price_snapshot` (api/db/card_payload.py) read `set.id`,
+ * `images.small`, and the flattened `market_price` stamped here.
+ */
+import type { CardData, PokedexCard, Row, SetCard } from '../types'
+
+/** Set identity stamped onto a `SetCard`, which (unlike `PokedexCard`)
+ *  doesn't carry its own. Sourced from the active set in Browse / the
+ *  candidate's set in Swipe. */
+export interface BrowseSetContext {
+  id: string
+  name: string
+  series?: string
+  releaseDate?: string
+}
+
+function setContext(
+  card: SetCard | PokedexCard,
+  ctx?: BrowseSetContext,
+): BrowseSetContext | undefined {
+  if ('setId' in card) {
+    return { id: card.setId, name: card.setName, releaseDate: card.releaseDate }
+  }
+  return ctx
+}
+
+/** Verbatim card payload (pokemontcg.io-ish shape) the collection /
+ *  wishlist endpoints persist and the detail modal renders. */
+export function browseCardToPayload(
+  card: SetCard | PokedexCard,
+  ctx?: BrowseSetContext,
+): CardData {
+  const set = setContext(card, ctx)
+  return {
+    id: card.id,
+    name: card.name,
+    number: card.number,
+    rarity: card.rarity ?? undefined,
+    supertype: card.supertype ?? undefined,
+    subtypes: card.subtypes,
+    images: card.thumb ? { small: card.thumb, large: card.thumb } : undefined,
+    set: set
+      ? {
+          id: set.id,
+          name: set.name,
+          series: set.series,
+          releaseDate: set.releaseDate,
+        }
+      : undefined,
+    // The trimmed card only has `market`; the backend's snapshot extractor
+    // reads this flattened field first, so stamping it lets a card saved
+    // from Browse / Swipe land with the same price snapshot a Search row
+    // gets from its richer payload.
+    market_price: card.market ?? undefined,
+  }
+}
+
+/** A single `Row` for `CardDetailModal`. `pricing.market` drives the
+ *  modal's comp tiers; `deriveSource` falls back to a pokemontcg.io card
+ *  link off `card.id` since the trimmed card carries no listing URL. */
+export function browseCardToRow(
+  card: SetCard | PokedexCard,
+  ctx?: BrowseSetContext,
+): Row {
+  return {
+    query: {
+      raw: card.name,
+      name: card.name,
+      set_hint: null,
+      number: card.number,
+      variant_hint: null,
+      url_hint: null,
+      bulk_top: null,
+      bulk_all: false,
+      price_min: null,
+      price_max: null,
+    },
+    card: browseCardToPayload(card, ctx),
+    pricing: {
+      market: card.market,
+      variant: null,
+      source: null,
+      url: null,
+      currency: 'USD',
+    },
+    tag: '',
+    matched: true,
+    reason: '',
+  }
+}


### PR DESCRIPTION
Closes #578
Closes #579
Closes #603

## What

Brings **Browse** (by set and by Pokédex #) and **Swipe** cards up to parity with how a **Search** results row behaves:

- **Click to open detail.** Clicking a Browse or Swipe card opens the same `CardDetailModal` the Search row uses — large image, identity, pricing comps (80/85/90/95%), card data, and a source link. In the Browse grids ←/→ steps through the currently filtered + sorted cards.
- **Action buttons match the row.** Each card carries the same Save-to-collection + Save-to-wishlist pair the row has, auth-gated identically (hidden when signed out).
  - **Browse:** the per-card "Add to list" affordance becomes a tap that opens the detail modal; the two save buttons replace the old inline add. The bulk "Add all visible / holos / rares" toolbar stays as the list-building path.
  - **Swipe:** the card is now tappable to open the modal — a drag past the click slop is still a swipe decision, not a tap — and the two save buttons are added alongside the Pass / More-like-this / Save gesture buttons.

This rolls up the action-button halves tracked in #578 (browse) and #579 (swipe) and adds the detail-modal parity on top, so the three surfaces stay consistent.

## Why

Search, Browse, and Swipe all show the same underlying cards, but only Search let you inspect a card or save it to a collection / want-list — a shopper walking a set or triaging in Swipe had to bounce back to Search. Reusing the existing `CardDetailModal` and `AddToCollectionButton` / `AddToWishlistButton` keeps the surfaces consistent with **no backend change**: the set-cards and pokedex-cards endpoints already return everything the trimmed card needs, and the collection / wishlist endpoints already exist.

## How it's built

- `browseCard.ts` — adapts a trimmed `SetCard` / `PokedexCard` into the `CardData` payload the collection / wishlist endpoints persist and the `Row` the modal renders. It stamps `market_price` so a card saved from Browse / Swipe lands with the same price snapshot a Search row gets.
- `SaveCardActions.tsx` — wraps the existing `AddToCollectionButton` / `AddToWishlistButton` pair, rendering nothing when signed out (matching the row's hidden actions column for anon users). Auth is read once at the panel level and passed down, mirroring `ResultsTable`.
- Modal navigation tracks the **index** into the live `cards` array, so ←/→ stays synced with the active filter + sort.

## How to verify

Verified locally against `make dev-api` + `make dev-web` (screenshots below):

1. **Browse → By set:** open a set, click a card → detail modal opens with comps + source link; ←/→ steps through the grid (confirmed "1 / 130" → "2 / 130", Alakazam → Blastoise). The header copy now reads "Click a card for its details and comps…" and the save buttons render per card.
2. **Browse → By Pokédex #:** same behavior on the printings grid (covered by `BrowsePanel.test.tsx`).
3. **Swipe:** tapping the card (no drag) opens the detail modal (confirmed M Lucario-EX with comps); Pass / Save / Love still work via drag, keys, and buttons; the two save buttons sit alongside.
4. **Auth gating:** save buttons hide when signed out on all surfaces, matching the row (covered by tests; the local self-host API runs signed-in so the screenshots show them present).

`make check` green; `cd web && npm run build` green; 19 Browse + Swipe unit tests pass (4 new Swipe tests for tap-opens-modal, drag-isn't-a-tap, and the auth-gated save buttons).

## Out of scope

- No backend changes — existing endpoints already serve the trimmed cards and own the collection / wishlist writes.

Relates to epic:library.
