### PR TITLE
feat: wire eBay comps into the lookup pipeline (CLI + API)

### DIFF
--- a/api/routes/lookup.py
+++ b/api/routes/lookup.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel
 from mgz_pkmn.lookup import find_card, find_top_cards
 from mgz_pkmn.parser import CardQuery, parse_line
 from mgz_pkmn.pricing import Pricing, extract_pricing
-from mgz_pkmn.sources import PriceChartingClient, TCGClient, TCGDexClient
+from mgz_pkmn.sources import EbayClient, PriceChartingClient, TCGClient, TCGDexClient
 from mgz_pkmn.sources.base import worse_cache_status
 from mgz_pkmn.spreadsheet import Row
 
@@ -65,11 +65,14 @@ class BulkRequest(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def _make_clients(settings: Settings) -> tuple[TCGClient, TCGDexClient, PriceChartingClient]:
+def _make_clients(
+    settings: Settings,
+) -> tuple[TCGClient, TCGDexClient, PriceChartingClient, EbayClient]:
     return (
         TCGClient(api_key=settings.api_key),
         TCGDexClient(),
         PriceChartingClient(),
+        EbayClient(),
     )
 
 
@@ -140,6 +143,7 @@ def _do_lookup(
     on_stage: Callable[[str], None] | None = None,
     *,
     cache_only: bool = False,
+    ebay: EbayClient | None = None,
 ) -> tuple[list[tuple[Row, str]], str]:
     """Run a blocking card lookup and return `(pairs, cache_status)`.
 
@@ -172,6 +176,17 @@ def _do_lookup(
     def _bump_status(s: str) -> None:
         status_acc[0] = worse_cache_status(status_acc[0], s)
 
+    def _with_ebay(pricing: Pricing, card: dict[str, Any]) -> Pricing:
+        """Fold eBay comps into `pricing` when the source is configured.
+
+        Auto-on when credentials are present; a no-op (eBay fields stay None)
+        otherwise, so an unconfigured deploy behaves exactly as before with no
+        extra network call.
+        """
+        if ebay is not None and ebay.auth.configured:
+            pricing.ebay_sold_median, pricing.ebay_active_floor = ebay.comps_for_card(card)
+        return pricing
+
     if q.bulk_top or q.bulk_all:
         try:
             effective_limit = None if q.bulk_all else q.bulk_top
@@ -189,7 +204,7 @@ def _do_lookup(
             top = []
             err = True
         for card in top:
-            pricing = extract_pricing(card, q.variant_hint)
+            pricing = _with_ebay(extract_pricing(card, q.variant_hint), card)
             out.append((Row(query=q, card=card, pricing=pricing, tag=settings.tag), "matched"))
         if not top:
             reason = "error" if err else "no_results"
@@ -213,7 +228,7 @@ def _do_lookup(
         if result.card:
             if on_stage is not None:
                 on_stage("pricing")
-            pricing = extract_pricing(result.card, q.variant_hint)
+            pricing = _with_ebay(extract_pricing(result.card, q.variant_hint), result.card)
             out.append(
                 (
                     Row(query=q, card=result.card, pricing=pricing, tag=settings.tag),
@@ -278,7 +293,7 @@ async def lookup(req: LookupRequest, current_user: CurrentUserOptional) -> JSONR
             headers={"X-Cache": "MISS"},
         )
 
-    pkmn, tcgdex, pc = _make_clients(req.settings)
+    pkmn, tcgdex, pc, ebay = _make_clients(req.settings)
     pairs, cache_status = await run_in_threadpool(
         _do_lookup,
         pkmn,
@@ -287,6 +302,7 @@ async def lookup(req: LookupRequest, current_user: CurrentUserOptional) -> JSONR
         q,
         req.settings,
         cache_only=_cache_only_for_user(current_user),
+        ebay=ebay,
     )
     return JSONResponse(
         content={"rows": [_row_to_dict(r, reason) for r, reason in pairs]},
@@ -335,7 +351,7 @@ async def bulk(req: BulkRequest, current_user: CurrentUserOptional) -> Streaming
     ]
     total = len(indexed)
 
-    pkmn, tcgdex, pc = _make_clients(req.settings)
+    pkmn, tcgdex, pc, ebay = _make_clients(req.settings)
     cache_only = _cache_only_for_user(current_user)
 
     async def event_stream():
@@ -382,6 +398,7 @@ async def bulk(req: BulkRequest, current_user: CurrentUserOptional) -> Streaming
                     req.settings,
                     on_stage,
                     cache_only=cache_only,
+                    ebay=ebay,
                 )
             )
             task.add_done_callback(lambda _t, _q=stage_queue: _q.put_nowait(_STAGE_DONE))

--- a/src/mgz_pkmn/cli/lookup.py
+++ b/src/mgz_pkmn/cli/lookup.py
@@ -21,7 +21,7 @@ from ..parser import CardQuery, read_input
 from ..pricing import Pricing, extract_pricing
 from ..report import build_json_report
 from ..sorting import DEFAULT_SORT, SORT_MODES, sort_rows
-from ..sources import PriceChartingClient, TCGClient, TCGDexClient
+from ..sources import EbayClient, PriceChartingClient, TCGClient, TCGDexClient
 from ..sources.base import MatchResult
 from ..spreadsheet import Row, write_spreadsheet
 from ._cache_warn import _warn_if_cache_large
@@ -68,10 +68,13 @@ def _build_row(
     pkmn_client: TCGClient,
     images_dir: Path,
     no_images: bool,
+    ebay: EbayClient | None = None,
 ) -> Row:
     """Build a spreadsheet row for a single matched card, optionally
     downloading its image into `images_dir`."""
     pricing = extract_pricing(card, query.variant_hint)
+    if ebay is not None:
+        pricing.ebay_sold_median, pricing.ebay_active_floor = ebay.comps_for_card(card)
     image_path: Path | None = None
     if not no_images:
         images = card.get("images") or {}
@@ -135,6 +138,7 @@ def _lookup_one_bulk(
     no_images: bool,
     counters: dict[str, int],
     t0: float,
+    ebay: EbayClient | None = None,
 ) -> list[Row]:
     """Handle a bulk top-N / all-set query. Returns the rows it produced."""
     try:
@@ -176,7 +180,13 @@ def _lookup_one_bulk(
         )
         rows.append(
             _build_row(
-                card, q, tag, pkmn_client=pkmn_client, images_dir=images_dir, no_images=no_images
+                card,
+                q,
+                tag,
+                pkmn_client=pkmn_client,
+                images_dir=images_dir,
+                no_images=no_images,
+                ebay=ebay,
             )
         )
     return rows
@@ -194,6 +204,7 @@ def _lookup_one_single(
     no_images: bool,
     counters: dict[str, int],
     t0: float,
+    ebay: EbayClient | None = None,
 ) -> Row:
     """Handle a single-card query. Returns the single row produced."""
     try:
@@ -212,7 +223,13 @@ def _lookup_one_single(
     pricing = extract_pricing(card, q.variant_hint)
     _print_matched_line(card, pricing, time.monotonic() - t0)
     return _build_row(
-        card, q, tag, pkmn_client=pkmn_client, images_dir=images_dir, no_images=no_images
+        card,
+        q,
+        tag,
+        pkmn_client=pkmn_client,
+        images_dir=images_dir,
+        no_images=no_images,
+        ebay=ebay,
     )
 
 
@@ -548,6 +565,17 @@ def register(cli: click.Group) -> None:
             "formatting without regenerating outputs on every run."
         ),
     )
+    @click.option(
+        "--ebay/--no-ebay",
+        "ebay_opt",
+        default=None,
+        help=(
+            "Fetch eBay sold/active listing comps for each matched card. "
+            "Defaults to on when eBay credentials (MGZ_PKMN_EBAY_TOKEN, or the "
+            "MGZ_PKMN_EBAY_CLIENT_ID / MGZ_PKMN_EBAY_CLIENT_SECRET pair) are "
+            "configured, off otherwise."
+        ),
+    )
     @click.option("-v", "--verbose", is_flag=True, help="Verbose output.")
     def lookup(
         input_paths: tuple[Path, ...],
@@ -566,6 +594,7 @@ def register(cli: click.Group) -> None:
         default_lang: str | None,
         sort_mode: str,
         print_summary_only: bool,
+        ebay_opt: bool | None,
         verbose: bool,
     ) -> None:
         """Look up Pokemon cards, fetch images and prices, and emit an .xlsx for card-show prep.
@@ -604,9 +633,19 @@ def register(cli: click.Group) -> None:
         tcgdex_client = TCGDexClient(verbose=verbose)
         pc_client = PriceChartingClient(verbose=verbose)
 
+        # eBay comps default to on when credentials are configured; --ebay /
+        # --no-ebay forces it either way. Unconfigured + auto stays a no-op:
+        # we pass no client, so a row's eBay fields stay blank and no warning
+        # fires for the common case of a CLI user without eBay keys.
+        ebay_client = EbayClient(verbose=verbose)
+        use_ebay = ebay_client.auth.configured if ebay_opt is None else ebay_opt
+        ebay = ebay_client if use_ebay else None
+
+        sources_line = "pokemontcg.io · TCGdex · PriceCharting"
+        if use_ebay:
+            sources_line += " · eBay comps"
         _print_section(
-            f"Looking up {len(tagged)} card{'s' if len(tagged) != 1 else ''} "
-            "across pokemontcg.io · TCGdex · PriceCharting"
+            f"Looking up {len(tagged)} card{'s' if len(tagged) != 1 else ''} across {sources_line}"
         )
 
         rows: list[Row] = []
@@ -630,6 +669,7 @@ def register(cli: click.Group) -> None:
                         no_images=no_images,
                         counters=counters,
                         t0=t0,
+                        ebay=ebay,
                     )
                 )
             else:
