### PR TITLE
docs: describe eBay as the fourth source; flip ADR-0020 to Accepted

### DIFF
--- a/docs/adr/0020-ebay-pricing-source.md
+++ b/docs/adr/0020-ebay-pricing-source.md
@@ -1,6 +1,6 @@
 # ADR 0020: eBay as a first-class pricing source
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-06-03
 - **Tags:** sources, pricing, auth, epic-ebay
 
@@ -16,10 +16,12 @@ pokemontcg.io path, but none of these surfaces give us **sold-listings
 distribution**, which is the single most useful signal for setting a
 realistic asking price at a card show.
 
-eBay's Developer API exposes both `findCompletedItems` (sold) and
-`findItemsAdvanced` (active) endpoints, with OAuth client credentials
-and rate limits that are workable for our scale (one listing-set
-fetched per resolved card, cached aggressively).
+eBay's Developer API exposes active listings via the **Browse API** and
+sold listings via the **Marketplace Insights API** (the legacy
+`findCompletedItems` / `findItemsAdvanced` Finding API endpoints were
+retired in early 2025), both reachable with OAuth client credentials and
+rate limits that are workable for our scale (one listing-set fetched per
+resolved card, cached aggressively).
 
 The `epic:ebay` umbrella tracks the implementation; this ADR records
 the source-layering decision and the contract.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,7 +30,7 @@ not just the shape.
 | [0017](0017-tropical-design-system.md) | Tropical design system — sun + palm + coconut, paired light/dark tokens | Accepted | 2026-05-31 |
 | [0018](0018-structural-vs-volatile-cache-with-swr.md) | Structural / volatile cache split with stale-while-revalidate on pricing | Accepted | 2026-06-01 |
 | [0019](0019-hosted-demo-identity-and-auth.md) | Hosted-demo identity and auth — cache-only anon, sign-in gates persistence, GitHub + magic-link + Google | Accepted | 2026-06-02 |
-| [0020](0020-ebay-pricing-source.md) | eBay as a first-class pricing source (sold + active listings, per-source TTL) | Proposed | 2026-06-03 |
+| [0020](0020-ebay-pricing-source.md) | eBay as a first-class pricing source (sold + active listings, per-source TTL) | Accepted | 2026-06-03 |
 | [0021](0021-tcgplayer-first-class-pricing.md) | First-class TCGPlayer pricing via the TCGPlayer API, with per-user OAuth tokens | Proposed | 2026-06-03 |
 | [0022](0022-query-dsl.md) | Structured query DSL with dual-mode + smart auto-detect (closes #39) | Proposed | 2026-06-03 |
 | [0023](0023-source-ensemble-pricing.md) | Source ensemble for pricing display, with user-selectable preferences (partially supersedes ADR-0002) | Proposed | 2026-06-03 |

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -1,11 +1,11 @@
 # Sources & coverage
 
-The tool layers three open data sources. Each line is tried against them
-in order; the first source that produces a usable match wins.
+The tool draws on four data sources. Three of them — [pokemontcg.io], [TCGdex], and [PriceCharting] — resolve the card itself: each line is tried against them in order, and the first source that produces a usable match wins. The fourth, [eBay], never resolves cards — listing titles are too unreliable for structural data — and instead contributes sold- and active-listing comps to the pricing ensemble (see [ADR-0020](adr/0020-ebay-pricing-source.md) and [ADR-0023](adr/0023-source-ensemble-pricing.md)).
 
 [pokemontcg.io]: https://pokemontcg.io
 [TCGdex]: https://tcgdex.dev
 [PriceCharting]: https://www.pricecharting.com
+[eBay]: https://www.ebay.com
 
 ## pokemontcg.io (default)
 


### PR DESCRIPTION
Closes #427

## What

Reframes `docs/sources.md` around the four-source layering and lands ADR-0020 as the accepted decision now that the eBay epic has shipped:

- `docs/sources.md` — the intro now says the tool draws on **four** sources: three resolution sources (pokemontcg.io → TCGdex → PriceCharting, first-match-wins) plus eBay, which never resolves cards and instead feeds sold/active comps into the pricing ensemble. Links out to ADR-0020 and ADR-0023. The detailed eBay section already landed in the earlier epic PRs and is unchanged.
- ADR-0020 — status flipped **Proposed → Accepted** (file header + index row in `docs/adr/README.md`).
- ADR-0020 Context — corrected the one stale present-tense claim: it described the retired Finding API endpoints (`findCompletedItems` / `findItemsAdvanced`) as current, but the shipped code uses the Browse API (active) and Marketplace Insights API (sold). Per this repo's convention an Accepted ADR reflects what the code actually does, so the fix rides along on the flip.

## Why

The eBay source is live (sold/active comps, per-source TTL, key-gated) but the docs still framed the tool as three sources and the ADR was still Proposed. This closes the documentation gap for the epic and makes ADR-0020 match reality.

## How to verify

- `docs/sources.md` intro reads "four data sources" and distinguishes resolution (first-match) from the eBay pricing-comps role.
- `docs/adr/0020-ebay-pricing-source.md` and the ADR index both show **Accepted**.
- `make check` is green (829 tests + lint + format + web/site).