### PR TITLE
feat(web): eBay comps column + sold sparkline in the results table and card popup

### DIFF
--- a/web/src/components/CardDetailModal.test.tsx
+++ b/web/src/components/CardDetailModal.test.tsx
@@ -510,4 +510,31 @@ describe('CardDetailModal', () => {
     // The title and the identity Name row both render the fallback.
     expect(screen.getAllByText('MissingMon').length).toBeGreaterThanOrEqual(1)
   })
+
+  it('shows the eBay comps section with median, floor, and raw comps when present', () => {
+    const row = buildRow({
+      pricing: {
+        ebay_sold_median: 230,
+        ebay_active_floor: 199.99,
+        ebay_sold_comps: [
+          { price: 220, date: '2026-01-01', condition: 'Used', url: null },
+          { price: 240, date: '2026-02-01', condition: 'Near Mint', url: null },
+        ],
+      },
+    })
+    render(<CardDetailModal rows={[row]} index={0} onChangeIndex={() => {}} />)
+    expect(screen.getByText('eBay comps')).toBeInTheDocument()
+    expect(screen.getByText('$230.00')).toBeInTheDocument() // sold median
+    expect(screen.getByText('$199.99')).toBeInTheDocument() // active floor
+    // Raw comps surface date + condition.
+    expect(screen.getByText('2026-02-01')).toBeInTheDocument()
+    expect(screen.getByText('Near Mint')).toBeInTheDocument()
+    // Sparkline summarises the series.
+    expect(screen.getByRole('img', { name: /recent ebay sold prices/i })).toBeInTheDocument()
+  })
+
+  it('omits the eBay comps section when there is no eBay data', () => {
+    render(<CardDetailModal rows={[buildRow()]} index={0} onChangeIndex={() => {}} />)
+    expect(screen.queryByText('eBay comps')).toBeNull()
+  })
 })

--- a/web/src/components/CardDetailModal.tsx
+++ b/web/src/components/CardDetailModal.tsx
@@ -18,8 +18,10 @@
 import * as Dialog from '@radix-ui/react-dialog'
 import { ChevronLeft, ChevronRight, ExternalLink, X } from 'lucide-react'
 import { useEffect } from 'react'
-import type { CardData, Row } from '../types'
+import type { CardData, EbaySoldComp, Pricing, Row } from '../types'
 import { formatComp, formatMoney } from '../utils/format'
