### PR TITLE
feat(web): age-scaled rarity floor + chase-weighted sampling in swipe mode

### DIFF
--- a/web/src/components/ExportBar.test.tsx
+++ b/web/src/components/ExportBar.test.tsx
@@ -72,6 +72,7 @@ describe('ExportBar', () => {
         sort: 'number',
         showTimer: false,
         showEbay: false,
+        swipeRarityFloor: 'chase',
       },
     })
     mockExportFile.mockReset()
@@ -145,6 +146,7 @@ describe('ExportBar', () => {
         sort: 'alpha',
         showTimer: false,
         showEbay: false,
+        swipeRarityFloor: 'chase',
       },
     })
 

--- a/web/src/components/LookupTimer.test.tsx
+++ b/web/src/components/LookupTimer.test.tsx
@@ -14,6 +14,7 @@ const DEFAULT_SETTINGS = {
   sort: 'number' as const,
   showTimer: false,
   showEbay: false,
+  swipeRarityFloor: 'chase' as const,
 }
 
 function row(name: string): Row {

--- a/web/src/components/SwipePanel.test.tsx
+++ b/web/src/components/SwipePanel.test.tsx
@@ -14,6 +14,7 @@ import { _resetSwipeProfileForTests } from './useSwipeProfile'
 import { _resetWishlistsCacheForTests } from './useWishlists'
 import { _resetCollectionsCacheForTests } from './useCollections'
 import { _resetAuthStoreForTests } from '../hooks/useAuth'
+import { useAppStore } from '../store'
 import type { SetCard } from '../types'
 
 vi.mock('../api/client', () => ({
@@ -104,6 +105,26 @@ describe('SwipePanel', () => {
     // With Math.random pinned to 0, the weighted sampler picks the
     // first unseen card in the array (Pikachu).
     expect(screen.getByText('Pikachu')).toBeInTheDocument()
+  })
+
+  it('rarity-floor control defaults to Chase cards and persists changes', async () => {
+    // A prior test may have left the persisted floor changed; pin it.
+    useAppStore.setState((s) => ({
+      settings: { ...s.settings, swipeRarityFloor: 'chase' },
+    }))
+    render(<SwipePanel active />)
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    const select = screen.getByLabelText('Rarity floor') as HTMLSelectElement
+    expect(select.value).toBe('chase')
+
+    fireEvent.change(select, { target: { value: 'all' } })
+    expect(useAppStore.getState().settings.swipeRarityFloor).toBe('all')
+
+    // Restore the default so the change doesn't leak into later tests.
+    useAppStore.setState((s) => ({
+      settings: { ...s.settings, swipeRarityFloor: 'chase' },
+    }))
   })
 
   it('renders the next card as an inert peek beneath the top card', async () => {

--- a/web/src/components/SwipePanel.tsx
+++ b/web/src/components/SwipePanel.tsx
@@ -28,7 +28,8 @@ import {
   X,
 } from 'lucide-react'
 import { useAuth } from '../hooks/useAuth'
-import type { Row, SetCard } from '../types'
+import { useAppStore } from '../store'
+import type { RarityFloor, Row, SetCard } from '../types'
 import { browseCardToPayload, browseCardToRow } from './browseCard'
 import { CardDetailModal } from './CardDetailModal'
 import { SaveCardActions } from './SaveCardActions'
@@ -63,10 +64,12 @@ interface SwipePanelProps {
 
 export function SwipePanel({ active }: SwipePanelProps) {
   const { profile, seenSet, act, clearSaved, reset } = useSwipeProfile()
+  const { settings, updateSettings } = useAppStore()
   const { current, upcoming, loading, exhausted, error, advance } =
     useSwipeCandidates({
       active,
       seenSet,
+      rarityFloor: settings.swipeRarityFloor,
     })
   const { user } = useAuth()
   const showSavedActions = user !== null
@@ -190,7 +193,14 @@ export function SwipePanel({ active }: SwipePanelProps) {
       aria-label="Swipe mode"
       className="flex flex-col gap-4 rounded-lg border border-sand-300 bg-sand-50 px-5 py-5 dark:border-husk-50 dark:bg-husk-200"
     >
-      <SwipeHeader savedCount={profile.saved.length} onReset={reset} />
+      <SwipeHeader
+        savedCount={profile.saved.length}
+        onReset={reset}
+        rarityFloor={settings.swipeRarityFloor}
+        onRarityFloorChange={(swipeRarityFloor) =>
+          updateSettings({ swipeRarityFloor })
+        }
+      />
 
       <div className="flex flex-col items-center gap-3">
         {error && (
@@ -292,15 +302,26 @@ export function SwipePanel({ active }: SwipePanelProps) {
   )
 }
 
+/** Floor options for the swipe-header control, most → least selective. */
+const RARITY_FLOOR_OPTIONS: { value: RarityFloor; label: string }[] = [
+  { value: 'chase', label: 'Chase cards' },
+  { value: 'rare', label: 'Rare and up' },
+  { value: 'all', label: 'Everything' },
+]
+
 function SwipeHeader({
   savedCount,
   onReset,
+  rarityFloor,
+  onRarityFloorChange,
 }: {
   savedCount: number
   onReset: () => void
+  rarityFloor: RarityFloor
+  onRarityFloorChange: (floor: RarityFloor) => void
 }) {
   return (
-    <div className="flex items-center justify-between">
+    <div className="flex items-start justify-between gap-3">
       <div>
         <h2 className="text-lg font-semibold text-coconut-700 dark:text-sand-50">
           Swipe
@@ -309,13 +330,30 @@ function SwipeHeader({
           One card at a time — right to save, left to pass, up for more like this.
         </p>
       </div>
-      <button
-        type="button"
-        onClick={onReset}
-        className="text-xs text-coconut-400 underline-offset-2 hover:underline dark:text-sand-300"
-      >
-        {savedCount > 0 ? `${savedCount} saved · reset` : 'Reset profile'}
-      </button>
+      <div className="flex shrink-0 items-center gap-3">
+        <label className="flex items-center gap-1.5 text-xs text-coconut-400 dark:text-sand-300">
+          <span className="sr-only sm:not-sr-only">Show</span>
+          <select
+            aria-label="Rarity floor"
+            value={rarityFloor}
+            onChange={(e) => onRarityFloorChange(e.target.value as RarityFloor)}
+            className="rounded-md border border-sand-300 bg-sand-50 px-2 py-1 text-xs text-coconut-700 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:border-husk-50 dark:bg-husk-100 dark:text-sand-50 dark:focus:ring-sun-300"
+          >
+            {RARITY_FLOOR_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="button"
+          onClick={onReset}
+          className="text-xs text-coconut-400 underline-offset-2 hover:underline dark:text-sand-300"
+        >
+          {savedCount > 0 ? `${savedCount} saved · reset` : 'Reset profile'}
+        </button>
+      </div>
     </div>
   )
 }

--- a/web/src/components/useSwipeCandidates.test.ts
+++ b/web/src/components/useSwipeCandidates.test.ts
@@ -5,6 +5,9 @@ import {
   DEFAULT_WEIGHT,
   rarityWeight,
   weightedSample,
+  rarityTier,
+  chaseTierForSet,
+  isEligible,
   STACK_SIZE,
   useSwipeCandidates,
 } from './useSwipeCandidates'
@@ -193,5 +196,147 @@ describe('useSwipeCandidates — prefetched stack', () => {
     act(() => result.current.advance())
     await waitFor(() => expect(result.current.exhausted).toBe(true))
     expect(result.current.current).toBeNull()
+  })
+})
+
+describe('rarityTier', () => {
+  it('collapses rarities into ordered bands', () => {
+    expect(rarityTier('Common')).toBe(0)
+    expect(rarityTier('Uncommon')).toBe(1)
+    expect(rarityTier('Rare')).toBe(2)
+    expect(rarityTier('Rare Holo')).toBe(2)
+    expect(rarityTier('Trainer Gallery Rare Holo')).toBe(2)
+    expect(rarityTier('Rare Holo EX')).toBe(3)
+    expect(rarityTier('Rare Holo VMAX')).toBe(3)
+    expect(rarityTier('Double Rare')).toBe(3)
+    expect(rarityTier('Ultra Rare')).toBe(3)
+    expect(rarityTier('Illustration Rare')).toBe(4)
+    expect(rarityTier('Special Illustration Rare')).toBe(4)
+    expect(rarityTier('Hyper Rare')).toBe(4)
+  })
+
+  it('treats null / unknown rarity as a low rare (tier 2)', () => {
+    expect(rarityTier(null)).toBe(2)
+    expect(rarityTier('Brand New Rarity')).toBe(2)
+  })
+})
+
+describe('chaseTierForSet', () => {
+  it('returns the highest tier present in the set', () => {
+    // Modern set — ceiling is Special Illustration Rare.
+    expect(
+      chaseTierForSet([
+        card('a', 'Common'),
+        card('b', 'Rare'),
+        card('c', 'Special Illustration Rare'),
+      ]),
+    ).toBe(4)
+    // Base-era set — ceiling is only Rare Holo.
+    expect(
+      chaseTierForSet([card('a', 'Common'), card('b', 'Rare Holo')]),
+    ).toBe(2)
+  })
+})
+
+describe('isEligible', () => {
+  it('all keeps every rarity', () => {
+    expect(isEligible('Common', 'all', 4)).toBe(true)
+  })
+
+  it('rare drops Common + Uncommon (absolute tier ≥ 2)', () => {
+    expect(isEligible('Common', 'rare', 4)).toBe(false)
+    expect(isEligible('Uncommon', 'rare', 4)).toBe(false)
+    expect(isEligible('Rare', 'rare', 4)).toBe(true)
+    expect(isEligible('Rare Holo', 'rare', 4)).toBe(true)
+  })
+
+  it('chase keeps only the set top tier — age-scaled', () => {
+    // Modern set (max tier 4) keeps only secret/illustration cards.
+    expect(isEligible('Rare Holo', 'chase', 4)).toBe(false)
+    expect(isEligible('Special Illustration Rare', 'chase', 4)).toBe(true)
+    // Base-era set (max tier 2) keeps its Rare Holos.
+    expect(isEligible('Rare Holo', 'chase', 2)).toBe(true)
+    expect(isEligible('Common', 'chase', 2)).toBe(false)
+  })
+})
+
+describe('useSwipeCandidates — rarity floor', () => {
+  beforeEach(() => {
+    mockFetchSets.mockReset()
+    mockFetchSetCards.mockReset()
+    mockFetchSets.mockResolvedValue(ONE_SET)
+  })
+
+  it('chase floor surfaces only the set top tier', async () => {
+    mockFetchSetCards.mockResolvedValue([
+      card('c1', 'Common'),
+      card('c2', 'Common'),
+      card('chase', 'Special Illustration Rare'),
+    ])
+    const { result } = renderHook(() =>
+      useSwipeCandidates({
+        active: true,
+        seenSet: new Set(),
+        rarityFloor: 'chase',
+        rng: () => 0,
+      }),
+    )
+
+    await waitFor(() => expect(result.current.current).not.toBeNull())
+    const ids = [
+      result.current.current!.card.id,
+      ...result.current.upcoming.map((c) => c.card.id),
+    ]
+    // Only the SIR clears the chase floor; the Commons are excluded.
+    expect(ids).toEqual(['chase'])
+  })
+
+  it('rare floor drops Common + Uncommon', async () => {
+    mockFetchSetCards.mockResolvedValue([
+      card('c', 'Common'),
+      card('u', 'Uncommon'),
+      card('r', 'Rare'),
+      card('h', 'Rare Holo'),
+    ])
+    const { result } = renderHook(() =>
+      useSwipeCandidates({
+        active: true,
+        seenSet: new Set(),
+        rarityFloor: 'rare',
+        rng: () => 0,
+      }),
+    )
+
+    await waitFor(() =>
+      expect([
+        result.current.current?.card.id,
+        ...result.current.upcoming.map((c) => c.card.id),
+      ]).toEqual(['r', 'h']),
+    )
+  })
+
+  it('all floor keeps Commons in the pool', async () => {
+    mockFetchSetCards.mockResolvedValue([
+      card('c1', 'Common'),
+      card('c2', 'Common'),
+      card('r', 'Rare'),
+    ])
+    const { result } = renderHook(() =>
+      useSwipeCandidates({
+        active: true,
+        seenSet: new Set(),
+        rarityFloor: 'all',
+        rng: () => 0,
+      }),
+    )
+
+    await waitFor(() =>
+      expect(result.current.upcoming.length).toBe(STACK_SIZE - 1),
+    )
+    const ids = [
+      result.current.current!.card.id,
+      ...result.current.upcoming.map((c) => c.card.id),
+    ]
+    expect(ids).toContain('c1')
   })
 })

--- a/web/src/components/useSwipeCandidates.ts
+++ b/web/src/components/useSwipeCandidates.ts
@@ -34,7 +34,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { fetchSetCards, fetchSets } from '../api/client'
 import { BAKED_SETS } from '../data/sets'
-import type { SetCard, SetInfo } from '../types'
+import type { RarityFloor, SetCard, SetInfo } from '../types'
 
 interface Candidate {
   card: SetCard
@@ -66,6 +66,11 @@ interface UseSwipeCandidatesOpts {
   /** Card IDs the user has already seen — filtered out of the pool. */
   seenSet: Set<string>
   /**
+   * Rarity floor — trims the candidate pool toward chase cards. Defaults
+   * to `chase` (each set's top tier). See {@link isEligible}.
+   */
+  rarityFloor?: RarityFloor
+  /**
    * Optional `Math.random` replacement. Production passes nothing
    * (defaults to `Math.random`); tests inject a deterministic source.
    */
@@ -73,55 +78,147 @@ interface UseSwipeCandidatesOpts {
 }
 
 /**
- * Per-rarity sampling weight. Higher = more likely to surface. The
- * spread between Common (1) and Special Illustration Rare (50) is
- * intentional — a typical set is overwhelmingly Common / Uncommon,
- * so a uniform sample would surface bulk first.
+ * Per-rarity sampling weight. Higher = more likely to surface. Swipe mode
+ * is a chase-card reel, not an inventory walk (#580): Ultra-tier and above
+ * carry weights ~100+ while Commons are fractional, so even when bulk is in
+ * the pool a draw lands on a chase card the overwhelming majority of the
+ * time.
  *
  * Keys are matched case-insensitively against the trimmed card's
  * `rarity` field, which mirrors pokemontcg.io's strings. Unknown
  * rarities fall back to {@link DEFAULT_WEIGHT}.
  */
 const RARITY_WEIGHTS: Record<string, number> = {
-  common: 1,
-  uncommon: 2,
-  rare: 5,
-  promo: 5,
-  'rare holo': 8,
-  'rare holo lv.x': 12,
-  'rare holo ex': 12,
-  'rare holo gx': 12,
-  'rare holo v': 12,
-  'rare holo vmax': 14,
-  'rare holo vstar': 14,
-  'double rare': 12,
-  'rare break': 20,
-  'radiant rare': 20,
-  'rare ace': 25,
-  'rare prime': 25,
-  'rare prism star': 25,
-  'rare shining': 30,
-  'rare star': 25,
-  'rare shiny': 25,
-  'shiny rare': 25,
-  'amazing rare': 25,
-  'shiny ultra rare': 35,
-  'ultra rare': 30,
-  'rare ultra': 30,
-  'illustration rare': 30,
-  'special illustration rare': 50,
-  'hyper rare': 40,
-  'rare secret': 40,
-  'rare rainbow': 40,
-  'trainer gallery rare holo': 18,
-  'ace spec rare': 25,
+  common: 0.25,
+  uncommon: 0.5,
+  rare: 4,
+  promo: 4,
+  'rare holo': 10,
+  'trainer gallery rare holo': 12,
+  'rare holo lv.x': 30,
+  'rare holo ex': 30,
+  'rare holo gx': 30,
+  'rare holo v': 30,
+  'rare holo vmax': 40,
+  'rare holo vstar': 40,
+  'double rare': 35,
+  'rare break': 45,
+  'radiant rare': 45,
+  'amazing rare': 45,
+  'rare ace': 45,
+  'ace spec rare': 45,
+  'rare prime': 45,
+  'rare prism star': 45,
+  'rare star': 45,
+  'rare shining': 45,
+  'rare shiny': 45,
+  'shiny rare': 45,
+  'ultra rare': 110,
+  'rare ultra': 110,
+  'illustration rare': 110,
+  'shiny ultra rare': 130,
+  'hyper rare': 150,
+  'rare secret': 150,
+  'rare rainbow': 150,
+  'special illustration rare': 160,
 }
 
-const DEFAULT_WEIGHT = 5
+/** Unknown rarity ≈ a low rare — keep it in the running without dominating. */
+const DEFAULT_WEIGHT = 8
 
 function rarityWeight(rarity: string | null): number {
   if (!rarity) return DEFAULT_WEIGHT
   return RARITY_WEIGHTS[rarity.toLowerCase()] ?? DEFAULT_WEIGHT
+}
+
+/** Tier 3 — rarer than a base rare: the ex/gx/v family, double rare, ultra
+ *  rare, and the assorted special-set rarities. */
+const ULTRA_TIER = new Set([
+  'rare holo lv.x',
+  'rare holo ex',
+  'rare holo gx',
+  'rare holo v',
+  'rare holo vmax',
+  'rare holo vstar',
+  'double rare',
+  'rare break',
+  'radiant rare',
+  'amazing rare',
+  'rare ace',
+  'ace spec rare',
+  'rare prime',
+  'rare prism star',
+  'rare star',
+  'rare shining',
+  'rare shiny',
+  'shiny rare',
+  'ultra rare',
+  'rare ultra',
+])
+
+/** Tier 4 — the chase ceiling: illustration / secret rarities. */
+const SECRET_TIER = new Set([
+  'illustration rare',
+  'special illustration rare',
+  'hyper rare',
+  'rare secret',
+  'rare rainbow',
+  'shiny ultra rare',
+])
+
+/**
+ * Absolute rarity tier — collapses the many rarity strings into ordered
+ * bands so the floor can compare across them: `0` common · `1` uncommon ·
+ * `2` rare (incl. base holos / trainer gallery) · `3` ultra ({@link
+ * ULTRA_TIER}) · `4` secret / illustration ({@link SECRET_TIER}). Null /
+ * unrecognised rarities fall back to `2`, matching {@link DEFAULT_WEIGHT}'s
+ * "treat as a low rare" stance.
+ */
+function rarityTier(rarity: string | null): number {
+  if (!rarity) return 2
+  const r = rarity.toLowerCase()
+  if (r === 'common') return 0
+  if (r === 'uncommon') return 1
+  if (SECRET_TIER.has(r)) return 4
+  if (ULTRA_TIER.has(r)) return 3
+  // Base rares + trainer gallery + anything unrecognised → low rare.
+  return 2
+}
+
+/** The highest rarity tier present in a set — its "chase" tier. */
+function chaseTierForSet(cards: SetCard[]): number {
+  let max = 0
+  for (const c of cards) {
+    const t = rarityTier(c.rarity)
+    if (t > max) max = t
+  }
+  return max
+}
+
+/**
+ * Whether a card clears the rarity floor. `all` keeps everything, `rare`
+ * drops Common + Uncommon (absolute tier ≥ 2), and `chase` keeps only the
+ * set's top tier — passed in as `setMaxTier` so the band scales with each
+ * set's era (Base Set → Rare Holo, modern → Special Illustration Rare).
+ */
+function isEligible(
+  rarity: string | null,
+  floor: RarityFloor,
+  setMaxTier: number,
+): boolean {
+  if (floor === 'all') return true
+  if (floor === 'rare') return rarityTier(rarity) >= 2
+  return rarityTier(rarity) >= setMaxTier
+}
+
+/** In-place-free Fisher–Yates shuffle driven by the injected rng. */
+function shuffled<T>(items: T[], rng: () => number): T[] {
+  const out = items.slice()
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1))
+    ;[out[i], out[j]] = [out[j], out[i]]
+  }
+  return out
 }
 
 /**
@@ -140,7 +237,7 @@ function weightedSample(weights: number[], rng: () => number): number {
 }
 
 export function useSwipeCandidates(opts: UseSwipeCandidatesOpts) {
-  const { active, seenSet, rng = Math.random } = opts
+  const { active, seenSet, rarityFloor = 'chase', rng = Math.random } = opts
   // Keep the rng behind a ref so an inline `rng` prop (a fresh function each
   // render) doesn't churn the `sampleOne`/`fill` callback identities and
   // re-fire the top-up effect on every render. Refreshed in an effect rather
@@ -177,6 +274,8 @@ export function useSwipeCandidates(opts: UseSwipeCandidatesOpts) {
   const fillingRef = useRef(false)
   // Tracks the seen-set size so we can detect a profile reset (shrink).
   const prevSeenSizeRef = useRef(seenSet.size)
+  // Tracks the active floor so we can rebuild the stack when it changes.
+  const prevFloorRef = useRef(rarityFloor)
 
   // Revalidate the baked catalog against the live `/api/v1/sets`
   // endpoint — silently fall back to the baked snapshot on failure.
@@ -197,22 +296,22 @@ export function useSwipeCandidates(opts: UseSwipeCandidatesOpts) {
     }
   }, [active])
 
-  // Sample one candidate, excluding any card id in `exclude` (already
-  // seen or already in the stack). Samples a random set, fetching its
-  // card list if not yet cached, then rarity-weighted-samples the pool
-  // of remaining cards. Recurses (bounded) past exhausted sets / fetch
-  // errors without blowing the stack.
+  // Sample one candidate, excluding any card id in `exclude` (already seen
+  // or already in the stack) and any card below `floor`. Walks the
+  // un-retired sets in a random order, fetching each on demand, and returns
+  // the first floor-eligible card it finds. Iterating each set at most once
+  // (rather than random-with-replacement) avoids coupon-collector
+  // false-exhaustion when chase-tier cards are sparse at the tail.
   const sampleOne = useCallback(
-    async (exclude: Set<string>): Promise<SampleResult> => {
+    async (exclude: Set<string>, floor: RarityFloor): Promise<SampleResult> => {
       if (allSets.length === 0) return { kind: 'exhausted' }
 
-      for (let attempt = 0; attempt < allSets.length + 4; attempt++) {
-        const available = allSets.filter(
-          (s) => !exhaustedSetsRef.current.has(s.id),
-        )
-        if (available.length === 0) return { kind: 'exhausted' }
+      const available = shuffled(
+        allSets.filter((s) => !exhaustedSetsRef.current.has(s.id)),
+        rngRef.current,
+      )
 
-        const set = available[Math.floor(rngRef.current() * available.length)]
+      for (const set of available) {
         let cards = cardsBySetRef.current[set.id]
 
         if (!cards) {
@@ -229,23 +328,31 @@ export function useSwipeCandidates(opts: UseSwipeCandidatesOpts) {
 
         const remaining = cards.filter((c) => !exclude.has(c.id))
         if (remaining.length === 0) {
-          // Every card in this set is seen-or-dealt — retire it. A reset
-          // clears both `exhaustedSetsRef` and `dealtRef` together, so
-          // this stays consistent.
+          // Every card in this set is seen-or-dealt — retire it (floor-
+          // independent, so a floor change never permanently strands a
+          // set). A reset clears both `exhaustedSetsRef` and `dealtRef`.
           exhaustedSetsRef.current.add(set.id)
           continue
         }
 
-        const weights = remaining.map((c) => rarityWeight(c.rarity))
+        const setMaxTier = chaseTierForSet(cards)
+        const eligible = remaining.filter((c) =>
+          isEligible(c.rarity, floor, setMaxTier),
+        )
+        // Eligible pool empty but cards remain → the floor filtered this
+        // set out for now. Skip it without retiring; a lower floor (or
+        // seeing its chase cards) brings it back.
+        if (eligible.length === 0) continue
+
+        const weights = eligible.map((c) => rarityWeight(c.rarity))
         const idx = weightedSample(weights, rngRef.current)
         return {
           kind: 'card',
-          card: { card: remaining[idx], setId: set.id, setName: set.name },
+          card: { card: eligible[idx], setId: set.id, setName: set.name },
         }
       }
 
-      // Defensive fallback — shouldn't happen unless the catalog is
-      // wedged in a tight loop of always-empty sets.
+      // No floor-eligible card anywhere in the catalog.
       return { kind: 'exhausted' }
     },
     [allSets],
@@ -265,7 +372,7 @@ export function useSwipeCandidates(opts: UseSwipeCandidatesOpts) {
         const exclude = new Set(seenSet)
         for (const id of dealtRef.current) exclude.add(id)
 
-        const res = await sampleOne(exclude)
+        const res = await sampleOne(exclude, rarityFloor)
 
         if (res.kind === 'error') {
           setState({
@@ -302,7 +409,7 @@ export function useSwipeCandidates(opts: UseSwipeCandidatesOpts) {
     } finally {
       fillingRef.current = false
     }
-  }, [allSets, seenSet, sampleOne])
+  }, [allSets, seenSet, rarityFloor, sampleOne])
 
   // Initial load + top-up: whenever the catalog changes or the queue has
   // drained to empty, fetch a fresh stack. `fill`'s own guards make the
@@ -327,6 +434,18 @@ export function useSwipeCandidates(opts: UseSwipeCandidatesOpts) {
     prevSeenSizeRef.current = seenSet.size
   }, [seenSet])
 
+  // Floor change → drop the prefetched stack (built under the old floor)
+  // so the top-up effect refills under the new one. Keep `dealtRef` /
+  // `exhaustedSetsRef` intact: already-shown cards still shouldn't repeat,
+  // and retired sets were walked floor-independently.
+  useEffect(() => {
+    if (rarityFloor !== prevFloorRef.current) {
+      prevFloorRef.current = rarityFloor
+      queueRef.current = []
+      setState({ queue: [], loading: true, exhausted: false, error: null })
+    }
+  }, [rarityFloor])
+
   const advance = useCallback(() => {
     queueRef.current = queueRef.current.slice(1)
     setState((s) => ({ ...s, queue: queueRef.current }))
@@ -343,6 +462,16 @@ export function useSwipeCandidates(opts: UseSwipeCandidatesOpts) {
   }
 }
 
-// Test-only: surface the rarity table + weighted sampler so unit
-// tests can pin the heuristic without going through the React tree.
-export { RARITY_WEIGHTS, DEFAULT_WEIGHT, rarityWeight, weightedSample, STACK_SIZE }
+// Test-only: surface the rarity table + weighted sampler + tier/floor
+// helpers so unit tests can pin the heuristics without going through the
+// React tree.
+export {
+  RARITY_WEIGHTS,
+  DEFAULT_WEIGHT,
+  rarityWeight,
+  weightedSample,
+  rarityTier,
+  chaseTierForSet,
+  isEligible,
+  STACK_SIZE,
+}

--- a/web/src/store/index.test.ts
+++ b/web/src/store/index.test.ts
@@ -263,6 +263,24 @@ describe('store: settings.showTimer', () => {
   })
 })
 
+describe('store: settings.swipeRarityFloor', () => {
+  afterEach(() => {
+    useAppStore.getState().resetSettings()
+  })
+
+  it("defaults to 'chase' and round-trips through updateSettings", () => {
+    expect(useAppStore.getState().settings.swipeRarityFloor).toBe('chase')
+    useAppStore.getState().updateSettings({ swipeRarityFloor: 'all' })
+    expect(useAppStore.getState().settings.swipeRarityFloor).toBe('all')
+  })
+
+  it('resetSettings restores it to chase', () => {
+    useAppStore.getState().updateSettings({ swipeRarityFloor: 'rare' })
+    useAppStore.getState().resetSettings()
+    expect(useAppStore.getState().settings.swipeRarityFloor).toBe('chase')
+  })
+})
+
 describe('store: lastSeenChangelogVersion', () => {
   beforeEach(() => useAppStore.setState({ lastSeenChangelogVersion: null }))
 

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -39,6 +39,10 @@ const DEFAULT_SETTINGS: Settings = {
   // yet (epic #416), so the column would be empty for now. The `merge`
   // below backfills this for users with persisted pre-#425 settings.
   showEbay: false,
+  // Swipe mode opens on the chase tier — only each set's top rarity — so a
+  // session feels like flipping chase cards, not walking bulk (#580). The
+  // `merge` below backfills this for users with older persisted settings.
+  swipeRarityFloor: 'chase',
 }
 
 interface AppState {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -141,6 +141,14 @@ export type SortMode =
 /** Export formats accepted by POST /api/v1/export. */
 export type ExportFormat = 'xlsx' | 'pdf' | 'condensed-pdf' | 'checklist'
 
+/**
+ * Swipe-mode rarity floor — how aggressively the candidate pool is trimmed
+ * toward chase cards. `all` keeps every rarity, `rare` drops Common +
+ * Uncommon, and `chase` keeps only each set's top rarity tier (age-scaled:
+ * Base Set → Rare Holo, modern sets → Special Illustration Rare / Hyper).
+ */
+export type RarityFloor = 'all' | 'rare' | 'chase'
+
 /** Application-level settings stored in Zustand and sent with each request. */
 export interface Settings {
   apiKey: string
@@ -152,6 +160,8 @@ export interface Settings {
   showTimer: boolean
   /** Show the eBay comps column (median sold + sparkline) in the results table. */
   showEbay: boolean
+  /** Swipe-mode rarity floor (swipe-header control; not in the settings drawer). */
+  swipeRarityFloor: RarityFloor
 }
 
 /** One input line tracked through the bulk lookup lifecycle. */


### PR DESCRIPTION
Closes #580

## What

Swipe mode now opens on chase cards. Two changes:

1. **Re-tuned weights** — `RARITY_WEIGHTS` rescaled so Ultra-tier and above carry ~100–160 while Commons are fractional (0.25). Even with bulk in the pool, a draw lands on a chase card the overwhelming majority of the time.
2. **Rarity floor control** in the swipe header — **Chase cards · Rare and up · Everything** — persisted in the settings store, default **Chase cards**.

## Why

Swipe mode is a taste-discovery / chase-card-surfacing tool, not an inventory walk. The old weights biased toward high rarity but not aggressively enough, so sessions still felt Common-heavy.

A flat absolute floor (e.g. "Ultra+") would break across eras: rarity has expanded over time, so Base Set tops out at Rare Holo and would be **emptied** by an Ultra+ floor, while modern sets go up through Special Illustration Rare / Hyper Rare. So the **Chase** level is derived *per set* from the rarities it actually contains — its top tier — which auto-scales with era without needing release dates: Base Set's chase = Rare Holo, a modern set's = Special Illustration Rare.

## How

- New pure helpers `rarityTier` (collapses rarity strings into ordered bands 0–4; unknown → low rare), `chaseTierForSet` (a set's top tier), and `isEligible(rarity, floor, setMaxTier)` carry the model and are unit-tested directly.
- `RarityFloor = 'all' | 'rare' | 'chase'` added to the `Settings` type + `DEFAULT_SETTINGS` (`'chase'`); the store's existing `persist` + `merge` backfills it for existing users — no migration. Not surfaced in the Settings drawer (stays swipe-local). The control lives in `SwipeHeader`.
- The sampler now **shuffles the un-retired sets and walks each once** (instead of random-with-replacement), so sparse chase tiers at the tail don't trigger coupon-collector false-exhaustion. A set is retired only when walked **floor-independently**, so changing the floor never permanently strands one; a floor change drops the prefetched stack and refills under the new floor.

## How to verify

Open the Swipe tab. At the default **Chase cards** every card is its set's top rarity tier (no Common / Uncommon / base Rare). Switch to **Everything** and bulk re-enters the pool (still weighted heavily toward Ultra+). **Rare and up** drops only Common + Uncommon. The choice persists across reloads.

Verified locally against the running app: default floor = `chase`; at Chase, 30+ sampled cards were all tier 3–4 (Rare Secret, Rare Shining, Illustration Rare, Rare Holo LV.X, Rare Rainbow) plus a few null-rarity cards that are their set's ceiling — zero bulk; the header select changes the floor and persists to the store. `make check` green; `web/` build + full vitest suite green, with new helper, sampler-floor, store, and control tests.

<!-- Header control screenshot ("Show [Chase cards ▾]") captured during verification; attach via the web UI. -->

## Notes

- Builds on the same file as #625 (the swipe card-stack prefetch), which merged to `main` first — branched off `main`, no conflict.
- Pure frontend: no `render.yaml` / API / env changes.