### PR TITLE
feat(api): carry ebay_sold / ebay_active comp signals through the output serializers

### DIFF
--- a/api/db/serialize.py
+++ b/api/db/serialize.py
@@ -47,6 +47,8 @@ def _pricing_to_dict(p: Pricing) -> dict[str, Any]:
         "source": p.source,
         "url": p.url,
         "currency": p.currency,
+        "ebay_sold_median": p.ebay_sold_median,
+        "ebay_active_floor": p.ebay_active_floor,
     }
 
 
@@ -111,6 +113,8 @@ def run_row_to_row(rr: RunRow) -> Row:
         source=p.get("source"),
         url=p.get("url"),
         currency=p.get("currency") or "USD",
+        ebay_sold_median=p.get("ebay_sold_median"),
+        ebay_active_floor=p.get("ebay_active_floor"),
     )
     return Row(
         query=query,

--- a/api/routes/export.py
+++ b/api/routes/export.py
@@ -37,6 +37,8 @@ class PricingIn(BaseModel):
     source: str | None = None
     url: str | None = None
     currency: str = "USD"
+    ebay_sold_median: float | None = None
+    ebay_active_floor: float | None = None
 
 
 class CardQueryIn(BaseModel):
@@ -185,6 +187,8 @@ def _to_row(
         source=r.pricing.source,
         url=r.pricing.url,
         currency=r.pricing.currency,
+        ebay_sold_median=r.pricing.ebay_sold_median,
+        ebay_active_floor=r.pricing.ebay_active_floor,
     )
     image_path = _download_card_image(r.card, images_dir, session)
     return Row(query=q, card=r.card, pricing=pricing, image_path=image_path, tag=r.tag)

--- a/api/routes/lookup.py
+++ b/api/routes/lookup.py
@@ -95,6 +95,8 @@ def _pricing_to_dict(p: Pricing) -> dict[str, Any]:
         "source": p.source,
         "url": p.url,
         "currency": p.currency,
+        "ebay_sold_median": p.ebay_sold_median,
+        "ebay_active_floor": p.ebay_active_floor,
     }
 
 

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -16,7 +16,9 @@ checklist live in their own pages — see [PDF binder](binder-pdf.md) and
 | Database | `pokemontcg.io`, `tcgdex (zh-tw)`, `pricecharting`, … |
 | Market | Currency-aware (`$` / `€`). |
 | 80% / 85% / 90% / 95% | Comps for negotiating at the table. |
-| Price Source | `tcgplayer`, `cardmarket`, or `pricecharting`. |
+| eBay Sold (median) | Median of recent eBay sold comps, when the eBay source contributed (else `—`). |
+| eBay Active (floor) | Cheapest current eBay active listing, when the eBay source contributed (else `—`). |
+| Price Source | `tcgplayer`, `cardmarket`, `pricecharting`, `ebay_active`, or `ebay_sold`. |
 | Listing URL | Hyperlink to the live listing. |
 
 A totals row at the bottom sums each price column. **Note:** the totals
@@ -54,7 +56,7 @@ alongside the spreadsheet.
 | `tags` | The same aggregate fields as `summary`, but per input file (per "Source" tag), plus the `highest_value_card` in that section. Run-level metadata like `sort_mode` is not repeated per tag. |
 | `highlights.most_valuable` | Top 5 priced cards across the whole run. |
 | `highlights.missing` | Every unmatched line + its tag, so you can iterate the input. |
-| `rows` | The full per-row payload (input, matched card, pricing, comps, image path). |
+| `rows` | The full per-row payload (input, matched card, pricing, comps, `ebay_sold_median` / `ebay_active_floor`, image path). |
 
 Mixed USD + EUR runs keep currencies separate in `totals_by_currency`
 and `stats_by_currency`. The headline `highest_value_card` per tag

--- a/src/mgz_pkmn/pricing.py
+++ b/src/mgz_pkmn/pricing.py
@@ -2,8 +2,23 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
+from statistics import median
 from typing import Any
