### PR TITLE
feat(api): per-source TTL cache for eBay comps (sold 7d, active 6h)

### DIFF
--- a/docs/cache.md
+++ b/docs/cache.md
@@ -27,7 +27,7 @@ governs when to *re-warm*, not when entries go stale.
 | Path | What it holds | Entry TTL |
 |---|---|---|
 | `api_structural/<sha1>.json` | Structural fields per cached request URL — name, set, number, rarity, attacks, images, etc. Anything that doesn't change once a card is printed. | None — indefinite. |
-| `api_pricing/<sha1>.json` | Volatile pricing fields per cached request URL — `tcgplayer.prices`, `cardmarket.prices`, `_pc_prices`, `_pc_url`. | 24 h (mtime-based). Stale reads return the cached value while a background refresh runs. |
+| `api_pricing/<sha1>.json` | Volatile pricing fields per cached request URL — `tcgplayer.prices`, `cardmarket.prices`, `_pc_prices`, `_pc_url` — **and** raw eBay listing-comp payloads (sold / active), keyed per source. | **Per-source** (mtime-based). pokemontcg.io pricing: 24 h. eBay sold comps: 7 d. eBay active listings: 6 h. Stale reads return the cached value while a background refresh runs. |
 | `api/<sha1>.json` | **Legacy** — pre-#372 combined payload. New writes never land here; existing entries are migrated to the split form lazily on first read. | No standalone TTL. On read the legacy file is split, the pricing slice's mtime is preserved, and the legacy file is unlinked — so a pre-existing 9-day-old legacy entry comes out STALE on the pricing side immediately after migration. |
 | `url_overrides.json` | `(name, set_hint)` → PriceCharting URL, recorded whenever you paste a PC URL on a line. | None — sticky until you overwrite or delete. |
 
