### PR TITLE
fix(web): prefetch a card stack in swipe mode so the next card reveals, not slides in

### DIFF
--- a/web/src/components/SwipePanel.test.tsx
+++ b/web/src/components/SwipePanel.test.tsx
@@ -106,20 +106,35 @@ describe('SwipePanel', () => {
     expect(screen.getByText('Pikachu')).toBeInTheDocument()
   })
 
+  it('renders the next card as an inert peek beneath the top card', async () => {
+    render(<SwipePanel active />)
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    // Only the top card is the interactive (testid) target; the prefetched
+    // next card sits beneath it as an aria-hidden peek so the swap reveals
+    // a card that's already mounted — no slide-in, no loader flash.
+    expect(screen.getAllByTestId('swipe-card')).toHaveLength(1)
+    await waitFor(() =>
+      expect(screen.getByText('Charizard')).toBeInTheDocument(),
+    )
+  })
+
   it('saves the card and advances when → is pressed', async () => {
     render(<SwipePanel active />)
     await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
 
     fireEvent.keyDown(window, { key: 'ArrowRight' })
 
+    // The save commits after the exit-animation timeout. Wait on the header
+    // chip directly — the next card now peeks in from the start, so its
+    // text appearing is no longer a reliable "advance happened" signal.
     await waitFor(
-      () => expect(screen.getByText('Charizard')).toBeInTheDocument(),
+      () =>
+        expect(
+          screen.getByRole('button', { name: /1 saved · reset/i }),
+        ).toBeInTheDocument(),
       POST_SWIPE_WAIT,
     )
-    // The save count chip in the header should show "1 saved · reset".
-    expect(
-      screen.getByRole('button', { name: /1 saved · reset/i }),
-    ).toBeInTheDocument()
   })
 
   it('passes (no save) when ← is pressed', async () => {
@@ -143,12 +158,12 @@ describe('SwipePanel', () => {
     fireEvent.keyDown(window, { key: 'ArrowUp' })
 
     await waitFor(
-      () => expect(screen.getByText('Charizard')).toBeInTheDocument(),
+      () =>
+        expect(
+          screen.getByRole('button', { name: /1 saved · reset/i }),
+        ).toBeInTheDocument(),
       POST_SWIPE_WAIT,
     )
-    expect(
-      screen.getByRole('button', { name: /1 saved · reset/i }),
-    ).toBeInTheDocument()
   })
 
   it('action-row buttons mirror the keyboard shortcuts', async () => {
@@ -158,12 +173,12 @@ describe('SwipePanel', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save' }))
 
     await waitFor(
-      () => expect(screen.getByText('Charizard')).toBeInTheDocument(),
+      () =>
+        expect(
+          screen.getByRole('button', { name: /1 saved · reset/i }),
+        ).toBeInTheDocument(),
       POST_SWIPE_WAIT,
     )
-    expect(
-      screen.getByRole('button', { name: /1 saved · reset/i }),
-    ).toBeInTheDocument()
   })
 
   it('a drag past the rightward threshold commits a save', async () => {
@@ -182,12 +197,12 @@ describe('SwipePanel', () => {
     fireEvent.pointerUp(card, { pointerId: 1, clientX: 200, clientY: 0 })
 
     await waitFor(
-      () => expect(screen.getByText('Charizard')).toBeInTheDocument(),
+      () =>
+        expect(
+          screen.getByRole('button', { name: /1 saved · reset/i }),
+        ).toBeInTheDocument(),
       POST_SWIPE_WAIT,
     )
-    expect(
-      screen.getByRole('button', { name: /1 saved · reset/i }),
-    ).toBeInTheDocument()
   })
 
   it('shows the exhausted state once every set has been walked', async () => {
@@ -195,15 +210,20 @@ describe('SwipePanel', () => {
     render(<SwipePanel active />)
     await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
     fireEvent.keyDown(window, { key: 'ArrowLeft' })
+    // Wait for the first pass to fully commit (Pikachu leaves the stack)
+    // before the next keystroke — while the exit animation is in flight the
+    // handler ignores input, so an instant peek must not race it.
     await waitFor(
-      () => expect(screen.getByText('Charizard')).toBeInTheDocument(),
+      () => expect(screen.queryByText('Pikachu')).not.toBeInTheDocument(),
       POST_SWIPE_WAIT,
     )
     fireEvent.keyDown(window, { key: 'ArrowLeft' })
-    await waitFor(() =>
-      expect(
-        screen.getByText(/You.ve seen every card in the recent sets|every card/i),
-      ).toBeInTheDocument(),
+    await waitFor(
+      () =>
+        expect(
+          screen.getByText(/You.ve seen every card in the recent sets|every card/i),
+        ).toBeInTheDocument(),
+      POST_SWIPE_WAIT,
     )
   })
 
@@ -416,12 +436,12 @@ describe('SwipePanel', () => {
     fireEvent.pointerUp(card, { pointerId: 1, clientX: 0, clientY: -200 })
 
     await waitFor(
-      () => expect(screen.getByText('Charizard')).toBeInTheDocument(),
+      () =>
+        expect(
+          screen.getByRole('button', { name: /1 saved · reset/i }),
+        ).toBeInTheDocument(),
       POST_SWIPE_WAIT,
     )
-    expect(
-      screen.getByRole('button', { name: /1 saved · reset/i }),
-    ).toBeInTheDocument()
   })
 
   it('the Pass and More-like-this action buttons commit decisions', async () => {
@@ -429,8 +449,10 @@ describe('SwipePanel', () => {
     await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
 
     fireEvent.click(screen.getByRole('button', { name: 'Pass' }))
+    // The action buttons are disabled mid-exit; wait for the pass to finish
+    // (Pikachu gone, Charizard promoted) before the second decision.
     await waitFor(
-      () => expect(screen.getByText('Charizard')).toBeInTheDocument(),
+      () => expect(screen.queryByText('Pikachu')).not.toBeInTheDocument(),
       POST_SWIPE_WAIT,
     )
 

--- a/web/src/components/SwipePanel.tsx
+++ b/web/src/components/SwipePanel.tsx
@@ -37,7 +37,7 @@ import {
   type SavedCard,
   type SwipeAction,
 } from './useSwipeProfile'
-import { useSwipeCandidates } from './useSwipeCandidates'
+import { STACK_SIZE, useSwipeCandidates } from './useSwipeCandidates'
 import { useWishlists } from './useWishlists'
 
 /** Horizontal-drag threshold (px) that commits a pass/save decision. */
@@ -63,10 +63,11 @@ interface SwipePanelProps {
 
 export function SwipePanel({ active }: SwipePanelProps) {
   const { profile, seenSet, act, clearSaved, reset } = useSwipeProfile()
-  const { current, loading, exhausted, error, advance } = useSwipeCandidates({
-    active,
-    seenSet,
-  })
+  const { current, upcoming, loading, exhausted, error, advance } =
+    useSwipeCandidates({
+      active,
+      seenSet,
+    })
   const { user } = useAuth()
   const showSavedActions = user !== null
 
@@ -76,7 +77,6 @@ export function SwipePanel({ active }: SwipePanelProps) {
   // `Row[]`, so a one-element array of the current card is enough — there's
   // no queue to step through here.
   const [detailOpen, setDetailOpen] = useState(false)
-  const cardRef = useRef<HTMLDivElement | null>(null)
   // Distinguishes a tap (opens the detail modal) from a drag (a swipe
   // decision). Set true once a pointer moves past the click slop so the
   // trailing click event after a drag doesn't pop the modal open.
@@ -211,32 +211,48 @@ export function SwipePanel({ active }: SwipePanelProps) {
         )}
 
         {current && (
-          <div
-            ref={cardRef}
-            data-testid="swipe-card"
-            role="button"
-            tabIndex={0}
-            aria-label={`View details for ${current.card.name}`}
-            onPointerDown={onPointerDown}
-            onPointerMove={onPointerMove}
-            onPointerUp={onPointerEnd}
-            onPointerCancel={onPointerEnd}
-            onClick={onCardClick}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.preventDefault()
-                setDetailOpen(true)
-              }
-            }}
-            style={cardTransformStyle(drag, outgoing)}
-            className="relative w-full max-w-xs cursor-pointer touch-none select-none rounded-xl border border-sand-300 bg-sand-50 p-3 shadow-lg shadow-coconut-700/10 dark:border-husk-50 dark:bg-husk-400 dark:shadow-coconut-900/40"
-          >
-            <CardArtwork card={current.card} />
-            <CardMeta
-              card={current.card}
-              setName={current.setName}
-            />
-            <DragHint drag={drag} outgoing={outgoing} />
+          // The whole stack renders as one keyed list so the next card
+          // keeps its DOM node as it's promoted from peek to top — it
+          // *rises* into place rather than the old node being reused and
+          // sliding back in from off-screen. `pb-4` reserves room for the
+          // deepest peek, which is translated below the top card.
+          <div className="w-full max-w-xs pb-4">
+            <div className="relative">
+              {[current, ...upcoming].slice(0, STACK_SIZE).map((cand, depth) =>
+                depth === 0 ? (
+                  <SwipeCard
+                    key={cand.card.id}
+                    card={cand.card}
+                    setName={cand.setName}
+                    depth={0}
+                    drag={drag}
+                    outgoing={outgoing}
+                    interactive
+                    onPointerDown={onPointerDown}
+                    onPointerMove={onPointerMove}
+                    onPointerUp={onPointerEnd}
+                    onPointerCancel={onPointerEnd}
+                    onClick={onCardClick}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault()
+                        setDetailOpen(true)
+                      }
+                    }}
+                  />
+                ) : (
+                  <SwipeCard
+                    key={cand.card.id}
+                    card={cand.card}
+                    setName={cand.setName}
+                    depth={depth}
+                    drag={null}
+                    outgoing={null}
+                    interactive={false}
+                  />
+                ),
+              )}
+            </div>
           </div>
         )}
 
@@ -300,6 +316,92 @@ function SwipeHeader({
       >
         {savedCount > 0 ? `${savedCount} saved · reset` : 'Reset profile'}
       </button>
+    </div>
+  )
+}
+
+/**
+ * Per-depth positioning for the cards peeking beneath the top card.
+ * Index = stack depth (0 is the top card, styled separately). Each peek
+ * sits slightly lower and smaller, edges showing like a physical deck;
+ * `transition-transform` (on the card) animates the rise as it's promoted.
+ */
+const PEEK_CLASSES = [
+  '',
+  'absolute inset-0 z-10 scale-95 translate-y-2',
+  'absolute inset-0 z-0 scale-90 translate-y-4',
+]
+
+/** Shared card chrome for both the interactive top card and the peeks. */
+const CARD_BASE =
+  'w-full rounded-xl border border-sand-300 bg-sand-50 p-3 shadow-lg shadow-coconut-700/10 dark:border-husk-50 dark:bg-husk-400 dark:shadow-coconut-900/40'
+
+/**
+ * SwipeCard — one card in the stack. The top card (`interactive`) carries
+ * the drag/exit transform and all the gesture handlers; peeks are inert
+ * (`pointer-events-none`, `aria-hidden`) and positioned by their depth.
+ * Both branches return a `<div>` so React keeps the DOM node when a peek
+ * is promoted to the top — that node persistence is what makes the rise
+ * animate instead of snapping.
+ */
+function SwipeCard({
+  card,
+  setName,
+  depth,
+  drag,
+  outgoing,
+  interactive,
+  onPointerDown,
+  onPointerMove,
+  onPointerUp,
+  onPointerCancel,
+  onClick,
+  onKeyDown,
+}: {
+  card: SetCard
+  setName: string
+  depth: number
+  drag: Drag | null
+  outgoing: SwipeAction | null
+  interactive: boolean
+  onPointerDown?: (e: React.PointerEvent<HTMLDivElement>) => void
+  onPointerMove?: (e: React.PointerEvent<HTMLDivElement>) => void
+  onPointerUp?: (e: React.PointerEvent<HTMLDivElement>) => void
+  onPointerCancel?: (e: React.PointerEvent<HTMLDivElement>) => void
+  onClick?: () => void
+  onKeyDown?: (e: React.KeyboardEvent<HTMLDivElement>) => void
+}) {
+  if (interactive) {
+    return (
+      <div
+        data-testid="swipe-card"
+        role="button"
+        tabIndex={0}
+        aria-label={`View details for ${card.name}`}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerCancel}
+        onClick={onClick}
+        onKeyDown={onKeyDown}
+        style={cardTransformStyle(drag, outgoing)}
+        className={`relative z-20 cursor-pointer touch-none select-none ${CARD_BASE}`}
+      >
+        <CardArtwork card={card} />
+        <CardMeta card={card} setName={setName} />
+        <DragHint drag={drag} outgoing={outgoing} />
+      </div>
+    )
+  }
+  return (
+    <div
+      aria-hidden
+      className={`pointer-events-none select-none transition-transform duration-200 ease-out ${
+        PEEK_CLASSES[depth] ?? PEEK_CLASSES[PEEK_CLASSES.length - 1]
+      } ${CARD_BASE}`}
+    >
+      <CardArtwork card={card} />
+      <CardMeta card={card} setName={setName} />
     </div>
   )
 }

--- a/web/src/components/useSwipeCandidates.test.ts
+++ b/web/src/components/useSwipeCandidates.test.ts
@@ -1,10 +1,15 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import {
   RARITY_WEIGHTS,
   DEFAULT_WEIGHT,
   rarityWeight,
   weightedSample,
+  STACK_SIZE,
+  useSwipeCandidates,
 } from './useSwipeCandidates'
+import { fetchSets, fetchSetCards } from '../api/client'
+import type { SetCard } from '../types'
 
 describe('rarityWeight', () => {
   it('returns the default for null / unknown rarities', () => {
@@ -69,5 +74,124 @@ describe('weightedSample', () => {
     // picks index 0, rng→1 picks the last index.
     expect(weightedSample([0, 0, 0], () => 0)).toBe(0)
     expect(weightedSample([0, 0, 0], () => 0.99)).toBe(2)
+  })
+})
+
+vi.mock('../api/client', () => ({
+  fetchSets: vi.fn(),
+  fetchSetCards: vi.fn(),
+}))
+// Empty baked catalog so the live `fetchSets` mock is the sole source of
+// truth — keeps the queue deterministic under the injected rng.
+vi.mock('../data/sets', () => ({ BAKED_SETS: [] }))
+
+const mockFetchSets = vi.mocked(fetchSets)
+const mockFetchSetCards = vi.mocked(fetchSetCards)
+
+function card(id: string, rarity: string | null = 'Common'): SetCard {
+  return {
+    id,
+    name: id.toUpperCase(),
+    number: id,
+    rarity,
+    supertype: 'Pokémon',
+    subtypes: ['Basic'],
+    thumb: null,
+    market: 1,
+  }
+}
+
+const ONE_SET = [
+  { id: 'sv1', name: 'Scarlet & Violet', series: 'SV', total: 4, releaseDate: '2023/03/31' },
+]
+
+describe('useSwipeCandidates — prefetched stack', () => {
+  beforeEach(() => {
+    mockFetchSets.mockReset()
+    mockFetchSetCards.mockReset()
+    mockFetchSets.mockResolvedValue(ONE_SET)
+    // rng pinned to 0 means the weighted sampler always takes the first
+    // *eligible* card, so the queue fills in array order minus exclusions.
+    mockFetchSetCards.mockResolvedValue([
+      card('a'),
+      card('b'),
+      card('c'),
+      card('d'),
+    ])
+  })
+
+  it('prefetches a full, de-duplicated stack', async () => {
+    const seenSet = new Set<string>()
+    const { result } = renderHook(() =>
+      useSwipeCandidates({ active: true, seenSet, rng: () => 0 }),
+    )
+
+    await waitFor(() =>
+      expect(result.current.upcoming.length).toBe(STACK_SIZE - 1),
+    )
+    const ids = [
+      result.current.current!.card.id,
+      ...result.current.upcoming.map((c) => c.card.id),
+    ]
+    // Top + peeks are all distinct — no card appears twice in the stack.
+    expect(new Set(ids).size).toBe(STACK_SIZE)
+    expect(ids).toEqual(['a', 'b', 'c'])
+  })
+
+  it('advance() promotes the next card with no extra fetch', async () => {
+    const seenSet = new Set<string>()
+    const { result } = renderHook(() =>
+      useSwipeCandidates({ active: true, seenSet, rng: () => 0 }),
+    )
+
+    await waitFor(() =>
+      expect(result.current.upcoming.length).toBe(STACK_SIZE - 1),
+    )
+    // The whole stack came from a single set fetch.
+    expect(mockFetchSetCards).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      result.current.advance()
+    })
+
+    // The former peek is the new top immediately — no loader, and the
+    // background top-up reuses the cached card list (still one fetch).
+    await waitFor(() => expect(result.current.current!.card.id).toBe('b'))
+    expect(result.current.upcoming.map((c) => c.card.id)).toEqual(['c', 'd'])
+    expect(mockFetchSetCards).toHaveBeenCalledTimes(1)
+  })
+
+  it('never stacks a card the user has already seen', async () => {
+    const seenSet = new Set<string>(['a'])
+    const { result } = renderHook(() =>
+      useSwipeCandidates({ active: true, seenSet, rng: () => 0 }),
+    )
+
+    await waitFor(() =>
+      expect(result.current.upcoming.length).toBe(STACK_SIZE - 1),
+    )
+    const ids = [
+      result.current.current!.card.id,
+      ...result.current.upcoming.map((c) => c.card.id),
+    ]
+    expect(ids).not.toContain('a')
+    expect(ids).toEqual(['b', 'c', 'd'])
+  })
+
+  it('surfaces the exhausted state once the catalog is walked', async () => {
+    mockFetchSetCards.mockReset()
+    mockFetchSetCards.mockResolvedValue([card('a'), card('b')])
+
+    const seenSet = new Set<string>()
+    const { result } = renderHook(() =>
+      useSwipeCandidates({ active: true, seenSet, rng: () => 0 }),
+    )
+
+    // Two cards, stack of three → the stack holds both, then exhausts.
+    await waitFor(() => expect(result.current.upcoming.length).toBe(1))
+    act(() => result.current.advance())
+    act(() => result.current.advance())
+    await waitFor(() => expect(result.current.exhausted).toBe(true))
+    expect(result.current.current).toBeNull()
   })
 })

--- a/web/src/components/useSwipeCandidates.ts
+++ b/web/src/components/useSwipeCandidates.ts
@@ -1,16 +1,25 @@
 /**
- * useSwipeCandidates — feeds the next card to the Swipe surface.
+ * useSwipeCandidates — feeds the Swipe surface a small prefetched *stack*
+ * of cards.
  *
  * V1 heuristic per [#483](https://github.com/mgzwarrior/mgz-pkmn/issues/483):
  *
  *   1. Pull the full set catalog (BAKED_SETS + live `/api/v1/sets`
  *      revalidation). No recency bias — every set is in the pool.
- *   2. On each `pick()`, choose a random set the user hasn't already
+ *   2. On each `sampleOne()`, choose a random set the user hasn't already
  *      exhausted, fetch its trimmed card list on demand, then sample
- *      one unseen card with **rarity-weighted random selection**
+ *      one un-dealt card with **rarity-weighted random selection**
  *      (heavily biased toward higher-rarity cards via `RARITY_WEIGHTS`).
- *      If the chosen set is fully seen, mark it exhausted and recurse.
+ *      If the chosen set is fully dealt, mark it exhausted and recurse.
  *   3. When every set is exhausted, surface the exhausted state.
+ *
+ * Rather than tracking a single `current` card, the hook keeps a queue of
+ * up to {@link STACK_SIZE} candidates so the consumer can render the next
+ * few cards as a real stack and reveal — not refetch — the next card when
+ * the top one is swiped away ([#624](https://github.com/mgzwarrior/mgz-pkmn/issues/624)).
+ * `advance()` drops the top card and tops the queue back up in the
+ * background; because the next card is already fetched there's no loader
+ * flash between swipes.
  *
  * The taste profile (rarity / set / supertype counters) tracked by
  * `useSwipeProfile` is intentionally *not* fed back into selection
@@ -18,9 +27,9 @@
  * rarity-weighted random across the whole catalog, not a recency-
  * or profile-shaped walk.
  *
- * The hook returns `{ current, advance, loading, exhausted, error }`.
- * The consumer calls `advance()` after each swipe; profile updates
- * happen separately in `useSwipeProfile.act`.
+ * The hook returns `{ current, upcoming, advance, loading, exhausted,
+ * error }`. The consumer calls `advance()` after each swipe; profile
+ * updates happen separately in `useSwipeProfile.act`.
  */
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { fetchSetCards, fetchSets } from '../api/client'
@@ -33,14 +42,23 @@ interface Candidate {
   setName: string
 }
 
+/** Top card + the cards peeking beneath it. */
+const STACK_SIZE = 3
+
 interface State {
-  /** Current candidate, or null while we're loading the next batch. */
-  current: Candidate | null
+  /** Prefetched stack; `queue[0]` is the current (top) card. */
+  queue: Candidate[]
   loading: boolean
   /** True only when every set in the catalog has been walked end-to-end. */
   exhausted: boolean
   error: string | null
 }
+
+/** Result of a single sampling attempt. */
+type SampleResult =
+  | { kind: 'card'; card: Candidate }
+  | { kind: 'exhausted' }
+  | { kind: 'error'; message: string }
 
 interface UseSwipeCandidatesOpts {
   /** Whether the consumer is currently visible. Pauses fetching when false. */
@@ -123,9 +141,17 @@ function weightedSample(weights: number[], rng: () => number): number {
 
 export function useSwipeCandidates(opts: UseSwipeCandidatesOpts) {
   const { active, seenSet, rng = Math.random } = opts
+  // Keep the rng behind a ref so an inline `rng` prop (a fresh function each
+  // render) doesn't churn the `sampleOne`/`fill` callback identities and
+  // re-fire the top-up effect on every render. Refreshed in an effect rather
+  // than during render so we never write a ref mid-render.
+  const rngRef = useRef(rng)
+  useEffect(() => {
+    rngRef.current = rng
+  })
 
   const [state, setState] = useState<State>({
-    current: null,
+    queue: [],
     loading: false,
     exhausted: false,
     error: null,
@@ -136,9 +162,21 @@ export function useSwipeCandidates(opts: UseSwipeCandidatesOpts) {
   // to be sampled on each pick.
   const [allSets, setAllSets] = useState<SetInfo[]>(() => [...BAKED_SETS])
   const cardsBySetRef = useRef<Record<string, SetCard[]>>({})
-  // Sets the user has fully seen — skipped on subsequent picks so
+  // Sets the user has fully walked — skipped on subsequent picks so
   // we don't fetch them again.
   const exhaustedSetsRef = useRef<Set<string>>(new Set())
+  // Authoritative copy of the queue so the async fill loop and `advance`
+  // read fresh values across `await`s without waiting for a re-render.
+  const queueRef = useRef<Candidate[]>([])
+  // Every card id ever placed in the stack this session. Excluded from
+  // sampling so a just-swiped card can never resurface deeper in the
+  // queue, even before the profile's `seen` set has caught up. Cleared
+  // on profile reset (see below) so cards come back.
+  const dealtRef = useRef<Set<string>>(new Set())
+  // Guards against two `fill()` runs fetching into the queue at once.
+  const fillingRef = useRef(false)
+  // Tracks the seen-set size so we can detect a profile reset (shrink).
+  const prevSeenSizeRef = useRef(seenSet.size)
 
   // Revalidate the baked catalog against the live `/api/v1/sets`
   // endpoint — silently fall back to the baked snapshot on failure.
@@ -159,97 +197,145 @@ export function useSwipeCandidates(opts: UseSwipeCandidatesOpts) {
     }
   }, [active])
 
-  // Pick the next candidate by sampling a random set, fetching its
-  // card list if not yet cached, then rarity-weighted-sampling the
-  // unseen card pool.
-  const pick = useCallback(async () => {
-    if (allSets.length === 0) return
+  // Sample one candidate, excluding any card id in `exclude` (already
+  // seen or already in the stack). Samples a random set, fetching its
+  // card list if not yet cached, then rarity-weighted-samples the pool
+  // of remaining cards. Recurses (bounded) past exhausted sets / fetch
+  // errors without blowing the stack.
+  const sampleOne = useCallback(
+    async (exclude: Set<string>): Promise<SampleResult> => {
+      if (allSets.length === 0) return { kind: 'exhausted' }
 
-    setState((s) => ({ ...s, loading: true, error: null }))
+      for (let attempt = 0; attempt < allSets.length + 4; attempt++) {
+        const available = allSets.filter(
+          (s) => !exhaustedSetsRef.current.has(s.id),
+        )
+        if (available.length === 0) return { kind: 'exhausted' }
 
-    // Recurse up to N times to skip exhausted sets / loop on fetch
-    // errors without blowing the stack. N is bounded by the catalog
-    // size + a small slack — the exhausted-set ref means we never
-    // re-roll the same set in a single pick.
-    for (let attempt = 0; attempt < allSets.length + 4; attempt++) {
-      const available = allSets.filter(
-        (s) => !exhaustedSetsRef.current.has(s.id),
-      )
-      if (available.length === 0) {
-        setState({
-          current: null,
-          loading: false,
-          exhausted: true,
-          error: null,
-        })
-        return
-      }
+        const set = available[Math.floor(rngRef.current() * available.length)]
+        let cards = cardsBySetRef.current[set.id]
 
-      const set = available[Math.floor(rng() * available.length)]
-      let cards = cardsBySetRef.current[set.id]
+        if (!cards) {
+          try {
+            cards = await fetchSetCards(set.id)
+            cardsBySetRef.current[set.id] = cards
+          } catch (e) {
+            return {
+              kind: 'error',
+              message: e instanceof Error ? e.message : String(e),
+            }
+          }
+        }
 
-      if (!cards) {
-        try {
-          cards = await fetchSetCards(set.id)
-          cardsBySetRef.current[set.id] = cards
-        } catch (e) {
-          setState({
-            current: null,
-            loading: false,
-            exhausted: false,
-            error: e instanceof Error ? e.message : String(e),
-          })
-          return
+        const remaining = cards.filter((c) => !exclude.has(c.id))
+        if (remaining.length === 0) {
+          // Every card in this set is seen-or-dealt — retire it. A reset
+          // clears both `exhaustedSetsRef` and `dealtRef` together, so
+          // this stays consistent.
+          exhaustedSetsRef.current.add(set.id)
+          continue
+        }
+
+        const weights = remaining.map((c) => rarityWeight(c.rarity))
+        const idx = weightedSample(weights, rngRef.current)
+        return {
+          kind: 'card',
+          card: { card: remaining[idx], setId: set.id, setName: set.name },
         }
       }
 
-      const unseen = cards.filter((c) => !seenSet.has(c.id))
-      if (unseen.length === 0) {
-        exhaustedSetsRef.current.add(set.id)
-        continue
+      // Defensive fallback — shouldn't happen unless the catalog is
+      // wedged in a tight loop of always-empty sets.
+      return { kind: 'exhausted' }
+    },
+    [allSets],
+  )
+
+  // Top the queue back up to STACK_SIZE, fetching the next candidates in
+  // the background. Only flips `loading` when the queue is empty so
+  // refilling the tail never flashes the loader between swipes.
+  const fill = useCallback(async () => {
+    if (fillingRef.current || allSets.length === 0) return
+    fillingRef.current = true
+    try {
+      while (queueRef.current.length < STACK_SIZE) {
+        if (queueRef.current.length === 0) {
+          setState((s) => ({ ...s, loading: true, error: null }))
+        }
+        const exclude = new Set(seenSet)
+        for (const id of dealtRef.current) exclude.add(id)
+
+        const res = await sampleOne(exclude)
+
+        if (res.kind === 'error') {
+          setState({
+            queue: queueRef.current,
+            loading: false,
+            exhausted: false,
+            error: res.message,
+          })
+          return
+        }
+        if (res.kind === 'exhausted') {
+          // Stop topping up. Only the *whole* catalog being walked
+          // surfaces the exhausted state — a short tail (e.g. the last
+          // few cards excluded by the in-flight stack) just leaves a
+          // smaller stack that self-heals as the user swipes.
+          setState({
+            queue: queueRef.current,
+            loading: false,
+            exhausted: queueRef.current.length === 0,
+            error: null,
+          })
+          return
+        }
+
+        dealtRef.current.add(res.card.card.id)
+        queueRef.current = [...queueRef.current, res.card]
+        setState({
+          queue: queueRef.current,
+          loading: false,
+          exhausted: false,
+          error: null,
+        })
       }
-
-      const weights = unseen.map((c) => rarityWeight(c.rarity))
-      const idx = weightedSample(weights, rng)
-      const chosen = unseen[idx]
-      setState({
-        current: { card: chosen, setId: set.id, setName: set.name },
-        loading: false,
-        exhausted: false,
-        error: null,
-      })
-      return
+    } finally {
+      fillingRef.current = false
     }
+  }, [allSets, seenSet, sampleOne])
 
-    // Defensive fallback — shouldn't happen unless the catalog is
-    // wedged in a tight loop of always-empty sets.
-    setState({
-      current: null,
-      loading: false,
-      exhausted: true,
-      error: null,
-    })
-  }, [allSets, seenSet, rng])
-
-  // Whenever the set list changes (initial load + revalidation) or
-  // the seen set updates (consumer swiped), advance to a fresh
-  // candidate. See `useBrowseController` for the same eslint-disable
-  // pattern — the cascading-render risk is mitigated by the
-  // early-return guards inside `pick`.
-  /* eslint-disable react-hooks/set-state-in-effect */
+  // Initial load + top-up: whenever the catalog changes or the queue has
+  // drained to empty, fetch a fresh stack. `fill`'s own guards make the
+  // non-empty / in-flight cases cheap no-ops.
   useEffect(() => {
     if (!active) return
     if (allSets.length === 0) return
-    void pick()
-  }, [active, allSets, pick])
-  /* eslint-enable react-hooks/set-state-in-effect */
+    if (queueRef.current.length > 0) return
+    void fill()
+  }, [active, allSets, fill])
+
+  // Detect a profile reset (the seen set shrinking) and start the walk
+  // over: clear the dealt/exhausted bookkeeping and the stack so the
+  // top-up effect above re-fills from scratch.
+  useEffect(() => {
+    if (seenSet.size < prevSeenSizeRef.current) {
+      dealtRef.current = new Set()
+      exhaustedSetsRef.current = new Set()
+      queueRef.current = []
+      setState({ queue: [], loading: true, exhausted: false, error: null })
+    }
+    prevSeenSizeRef.current = seenSet.size
+  }, [seenSet])
 
   const advance = useCallback(() => {
-    void pick()
-  }, [pick])
+    queueRef.current = queueRef.current.slice(1)
+    setState((s) => ({ ...s, queue: queueRef.current }))
+    void fill()
+  }, [fill])
 
   return {
-    current: state.current,
+    current: state.queue[0] ?? null,
+    upcoming: state.queue.slice(1),
     loading: state.loading,
     exhausted: state.exhausted,
     error: state.error,
@@ -259,4 +345,4 @@ export function useSwipeCandidates(opts: UseSwipeCandidatesOpts) {
 
 // Test-only: surface the rarity table + weighted sampler so unit
 // tests can pin the heuristic without going through the React tree.
-export { RARITY_WEIGHTS, DEFAULT_WEIGHT, rarityWeight, weightedSample }
+export { RARITY_WEIGHTS, DEFAULT_WEIGHT, rarityWeight, weightedSample, STACK_SIZE }


### PR DESCRIPTION
Closes #624

## What

Swipe mode now deals from a real prefetched **stack**: the next couple of cards sit slightly scaled and offset beneath the top card (peeking like a physical deck), and swiping the top card off *reveals* the one already mounted underneath. The queue tops itself up in the background as you swipe.

## Why

Swiping felt laggy, and it came down to two things:

1. **Reused DOM node.** The card `<div>` had no React `key`, so when the current card swapped React reused the same element — which still carried the exit transform (`translate(480px) rotate(16deg)`). The new card's idle style only transitions `transform`, so the browser animated the *new* card back from off-screen into the center. Every new card slid in from where the last one flew off, reading as the animation "returning to its starting point".
2. **No prefetch.** Each swipe waited 180ms, then `advance()` set `loading: true` and, if the next random set wasn't cached, awaited a network fetch — an occasional "Finding a card…" flash between cards.

## How

- `useSwipeCandidates` keeps a queue of up to `STACK_SIZE` candidates (`current` + the peeks). `sampleOne()` does one rarity-weighted draw; `fill()` tops the queue up in the background and only flips `loading` when the queue is empty, so refilling the tail never flashes the loader. `advance()` drops the top card and refills — the next card is already fetched, so the swap is instant.
- `SwipePanel` renders the whole stack as **one keyed list** (`key={card.id}`). That node persistence is the fix: the former peek keeps its DOM node as it's promoted to top, so it *rises* into place (scale 0.95 → 1) while the swiped card simply unmounts — no reuse, no slide-in.
- A session-scoped `dealt` set excludes any card already placed in the stack, so a just-swiped card can't resurface deeper in the queue (cleared on profile reset so cards still come back). `rng` is held behind a ref so an inline `rng` prop can't churn the fill callbacks.

## How to verify

Open the Swipe tab and swipe a few cards. The next card peeks beneath the top and rises smoothly to full size as the top flies off — no slide-in from the side, no loader flash.

Verified locally against the running app:

- Stack renders top (`relative z-20`) + two peeks (`scale-95 translate-y-2 z-10`, `scale-90 translate-y-4 z-0`); only the top card carries `data-testid="swipe-card"`, peeks are `aria-hidden`.
- During a swipe's exit animation: no loader text, and the next card is already mounted beneath. After the swap the former peek is the new top and the queue tops back up in the background (a fresh card appended to the tail). No console errors.

`make check` green; `web/` build, ESLint, and the full vitest suite (350 tests) green. New hook tests cover the prefetch, de-dup, instant `advance()` (no extra fetch), and the exhausted path.