@@ -645,6 +685,7 @@ def register(cli: click.Group) -> None:
                         no_images=no_images,
                         counters=counters,
                         t0=t0,
+                        ebay=ebay,
                     )
                 )
 

--- a/src/mgz_pkmn/sources/ebay_client.py
+++ b/src/mgz_pkmn/sources/ebay_client.py
@@ -26,8 +26,10 @@ sold comps for 7 days, active listings for 6 hours, with stale-while-revalidate
 background refresh — the same machinery the pokemontcg.io pricing slice uses
 (ADR-0018).
 
-Wiring these comps into the lookup pipeline + export serializers is #423 /
-the ensemble work; this module is just the adapter.
+:meth:`EbayClient.comps_for_card` is the lookup pipeline's entry point (#617):
+it turns a resolved card into the (sold median, active floor) pair the
+``Pricing`` dataclass carries; the CLI and API finalize-pricing sites call it
+per resolved card.
 """
 
 from __future__ import annotations
@@ -40,7 +42,7 @@ from typing import Any
 import requests
 
 from .. import cache as disk_cache
-from ..pricing import Pricing
+from ..pricing import Pricing, summarize_ebay_comps
 from ._common import USER_AGENT
 from .ebay import EbayAuthClient, EbayAuthError
 
@@ -65,6 +67,22 @@ _UNCONFIGURED_HINT = (
 #: Titles matching these skew raw-single comps (graded slabs inflate, lots /
 #: bundles aren't a single card) — drop them before returning comps.
 _EXCLUDE_TITLE_RE = re.compile(r"\b(psa|bgs|cgc|sgc|lot|bundle|playset|x\s?\d)\b", re.IGNORECASE)
+
+
+def ebay_query_for_card(card: dict[str, Any]) -> str:
+    """Build an eBay keyword query for a resolved card.
+
+    Name + set name + collector number — specific enough to pull raw singles
+    of the exact printing without over-constraining the search. Returns an
+    empty string when the card has no usable name, which the pipeline treats
+    as "no comps to fetch".
+    """
+    name = (card.get("name") or "").strip()
+    if not name:
+        return ""
+    set_name = ((card.get("set") or {}).get("name") or "").strip()
+    number = str(card.get("number") or "").strip()
+    return " ".join(part for part in (name, set_name, number) if part)
 
 
 class EbayClient:
@@ -113,6 +131,23 @@ class EbayClient:
         if self._sold_enabled:
             comps += self._fetch_sold(query, limit=limit)
         return comps
+
+    def comps_for_card(
+        self, card: dict[str, Any], *, limit: int = 50
+    ) -> tuple[float | None, float | None]:
+        """Fetch comps for a resolved card, reduced to (sold median, active floor).
+
+        The lookup pipeline's entry point: turns a resolved card into the two
+        scalar signals the :class:`~mgz_pkmn.pricing.Pricing` dataclass carries.
+        A card with no name, or a fetch that yields no comps (unconfigured
+        source, network hiccup, nothing relevant listed), returns
+        ``(None, None)`` — leaving the row's eBay fields blank rather than
+        raising.
+        """
+        query = ebay_query_for_card(card)
+        if not query:
+            return None, None
+        return summarize_ebay_comps(self.fetch_comps(query, limit=limit))
 
     def _warn_unconfigured(self) -> None:
         """Warn once that eBay comps are off because no credentials are set.