@@ -48,6 +48,14 @@ semantics** ([#372](https://github.com/mgzwarrior/mgz-pkmn/issues/372),
   is returned **immediately** and a background thread re-fetches
   the upstream URL and writes a fresh pricing slice for the next
   request. This is the **stale-while-revalidate** pattern.
+
+eBay listing comps share the `api_pricing/` slice but carry their own
+freshness windows ([#424](https://github.com/mgzwarrior/mgz-pkmn/issues/424),
+[ADR-0020](adr/0020-ebay-pricing-source.md)): **sold** comps for **7 days**
+(recent sales stay useful day-to-day) and **active** listings for **6 hours**
+(a stale floor misleads at the table). Each tier is fetched and cached
+independently, with the same stale-while-revalidate refresh. `pricing_ttl_for_source`
+in `cache.py` resolves a `Pricing.source` to its window.
 
 `/api/v1/lookup` advertises which path served the request through
 an **`X-Cache`** response header:

--- a/src/mgz_pkmn/cache.py
+++ b/src/mgz_pkmn/cache.py
@@ -51,6 +51,14 @@ DEFAULT_API_TTL_SECONDS = 7 * 24 * 60 * 60  # one week
 # Split API cache (#372): structural fields cached indefinitely, pricing
 # fields cached for 24h with stale-while-revalidate. See ADR-0018.
 DEFAULT_PRICING_TTL_SECONDS = 24 * 60 * 60  # one day
+# Per-source pricing TTLs (#424, ADR-0020). eBay listing comps live in the
+# same `api_pricing/` slice as the pokemontcg.io pricing, but each eBay tier
+# carries its own freshness window: sold comps are stable (a week of recent
+# sales stays useful day-to-day), active listings are volatile (a floor that's
+# six hours old is already suspect at a card show). `pricing_ttl_for_source`
+# resolves a `Pricing.source` string to its window.
+EBAY_SOLD_TTL_SECONDS = 7 * 24 * 60 * 60  # one week
+EBAY_ACTIVE_TTL_SECONDS = 6 * 60 * 60  # six hours
 # Card-dict keys that carry volatile price data. Everything else is
 # structural. Order is irrelevant; existence checks drive the split.
 _PRICING_KEYS: tuple[str, ...] = ("tcgplayer", "cardmarket", "_pc_prices", "_pc_url")
@@ -625,13 +633,73 @@ def write_pricing_only(key: str, cards: list[dict[str, Any]]) -> None:
     _atomic_write_json(_api_pricing_path(key), pricings)
 
 
-def spawn_pricing_refresh(key: str, refetch: Callable[[], list[dict[str, Any]] | None]) -> bool:
+def pricing_ttl_for_source(source: str | None) -> float:
+    """Resolve a `Pricing.source` string to its pricing-cache TTL (#424).
+
+    eBay's two tiers carry distinct windows per ADR-0020 (sold 7d, active
+    6h); everything else falls back to the ADR-0018 default. The eBay adapter
+    passes its tier's source here so a `read_pricing_payload` HIT/STALE split
+    lands on the right clock."""
+    if source == "ebay_sold":
+        return EBAY_SOLD_TTL_SECONDS
+    if source == "ebay_active":
+        return EBAY_ACTIVE_TTL_SECONDS
+    return DEFAULT_PRICING_TTL_SECONDS
+
+
+def read_pricing_payload(key: str, *, ttl_seconds: float) -> tuple[Any | None, str]:
+    """Read an arbitrary pricing payload from the `api_pricing/` slice (#424).
+
+    The non-card pricing sources (eBay) cache their raw upstream payload here
+    rather than through `read_api_split`, which is card-shaped (structural +
+    pricing). Returns `(payload, status)` where status is `HIT` (within TTL),
+    `STALE` (present but past TTL — caller should serve it and spawn a
+    background refresh), or `MISS` (absent / unreadable / cache disabled).
+
+    Intentionally does not touch the `_api_hits` / `_api_fetches` counters:
+    those drive the pokemontcg-centric `pkmn lookup` summary tail, and eBay
+    comps aren't part of that line. Background refreshes are tallied via
+    `pricing_counters()` like the card slice."""
+    if _disabled():
+        return (None, "MISS")
+    p = _api_pricing_path(key)
+    if not p.exists():
+        return (None, "MISS")
+    try:
+        payload = json.loads(p.read_text(encoding="utf-8"))
+        age = time.time() - p.stat().st_mtime
+    except (OSError, json.JSONDecodeError):
+        return (None, "MISS")
+    return (payload, "HIT" if age <= ttl_seconds else "STALE")
+
+
+def write_pricing_payload(key: str, payload: Any) -> None:
+    """Atomically write an arbitrary pricing payload to the `api_pricing/`
+    slice, refreshing its mtime. Counterpart to `read_pricing_payload`;
+    doubles as the `spawn_pricing_refresh` writer for non-card sources."""
+    if _disabled():
+        return
+    _atomic_write_json(_api_pricing_path(key), payload)
+
+
+def spawn_pricing_refresh(
+    key: str,
+    refetch: Callable[[], Any],
+    *,
+    writer: Callable[[str, Any], None] = write_pricing_only,
+) -> bool:
     """Spawn a daemon thread that re-fetches `key` and writes a fresh pricing slice.
 
     Coalesces concurrent stale reads on the same key: if a refresh is
     already in flight, returns False and does nothing. Otherwise registers
     the key, starts the thread, and returns True. The thread always
     discards the key from the in-flight set on exit (success or failure).
+
+    `writer` lands the refetched payload. It defaults to `write_pricing_only`
+    (the card-slice writer); non-card sources (eBay, #424) pass
+    `write_pricing_payload` so the raw payload round-trips unchanged. A
+    `None` refetch result writes nothing — a soft upstream failure (e.g. a
+    gated eBay 403) leaves the stale entry in place rather than clobbering it.
     """
     with _inflight_lock:
         if key in _inflight_pricing:
@@ -644,7 +712,7 @@ def spawn_pricing_refresh(key: str, refetch: Callable[[], list[dict[str, Any]] |
         try:
             fresh = refetch()
             if fresh is not None:
-                write_pricing_only(key, fresh)
+                writer(key, fresh)
                 _pricing_refresh_writes += 1
         except Exception:
             logger.exception("background pricing refresh failed for key=%s", key)

--- a/src/mgz_pkmn/sources/ebay_client.py
+++ b/src/mgz_pkmn/sources/ebay_client.py
@@ -20,6 +20,12 @@ dataclass as additional sources:
   ``MGZ_PKMN_EBAY_SOLD_ENABLED`` (default off) and fails soft on a 403 — it's
   a no-op until access is granted.
 
+Each tier is cached cache-aside in the shared ``api_pricing/`` slice with a
+per-source TTL (#424, [ADR-0020](../../../docs/adr/0020-ebay-pricing-source.md)):
+sold comps for 7 days, active listings for 6 hours, with stale-while-revalidate
+background refresh — the same machinery the pokemontcg.io pricing slice uses
+(ADR-0018).
+
 Wiring these comps into the lookup pipeline + export serializers is #423 /
 the ensemble work; this module is just the adapter.
 """
@@ -33,6 +39,7 @@ from typing import Any
 
 import requests
 
+from .. import cache as disk_cache
 from ..pricing import Pricing
 from ._common import USER_AGENT
 from .ebay import EbayAuthClient, EbayAuthError
@@ -91,20 +98,71 @@ class EbayClient:
         return comps
 
     def _fetch_active(self, query: str, *, limit: int) -> list[Pricing]:
-        url = f"{self.api_base}{_BROWSE_SEARCH_PATH}"
-        payload = self._get_json(url, params={"q": query, "limit": limit})
-        if payload is None:
-            return []
-        return self._parse_listings(payload.get("itemSummaries") or [], source="ebay_active")
+        return self._fetch_tier(
+            query,
+            limit=limit,
+            source="ebay_active",
+            url=f"{self.api_base}{_BROWSE_SEARCH_PATH}",
+            results_key="itemSummaries",
+        )
 
     def _fetch_sold(self, query: str, *, limit: int) -> list[Pricing]:
-        url = f"{self.api_base}{_INSIGHTS_SEARCH_PATH}"
         # Insights access is gated server-side; a 403 here means this app
         # hasn't been granted the API yet — degrade to no sold comps.
-        payload = self._get_json(url, params={"q": query, "limit": limit}, soft_statuses=(403,))
-        if payload is None:
-            return []
-        return self._parse_listings(payload.get("itemSales") or [], source="ebay_sold")
+        return self._fetch_tier(
+            query,
+            limit=limit,
+            source="ebay_sold",
+            url=f"{self.api_base}{_INSIGHTS_SEARCH_PATH}",
+            results_key="itemSales",
+            soft_statuses=(403,),
+        )
+
+    def _fetch_tier(
+        self,
+        query: str,
+        *,
+        limit: int,
+        source: str,
+        url: str,
+        results_key: str,
+        soft_statuses: tuple[int, ...] = (),
+    ) -> list[Pricing]:
+        """Cache-aside fetch + parse for one eBay tier (#424, ADR-0020).
+
+        The raw upstream payload is cached in the `api_pricing/` slice with a
+        per-source TTL (`pricing_ttl_for_source`): a HIT parses straight from
+        disk, a STALE serves the cached payload and kicks off a background
+        refresh, and a MISS fetches the network, writes, then parses. The
+        cache is transparently bypassed under ``MGZ_PKMN_NO_CACHE`` (the read
+        misses and the write is a no-op), so an uncached run behaves exactly
+        as before.
+        """
+        params = {"q": query, "limit": limit}
+        cache_key = self._cache_key(source, query, limit)
+        ttl = disk_cache.pricing_ttl_for_source(source)
+        cached, status = disk_cache.read_pricing_payload(cache_key, ttl_seconds=ttl)
+        if status == "STALE":
+            if self.verbose:
+                print(f"  stale {url} (background refresh kicked off)", file=sys.stderr)
+            disk_cache.spawn_pricing_refresh(
+                cache_key,
+                lambda: self._get_json(url, params=params, soft_statuses=soft_statuses),
+                writer=disk_cache.write_pricing_payload,
+            )
+        elif status == "MISS":
+            cached = self._get_json(url, params=params, soft_statuses=soft_statuses)
+            if cached is None:
+                return []
+            disk_cache.write_pricing_payload(cache_key, cached)
+        elif self.verbose:
+            print(f"  cached {url}", file=sys.stderr)
+        return self._parse_listings((cached or {}).get(results_key) or [], source=source)
+
+    def _cache_key(self, source: str, query: str, limit: int) -> str:
+        """Stable per-tier cache key. Environment + marketplace keep sandbox /
+        production and per-marketplace results from colliding."""
+        return f"ebay:{self.auth.environment}:{source}:{self.marketplace_id}:{query}:{limit}"
 
     def _get_json(
         self,

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -806,6 +806,84 @@ class SwrCoordinatorTests(_IsolatedCacheDirMixin):
         attempts, writes = cache.pricing_counters()
         self.assertEqual((attempts, writes), (1, 0))
 
+    def test_spawn_pricing_refresh_honours_custom_writer(self) -> None:
+        # Non-card sources (eBay, #424) pass write_pricing_payload so the raw
+        # payload round-trips unchanged instead of going through the card split.
+        self._patch_thread_sync()
+        cache.write_pricing_payload("k", {"old": True})
+        cache.spawn_pricing_refresh(
+            "k",
+            lambda: {"itemSales": [{"price": {"value": "5"}}]},
+            writer=cache.write_pricing_payload,
+        )
+        payload, _ = cache.read_pricing_payload("k", ttl_seconds=3600)
+        self.assertEqual(payload, {"itemSales": [{"price": {"value": "5"}}]})
+        self.assertNotIn("k", cache._inflight_pricing)
+
+
+class PricingTtlPolicyTests(unittest.TestCase):
+    """Per-source TTL policy (#424, ADR-0020)."""
+
+    def test_ebay_sold_is_seven_days(self) -> None:
+        self.assertEqual(cache.pricing_ttl_for_source("ebay_sold"), 7 * 24 * 3600)
+
+    def test_ebay_active_is_six_hours(self) -> None:
+        self.assertEqual(cache.pricing_ttl_for_source("ebay_active"), 6 * 3600)
+
+    def test_unknown_and_none_sources_fall_back_to_default(self) -> None:
+        self.assertEqual(
+            cache.pricing_ttl_for_source("tcgplayer"), cache.DEFAULT_PRICING_TTL_SECONDS
+        )
+        self.assertEqual(cache.pricing_ttl_for_source(None), cache.DEFAULT_PRICING_TTL_SECONDS)
+
+
+class PricingPayloadCacheTests(_IsolatedCacheDirMixin):
+    """read_pricing_payload / write_pricing_payload — the non-card pricing
+    slice eBay comps use (#424)."""
+
+    def test_round_trip_hit_within_ttl(self) -> None:
+        cache.write_pricing_payload("k", {"itemSummaries": [1, 2]})
+        payload, status = cache.read_pricing_payload("k", ttl_seconds=3600)
+        self.assertEqual(status, "HIT")
+        self.assertEqual(payload, {"itemSummaries": [1, 2]})
+
+    def test_miss_when_absent(self) -> None:
+        payload, status = cache.read_pricing_payload("k", ttl_seconds=3600)
+        self.assertEqual(status, "MISS")
+        self.assertIsNone(payload)
+
+    def test_stale_past_ttl_still_serves_value(self) -> None:
+        cache.write_pricing_payload("k", {"x": 1})
+        _backdate(cache._api_pricing_path("k"), 7200)
+        payload, status = cache.read_pricing_payload("k", ttl_seconds=3600)
+        self.assertEqual(status, "STALE")
+        self.assertEqual(payload, {"x": 1})
+
+    def test_same_age_entry_is_stale_for_active_but_hit_for_sold(self) -> None:
+        # A 7-hour-old entry is past the 6h active window but inside the 7d
+        # sold window — the TTL really is resolved per source, not globally.
+        cache.write_pricing_payload("k", {"x": 1})
+        _backdate(cache._api_pricing_path("k"), 7 * 3600)
+        _, active = cache.read_pricing_payload(
+            "k", ttl_seconds=cache.pricing_ttl_for_source("ebay_active")
+        )
+        _, sold = cache.read_pricing_payload(
+            "k", ttl_seconds=cache.pricing_ttl_for_source("ebay_sold")
+        )
+        self.assertEqual(active, "STALE")
+        self.assertEqual(sold, "HIT")
+
+    def test_no_cache_env_suppresses_reads_and_writes(self) -> None:
+        os.environ[cache._NO_CACHE_ENV] = "1"
+        try:
+            cache.write_pricing_payload("k", {"x": 1})
+            self.assertFalse(cache._api_pricing_path("k").exists())
+            payload, status = cache.read_pricing_payload("k", ttl_seconds=3600)
+            self.assertEqual(status, "MISS")
+            self.assertIsNone(payload)
+        finally:
+            os.environ.pop(cache._NO_CACHE_ENV, None)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ebay_client.py
+++ b/tests/test_ebay_client.py
@@ -8,7 +8,10 @@ token so the token path never touches the network.
 
 from __future__ import annotations
 
+import os
 import sys
+import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -17,6 +20,7 @@ import requests
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
+from mgz_pkmn import cache
 from mgz_pkmn.sources.ebay_client import EbayClient
 
 
@@ -101,7 +105,22 @@ def _client(**kwargs) -> EbayClient:
     return EbayClient(**kwargs)
 
 
-class ActiveCompsTests(unittest.TestCase):
+class _NoCacheTestCase(unittest.TestCase):
+    """Bypass the disk cache so these tests exercise the network + parse path
+    directly. The per-source caching layer is covered in EbayCacheTests."""
+
+    def setUp(self) -> None:
+        self._old_no_cache = os.environ.get(cache._NO_CACHE_ENV)
+        os.environ[cache._NO_CACHE_ENV] = "1"
+
+    def tearDown(self) -> None:
+        if self._old_no_cache is None:
+            os.environ.pop(cache._NO_CACHE_ENV, None)
+        else:
+            os.environ[cache._NO_CACHE_ENV] = self._old_no_cache
+
+
+class ActiveCompsTests(_NoCacheTestCase):
     def test_active_listings_become_ebay_active_pricing(self) -> None:
         client = _client()
         with patch.object(client.session, "get", return_value=_FakeResponse(_BROWSE_FIXTURE)):
@@ -141,7 +160,7 @@ class ActiveCompsTests(unittest.TestCase):
         self.assertEqual(len(comps), 2)
 
 
-class SoldCompsTests(unittest.TestCase):
+class SoldCompsTests(_NoCacheTestCase):
     def test_sold_disabled_by_default_skips_insights(self) -> None:
         client = _client()
         with patch.object(
@@ -181,6 +200,75 @@ class SoldCompsTests(unittest.TestCase):
         # Active still returned; no sold comps, no raise.
         self.assertTrue(comps)
         self.assertTrue(all(c.source == "ebay_active" for c in comps))
+
+
+class EbayCacheTests(unittest.TestCase):
+    """Per-source TTL caching of eBay comps (#424, ADR-0020). Each test runs
+    against a fresh tempdir cache so the first fetch always MISSes."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._old_xdg = os.environ.get("XDG_CACHE_HOME")
+        self._old_no_cache = os.environ.get(cache._NO_CACHE_ENV)
+        os.environ["XDG_CACHE_HOME"] = self._tmp.name
+        os.environ.pop(cache._NO_CACHE_ENV, None)
+
+    def tearDown(self) -> None:
+        if self._old_xdg is None:
+            os.environ.pop("XDG_CACHE_HOME", None)
+        else:
+            os.environ["XDG_CACHE_HOME"] = self._old_xdg
+        if self._old_no_cache is None:
+            os.environ.pop(cache._NO_CACHE_ENV, None)
+        else:
+            os.environ[cache._NO_CACHE_ENV] = self._old_no_cache
+        with cache._inflight_lock:
+            cache._inflight_pricing.clear()
+        self._tmp.cleanup()
+
+    def _age(self, key: str, seconds: float) -> None:
+        """Backdate a cached entry's mtime by `seconds` to force a TTL gate."""
+        t = time.time() - seconds
+        os.utime(cache._api_pricing_path(key), (t, t))
+
+    def test_miss_fetches_network_then_second_call_hits_cache(self) -> None:
+        client = _client()
+        with patch.object(
+            client.session, "get", return_value=_FakeResponse(_BROWSE_FIXTURE)
+        ) as get:
+            first = client.fetch_comps("Charizard")
+            second = client.fetch_comps("Charizard")
+        # Second call served from disk — the network was hit exactly once.
+        self.assertEqual(get.call_count, 1)
+        self.assertEqual([c.market for c in first], [c.market for c in second])
+
+    def test_active_stale_past_six_hours_spawns_refresh(self) -> None:
+        # An entry 7h old is past the active window → STALE → background
+        # refresh fires, and the stale comps are still served immediately.
+        client = _client()
+        key = client._cache_key("ebay_active", "Charizard", 50)
+        cache.write_pricing_payload(key, _BROWSE_FIXTURE)
+        self._age(key, 7 * 3600)
+        with patch.object(cache, "spawn_pricing_refresh", return_value=True) as spawn:
+            comps = client.fetch_comps("Charizard")
+        self.assertTrue(comps)
+        self.assertEqual(spawn.call_count, 1)
+        # The refresh writes through the raw-payload writer, not the card split.
+        self.assertIs(spawn.call_args.kwargs["writer"], cache.write_pricing_payload)
+
+    def test_sold_still_hits_at_seven_hours_no_network(self) -> None:
+        # The same 7h age is a HIT for the sold tier (7d window). With the
+        # active entry fresh too, the whole fetch serves from cache.
+        client = _client(sold_enabled=True)
+        active_key = client._cache_key("ebay_active", "Charizard", 50)
+        sold_key = client._cache_key("ebay_sold", "Charizard", 50)
+        cache.write_pricing_payload(active_key, _BROWSE_FIXTURE)  # fresh → HIT
+        cache.write_pricing_payload(sold_key, _INSIGHTS_FIXTURE)
+        self._age(sold_key, 7 * 3600)  # 7h < 7d → still HIT
+        with patch.object(client.session, "get") as get:
+            comps = client.fetch_comps("Charizard")
+        self.assertEqual({c.source for c in comps}, {"ebay_active", "ebay_sold"})
+        get.assert_not_called()  # both tiers served from cache
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #424

## What

Caches eBay listing comps cache-aside in the shared `api_pricing/` slice with a **per-source TTL**, extending ADR-0018's single-TTL pricing model exactly as ADR-0020 specifies.

- **`cache.py`**
  - `pricing_ttl_for_source(source)` — the policy: `ebay_sold` → 7 days, `ebay_active` → 6 hours, everything else → the 24h ADR-0018 default.
  - `read_pricing_payload` / `write_pricing_payload` — a raw-payload read/write pair in the `api_pricing/` directory for the non-card pricing sources (eBay comps aren't card-shaped, so they don't fit `read_api_split`'s structural+pricing split). Read returns `(payload, HIT/STALE/MISS)`.
  - `spawn_pricing_refresh(..., writer=...)` — now takes an optional writer (default unchanged) so the eBay path round-trips its raw payload through the same stale-while-revalidate coalescing machinery.
- **`EbayClient`** fetches each tier through a cache-aside helper: HIT parses straight from disk, STALE serves the cached comps and kicks off a background refresh, MISS hits the network then writes. `MGZ_PKMN_NO_CACHE` transparently bypasses the layer.
- `docs/cache.md` documents the per-source windows.

## Why

Part of the eBay pricing epic (#416). eBay's API is rate-limited (5000 calls/day on the default tier), and sold-sales data is stable while active listings are volatile — so the two tiers want different freshness windows. This is the caching contract ADR-0020 records; #422 built the adapter, #423 the serializers, this is the cache policy.

## How to verify

```bash
uv run python -m pytest tests/test_cache.py tests/test_ebay_client.py -q
make check
```

- `tests/test_cache.py`: the TTL policy, the `read/write_pricing_payload` round-trip (HIT/STALE/MISS, no-cache suppression), the *same-age-entry-is-STALE-for-active-but-HIT-for-sold* proof that the TTL really is per-source, and the custom-writer SWR path.
- `tests/test_ebay_client.py`: MISS→write→second-call-HIT (network hit once), active STALE at 7h spawns a refresh through `write_pricing_payload`, sold still HITs at 7h with no network. The existing network-behavior tests are pinned to `MGZ_PKMN_NO_CACHE` so they keep asserting the raw fetch/parse path.

## Scope note

This delivers the cache policy + SWR-per-source. The eBay adapter isn't in the lookup pipeline yet (deferred to the ensemble work, ADR-0023), so surfacing eBay's HIT/STALE/MISS on the `/lookup` `X-Cache` header belongs to that issue — this change leaves the existing pokemontcg.io `X-Cache` path untouched and correct.