### PR TITLE
feat(api): EbayClient adapter for sold + active listing comps

### DIFF
--- a/docs/sources.md
+++ b/docs/sources.md
@@ -47,6 +47,13 @@ Configure one of two ways:
 
 `MGZ_PKMN_EBAY_ENV` selects the host: unset (or anything other than `sandbox`) targets production (`api.ebay.com`); set it to `sandbox` to target `api.sandbox.ebay.com`.
 
+### Active vs sold comps
+
+`EbayClient.fetch_comps(query)` returns two flavors of comp, both filtered to raw singles (graded slabs, lots, and bundles are dropped) and deduped on item id:
+
+- **Active** (`source="ebay_active"`) — what's listed right now, from the **Browse API**. Available with the application token above, so this tier is always on.
+- **Sold** (`source="ebay_sold"`) — recent sales, from the **Marketplace Insights API**. That API is limited-release (it needs separate eBay business approval; the legacy `findCompletedItems` Finding API was retired in early 2025), so the sold path is gated behind `MGZ_PKMN_EBAY_SOLD_ENABLED` (default off) and fails soft on a 403. Leave it off until eBay grants Insights access to your app, then set it to `1` / `true`.
+
 ### Sandbox credentials
 
 Develop against the sandbox first. In the eBay Developer portal your keyset exposes both a **Production** and a **Sandbox** set of App ID (client id) / Cert ID (client secret). For local sandbox work:

--- a/src/mgz_pkmn/sources/__init__.py
+++ b/src/mgz_pkmn/sources/__init__.py
@@ -1,6 +1,7 @@
 """Data-source adapters: pokemontcg.io, TCGdex, PriceCharting, eBay."""
 
 from .ebay import EbayAuthClient, EbayAuthError
+from .ebay_client import EbayClient
 from .pokemontcg import TCGClient, search_pokemontcg
 from .pricecharting import PriceChartingClient
 from .tcgdex import TCGDexClient, search_tcgdex