@@ -268,4 +303,4 @@ class EbayClient:
         return comps
 
 
-__all__ = ["SOLD_ENABLED_ENV", "EbayClient"]
+__all__ = ["SOLD_ENABLED_ENV", "EbayClient", "ebay_query_for_card"]

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -266,7 +266,7 @@ class BulkStageStreamTests(unittest.TestCase):
         from mgz_pkmn.pricing import Pricing
         from mgz_pkmn.spreadsheet import Row
 
-        def fake(pkmn, tcgdex, pc, q, settings, on_stage=None, *, cache_only=False):
+        def fake(pkmn, tcgdex, pc, q, settings, on_stage=None, *, cache_only=False, ebay=None):
             if on_stage is not None:
                 on_stage("looking_up")
                 on_stage("fallback")
@@ -296,7 +296,7 @@ class BulkStageStreamTests(unittest.TestCase):
         from mgz_pkmn.pricing import Pricing
         from mgz_pkmn.spreadsheet import Row
 
-        def fake(pkmn, tcgdex, pc, q, settings, on_stage=None, *, cache_only=False):
+        def fake(pkmn, tcgdex, pc, q, settings, on_stage=None, *, cache_only=False, ebay=None):
             if on_stage is not None:
                 on_stage("looking_up")
             return [(Row(query=q, card=None, pricing=Pricing(), tag=""), "no_candidates")], "MISS"