+import { EbaySparkline } from './EbaySparkline'
+import { hasEbayData, soldPriceSeries } from './ebayComps'
 
 interface Props {
   /** The already filtered + sorted row set the parent table is showing. */
@@ -243,11 +245,97 @@ function CardDetailBody({
               </div>
             </div>
 
+            <EbayCompsBlock pricing={pricing} />
+
             <CardMetadataBlock card={card} />
           </div>
         </div>
       </div>
     </>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// EbayCompsBlock — median sold + active floor, a sparkline, and the raw
+// recent sold comps (date · condition · price). Shown only when the eBay
+// source contributed (epic #416); otherwise the section is omitted so the
+// popup stays clean for cards with no eBay data.
+// ---------------------------------------------------------------------------
+
+function EbayCompsBlock({ pricing }: { pricing: Pricing }) {
+  if (!hasEbayData(pricing)) return null
+  const comps = pricing.ebay_sold_comps ?? []
+
+  return (
+    <div>
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-coconut-400 dark:text-sand-300 mb-2">
+        eBay comps
+      </h3>
+      <div className="rounded-md border border-sand-300 dark:border-husk-50 bg-sand-50 dark:bg-husk-400 p-3 space-y-3">
+        <div className="flex items-end justify-between gap-3">
+          <div className="space-y-1">
+            <PriceLine
+              label="Sold (median)"
+              value={formatMoney(pricing.ebay_sold_median ?? null, pricing.currency)}
+            />
+            <PriceLine
+              label="Active (floor)"
+              value={formatMoney(pricing.ebay_active_floor ?? null, pricing.currency)}
+            />
+          </div>
+          <EbaySparkline
+            values={soldPriceSeries(pricing.ebay_sold_comps)}
+            currency={pricing.currency}
+            className="h-8 w-28 flex-shrink-0"
+          />
+        </div>
+
+        {comps.length > 0 && (
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="text-coconut-400 dark:text-sand-400 text-left">
+                <th className="font-medium py-1">Date</th>
+                <th className="font-medium py-1">Condition</th>
+                <th className="font-medium py-1 text-right">Price</th>
+              </tr>
+            </thead>
+            <tbody>
+              {comps.map((c, i) => (
+                <EbayCompRow key={i} comp={c} currency={pricing.currency} />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  )
+}
+
+function EbayCompRow({ comp, currency }: { comp: EbaySoldComp; currency: string }) {
+  const priceCell = (
+    <span className="font-mono tabular-nums text-coconut-600 dark:text-sand-200">
+      {formatMoney(comp.price, currency)}
+    </span>
+  )
+  return (
+    <tr className="border-t border-sand-200 dark:border-husk-100">
+      <td className="py-1 text-coconut-600 dark:text-sand-200">{comp.date ?? '—'}</td>
+      <td className="py-1 text-coconut-600 dark:text-sand-200">{comp.condition ?? '—'}</td>
+      <td className="py-1 text-right">
+        {comp.url ? (
+          <a
+            href={comp.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-palm-500 dark:text-sun-300 hover:text-palm-400 dark:hover:text-sun-200"
+          >
+            {priceCell}
+          </a>
+        ) : (
+          priceCell
+        )}
+      </td>
+    </tr>
   )
 }
 

--- a/web/src/components/EbaySparkline.test.tsx
+++ b/web/src/components/EbaySparkline.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { EbaySparkline } from './EbaySparkline'
+
+describe('EbaySparkline', () => {
+  it('renders nothing for fewer than two points', () => {
+    const { container } = render(<EbaySparkline values={[]} />)
+    expect(container.querySelector('svg')).toBeNull()
+    const { container: one } = render(<EbaySparkline values={[5]} />)
+    expect(one.querySelector('svg')).toBeNull()
+  })
+
+  it('renders an accessible polyline summarising the range', () => {
+    render(<EbaySparkline values={[10, 30, 20]} />)
+    const svg = screen.getByRole('img', { name: /recent ebay sold prices/i })
+    expect(svg).toBeInTheDocument()
+    // aria summary names the count + low/high.
+    expect(svg).toHaveAttribute('aria-label', expect.stringContaining('3 sales'))
+    expect(svg).toHaveAttribute('aria-label', expect.stringContaining('$10.00'))
+    expect(svg).toHaveAttribute('aria-label', expect.stringContaining('$30.00'))
+    expect(svg.querySelector('polyline')).not.toBeNull()
+  })
+
+  it('uses the currency symbol in the summary', () => {
+    render(<EbaySparkline values={[1, 2]} currency="EUR" />)
+    const svg = screen.getByRole('img')
+    expect(svg).toHaveAttribute('aria-label', expect.stringContaining('€'))
+  })
+})

--- a/web/src/components/EbaySparkline.tsx
+++ b/web/src/components/EbaySparkline.tsx
@@ -1,0 +1,67 @@
+/**
+ * EbaySparkline — a tiny inline line chart of recent eBay sold prices (#425).
+ *
+ * Deliberately dependency-free: a single normalised `<polyline>` in an SVG
+ * sized by its wrapper. Colour comes from `currentColor` so the caller sets
+ * the design-system token via a Tailwind text-* class — no hardcoded hex.
+ *
+ * Accessibility: the SVG carries `role="img"` and an `aria-label` summarising
+ * the trend (count + low/high), so screen readers get the gist without the
+ * decorative path. Renders nothing for fewer than two points — a trend line
+ * needs at least two.
+ */
+
+interface Props {
+  /** Sold prices in chronological order (oldest → newest). */
+  values: number[]
+  /** Currency symbol context for the aria summary. */
+  currency?: string
+  className?: string
+}
+
+// viewBox units — the wrapper's Tailwind width/height does the real sizing;
+// preserveAspectRatio="none" lets the curve stretch to fill it.
+const VB_W = 100
+const VB_H = 24
+const PAD = 2
+
+export function EbaySparkline({ values, currency = 'USD', className = '' }: Props) {
+  if (values.length < 2) return null
+
+  const min = Math.min(...values)
+  const max = Math.max(...values)
+  const range = max - min || 1
+  const stepX = (VB_W - PAD * 2) / (values.length - 1)
+
+  const points = values
+    .map((v, i) => {
+      const x = PAD + i * stepX
+      // Invert Y: SVG origin is top-left, but higher price should sit higher.
+      const y = PAD + (1 - (v - min) / range) * (VB_H - PAD * 2)
+      return `${x.toFixed(2)},${y.toFixed(2)}`
+    })
+    .join(' ')
+
+  const sym = currency === 'EUR' ? '€' : '$'
+  const ariaLabel = `Recent eBay sold prices: ${values.length} sales, low ${sym}${min.toFixed(2)}, high ${sym}${max.toFixed(2)}`
+
+  return (
+    <svg
+      viewBox={`0 0 ${VB_W} ${VB_H}`}
+      preserveAspectRatio="none"
+      role="img"
+      aria-label={ariaLabel}
+      className={`text-palm-500 dark:text-sun-300 ${className}`}
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
+  )
+}

--- a/web/src/components/ExportBar.test.tsx
+++ b/web/src/components/ExportBar.test.tsx
@@ -71,6 +71,7 @@ describe('ExportBar', () => {
         dedupe: false,
         sort: 'number',
         showTimer: false,
+        showEbay: false,
       },
     })
     mockExportFile.mockReset()
@@ -143,6 +144,7 @@ describe('ExportBar', () => {
         dedupe: true,
         sort: 'alpha',
         showTimer: false,
+        showEbay: false,
       },
     })
 

--- a/web/src/components/LookupTimer.test.tsx
+++ b/web/src/components/LookupTimer.test.tsx
@@ -13,6 +13,7 @@ const DEFAULT_SETTINGS = {
   dedupe: false,
   sort: 'number' as const,
   showTimer: false,
+  showEbay: false,
 }
 
 function row(name: string): Row {

--- a/web/src/components/ResultsTable.test.tsx
+++ b/web/src/components/ResultsTable.test.tsx
@@ -569,4 +569,62 @@ describe('ResultsTable: header sort cycle', () => {
 
     useAppStore.setState({ rows: [] })
   })
+
+  it('shows the eBay column with median + sparkline when the setting is on', () => {
+    useAppStore.getState().updateSettings({ showEbay: true })
+    useAppStore.setState({
+      rows: [
+        makeRow({
+          card: { id: 'x', name: 'Charizard', number: '4', set: { name: 'Base Set' } },
+          pricing: {
+            market: 250,
+            currency: 'USD',
+            variant: null,
+            source: 'TCGPlayer',
+            url: null,
+            ebay_sold_median: 230,
+            ebay_active_floor: 199.99,
+            ebay_sold_comps: [
+              { price: 220, date: '2026-01-01', condition: 'Used', url: null },
+              { price: 240, date: '2026-02-01', condition: 'Used', url: null },
+            ],
+          },
+        }),
+      ],
+      isRunning: false,
+      progress: null,
+    })
+    render(<ResultsTable />)
+    expect(screen.getByText('eBay sold')).toBeInTheDocument()
+    expect(screen.getByText('$230.00')).toBeInTheDocument()
+    expect(
+      screen.getByRole('img', { name: /recent ebay sold prices/i }),
+    ).toBeInTheDocument()
+    useAppStore.getState().updateSettings({ showEbay: false })
+    useAppStore.setState({ rows: [] })
+  })
+
+  it('hides the eBay column when the setting is off', () => {
+    useAppStore.getState().updateSettings({ showEbay: false })
+    useAppStore.setState({
+      rows: [
+        makeRow({
+          card: { id: 'x', name: 'Charizard', set: { name: 'Base Set' } },
+          pricing: {
+            market: 250,
+            currency: 'USD',
+            variant: null,
+            source: 'TCGPlayer',
+            url: null,
+            ebay_sold_median: 230,
+          },
+        }),
+      ],
+      isRunning: false,
+      progress: null,
+    })
+    render(<ResultsTable />)
+    expect(screen.queryByText('eBay sold')).toBeNull()
+    useAppStore.setState({ rows: [] })
+  })
 })

--- a/web/src/components/ResultsTable.tsx
+++ b/web/src/components/ResultsTable.tsx
@@ -21,6 +21,8 @@ import { formatComp, formatMoney } from '../utils/format'
 import { AddToCollectionButton } from './AddToCollectionButton'
 import { AddToWishlistButton } from './AddToWishlistButton'
 import { CardDetailModal } from './CardDetailModal'
+import { EbaySparkline } from './EbaySparkline'
+import { soldPriceSeries } from './ebayComps'
 import { SaveSearchButton } from './SaveSearchButton'
 import {
   applyFilters,
@@ -204,6 +206,11 @@ export function ResultsTable({ onRerunLine }: Props) {
               <th className="px-3 py-2 text-xs font-medium text-coconut-400 dark:text-sand-300 text-right hidden xl:table-cell">85%</th>
               <th className="px-3 py-2 text-xs font-medium text-coconut-400 dark:text-sand-300 text-right hidden xl:table-cell">90%</th>
               <th className="px-3 py-2 text-xs font-medium text-coconut-400 dark:text-sand-300 text-right hidden xl:table-cell">95%</th>
+              {settings.showEbay && (
+                <th className="px-3 py-2 text-xs font-medium text-coconut-400 dark:text-sand-300 text-right hidden lg:table-cell">
+                  eBay sold
+                </th>
+              )}
               <SortableHeader
                 label="Source"
                 column="source"
@@ -284,6 +291,11 @@ export function ResultsTable({ onRerunLine }: Props) {
                 <th className="hidden xl:table-cell">
                   <span className="sr-only">95% (no filter)</span>
                 </th>
+                {settings.showEbay && (
+                  <th className="hidden lg:table-cell">
+                    <span className="sr-only">eBay sold (no filter)</span>
+                  </th>
+                )}
                 <FilterCell className="hidden sm:table-cell">
                   <FilterInput
                     aria-label="Filter by source"
@@ -305,13 +317,14 @@ export function ResultsTable({ onRerunLine }: Props) {
                 row={row}
                 showImage={!settings.noImages}
                 showSavedActions={showSavedActions}
+                showEbay={settings.showEbay}
                 onRerunLine={onRerunLine}
                 onOpenDetail={() => setDetailIndex(displayedIdx)}
               />
             ))}
             {isRunning && (
               <tr>
-                <td colSpan={12} className="py-2 px-3">
+                <td colSpan={13} className="py-2 px-3">
                   <div className="h-1 w-24 rounded animate-pulse bg-sand-200 dark:bg-husk-100" />
                 </td>
               </tr>
@@ -414,12 +427,14 @@ function ResultRow({
   row,
   showImage,
   showSavedActions,
+  showEbay,
   onRerunLine,
   onOpenDetail,
 }: {
   row: Row
   showImage: boolean
   showSavedActions: boolean
+  showEbay: boolean
   onRerunLine?: (line: string) => void
   onOpenDetail?: () => void
 }) {
@@ -582,6 +597,27 @@ function ResultRow({
           {formatComp(p.market, 95, p.currency)}
         </td>
 
+        {/* eBay sold — median + sparkline of recent sales. Empty until the
+            eBay source is wired into lookup (epic #416). */}
+        {showEbay && (
+          <td className="px-3 py-2 text-right hidden lg:table-cell">
+            {p.ebay_sold_median != null ? (
+              <div className="flex flex-col items-end gap-0.5">
+                <span className="font-mono tabular-nums text-xs text-coconut-600 dark:text-sand-200">
+                  {formatMoney(p.ebay_sold_median, p.currency)}
+                </span>
+                <EbaySparkline
+                  values={soldPriceSeries(p.ebay_sold_comps)}
+                  currency={p.currency}
+                  className="h-4 w-16"
+                />
+              </div>
+            ) : (
+              <span className="text-xs text-coconut-400 dark:text-sand-300">—</span>
+            )}
+          </td>
+        )}
+
         {/* Price source */}
         <td className="px-3 py-2 text-xs text-coconut-400 dark:text-sand-300 hidden sm:table-cell">
           {p.source ?? '—'}
@@ -606,7 +642,7 @@ function ResultRow({
       {/* Override URL form (inline, expands below row) */}
       {showOverrideForm && (
         <tr className="border-b border-sand-200 dark:border-husk-100 bg-sand-100 dark:bg-husk-200/60">
-          <td colSpan={12} className="px-3 py-2">
+          <td colSpan={13} className="px-3 py-2">
             <div className="flex items-center gap-2">
               <input
                 type="url"

--- a/web/src/components/SettingsDrawer.test.tsx
+++ b/web/src/components/SettingsDrawer.test.tsx
@@ -23,6 +23,7 @@ vi.mock('../store', () => ({
       dedupe: false,
       sort: 'number',
       showTimer: false,
+      showEbay: false,
     },
     updateSettings: mockUpdateSettings,
     resetSettings: mockResetSettings,
@@ -80,6 +81,13 @@ describe('SettingsDrawer', () => {
     fireEvent.click(screen.getByRole('button', { name: /settings/i }))
     fireEvent.click(screen.getByLabelText(/show lookup timer/i))
     expect(mockUpdateSettings).toHaveBeenCalledWith({ showTimer: true })
+  })
+
+  it('toggling "Show eBay comps" calls updateSettings({ showEbay: true })', () => {
+    render(<SettingsDrawer />)
+    fireEvent.click(screen.getByRole('button', { name: /settings/i }))
+    fireEvent.click(screen.getByLabelText(/show ebay comps/i))
+    expect(mockUpdateSettings).toHaveBeenCalledWith({ showEbay: true })
   })
 
   it('cache-stats panel renders the values returned by /cache/stats', async () => {

--- a/web/src/components/SettingsDrawer.tsx
+++ b/web/src/components/SettingsDrawer.tsx
@@ -146,6 +146,13 @@ export function SettingsDrawer() {
                 checked={settings.showTimer}
                 onChange={(v) => updateSettings({ showTimer: v })}
               />
+              <Toggle
+                id="showEbay"
+                label="Show eBay comps"
+                description="Adds an eBay column with the median sold price and a sparkline of recent sales"
+                checked={settings.showEbay}
+                onChange={(v) => updateSettings({ showEbay: v })}
+              />
             </div>
 
             <CacheStatsPanel />

--- a/web/src/components/a11y.test.tsx
+++ b/web/src/components/a11y.test.tsx
@@ -94,6 +94,7 @@ const { storeState, storeApi } = vi.hoisted(() => {
       dedupe: false,
       sort: 'number' as const,
       showTimer: false,
+      showEbay: false,
     },
     runs: [] as unknown[],
     currentRunId: null as number | null,
@@ -242,6 +243,50 @@ describe('a11y: ResultsTable (populated + filters expanded)', () => {
     fireEvent.click(screen.getByRole('button', { name: /^filter$/i }))
     const results = await axe(container)
     expect(results).toHaveNoViolations()
+  })
+})
+
+// eBay column coverage — the column + sparkline only mount when the setting
+// is on and a row carries eBay data, so seed both to scan the real markup
+// (the SVG sparkline carries its own role="img" + aria-label).
+describe('a11y: ResultsTable (eBay column enabled)', () => {
+  it('eBay column + sparkline have no violations', async () => {
+    storeState.settings.showEbay = true
+    storeState.rows = [
+      {
+        query: { raw: 'Charizard | Base Set | 4', name: 'Charizard' },
+        card: {
+          id: 'base1-4',
+          name: 'Charizard',
+          number: '4',
+          rarity: 'Rare Holo',
+          set: { id: 'base1', name: 'Base Set', series: 'Base' },
+        },
+        pricing: {
+          market: 250,
+          currency: 'USD',
+          variant: 'holofoil',
+          source: 'TCGPlayer',
+          url: null,
+          ebay_sold_median: 230,
+          ebay_active_floor: 199.99,
+          ebay_sold_comps: [
+            { price: 220, date: '2026-01-01', condition: 'Used', url: null },
+            { price: 240, date: '2026-02-01', condition: 'Near Mint', url: null },
+          ],
+        },
+        tag: 'demo',
+        matched: true,
+        reason: '',
+      } as Row,
+    ]
+    try {
+      const { container } = render(<ResultsTable />)
+      const results = await axe(container)
+      expect(results).toHaveNoViolations()
+    } finally {
+      storeState.settings.showEbay = false
+    }
   })
 })
 

--- a/web/src/components/ebayComps.test.ts
+++ b/web/src/components/ebayComps.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { hasEbayData, soldPriceSeries } from './ebayComps'
+import type { EbaySoldComp } from '../types'
+
+function comp(over: Partial<EbaySoldComp> = {}): EbaySoldComp {
+  return { price: 10, date: null, condition: null, url: null, ...over }
+}
+
+describe('soldPriceSeries', () => {
+  it('returns [] for null / empty', () => {
+    expect(soldPriceSeries(null)).toEqual([])
+    expect(soldPriceSeries(undefined)).toEqual([])
+    expect(soldPriceSeries([])).toEqual([])
+  })
+
+  it('sorts oldest → newest when every comp is dated', () => {
+    const comps = [
+      comp({ price: 30, date: '2026-03-01' }),
+      comp({ price: 10, date: '2026-01-01' }),
+      comp({ price: 20, date: '2026-02-01' }),
+    ]
+    expect(soldPriceSeries(comps)).toEqual([10, 20, 30])
+  })
+
+  it('reverses source order (newest-first → oldest-first) when dates are missing', () => {
+    // No dates → comps are newest-first as given; reverse so newest is last.
+    const comps = [comp({ price: 3 }), comp({ price: 2 }), comp({ price: 1 })]
+    expect(soldPriceSeries(comps)).toEqual([1, 2, 3])
+  })
+
+  it('falls back to reversal when only some comps are dated', () => {
+    const comps = [comp({ price: 3, date: '2026-03-01' }), comp({ price: 1 })]
+    expect(soldPriceSeries(comps)).toEqual([1, 3])
+  })
+})
+
+describe('hasEbayData', () => {
+  it('is false when every signal is absent', () => {
+    expect(hasEbayData({})).toBe(false)
+    expect(
+      hasEbayData({ ebay_sold_median: null, ebay_active_floor: null, ebay_sold_comps: [] }),
+    ).toBe(false)
+  })
+
+  it('is true when any signal is present', () => {
+    expect(hasEbayData({ ebay_sold_median: 12 })).toBe(true)
+    expect(hasEbayData({ ebay_active_floor: 9 })).toBe(true)
+    expect(hasEbayData({ ebay_sold_comps: [comp()] })).toBe(true)
+  })
+})

--- a/web/src/components/ebayComps.ts
+++ b/web/src/components/ebayComps.ts
@@ -1,0 +1,37 @@
+/**
+ * eBay comp helpers shared by the results-table column and the card popup
+ * (#425). Pure functions, unit-tested in ebayComps.test.ts.
+ */
+import type { EbaySoldComp } from '../types'
+
+/**
+ * Chronological (oldest → newest) sold prices for the sparkline.
+ *
+ * Comps arrive newest-first as the source returns them. When every comp
+ * carries a parseable date we sort ascending by it; otherwise we just
+ * reverse the as-given order so the most recent sale lands on the right of
+ * the sparkline either way.
+ */
+export function soldPriceSeries(comps: EbaySoldComp[] | null | undefined): number[] {
+  if (!comps || comps.length === 0) return []
+  const allDated = comps.every((c) => c.date != null && !Number.isNaN(Date.parse(c.date)))
+  if (allDated) {
+    return [...comps]
+      .sort((a, b) => Date.parse(a.date as string) - Date.parse(b.date as string))
+      .map((c) => c.price)
+  }
+  return comps.map((c) => c.price).reverse()
+}
+
+/** True when a row carries any eBay signal worth surfacing. */
+export function hasEbayData(p: {
+  ebay_sold_median?: number | null
+  ebay_active_floor?: number | null
+  ebay_sold_comps?: EbaySoldComp[] | null
+}): boolean {
+  return (
+    p.ebay_sold_median != null ||
+    p.ebay_active_floor != null ||
+    (p.ebay_sold_comps != null && p.ebay_sold_comps.length > 0)
+  )
+}

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -35,6 +35,10 @@ const DEFAULT_SETTINGS: Settings = {
   dedupe: false,
   sort: 'number',
   showTimer: false,
+  // Off by default: the eBay source isn't wired into the lookup pipeline
+  // yet (epic #416), so the column would be empty for now. The `merge`
+  // below backfills this for users with persisted pre-#425 settings.
+  showEbay: false,
 }
 
 interface AppState {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -13,12 +13,34 @@ export interface CardQuery {
   price_max: number | null
 }
 
+/**
+ * One raw eBay sold comp surfaced in the card detail popup (#425). The
+ * lookup pipeline's eBay source (epic #416) emits these; until that wiring
+ * lands they're absent and the UI degrades to "no eBay data".
+ */
+export interface EbaySoldComp {
+  price: number
+  /** ISO date of the sale, or null when the source didn't report one. */
+  date: string | null
+  condition: string | null
+  url: string | null
+}
+
 export interface Pricing {
   market: number | null
   variant: string | null
   source: string | null
   url: string | null
   currency: string
+  /**
+   * eBay comp signals (#423/#425). Optional: the scalars are absent on runs
+   * persisted before #423, and the raw comps list isn't on the wire until
+   * the eBay source is wired into the lookup pipeline (epic #416).
+   */
+  ebay_sold_median?: number | null
+  ebay_active_floor?: number | null
+  /** Recent raw sold comps, newest-first as the source returns them. */
+  ebay_sold_comps?: EbaySoldComp[] | null
 }
 
 export interface CardSet {
@@ -128,6 +150,8 @@ export interface Settings {
   dedupe: boolean
   sort: SortMode
   showTimer: boolean
+  /** Show the eBay comps column (median sold + sparkline) in the results table. */
+  showEbay: boolean
 }
 
 /** One input line tracked through the bulk lookup lifecycle. */


### PR DESCRIPTION
Closes #425

## What

Adds an opt-in **eBay comps** surface to the web app:

- **Results table** — a new eBay column showing the **median sold** price and a dependency-free **sparkline** of recent sales. Gated behind a new **Show eBay comps** toggle in Settings (default off). Mobile-responsive: the column shows at `lg+` and stays out of the way on narrow viewports.
- **Card detail popup** — an **eBay comps** section with median sold, active floor, the same sparkline, and a table of the **raw recent comps (date · condition · price)**, each row linking out to the listing when a URL is present. Shown whenever a card carries eBay data, so detail-on-demand stays complete regardless of the column toggle.

## Why

Part of the eBay pricing epic (#416). #422 built the adapter, #423 the serializers (median/floor scalars on the API response), #424 the cache policy — this is the web surface that puts the comps in front of the user at the table.

## Design notes

- **Contract-driven, frontend-only.** The eBay source isn't wired into the lookup pipeline yet (deferred to the ensemble work, ADR-0023), so no eBay data flows to the SPA today. The web `Pricing` type gains `ebay_sold_median` / `ebay_active_floor` (already on the wire from #423) and `ebay_sold_comps` (the forward-looking raw-comps list the wiring will populate). All three are **optional**, so today's rows — and runs persisted before #423 — render gracefully empty (`—` / no section) until the data lands. The column + sparkline + popup are fully built and tested against mock data, ready for that wiring.
- **Toggle defaults off** so today's users don't get an empty column; it backfills cleanly for users with persisted pre-#425 settings via the store's existing `merge`.
- **No new dependencies** — the sparkline is a single normalised `<polyline>` SVG coloured via `currentColor` + a design-system token class (no raw hex).

## How to verify

```bash
cd web && npm test && npm run lint && npm run build
```

- `ebayComps.test.ts` / `EbaySparkline.test.tsx` — the comp-series reducer (date-sorted vs reversed), `hasEbayData`, and the sparkline (renders for ≥2 points, accessible `role="img"` + aria summary, currency symbol).
- `ResultsTable.test.tsx` — column + median + sparkline appear when the setting is on; absent when off.
- `CardDetailModal.test.tsx` — the eBay section shows median/floor/raw comps when present, and is omitted otherwise.
- `SettingsDrawer.test.tsx` — the toggle calls `updateSettings({ showEbay: true })`.
- `a11y.test.tsx` — **axe-clean** scan of the populated eBay column + sparkline.

**Manual preview check:** ran the dev server, confirmed a clean boot (no console errors) and that the **Show eBay comps** toggle renders in Settings with the correct label/description, off by default. Screenshot below.

> Note: the live column/popup render empty in the running app because no eBay data flows yet (see Design notes); the data-rich states are exercised deterministically by the unit + axe tests against mock rows.

<!-- Settings drawer screenshot: the new "Show eBay comps" toggle, consistent with the existing toggles, off by default. -->