@@ -8,6 +9,7 @@ from .tcgdex import TCGDexClient, search_tcgdex
 __all__ = [
     "EbayAuthClient",
     "EbayAuthError",
+    "EbayClient",
     "PriceChartingClient",
     "TCGClient",
     "TCGDexClient",

--- a/src/mgz_pkmn/sources/ebay_client.py
+++ b/src/mgz_pkmn/sources/ebay_client.py
@@ -1,0 +1,183 @@
+"""eBay listing-comps adapter (#422).
+
+Turns a card query into eBay pricing comps for the pricing ensemble
+(see [ADR-0020](../../../docs/adr/0020-ebay-pricing-source.md) and
+[ADR-0023](../../../docs/adr/0023-source-ensemble-pricing.md)). Mirrors the
+client shape of ``pricecharting.py`` / ``pokemontcg.py``: a ``requests``
+session, a per-call timeout, and network errors swallowed into an empty
+result so a source hiccup never breaks the wider lookup.
+
+Two tiers, both flowing through the existing :class:`~mgz_pkmn.pricing.Pricing`
+dataclass as additional sources:
+
+- **Active** (``source="ebay_active"``) — what's listed right now, from the
+  **Browse API**. Generally available with the application access token
+  :class:`EbayAuthClient` mints.
+- **Sold** (``source="ebay_sold"``) — recent sales, from the **Marketplace
+  Insights API**. That API is limited-release (separate eBay business
+  approval; the legacy ``findCompletedItems`` Finding API was decommissioned
+  in early 2025), so the sold path is **gated** behind
+  ``MGZ_PKMN_EBAY_SOLD_ENABLED`` (default off) and fails soft on a 403 — it's
+  a no-op until access is granted.
+
+Wiring these comps into the lookup pipeline + export serializers is #423 /
+the ensemble work; this module is just the adapter.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from typing import Any
+
+import requests
+
+from ..pricing import Pricing
+from ._common import USER_AGENT
+from .ebay import EbayAuthClient, EbayAuthError
+
+_PROD_API_BASE = "https://api.ebay.com"
+_SANDBOX_API_BASE = "https://api.sandbox.ebay.com"
+
+_BROWSE_SEARCH_PATH = "/buy/browse/v1/item_summary/search"
+_INSIGHTS_SEARCH_PATH = "/buy/marketplace_insights/v1/item_sales/search"
+
+#: Capability flag for the gated sold path.
+SOLD_ENABLED_ENV = "MGZ_PKMN_EBAY_SOLD_ENABLED"
+
+#: Titles matching these skew raw-single comps (graded slabs inflate, lots /
+#: bundles aren't a single card) — drop them before returning comps.
+_EXCLUDE_TITLE_RE = re.compile(r"\b(psa|bgs|cgc|sgc|lot|bundle|playset|x\s?\d)\b", re.IGNORECASE)
+
+
+class EbayClient:
+    """Fetches eBay sold + active listing comps for a card query."""
+
+    def __init__(
+        self,
+        *,
+        auth: EbayAuthClient | None = None,
+        marketplace_id: str = "EBAY_US",
+        sold_enabled: bool | None = None,
+        session: requests.Session | None = None,
+        verbose: bool = False,
+    ) -> None:
+        self.auth = auth or EbayAuthClient()
+        self.marketplace_id = marketplace_id
+        self.session = session or requests.Session()
+        self.session.headers.setdefault("User-Agent", USER_AGENT)
+        self.verbose = verbose
+        if sold_enabled is None:
+            sold_enabled = os.environ.get(SOLD_ENABLED_ENV, "").strip() in ("1", "true", "True")
+        self._sold_enabled = sold_enabled
+
+    @property
+    def api_base(self) -> str:
+        """Browse / Insights host, kept consistent with the token host."""
+        return _SANDBOX_API_BASE if self.auth.environment == "sandbox" else _PROD_API_BASE
+
+    def fetch_comps(self, query: str, *, limit: int = 50) -> list[Pricing]:
+        """Return deduped, condition-filtered comps for ``query``.
+
+        Always fetches active listings; additionally fetches sold listings
+        when the gated sold path is enabled. A network or auth failure on
+        either tier yields no comps for that tier rather than raising, so a
+        flaky source degrades to "no eBay price" instead of breaking lookup.
+        """
+        comps = self._fetch_active(query, limit=limit)
+        if self._sold_enabled:
+            comps += self._fetch_sold(query, limit=limit)
+        return comps
+
+    def _fetch_active(self, query: str, *, limit: int) -> list[Pricing]:
+        url = f"{self.api_base}{_BROWSE_SEARCH_PATH}"
+        payload = self._get_json(url, params={"q": query, "limit": limit})
+        if payload is None:
+            return []
+        return self._parse_listings(payload.get("itemSummaries") or [], source="ebay_active")
+
+    def _fetch_sold(self, query: str, *, limit: int) -> list[Pricing]:
+        url = f"{self.api_base}{_INSIGHTS_SEARCH_PATH}"
+        # Insights access is gated server-side; a 403 here means this app
+        # hasn't been granted the API yet — degrade to no sold comps.
+        payload = self._get_json(url, params={"q": query, "limit": limit}, soft_statuses=(403,))
+        if payload is None:
+            return []
+        return self._parse_listings(payload.get("itemSales") or [], source="ebay_sold")
+
+    def _get_json(
+        self,
+        url: str,
+        *,
+        params: dict[str, Any],
+        soft_statuses: tuple[int, ...] = (),
+    ) -> dict[str, Any] | None:
+        """GET ``url`` with the bearer token, retrying once on a 401 with a
+        force-refreshed token (the #421 auth seam). Returns parsed JSON, or
+        ``None`` on any error / soft status so callers fail soft."""
+        try:
+            resp = self._authed_get(url, params=params)
+            if resp.status_code == 401:
+                # Token may have expired mid-flight — re-mint once and retry.
+                resp = self._authed_get(url, params=params, force_refresh=True)
+            if resp.status_code in soft_statuses:
+                if self.verbose:
+                    print(f"  ! ebay {resp.status_code} for {url} (soft)", file=sys.stderr)
+                return None
+            resp.raise_for_status()
+            return resp.json()
+        except (requests.RequestException, EbayAuthError, ValueError) as exc:
+            if self.verbose:
+                print(f"  ! ebay fetch failed: {exc}", file=sys.stderr)
+            return None
+
+    def _authed_get(
+        self, url: str, *, params: dict[str, Any], force_refresh: bool = False
+    ) -> requests.Response:
+        token = self.auth.get_token(force_refresh=force_refresh)
+        if self.verbose:
+            print(f"  GET {url}", file=sys.stderr)
+        return self.session.get(
+            url,
+            params=params,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "X-EBAY-C-MARKETPLACE-ID": self.marketplace_id,
+            },
+            timeout=20,
+        )
+
+    def _parse_listings(self, items: list[dict[str, Any]], *, source: str) -> list[Pricing]:
+        """Normalize Browse / Insights items into ``Pricing`` comps, dropping
+        graded slabs / lots and de-duplicating on eBay item id."""
+        comps: list[Pricing] = []
+        seen: set[str] = set()
+        for item in items:
+            title = item.get("title") or ""
+            if _EXCLUDE_TITLE_RE.search(title):
+                continue
+            price = (item.get("price") or {}).get("value")
+            if price is None:
+                continue
+            try:
+                market = float(price)
+            except (TypeError, ValueError):
+                continue
+            dedupe_key = str(item.get("itemId") or f"{title}:{price}")
+            if dedupe_key in seen:
+                continue
+            seen.add(dedupe_key)
+            comps.append(
+                Pricing(
+                    market=market,
+                    variant=item.get("condition"),
+                    source=source,
+                    url=item.get("itemWebUrl"),
+                    currency=(item.get("price") or {}).get("currency") or "USD",
+                )
+            )
+        return comps
+
+
+__all__ = ["SOLD_ENABLED_ENV", "EbayClient"]

--- a/tests/test_ebay_client.py
+++ b/tests/test_ebay_client.py
@@ -1,0 +1,187 @@
+"""Tests for the eBay listing-comps adapter (#422).
+
+Mocked-fixture unit tests (the repo's unittest + unittest.mock style; the
+sandbox cassette suite is #428). Fixtures encode the real Browse /
+Marketplace-Insights response shapes. A fake auth client returns a static
+token so the token path never touches the network.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from mgz_pkmn.sources.ebay_client import EbayClient
+
+
+class _FakeAuth:
+    """Stand-in EbayAuthClient: hands out a static token, records refreshes."""
+
+    def __init__(self, environment: str = "production") -> None:
+        self.environment = environment
+        self.refresh_calls = 0
+
+    def get_token(self, *, force_refresh: bool = False) -> str:
+        if force_refresh:
+            self.refresh_calls += 1
+            return "REFRESHED"
+        return "TOKEN"
+
+
+class _FakeResponse:
+    def __init__(self, payload: dict, status_code: int = 200) -> None:
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"status {self.status_code}")
+
+    def json(self) -> dict:
+        return self._payload
+
+
+_BROWSE_FIXTURE = {
+    "itemSummaries": [
+        {
+            "itemId": "v1|1|0",
+            "title": "Charizard 4/102 Base Set",
+            "price": {"value": "250.00", "currency": "USD"},
+            "condition": "Used",
+            "itemWebUrl": "https://www.ebay.com/itm/1",
+        },
+        {
+            "itemId": "v1|2|0",
+            "title": "Charizard PSA 9 Base Set",  # graded → filtered out
+            "price": {"value": "1200.00", "currency": "USD"},
+            "condition": "Graded",
+            "itemWebUrl": "https://www.ebay.com/itm/2",
+        },
+        {
+            "itemId": "v1|3|0",
+            "title": "Pokemon Base Set lot of 50 cards",  # lot → filtered out
+            "price": {"value": "40.00", "currency": "USD"},
+            "itemWebUrl": "https://www.ebay.com/itm/3",
+        },
+        {
+            "itemId": "v1|1|0",  # duplicate itemId → deduped
+            "title": "Charizard 4/102 Base Set",
+            "price": {"value": "250.00", "currency": "USD"},
+            "itemWebUrl": "https://www.ebay.com/itm/1",
+        },
+        {
+            "itemId": "v1|4|0",
+            "title": "Charizard 4/102 Base Set near mint",
+            "price": {"value": "199.99", "currency": "USD"},
+            "itemWebUrl": "https://www.ebay.com/itm/4",
+        },
+    ]
+}
+
+_INSIGHTS_FIXTURE = {
+    "itemSales": [
+        {
+            "itemId": "s1",
+            "title": "Charizard 4/102 Base Set",
+            "price": {"value": "230.00", "currency": "USD"},
+            "itemWebUrl": "https://www.ebay.com/itm/s1",
+        }
+    ]
+}
+
+
+def _client(**kwargs) -> EbayClient:
+    kwargs.setdefault("auth", _FakeAuth())
+    return EbayClient(**kwargs)
+
+
+class ActiveCompsTests(unittest.TestCase):
+    def test_active_listings_become_ebay_active_pricing(self) -> None:
+        client = _client()
+        with patch.object(client.session, "get", return_value=_FakeResponse(_BROWSE_FIXTURE)):
+            comps = client.fetch_comps("Charizard 4/102 Base Set")
+        # Graded + lot dropped, duplicate itemId collapsed → 2 comps remain.
+        self.assertEqual(len(comps), 2)
+        self.assertTrue(all(c.source == "ebay_active" for c in comps))
+        self.assertEqual([c.market for c in comps], [250.00, 199.99])
+        self.assertEqual(comps[0].url, "https://www.ebay.com/itm/1")
+        self.assertEqual(comps[0].currency, "USD")
+
+    def test_marketplace_header_and_bearer_token_sent(self) -> None:
+        client = _client()
+        with patch.object(
+            client.session, "get", return_value=_FakeResponse(_BROWSE_FIXTURE)
+        ) as get:
+            client.fetch_comps("Charizard")
+        _, kwargs = get.call_args
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer TOKEN")
+        self.assertEqual(kwargs["headers"]["X-EBAY-C-MARKETPLACE-ID"], "EBAY_US")
+
+    def test_sandbox_environment_targets_sandbox_host(self) -> None:
+        client = _client(auth=_FakeAuth(environment="sandbox"))
+        self.assertIn("api.sandbox.ebay.com", client.api_base)
+
+    def test_network_error_returns_no_comps(self) -> None:
+        client = _client()
+        with patch.object(client.session, "get", side_effect=requests.ConnectionError("boom")):
+            self.assertEqual(client.fetch_comps("Charizard"), [])
+
+    def test_401_retries_once_with_force_refresh(self) -> None:
+        client = _client()
+        responses = [_FakeResponse({}, status_code=401), _FakeResponse(_BROWSE_FIXTURE)]
+        with patch.object(client.session, "get", side_effect=responses):
+            comps = client.fetch_comps("Charizard")
+        self.assertEqual(client.auth.refresh_calls, 1)
+        self.assertEqual(len(comps), 2)
+
+
+class SoldCompsTests(unittest.TestCase):
+    def test_sold_disabled_by_default_skips_insights(self) -> None:
+        client = _client()
+        with patch.object(
+            client.session, "get", return_value=_FakeResponse(_BROWSE_FIXTURE)
+        ) as get:
+            client.fetch_comps("Charizard")
+        # Only the Browse endpoint was hit.
+        urls = [call.args[0] for call in get.call_args_list]
+        self.assertTrue(all("item_summary/search" in u for u in urls))
+        self.assertFalse(any("item_sales/search" in u for u in urls))
+
+    def test_sold_enabled_adds_ebay_sold_comps(self) -> None:
+        client = _client(sold_enabled=True)
+
+        def _route(url, **_kwargs):
+            if "item_sales/search" in url:
+                return _FakeResponse(_INSIGHTS_FIXTURE)
+            return _FakeResponse(_BROWSE_FIXTURE)
+
+        with patch.object(client.session, "get", side_effect=_route):
+            comps = client.fetch_comps("Charizard")
+        sources = {c.source for c in comps}
+        self.assertEqual(sources, {"ebay_active", "ebay_sold"})
+        sold = [c for c in comps if c.source == "ebay_sold"]
+        self.assertEqual(sold[0].market, 230.00)
+
+    def test_sold_403_degrades_to_no_sold_comps(self) -> None:
+        client = _client(sold_enabled=True)
+
+        def _route(url, **_kwargs):
+            if "item_sales/search" in url:
+                return _FakeResponse({}, status_code=403)
+            return _FakeResponse(_BROWSE_FIXTURE)
+
+        with patch.object(client.session, "get", side_effect=_route):
+            comps = client.fetch_comps("Charizard")
+        # Active still returned; no sold comps, no raise.
+        self.assertTrue(comps)
+        self.assertTrue(all(c.source == "ebay_active" for c in comps))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #422

## What

Adds `src/mgz_pkmn/sources/ebay_client.py` — `EbayClient.fetch_comps(query)` returns deduped, condition-filtered `Pricing` comps for a card query, mirroring the client shape of `pricecharting.py` / `pokemontcg.py` (a `requests` session, a per-call timeout, and network errors swallowed into an empty result).

Two tiers, both surfacing as `Pricing` entries:

- **Active** (`source="ebay_active"`) — current listings from the **Browse API**. Available with the application token, so it's always on.
- **Sold** (`source="ebay_sold"`) — recent sales from the **Marketplace Insights API**. Insights is limited-release (separate eBay business approval; the legacy `findCompletedItems` Finding API was retired in early 2025), so the sold path is gated behind `MGZ_PKMN_EBAY_SOLD_ENABLED` (default off) and fails soft on a 403 — a no-op until access is granted.

Parsing drops graded slabs / lots / bundles (title regex) and de-dupes on eBay item id. Builds on the #421 `EbayAuthClient`: a 401 retries once with a force-refreshed token. `docs/sources.md` documents the active-vs-sold split and the new gate.

## Why

Part of the eBay pricing epic (#416, ADR-0020 / ADR-0023). This is the source adapter; wiring the comps into the lookup pipeline + export serializers is #423 / the ensemble work.

## How to verify

```bash
uv run python -m pytest tests/test_ebay_client.py -q
make check
```

Mocked-fixture unit tests cover: active listings → `ebay_active` comps with graded/lot filtering + dedup, bearer-token + marketplace header, sandbox host selection, network-error fail-soft, 401 single-retry, sold disabled by default, sold-enabled adds `ebay_sold` comps, and sold-403 degrades to active-only. The sandbox cassette suite is #428.