+
+# The price sources a `Pricing.source` may name. pokemontcg.io exposes
+# tcgplayer + cardmarket; pricecharting is the URL-hint path; ebay_active /
+# ebay_sold come from the eBay Browse / Marketplace-Insights adapter
+# (`sources.ebay_client`). Documentation-only — the pipeline fails soft on an
+# unknown source rather than validating against this set.
+PRICE_SOURCES = (
+    "tcgplayer",
+    "cardmarket",
+    "pricecharting",
+    "ebay_active",
+    "ebay_sold",
+)
 
 # Variants we look at when picking a market price, in preference order.
 PRICE_VARIANT_PREFERENCE = (
@@ -24,9 +39,30 @@ COMP_PERCENTS = (80, 85, 90, 95)
 class Pricing:
     market: float | None = None
     variant: str | None = None
-    source: str | None = None  # "tcgplayer" | "cardmarket" | "pricecharting"
+    source: str | None = None  # one of PRICE_SOURCES
     url: str | None = None
     currency: str = "USD"
+    # eBay listing-comp signals carried alongside the primary market price:
+    # the median of recent sold comps and the lowest current active listing.
+    # Both stay None until the eBay source contributes (see summarize_ebay_comps).
+    ebay_sold_median: float | None = None
+    ebay_active_floor: float | None = None
+
+
+def summarize_ebay_comps(comps: Iterable[Pricing]) -> tuple[float | None, float | None]:
+    """Reduce eBay comps into (median sold, active floor).
+
+    Takes the ``ebay_sold`` / ``ebay_active`` ``Pricing`` entries the eBay
+    adapter (`sources.ebay_client.EbayClient.fetch_comps`) returns and folds
+    them into the two scalar signals the serializers carry: the median of the
+    sold prices and the floor (cheapest) of the active listings. Either is
+    ``None`` when that tier contributed no priced comps.
+    """
+    sold = [c.market for c in comps if c.source == "ebay_sold" and c.market is not None]
+    active = [c.market for c in comps if c.source == "ebay_active" and c.market is not None]
+    median_sold = round(median(sold), 2) if sold else None
+    active_floor = round(min(active), 2) if active else None
+    return median_sold, active_floor
 
 
 def extract_pricing(card: dict[str, Any], variant_hint: str | None) -> Pricing:

--- a/src/mgz_pkmn/report.py
+++ b/src/mgz_pkmn/report.py
@@ -195,6 +195,8 @@ def build_json_report(
             "source": r.pricing.source,
             "url": r.pricing.url,
             "comps": _comps(r.pricing.market),
+            "ebay_sold_median": r.pricing.ebay_sold_median,
+            "ebay_active_floor": r.pricing.ebay_active_floor,
             "over_max_price": _over_cap(r),
         }
         for r in rows

--- a/src/mgz_pkmn/spreadsheet.py
+++ b/src/mgz_pkmn/spreadsheet.py
@@ -34,8 +34,10 @@ HEADERS = [
     "85%",  # M
     "90%",  # N
     "95%",  # O
-    "Price Source",  # P
-    "Listing URL",  # Q
+    "eBay Sold (median)",  # P
+    "eBay Active (floor)",  # Q
+    "Price Source",  # R
+    "Listing URL",  # S
 ]
 
 
@@ -89,8 +91,10 @@ def write_spreadsheet(rows: list[Row], out_path: Path, max_price: float | None =
         "M": 10,
         "N": 10,
         "O": 10,
-        "P": 14,  # Price Source
-        "Q": 38,  # Listing URL
+        "P": 16,  # eBay Sold (median)
+        "Q": 16,  # eBay Active (floor)
+        "R": 14,  # Price Source
+        "S": 38,  # Listing URL
     }
     for col, w in widths.items():
         ws.column_dimensions[col].width = w
@@ -133,9 +137,16 @@ def write_spreadsheet(rows: list[Row], out_path: Path, max_price: float | None =
         else:
             ws.cell(row=i, column=11, value="—")
 
-        ws.cell(row=i, column=16, value=row.pricing.source or "")
+        for offset, value in enumerate(
+            (row.pricing.ebay_sold_median, row.pricing.ebay_active_floor)
+        ):
+            cell = ws.cell(row=i, column=16 + offset, value=value if value is not None else "—")
+            if value is not None:
+                cell.number_format = money_fmt
+
+        ws.cell(row=i, column=18, value=row.pricing.source or "")
         if row.pricing.url:
-            link_cell = ws.cell(row=i, column=17, value=row.pricing.url)
+            link_cell = ws.cell(row=i, column=19, value=row.pricing.url)
             link_cell.hyperlink = row.pricing.url
             link_cell.font = Font(color=palette.hex("fg-link"), underline="single")
 

--- a/tests/test_ebay_serializers.py
+++ b/tests/test_ebay_serializers.py
@@ -1,0 +1,131 @@
+"""Tests for the eBay comp signals on the output serializers (#423).
+
+Covers the `summarize_ebay_comps` reducer and the three serializer surfaces
+the issue names — xlsx columns, the JSON report rows payload, and (via the
+shared `_pricing_to_dict`) the wire shape. The acceptance contract is:
+existing fields unchanged when no eBay data is present, the new fields /
+columns populated when it is.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from openpyxl import load_workbook
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from mgz_pkmn.parser import CardQuery
+from mgz_pkmn.pricing import Pricing, summarize_ebay_comps
+from mgz_pkmn.report import build_json_report
+from mgz_pkmn.spreadsheet import HEADERS, Row, write_spreadsheet
+
+
+def _row(pricing: Pricing, tag: str = "list-a") -> Row:
+    return Row(
+        query=CardQuery(raw="Charizard", name="Charizard"),
+        card={"id": "x", "name": "Charizard", "number": "4", "set": {"name": "Base"}},
+        pricing=pricing,
+        tag=tag,
+    )
+
+
+class SummarizeEbayCompsTests(unittest.TestCase):
+    def test_median_sold_and_active_floor(self) -> None:
+        comps = [
+            Pricing(market=230.0, source="ebay_sold"),
+            Pricing(market=250.0, source="ebay_sold"),
+            Pricing(market=210.0, source="ebay_sold"),
+            Pricing(market=199.99, source="ebay_active"),
+            Pricing(market=240.0, source="ebay_active"),
+        ]
+        median_sold, active_floor = summarize_ebay_comps(comps)
+        self.assertEqual(median_sold, 230.0)  # median of 210/230/250
+        self.assertEqual(active_floor, 199.99)  # cheapest active
+
+    def test_each_tier_independent(self) -> None:
+        # Only active comps present → sold stays None, and vice versa.
+        self.assertEqual(
+            summarize_ebay_comps([Pricing(market=10.0, source="ebay_active")]),
+            (None, 10.0),
+        )
+        self.assertEqual(
+            summarize_ebay_comps([Pricing(market=10.0, source="ebay_sold")]),
+            (10.0, None),
+        )
+
+    def test_empty_and_unpriced_comps_yield_none(self) -> None:
+        self.assertEqual(summarize_ebay_comps([]), (None, None))
+        self.assertEqual(
+            summarize_ebay_comps([Pricing(market=None, source="ebay_sold")]),
+            (None, None),
+        )
+
+    def test_ignores_non_ebay_sources(self) -> None:
+        self.assertEqual(
+            summarize_ebay_comps([Pricing(market=5.0, source="tcgplayer")]),
+            (None, None),
+        )
+
+
+class PricingDefaultsTests(unittest.TestCase):
+    def test_ebay_fields_default_to_none(self) -> None:
+        p = Pricing(market=12.5)
+        self.assertIsNone(p.ebay_sold_median)
+        self.assertIsNone(p.ebay_active_floor)
+
+
+class XlsxColumnTests(unittest.TestCase):
+    def test_headers_carry_ebay_columns_before_price_source(self) -> None:
+        self.assertEqual(
+            HEADERS[15:19],
+            ["eBay Sold (median)", "eBay Active (floor)", "Price Source", "Listing URL"],
+        )
+
+    def _write_and_load(self, pricing: Pricing):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "cards.xlsx"
+            write_spreadsheet([_row(pricing)], out)
+            return load_workbook(out).active
+
+    def test_ebay_cells_populated_when_present(self) -> None:
+        ws = self._write_and_load(
+            Pricing(
+                market=250.0, source="ebay_active", ebay_sold_median=230.0, ebay_active_floor=199.99
+            )
+        )
+        # Row 2, columns P (16) / Q (17) carry the aggregates; R (18) the source.
+        self.assertEqual(ws.cell(row=2, column=16).value, 230.0)
+        self.assertEqual(ws.cell(row=2, column=17).value, 199.99)
+        self.assertEqual(ws.cell(row=2, column=18).value, "ebay_active")
+
+    def test_ebay_cells_dash_when_absent(self) -> None:
+        ws = self._write_and_load(Pricing(market=12.5, source="tcgplayer"))
+        self.assertEqual(ws.cell(row=2, column=16).value, "—")
+        self.assertEqual(ws.cell(row=2, column=17).value, "—")
+        self.assertEqual(ws.cell(row=2, column=18).value, "tcgplayer")
+
+
+class JsonReportTests(unittest.TestCase):
+    def _rows_payload(self, pricing: Pricing) -> dict:
+        payload = build_json_report(rows=[_row(pricing)], counters={}, input_lines=1, elapsed=1.0)
+        return payload["rows"][0]
+
+    def test_rows_carry_ebay_signals_when_present(self) -> None:
+        row = self._rows_payload(
+            Pricing(market=250.0, ebay_sold_median=230.0, ebay_active_floor=199.99)
+        )
+        self.assertEqual(row["ebay_sold_median"], 230.0)
+        self.assertEqual(row["ebay_active_floor"], 199.99)
+
+    def test_rows_carry_null_ebay_signals_when_absent(self) -> None:
+        row = self._rows_payload(Pricing(market=12.5))
+        self.assertIsNone(row["ebay_sold_median"])
+        self.assertIsNone(row["ebay_active_floor"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -570,6 +570,24 @@ class SerializeRoundTripTests(unittest.TestCase):
         self.assertEqual(restored.query.price_min, 10.0)
         self.assertEqual(restored.query.price_max, 50.0)
 
+    def test_ebay_comp_signals_round_trip(self) -> None:
+        """`ebay_sold_median` / `ebay_active_floor` survive the Row → RunRow →
+        Row round-trip via `pricing_json` (#423)."""
+        from api.db.serialize import row_to_run_row, run_row_to_row
+        from mgz_pkmn.parser import CardQuery
+        from mgz_pkmn.pricing import Pricing
+        from mgz_pkmn.spreadsheet import Row
+
+        row = Row(
+            query=CardQuery(raw="charizard", name="charizard"),
+            card={"id": "x"},
+            pricing=Pricing(market=250.0, ebay_sold_median=230.0, ebay_active_floor=199.99),
+            tag="",
+        )
+        restored = run_row_to_row(row_to_run_row(row, position=0))
+        self.assertEqual(restored.pricing.ebay_sold_median, 230.0)
+        self.assertEqual(restored.pricing.ebay_active_floor, 199.99)
+
     def test_currency_is_null_on_unpriced_miss(self) -> None:
         """An unmatched/unpriced row stores `currency = NULL`, not the
         `Pricing.currency` "USD" default."""


### PR DESCRIPTION
Closes #423

## What

Extends the `Pricing` model and every serializer to carry the eBay listing comps the #422 adapter produces, so they surface cleanly in exports.

- **`Pricing`** gains two optional fields — `ebay_sold_median` and `ebay_active_floor` — both defaulting to `None`.
- **`summarize_ebay_comps(comps)`** folds an adapter's `list[Pricing]` into those two scalars: the median of the `ebay_sold` comps and the floor (cheapest) of the `ebay_active` comps. Either is `None` when that tier contributed no priced comps. This is the seam the lookup-pipeline wiring will call.
- **`PRICE_SOURCES`** names all valid `Pricing.source` strings, now including `ebay_active` / `ebay_sold` (documentation-only — the pipeline still fails soft on an unknown source).
- **Serializers threaded:** the xlsx export (two new columns, `eBay Sold (median)` / `eBay Active (floor)`, between the comp tiers and `Price Source`), the JSON report rows payload, the live web-API lookup response, the runs-persistence round-trip (`pricing_json`), and the export-request `PricingIn` model.
- `docs/outputs.md` documents the new columns + extended `Price Source` values.

## Why

Part of the eBay pricing epic (#416, ADR-0020 / ADR-0023). #422 built the adapter that emits `ebay_active` / `ebay_sold` comps; this is the output half that lets them travel through the spreadsheet, JSON report, and web API. The aggregation into a single median-sold + active-floor per card is the shape the exports want.

## How to verify

```bash
uv run python -m pytest tests/test_ebay_serializers.py tests/test_persistence.py -q
make check
```

`tests/test_ebay_serializers.py` covers the reducer (median sold, active floor, per-tier independence, empty/unpriced/non-eBay inputs), the xlsx column layout + populated/`—` cells, and the JSON rows payload (populated + null). `tests/test_persistence.py` gains a `Row → RunRow → Row` round-trip asserting the fields survive `pricing_json`. The acceptance contract — exports unchanged when no eBay data is present, fields populated when it is — falls out of the `None` defaults.

Note: this is the data-model + serializer layer. Calling the `EbayClient` adapter live during a lookup (so these fields populate in a real run) is the remaining ensemble-wiring work.