--- a/tests/test_ebay_client.py
+++ b/tests/test_ebay_client.py
@@ -22,7 +22,7 @@ import requests
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from mgz_pkmn import cache
-from mgz_pkmn.sources.ebay_client import EbayClient
+from mgz_pkmn.sources.ebay_client import EbayClient, ebay_query_for_card
 
 
 class _FakeAuth:
@@ -289,6 +289,89 @@ class EbayCacheTests(unittest.TestCase):
             comps = client.fetch_comps("Charizard")
         self.assertEqual({c.source for c in comps}, {"ebay_active", "ebay_sold"})
         get.assert_not_called()  # both tiers served from cache
+
+
+class EbayQueryForCardTests(unittest.TestCase):
+    def test_builds_name_set_number_query(self) -> None:
+        card = {"name": "Charizard", "set": {"name": "Base Set"}, "number": "4"}
+        self.assertEqual(ebay_query_for_card(card), "Charizard Base Set 4")
+
+    def test_omits_missing_parts(self) -> None:
+        self.assertEqual(ebay_query_for_card({"name": "Pikachu"}), "Pikachu")
+
+    def test_no_name_yields_empty_query(self) -> None:
+        self.assertEqual(ebay_query_for_card({"set": {"name": "Base Set"}, "number": "4"}), "")
+
+
+class CompsForCardTests(_NoCacheTestCase):
+    def test_reduces_active_listings_to_floor(self) -> None:
+        client = _client()
+        card = {"name": "Charizard", "set": {"name": "Base Set"}, "number": "4"}
+        with patch.object(client.session, "get", return_value=_FakeResponse(_BROWSE_FIXTURE)):
+            sold, active = client.comps_for_card(card)
+        # Sold tier off by default → no median; active floor is the cheapest
+        # raw single after graded/lot drops (199.99 < 250.00).
+        self.assertIsNone(sold)
+        self.assertEqual(active, 199.99)
+
+    def test_sold_enabled_yields_sold_median(self) -> None:
+        client = _client(sold_enabled=True)
+        card = {"name": "Charizard", "set": {"name": "Base Set"}, "number": "4"}
+
+        def _route(url, **_kwargs):
+            if "item_sales/search" in url:
+                return _FakeResponse(_INSIGHTS_FIXTURE)
+            return _FakeResponse(_BROWSE_FIXTURE)
+
+        with patch.object(client.session, "get", side_effect=_route):
+            sold, active = client.comps_for_card(card)
+        self.assertEqual(sold, 230.00)
+        self.assertEqual(active, 199.99)
+
+    def test_nameless_card_skips_fetch(self) -> None:
+        client = _client()
+        with patch.object(client.session, "get") as get:
+            self.assertEqual(client.comps_for_card({"number": "4"}), (None, None))
+        get.assert_not_called()
+
+
+class BuildRowWiringTests(_NoCacheTestCase):
+    """The CLI finalize-pricing site folds eBay comps into the row's Pricing."""
+
+    def test_build_row_attaches_ebay_comps(self) -> None:
+        from mgz_pkmn.cli.lookup import _build_row
+        from mgz_pkmn.parser import CardQuery
+
+        client = _client()
+        card = {"name": "Charizard", "set": {"name": "Base Set"}, "number": "4"}
+        with patch.object(client.session, "get", return_value=_FakeResponse(_BROWSE_FIXTURE)):
+            row = _build_row(
+                card,
+                CardQuery(raw="Charizard", name="Charizard"),
+                "t1",
+                pkmn_client=None,
+                images_dir=Path("."),
+                no_images=True,
+                ebay=client,
+            )
+        self.assertEqual(row.pricing.ebay_active_floor, 199.99)
+        self.assertIsNone(row.pricing.ebay_sold_median)
+
+    def test_build_row_without_ebay_leaves_fields_none(self) -> None:
+        from mgz_pkmn.cli.lookup import _build_row
+        from mgz_pkmn.parser import CardQuery
+
+        card = {"name": "Charizard", "set": {"name": "Base Set"}, "number": "4"}
+        row = _build_row(
+            card,
+            CardQuery(raw="Charizard", name="Charizard"),
+            "t1",
+            pkmn_client=None,
+            images_dir=Path("."),
+            no_images=True,
+        )
+        self.assertIsNone(row.pricing.ebay_active_floor)
+        self.assertIsNone(row.pricing.ebay_sold_median)
 
 
 if __name__ == "__main__":

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -177,7 +177,9 @@ class BulkPersistenceTests(_IsolatedDbMixin):
         # persistence shape, not match correctness.
         from api.routes import lookup as lookup_route
 
-        def fake_do_lookup(pkmn, tcgdex, pc, q, settings, on_stage=None, *, cache_only=False):
+        def fake_do_lookup(
+            pkmn, tcgdex, pc, q, settings, on_stage=None, *, cache_only=False, ebay=None
+        ):
             from mgz_pkmn.pricing import Pricing
             from mgz_pkmn.spreadsheet import Row
 
@@ -508,7 +510,9 @@ class SavedSearchesAuthGateTests(_IsolatedDbMixin):
         from api.main import app
         from api.routes import lookup as lookup_route
 
-        def fake_do_lookup(pkmn, tcgdex, pc, q, settings, on_stage=None, *, cache_only=False):
+        def fake_do_lookup(
+            pkmn, tcgdex, pc, q, settings, on_stage=None, *, cache_only=False, ebay=None
+        ):
             from mgz_pkmn.pricing import Pricing
             from mgz_pkmn.spreadsheet import Row
 


### PR DESCRIPTION
Closes #617

## What

Connects the eBay adapter to the lookup pipeline so a resolved card's `ebay_sold_median` / `ebay_active_floor` actually get populated.

- `EbayClient.comps_for_card(card)` + `ebay_query_for_card(card)` — turn a resolved card into the (sold median, active floor) pair the `Pricing` dataclass carries (query = name + set + number, reduced via the existing `summarize_ebay_comps`).
- CLI: enrich in `_build_row`, covering both the single and bulk paths. New `--ebay/--no-ebay` flag; defaults to on when eBay credentials are configured, off otherwise.
- API: enrich in `_do_lookup` (both the `/lookup` and SSE paths), auto-on when configured.
- Tests for the query builder, `comps_for_card`, and the `_build_row` wiring; updated the existing `_do_lookup` mocks for the new `ebay` kwarg.

## Why

Every layer of the eBay epic landed — auth (#421), the adapter (#422), serializers (#423), per-source TTL cache (#424), the web comps column (#425), the runbook (#426) — but **nothing ever called `EbayClient.fetch_comps()` during a lookup.** The `ebay_*` fields were hardcoded `None` through every serializer and the results-table column always rendered empty. The fetch fell through the cracks: there was a child issue for every layer around the call but none for the call itself, which is why the epic's "≥95% of resolved cards show eBay comps" acceptance couldn't be met. This is that missing wire.

Auto-on when credentials are present; a complete no-op (no extra network, no warning) when they aren't, so unconfigured runs are byte-for-byte unchanged.

## How to verify

`make check` is green (837 tests + lint + format + complexity + web + site).

Live run against **production** eBay (Browse / active tier; sold tier gated off) — `pkmn lookup … --no-cache --report-json`:

| card | market | ebay_active_floor | ebay_sold_median |
|---|---|---|---|
| Charizard (Base Set 4) | 427.38 | 41.95 | — |
| Blastoise (Base Set 2) | 121.99 | 15.00 | — |
| Pikachu (Base Set 58) | 7.54 | 1.79 | — |

Each card fired a real `GET api.ebay.com/buy/browse/v1/item_summary/search`, the app token minted cleanly, and the floor landed on each row end-to-end (CLI → `Pricing` → JSON report). `ebay_sold_median` is `None` because Marketplace Insights is gated behind `MGZ_PKMN_EBAY_SOLD_ENABLED` (default off).

To reproduce: set `MGZ_PKMN_EBAY_CLIENT_ID` / `MGZ_PKMN_EBAY_CLIENT_SECRET`, then `pkmn lookup <file> --no-cache --report-json out.json` and read `ebay_active_floor` per row.

## Notes

The active *floor* is the cheapest matching raw single, and a keyword search pulls in loosely-related listings, so floors skew low (per ADR-0020's "what's listed right now" framing). Query-relevance tuning is a reasonable follow-up, out of scope here.