### PR TITLE
feat(web): library-aware swipe exclusion — no-repeat memory + hide owned/chasing

### DIFF
--- a/api/db/models.py
+++ b/api/db/models.py
@@ -358,6 +358,56 @@ class WishlistItem(Base):
     wishlist: Mapped[Wishlist] = relationship(back_populates="items")
 
 
+#: Allowed values for ``SwipeSeen.swipe_dir`` — the decision that retired
+#: the card from the deck. Mirror the SPA's swipe vocabulary (left / right /
+#: up); nullable so a backfill or a future "mark seen without a decision"
+#: path can omit it.
+SWIPE_DIR_PASS = "pass"
+SWIPE_DIR_SAVE = "save"
+SWIPE_DIR_LOVE = "love"
+
+
+class SwipeSeen(Base):
+    """One row per card a user has been shown in swipe mode (#581).
+
+    Promotes the swipe deck's "already seen" memory from the SPA's
+    session-local ``localStorage`` set to durable per-user state, so the
+    same chase card never resurfaces across sessions until the user resets
+    the deck. Keyed on the promoted ``(card_set_id, card_number)`` identity
+    — the same pair indexed on ``collection_items`` / ``wishlist_items`` —
+    so the library-aware exclusion query unions cleanly across all three
+    tables.
+
+    Append-only and idempotent: the unique constraint on
+    ``(user_id, card_set_id, card_number)`` makes re-seeing a card a no-op
+    rather than a duplicate row. Reset clears the user's rows."""
+
+    __tablename__ = "swipe_seen"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id",
+            "card_set_id",
+            "card_number",
+            name="uq_swipe_seen_user_card",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        default=DEFAULT_USER_ID,
+        nullable=False,
+        index=True,
+    )
+    card_set_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    card_number: Mapped[str] = mapped_column(String(16), nullable=False)
+    seen_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, nullable=False
+    )
+    #: One of the ``SWIPE_DIR_*`` constants, or null when unknown.
+    swipe_dir: Mapped[str | None] = mapped_column(String(8), nullable=True)
+
+
 class RunRow(Base):
     __tablename__ = "run_rows"
 

--- a/api/main.py
+++ b/api/main.py
@@ -58,6 +58,7 @@ from .routes import (
     runs,
     set_cards,
     sets,
+    swipe,
     wishlists,
 )
 
@@ -540,6 +541,7 @@ app.include_router(changelog.router, prefix="/api/v1", tags=["changelog"])
 app.include_router(runs.router, prefix="/api/v1", tags=["runs"])
 app.include_router(collections.router, prefix="/api/v1", tags=["collections"])
 app.include_router(wishlists.router, prefix="/api/v1", tags=["wishlists"])
+app.include_router(swipe.router, prefix="/api/v1", tags=["swipe"])
 app.include_router(cache_route.router, prefix="/api/v1", tags=["cache"])
 app.include_router(ebay.router, prefix="/api/v1", tags=["ebay"])
 app.include_router(auth_routes.router, prefix="/api/v1", tags=["auth"])

--- a/api/migrations/versions/b3f1a9c2d7e4_swipe_seen.py
+++ b/api/migrations/versions/b3f1a9c2d7e4_swipe_seen.py
@@ -1,0 +1,64 @@
+"""swipe_seen — per-user "already shown" memory for swipe mode
+
+Child slice of the library rethink RFC (#501); see #581. Promotes the
+swipe deck's no-repeat memory from the SPA's session-local
+``localStorage`` set to durable per-user state, so a chase card never
+resurfaces across sessions until the user resets the deck.
+
+Keyed on the promoted ``(card_set_id, card_number)`` identity — the same
+pair indexed on ``collection_items`` / ``wishlist_items`` by the #574
+rework — so the library-aware exclusion query (``GET /swipe/excluded``)
+unions seen + owned + chasing across all three tables on the same shape.
+
+Append-only and idempotent: the unique constraint on
+``(user_id, card_set_id, card_number)`` makes re-seeing a card a no-op.
+
+Revision ID: b3f1a9c2d7e4
+Revises: c01ec71011a7
+Create Date: 2026-06-11
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b3f1a9c2d7e4"
+down_revision: str | Sequence[str] | None = "c01ec71011a7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "swipe_seen",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("card_set_id", sa.String(length=64), nullable=False),
+        sa.Column("card_number", sa.String(length=16), nullable=False),
+        sa.Column("seen_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("swipe_dir", sa.String(length=8), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "user_id",
+            "card_set_id",
+            "card_number",
+            name="uq_swipe_seen_user_card",
+        ),
+    )
+    # The exclusion query filters by user_id then unions on the card
+    # identity; a leading-user_id index keeps both the per-user fetch and
+    # the idempotent-insert conflict check off a table scan.
+    op.create_index(
+        "ix_swipe_seen_user_id",
+        "swipe_seen",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_swipe_seen_user_id", table_name="swipe_seen")
+    op.drop_table("swipe_seen")

--- a/api/routes/swipe.py
+++ b/api/routes/swipe.py
@@ -1,0 +1,167 @@
+"""`/api/v1/swipe` — library-aware swipe-deck memory + exclusion (#581).
+
+Two controls for the swipe discovery surface, both per-user and durable:
+
+1. **No-repeat memory.** Every card shown is recorded in ``swipe_seen``;
+   the SPA folds the persisted set into its candidate filter so a card
+   never resurfaces across sessions until the deck is reset.
+2. **Library-aware exclusion.** Opt-in flags fold the user's owned
+   (``collection_items``) and chased (``wishlist_items``) cards into the
+   same exclusion set, so the deck stops serving cards already catalogued.
+
+All three sources share the promoted ``(card_set_id, card_number)``
+identity from the #574 rework, so the exclusion is a single union keyed
+on that pair. The SPA still samples client-side; this endpoint only hands
+back *which* identities to skip.
+
+Endpoints:
+
+- ``GET    /swipe/excluded``  identities to skip (seen + owned? + chasing?)
+- ``POST   /swipe/seen``      record one shown card (idempotent)
+- ``DELETE /swipe/seen``      reset the deck (all, or one set)
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query, Response
+from pydantic import BaseModel, Field
+from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from ..auth.session import current_user_or_default
+from ..db.models import (
+    Collection,
+    CollectionItem,
+    SwipeSeen,
+    User,
+    Wishlist,
+    WishlistItem,
+)
+from ..db.session import get_db
+
+router = APIRouter()
+
+DbSession = Annotated[Session, Depends(get_db)]
+CurrentUser = Annotated[User, Depends(current_user_or_default)]
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class CardIdentity(BaseModel):
+    """The promoted ``(set_id, number)`` pair the SPA keys exclusion on."""
+
+    set_id: str
+    number: str
+
+
+class SwipeSeenCreate(BaseModel):
+    set_id: str = Field(min_length=1, max_length=64)
+    number: str = Field(min_length=1, max_length=16)
+    # The decision that retired the card. Free-form on the wire (the SPA
+    # sends pass / save / love); stored verbatim, truncated to the column.
+    dir: str | None = Field(default=None, max_length=8)
+
+
+class ExcludedOut(BaseModel):
+    cards: list[CardIdentity]
+    total: int
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@router.get("/swipe/excluded")
+def list_excluded(
+    db: DbSession,
+    current_user: CurrentUser,
+    owned: Annotated[bool, Query()] = False,
+    chasing: Annotated[bool, Query()] = False,
+) -> dict:
+    """Identities the swipe deck should skip for the current user.
+
+    Always includes the persisted ``swipe_seen`` set. ``owned`` folds in
+    cards in any of the user's collections; ``chasing`` folds in cards on
+    any of their wishlists. Only rows whose promoted identity is fully
+    populated (both ``card_set_id`` and ``card_number`` non-null) can be
+    matched against a candidate, so partial rows are skipped."""
+    pairs: set[tuple[str, str]] = set()
+
+    seen_rows = db.execute(
+        select(SwipeSeen.card_set_id, SwipeSeen.card_number).where(
+            SwipeSeen.user_id == current_user.id
+        )
+    ).all()
+    pairs.update((s, n) for s, n in seen_rows if s and n)
+
+    if owned:
+        owned_rows = db.execute(
+            select(CollectionItem.card_set_id, CollectionItem.card_number)
+            .join(Collection, CollectionItem.collection_id == Collection.id)
+            .where(Collection.user_id == current_user.id)
+        ).all()
+        pairs.update((s, n) for s, n in owned_rows if s and n)
+
+    if chasing:
+        chasing_rows = db.execute(
+            select(WishlistItem.card_set_id, WishlistItem.card_number)
+            .join(Wishlist, WishlistItem.wishlist_id == Wishlist.id)
+            .where(Wishlist.user_id == current_user.id)
+        ).all()
+        pairs.update((s, n) for s, n in chasing_rows if s and n)
+
+    cards = [CardIdentity(set_id=s, number=n) for s, n in pairs]
+    return ExcludedOut(cards=cards, total=len(cards)).model_dump()
+
+
+@router.post("/swipe/seen", status_code=204)
+def record_seen(
+    req: SwipeSeenCreate,
+    db: DbSession,
+    current_user: CurrentUser,
+) -> Response:
+    """Record one shown card. Idempotent: re-seeing a card is a no-op.
+
+    The unique constraint on ``(user_id, card_set_id, card_number)`` is
+    the source of truth — a concurrent duplicate insert raises
+    ``IntegrityError``, which we swallow so the call still reports success
+    (the card is, after all, already recorded as seen)."""
+    row = SwipeSeen(
+        user_id=current_user.id,
+        card_set_id=req.set_id,
+        card_number=req.number,
+        swipe_dir=req.dir,
+        seen_at=datetime.now(UTC),
+    )
+    db.add(row)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+    return Response(status_code=204)
+
+
+@router.delete("/swipe/seen", status_code=204)
+def reset_seen(
+    db: DbSession,
+    current_user: CurrentUser,
+    set_id: Annotated[str | None, Query()] = None,
+) -> Response:
+    """Clear the user's seen memory — the whole deck, or one set.
+
+    Scoping to a set (``?set_id=sv8``) is the future-proofing nicety from
+    #581: "reset Crown Zenith" without nuking the rest of the history."""
+    stmt = delete(SwipeSeen).where(SwipeSeen.user_id == current_user.id)
+    if set_id is not None:
+        stmt = stmt.where(SwipeSeen.card_set_id == set_id)
+    db.execute(stmt)
+    db.commit()
+    return Response(status_code=204)

--- a/tests/test_swipe.py
+++ b/tests/test_swipe.py
@@ -1,0 +1,216 @@
+"""Tests for `/api/v1/swipe` — library-aware swipe-deck memory (#581).
+
+Covers:
+
+- Alembic migration up/down round-trip for `swipe_seen`.
+- Recording a shown card + idempotent re-record (no duplicate row).
+- `GET /swipe/excluded`: seen-only, plus opt-in owned / chasing unions.
+- Reset: clearing the whole deck and scoping the reset to one set.
+
+Mirrors the isolation pattern from `tests/test_wishlists.py`.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+from sqlalchemy import func, inspect, select
+
+from api.db import session as session_mod
+from api.db.migrate import upgrade_head
+from api.db.models import SwipeSeen
+
+
+class _IsolatedDbMixin(unittest.TestCase):
+    """Point MGZ_PKMN_DATABASE_URL at a fresh sqlite file per test."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._db_path = Path(self._tmp.name) / "test.db"
+        self._old_url = os.environ.get("MGZ_PKMN_DATABASE_URL")
+        os.environ["MGZ_PKMN_DATABASE_URL"] = f"sqlite:///{self._db_path}"
+        session_mod.reset_engine()
+
+    def tearDown(self) -> None:
+        session_mod.reset_engine()
+        if self._old_url is None:
+            os.environ.pop("MGZ_PKMN_DATABASE_URL", None)
+        else:
+            os.environ["MGZ_PKMN_DATABASE_URL"] = self._old_url
+        self._tmp.cleanup()
+
+
+CHARIZARD = {
+    "id": "base1-4",
+    "name": "Charizard",
+    "set": {"id": "base1", "name": "Base Set"},
+    "number": "4",
+    "rarity": "Rare Holo",
+    "images": {"small": "https://example.com/charizard.png"},
+}
+BLASTOISE = {
+    "id": "base1-2",
+    "name": "Blastoise",
+    "set": {"id": "base1", "name": "Base Set"},
+    "number": "2",
+    "rarity": "Rare Holo",
+}
+PIKACHU = {
+    "id": "base1-58",
+    "name": "Pikachu",
+    "set": {"id": "base1", "name": "Base Set"},
+    "number": "58",
+    "rarity": "Common",
+}
+
+
+# ---------------------------------------------------------------------------
+# Migration round-trip
+# ---------------------------------------------------------------------------
+
+
+class SwipeMigrationTests(_IsolatedDbMixin):
+    def test_upgrade_creates_swipe_seen(self) -> None:
+        engine = session_mod.get_engine()
+        upgrade_head(engine)
+        self.assertIn("swipe_seen", set(inspect(engine).get_table_names()))
+
+    def test_round_trip_downgrade_then_reupgrade(self) -> None:
+        from alembic import command
+
+        from api.db import migrate as migrate_mod
+
+        engine = session_mod.get_engine()
+        upgrade_head(engine)
+        self.assertIn("swipe_seen", set(inspect(engine).get_table_names()))
+
+        cfg = migrate_mod._alembic_config()
+        cfg.set_main_option("sqlalchemy.url", str(engine.url))
+        # Step back to the collections-rework revision underneath this one;
+        # swipe_seen comes down, the rest of the schema survives.
+        command.downgrade(cfg, "c01ec71011a7")
+        names = set(inspect(engine).get_table_names())
+        self.assertNotIn("swipe_seen", names)
+        self.assertIn("collection_items", names)
+
+        upgrade_head(engine)
+        self.assertIn("swipe_seen", set(inspect(engine).get_table_names()))
+
+
+# ---------------------------------------------------------------------------
+# Endpoint behavior
+# ---------------------------------------------------------------------------
+
+
+class SwipeEndpointTests(_IsolatedDbMixin):
+    def _client(self) -> TestClient:
+        from api.main import app
+
+        return TestClient(app)
+
+    def test_excluded_is_empty_initially(self) -> None:
+        with self._client() as c:
+            resp = c.get("/api/v1/swipe/excluded")
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.json(), {"cards": [], "total": 0})
+
+    def test_record_seen_then_excluded(self) -> None:
+        with self._client() as c:
+            resp = c.post(
+                "/api/v1/swipe/seen",
+                json={"set_id": "base1", "number": "4", "dir": "save"},
+            )
+            self.assertEqual(resp.status_code, 204)
+
+            body = c.get("/api/v1/swipe/excluded").json()
+            self.assertEqual(body["total"], 1)
+            self.assertEqual(body["cards"], [{"set_id": "base1", "number": "4"}])
+
+    def test_record_seen_is_idempotent(self) -> None:
+        with self._client() as c:
+            for _ in range(3):
+                resp = c.post(
+                    "/api/v1/swipe/seen",
+                    json={"set_id": "base1", "number": "4"},
+                )
+                self.assertEqual(resp.status_code, 204)
+
+            body = c.get("/api/v1/swipe/excluded").json()
+            self.assertEqual(body["total"], 1)
+            with session_mod.get_session_factory()() as s:
+                count = s.scalar(select(func.count(SwipeSeen.id)))
+                self.assertEqual(count, 1)
+
+    def test_excluded_owned_opt_in(self) -> None:
+        with self._client() as c:
+            cid = c.post("/api/v1/collections", json={"name": "Show Binder"}).json()["id"]
+            c.post(f"/api/v1/collections/{cid}/items", json={"card": BLASTOISE})
+
+            # Owned card is invisible until the flag is set.
+            self.assertEqual(c.get("/api/v1/swipe/excluded").json()["total"], 0)
+
+            owned = c.get("/api/v1/swipe/excluded?owned=true").json()
+            self.assertEqual(owned["total"], 1)
+            self.assertIn({"set_id": "base1", "number": "2"}, owned["cards"])
+
+    def test_excluded_chasing_opt_in(self) -> None:
+        with self._client() as c:
+            wid = c.post("/api/v1/wishlists", json={"name": "Hunt"}).json()["id"]
+            c.post(f"/api/v1/wishlists/{wid}/items", json={"card": PIKACHU})
+
+            self.assertEqual(c.get("/api/v1/swipe/excluded").json()["total"], 0)
+
+            chasing = c.get("/api/v1/swipe/excluded?chasing=true").json()
+            self.assertEqual(chasing["total"], 1)
+            self.assertIn({"set_id": "base1", "number": "58"}, chasing["cards"])
+
+    def test_excluded_unions_and_dedupes(self) -> None:
+        with self._client() as c:
+            # Charizard is both seen and owned — it must appear once.
+            c.post("/api/v1/swipe/seen", json={"set_id": "base1", "number": "4"})
+            cid = c.post("/api/v1/collections", json={"name": "Binder"}).json()["id"]
+            c.post(f"/api/v1/collections/{cid}/items", json={"card": CHARIZARD})
+            c.post(f"/api/v1/collections/{cid}/items", json={"card": BLASTOISE})
+            wid = c.post("/api/v1/wishlists", json={"name": "Hunt"}).json()["id"]
+            c.post(f"/api/v1/wishlists/{wid}/items", json={"card": PIKACHU})
+
+            body = c.get("/api/v1/swipe/excluded?owned=true&chasing=true").json()
+            pairs = {(card["set_id"], card["number"]) for card in body["cards"]}
+            self.assertEqual(
+                pairs,
+                {("base1", "4"), ("base1", "2"), ("base1", "58")},
+            )
+            self.assertEqual(body["total"], 3)
+
+    def test_reset_clears_all(self) -> None:
+        with self._client() as c:
+            c.post("/api/v1/swipe/seen", json={"set_id": "base1", "number": "4"})
+            c.post("/api/v1/swipe/seen", json={"set_id": "sv8", "number": "100"})
+            self.assertEqual(c.get("/api/v1/swipe/excluded").json()["total"], 2)
+
+            resp = c.delete("/api/v1/swipe/seen")
+            self.assertEqual(resp.status_code, 204)
+            self.assertEqual(c.get("/api/v1/swipe/excluded").json()["total"], 0)
+
+    def test_reset_scoped_to_one_set(self) -> None:
+        with self._client() as c:
+            c.post("/api/v1/swipe/seen", json={"set_id": "base1", "number": "4"})
+            c.post("/api/v1/swipe/seen", json={"set_id": "sv8", "number": "100"})
+
+            resp = c.delete("/api/v1/swipe/seen?set_id=base1")
+            self.assertEqual(resp.status_code, 204)
+
+            body = c.get("/api/v1/swipe/excluded").json()
+            self.assertEqual(body["cards"], [{"set_id": "sv8", "number": "100"}])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -646,3 +646,59 @@ export async function addCardToWishlist(
   if (!res.ok) throw new Error(`add to wishlist failed: ${res.status}`)
   return (await res.json()) as WishlistItem
 }
+
+// ---------------------------------------------------------------------------
+// swipe (library-aware deck memory + exclusion, #581)
+// ---------------------------------------------------------------------------
+
+/** The promoted `(set_id, number)` identity the swipe deck excludes on. */
+export interface SwipeCardIdentity {
+  set_id: string
+  number: string
+}
+
+/**
+ * Identities the swipe deck should skip for the current user. Always
+ * includes the persisted "already seen" set; `owned` / `chasing` fold in
+ * the user's collection / wishlist cards respectively. The SPA keys its
+ * candidate filter on `${set_id}-${number}` so this composes directly with
+ * the client-side sampler.
+ */
+export async function fetchSwipeExcluded(opts?: {
+  owned?: boolean
+  chasing?: boolean
+}): Promise<SwipeCardIdentity[]> {
+  const params = new URLSearchParams()
+  if (opts?.owned) params.set('owned', 'true')
+  if (opts?.chasing) params.set('chasing', 'true')
+  const qs = params.toString()
+  const res = await fetch(`${BASE}/swipe/excluded${qs ? `?${qs}` : ''}`)
+  if (!res.ok) throw new Error(`swipe excluded failed: ${res.status}`)
+  const data = await res.json()
+  return data.cards as SwipeCardIdentity[]
+}
+
+/** Record one shown card so it never resurfaces across sessions. Idempotent. */
+export async function recordSwipeSeen(
+  setId: string,
+  number: string,
+  dir?: string,
+): Promise<void> {
+  const res = await fetch(`${BASE}/swipe/seen`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ set_id: setId, number, dir: dir ?? null }),
+  })
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`record swipe seen failed: ${res.status}`)
+  }
+}
+
+/** Reset the deck — clear the user's seen memory, or just one set's. */
+export async function resetSwipeSeen(setId?: string): Promise<void> {
+  const qs = setId ? `?set_id=${encodeURIComponent(setId)}` : ''
+  const res = await fetch(`${BASE}/swipe/seen${qs}`, { method: 'DELETE' })
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`reset swipe seen failed: ${res.status}`)
+  }
+}

--- a/web/src/components/ExportBar.test.tsx
+++ b/web/src/components/ExportBar.test.tsx
@@ -73,6 +73,8 @@ describe('ExportBar', () => {
         showTimer: false,
         showEbay: false,
         swipeRarityFloor: 'chase',
+        swipeExcludeOwned: false,
+        swipeExcludeChasing: false,
       },
     })
     mockExportFile.mockReset()
@@ -147,6 +149,8 @@ describe('ExportBar', () => {
         showTimer: false,
         showEbay: false,
         swipeRarityFloor: 'chase',
+        swipeExcludeOwned: false,
+        swipeExcludeChasing: false,
       },
     })
 

--- a/web/src/components/LookupTimer.test.tsx
+++ b/web/src/components/LookupTimer.test.tsx
@@ -15,6 +15,8 @@ const DEFAULT_SETTINGS = {
   showTimer: false,
   showEbay: false,
   swipeRarityFloor: 'chase' as const,
+  swipeExcludeOwned: false,
+  swipeExcludeChasing: false,
 }
 
 function row(name: string): Row {

--- a/web/src/components/SwipePanel.test.tsx
+++ b/web/src/components/SwipePanel.test.tsx
@@ -9,6 +9,9 @@ import {
   fetchWishlists,
   fetchMe,
   fetchCollections,
+  fetchSwipeExcluded,
+  recordSwipeSeen,
+  resetSwipeSeen,
 } from '../api/client'
 import { _resetSwipeProfileForTests } from './useSwipeProfile'
 import { _resetWishlistsCacheForTests } from './useWishlists'
@@ -30,6 +33,11 @@ vi.mock('../api/client', () => ({
   fetchCollections: vi.fn(),
   createCollection: vi.fn(),
   addCardToCollection: vi.fn(),
+  // Library-aware swipe exclusion (#581): the panel loads the persisted
+  // exclusion set on mount and records each swiped card.
+  fetchSwipeExcluded: vi.fn(),
+  recordSwipeSeen: vi.fn(),
+  resetSwipeSeen: vi.fn(),
 }))
 
 const mockFetchSets = vi.mocked(fetchSets)
@@ -39,6 +47,9 @@ const mockAddCardToWishlist = vi.mocked(addCardToWishlist)
 const mockFetchWishlists = vi.mocked(fetchWishlists)
 const mockFetchMe = vi.mocked(fetchMe)
 const mockFetchCollections = vi.mocked(fetchCollections)
+const mockFetchSwipeExcluded = vi.mocked(fetchSwipeExcluded)
+const mockRecordSwipeSeen = vi.mocked(recordSwipeSeen)
+const mockResetSwipeSeen = vi.mocked(resetSwipeSeen)
 
 function card(overrides: Partial<SetCard> = {}): SetCard {
   return {
@@ -82,11 +93,20 @@ describe('SwipePanel', () => {
     mockFetchSets.mockResolvedValue([
       { id: 'sv1', name: 'Scarlet & Violet', series: 'SV', total: 2, releaseDate: '2023/03/31' },
     ])
+    // Distinct collector numbers per card: the library-aware exclusion
+    // (#581) keys on (set_id, number), so two cards sharing a number would
+    // be treated as the same identity. Real set data is unique here.
     mockFetchSetCards.mockResolvedValue([
-      card({ id: 'sv1-1', name: 'Pikachu', market: 5 }),
-      card({ id: 'sv1-2', name: 'Charizard', market: 50 }),
+      card({ id: 'sv1-1', name: 'Pikachu', number: '1', market: 5 }),
+      card({ id: 'sv1-2', name: 'Charizard', number: '2', market: 50 }),
     ])
     mockFetchWishlists.mockResolvedValue([])
+    mockFetchSwipeExcluded.mockReset()
+    mockFetchSwipeExcluded.mockResolvedValue([])
+    mockRecordSwipeSeen.mockReset()
+    mockRecordSwipeSeen.mockResolvedValue(undefined)
+    mockResetSwipeSeen.mockReset()
+    mockResetSwipeSeen.mockResolvedValue(undefined)
     // Pin the rarity-weighted sampler so candidate order is deterministic.
     // `Math.random() === 0` picks the first available set and the first
     // unseen card; after a swipe, the same source picks the remaining card.
@@ -95,6 +115,15 @@ describe('SwipePanel', () => {
 
   afterEach(() => {
     randomSpy.mockRestore()
+    // The store persists across tests; reset the opt-in library toggles so
+    // a test that flips them doesn't leak into the next (#581).
+    useAppStore.setState((s) => ({
+      settings: {
+        ...s.settings,
+        swipeExcludeOwned: false,
+        swipeExcludeChasing: false,
+      },
+    }))
   })
 
   it('renders the current candidate card', async () => {
@@ -402,6 +431,54 @@ describe('SwipePanel', () => {
     expect(
       screen.queryByRole('button', { name: /save to wishlist/i }),
     ).not.toBeInTheDocument()
+  })
+
+  it('records each swiped card as seen (#581)', async () => {
+    render(<SwipePanel active />)
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    // The set id derives from the (unmocked) baked catalog the candidate was
+    // sampled from; the card number + decision are the deterministic parts.
+    await waitFor(() =>
+      expect(mockRecordSwipeSeen).toHaveBeenCalledWith(
+        expect.any(String),
+        '1',
+        'save',
+      ),
+    )
+  })
+
+  it('shows the library-aware exclusion toggles only when signed in (#581)', async () => {
+    render(<SwipePanel active />)
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+    // Signed out (the beforeEach default) → no library toggles.
+    expect(
+      screen.queryByRole('checkbox', { name: 'owned' }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('toggling "hide owned" updates settings and refetches exclusions (#581)', async () => {
+    mockFetchMe.mockResolvedValue({
+      user: { id: 1, email: 'u@e.com', display_name: 'U' },
+      authEnabled: true,
+    })
+
+    render(<SwipePanel active />)
+    await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
+
+    const owned = await screen.findByRole('checkbox', { name: 'owned' })
+    fireEvent.click(owned)
+
+    await waitFor(() =>
+      expect(useAppStore.getState().settings.swipeExcludeOwned).toBe(true),
+    )
+    await waitFor(() =>
+      expect(mockFetchSwipeExcluded).toHaveBeenCalledWith({
+        owned: true,
+        chasing: false,
+      }),
+    )
   })
 
   it('pressing Enter on the focused card opens the detail modal', async () => {

--- a/web/src/components/SwipePanel.tsx
+++ b/web/src/components/SwipePanel.tsx
@@ -39,6 +39,7 @@ import {
   type SwipeAction,
 } from './useSwipeProfile'
 import { STACK_SIZE, useSwipeCandidates } from './useSwipeCandidates'
+import { useSwipeExclusions } from './useSwipeExclusions'
 import { useWishlists } from './useWishlists'
 
 /** Horizontal-drag threshold (px) that commits a pass/save decision. */
@@ -65,14 +66,26 @@ interface SwipePanelProps {
 export function SwipePanel({ active }: SwipePanelProps) {
   const { profile, seenSet, act, clearSaved, reset } = useSwipeProfile()
   const { settings, updateSettings } = useAppStore()
+  const { excludedKeys, recordSeen, resetDeck } = useSwipeExclusions({
+    excludeOwned: settings.swipeExcludeOwned,
+    excludeChasing: settings.swipeExcludeChasing,
+  })
   const { current, upcoming, loading, exhausted, error, advance } =
     useSwipeCandidates({
       active,
       seenSet,
+      excludedKeys,
       rarityFloor: settings.swipeRarityFloor,
     })
   const { user } = useAuth()
   const showSavedActions = user !== null
+
+  // Reset both the local taste profile (session-local seen + saved) and the
+  // server-persisted deck memory, so "reset" surfaces a genuinely fresh deck.
+  const handleReset = useCallback(() => {
+    reset()
+    resetDeck()
+  }, [reset, resetDeck])
 
   const [drag, setDrag] = useState<Drag | null>(null)
   const [outgoing, setOutgoing] = useState<SwipeAction | null>(null)
@@ -100,12 +113,16 @@ export function SwipePanel({ active }: SwipePanelProps) {
       // Let the exit animation play before swapping the card.
       window.setTimeout(() => {
         act(current.card, current.setId, action)
+        // Persist the card as seen so it never resurfaces in a future
+        // session (#581). Local `seenSet` handles the in-session no-repeat;
+        // this is the durable layer.
+        recordSeen(current.setId, current.card.number, action)
         setOutgoing(null)
         setDrag(null)
         advance()
       }, 180)
     },
-    [current, act, advance],
+    [current, act, recordSeen, advance],
   )
 
   // Keyboard shortcuts — global while the panel is mounted + active.
@@ -195,10 +212,19 @@ export function SwipePanel({ active }: SwipePanelProps) {
     >
       <SwipeHeader
         savedCount={profile.saved.length}
-        onReset={reset}
+        onReset={handleReset}
         rarityFloor={settings.swipeRarityFloor}
         onRarityFloorChange={(swipeRarityFloor) =>
           updateSettings({ swipeRarityFloor })
+        }
+        showLibraryToggles={showSavedActions}
+        excludeOwned={settings.swipeExcludeOwned}
+        excludeChasing={settings.swipeExcludeChasing}
+        onExcludeOwnedChange={(swipeExcludeOwned) =>
+          updateSettings({ swipeExcludeOwned })
+        }
+        onExcludeChasingChange={(swipeExcludeChasing) =>
+          updateSettings({ swipeExcludeChasing })
         }
       />
 
@@ -213,7 +239,7 @@ export function SwipePanel({ active }: SwipePanelProps) {
         )}
 
         {exhausted && !current && (
-          <ExhaustedState onReset={reset} />
+          <ExhaustedState onReset={handleReset} />
         )}
 
         {!current && !exhausted && (
@@ -314,47 +340,103 @@ function SwipeHeader({
   onReset,
   rarityFloor,
   onRarityFloorChange,
+  showLibraryToggles,
+  excludeOwned,
+  excludeChasing,
+  onExcludeOwnedChange,
+  onExcludeChasingChange,
 }: {
   savedCount: number
   onReset: () => void
   rarityFloor: RarityFloor
   onRarityFloorChange: (floor: RarityFloor) => void
+  /** Library-aware toggles only make sense with a library — hidden when
+   *  signed out (the endpoints would 401). */
+  showLibraryToggles: boolean
+  excludeOwned: boolean
+  excludeChasing: boolean
+  onExcludeOwnedChange: (next: boolean) => void
+  onExcludeChasingChange: (next: boolean) => void
 }) {
   return (
-    <div className="flex items-start justify-between gap-3">
-      <div>
-        <h2 className="text-lg font-semibold text-coconut-700 dark:text-sand-50">
-          Swipe
-        </h2>
-        <p className="text-xs text-coconut-400 dark:text-sand-300">
-          One card at a time — right to save, left to pass, up for more like this.
-        </p>
-      </div>
-      <div className="flex shrink-0 items-center gap-3">
-        <label className="flex items-center gap-1.5 text-xs text-coconut-400 dark:text-sand-300">
-          <span className="sr-only sm:not-sr-only">Show</span>
-          <select
-            aria-label="Rarity floor"
-            value={rarityFloor}
-            onChange={(e) => onRarityFloorChange(e.target.value as RarityFloor)}
-            className="rounded-md border border-sand-300 bg-sand-50 px-2 py-1 text-xs text-coconut-700 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:border-husk-50 dark:bg-husk-100 dark:text-sand-50 dark:focus:ring-sun-300"
+    <div className="flex flex-col gap-2">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-coconut-700 dark:text-sand-50">
+            Swipe
+          </h2>
+          <p className="text-xs text-coconut-400 dark:text-sand-300">
+            One card at a time — right to save, left to pass, up for more like this.
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-3">
+          <label className="flex items-center gap-1.5 text-xs text-coconut-400 dark:text-sand-300">
+            <span className="sr-only sm:not-sr-only">Show</span>
+            <select
+              aria-label="Rarity floor"
+              value={rarityFloor}
+              onChange={(e) => onRarityFloorChange(e.target.value as RarityFloor)}
+              className="rounded-md border border-sand-300 bg-sand-50 px-2 py-1 text-xs text-coconut-700 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:border-husk-50 dark:bg-husk-100 dark:text-sand-50 dark:focus:ring-sun-300"
+            >
+              {RARITY_FLOOR_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            onClick={onReset}
+            className="text-xs text-coconut-400 underline-offset-2 hover:underline dark:text-sand-300"
           >
-            {RARITY_FLOOR_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-        </label>
-        <button
-          type="button"
-          onClick={onReset}
-          className="text-xs text-coconut-400 underline-offset-2 hover:underline dark:text-sand-300"
-        >
-          {savedCount > 0 ? `${savedCount} saved · reset` : 'Reset profile'}
-        </button>
+            {savedCount > 0 ? `${savedCount} saved · reset` : 'Reset profile'}
+          </button>
+        </div>
       </div>
+      {showLibraryToggles && (
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-xs text-coconut-400 dark:text-sand-300">
+          <span className="text-coconut-300 dark:text-sand-400">Hide</span>
+          <LibraryToggle
+            label="owned"
+            title="Don't show cards already in your collections"
+            checked={excludeOwned}
+            onChange={onExcludeOwnedChange}
+          />
+          <LibraryToggle
+            label="chasing"
+            title="Don't show cards already on your want-lists"
+            checked={excludeChasing}
+            onChange={onExcludeChasingChange}
+          />
+        </div>
+      )}
     </div>
+  )
+}
+
+/** One library-aware exclusion checkbox in the swipe header (#581). */
+function LibraryToggle({
+  label,
+  title,
+  checked,
+  onChange,
+}: {
+  label: string
+  title: string
+  checked: boolean
+  onChange: (next: boolean) => void
+}) {
+  return (
+    <label className="flex items-center gap-1.5" title={title}>
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        className="h-3.5 w-3.5 rounded border-sand-300 text-palm-500 focus:ring-palm-400 dark:border-husk-50 dark:bg-husk-100 dark:text-sun-300 dark:focus:ring-sun-300"
+      />
+      <span>{label}</span>
+    </label>
   )
 }
 

--- a/web/src/components/useSwipeCandidates.test.ts
+++ b/web/src/components/useSwipeCandidates.test.ts
@@ -181,6 +181,51 @@ describe('useSwipeCandidates — prefetched stack', () => {
     expect(ids).toEqual(['b', 'c', 'd'])
   })
 
+  it('drops cards matching an exclusion key (set_id, number) from the pool', async () => {
+    // `card(id)` sets number === id, so the key for card 'a' in set sv1 is
+    // 'sv1::a' — the shape the library-aware exclusion (#581) produces.
+    const seenSet = new Set<string>()
+    const excludedKeys = new Set<string>(['sv1::a', 'sv1::c'])
+    const { result } = renderHook(() =>
+      useSwipeCandidates({ active: true, seenSet, excludedKeys, rng: () => 0 }),
+    )
+
+    await waitFor(() => expect(result.current.current).not.toBeNull())
+    const ids = [
+      result.current.current!.card.id,
+      ...result.current.upcoming.map((c) => c.card.id),
+    ]
+    expect(ids).not.toContain('a')
+    expect(ids).not.toContain('c')
+    expect(ids).toEqual(['b', 'd'])
+  })
+
+  it('prunes a now-excluded card from the prefetched stack and tops up', async () => {
+    const seenSet = new Set<string>()
+    const { result, rerender } = renderHook(
+      ({ excludedKeys }) =>
+        useSwipeCandidates({ active: true, seenSet, excludedKeys, rng: () => 0 }),
+      { initialProps: { excludedKeys: new Set<string>() } },
+    )
+
+    await waitFor(() =>
+      expect(result.current.upcoming.length).toBe(STACK_SIZE - 1),
+    )
+    expect(result.current.current!.card.id).toBe('a')
+
+    // The top card becomes excluded (e.g. the user just turned on "hide
+    // owned"); it's pruned and 'b' rises to the top, backfilled by 'd'.
+    // Wait for the async top-up to settle before asserting the full stack.
+    rerender({ excludedKeys: new Set<string>(['sv1::a']) })
+    await waitFor(() => {
+      const ids = [
+        result.current.current?.card.id,
+        ...result.current.upcoming.map((c) => c.card.id),
+      ]
+      expect(ids).toEqual(['b', 'c', 'd'])
+    })
+  })
+
   it('surfaces the exhausted state once the catalog is walked', async () => {
     mockFetchSetCards.mockReset()
     mockFetchSetCards.mockResolvedValue([card('a'), card('b')])

--- a/web/src/components/useSwipeCandidates.ts
+++ b/web/src/components/useSwipeCandidates.ts
@@ -35,6 +35,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { fetchSetCards, fetchSets } from '../api/client'
 import { BAKED_SETS } from '../data/sets'
 import type { RarityFloor, SetCard, SetInfo } from '../types'
+import { exclusionKey } from './useSwipeExclusions'
 
 interface Candidate {
   card: SetCard
@@ -65,6 +66,15 @@ interface UseSwipeCandidatesOpts {
   active: boolean
   /** Card IDs the user has already seen — filtered out of the pool. */
   seenSet: Set<string>
+  /**
+   * Library-aware exclusion keys (#581), keyed by `${set_id}::${number}`
+   * (see {@link exclusionKey}). The persisted no-repeat set plus the
+   * opt-in owned / chasing cards. Unlike `seenSet` (card-id keyed, the
+   * SPA's session-local memory), these come from the server and survive
+   * across sessions. Excluded identities are dropped from new samples and
+   * pruned from the prefetched stack. Defaults to empty.
+   */
+  excludedKeys?: Set<string>
   /**
    * Rarity floor — trims the candidate pool toward chase cards. Defaults
    * to `chase` (each set's top tier). See {@link isEligible}.
@@ -236,8 +246,24 @@ function weightedSample(weights: number[], rng: () => number): number {
   return weights.length - 1
 }
 
+const EMPTY_KEYS: Set<string> = new Set()
+
 export function useSwipeCandidates(opts: UseSwipeCandidatesOpts) {
-  const { active, seenSet, rarityFloor = 'chase', rng = Math.random } = opts
+  const {
+    active,
+    seenSet,
+    excludedKeys = EMPTY_KEYS,
+    rarityFloor = 'chase',
+    rng = Math.random,
+  } = opts
+  // Read the live exclusion set at sample time (like `rngRef`) so an
+  // incremental `recordSeen` is honored on the next pick without churning
+  // the `sampleOne` / `fill` callback identities. Refreshed in an effect so
+  // we never write the ref mid-render.
+  const excludedKeysRef = useRef(excludedKeys)
+  useEffect(() => {
+    excludedKeysRef.current = excludedKeys
+  })
   // Keep the rng behind a ref so an inline `rng` prop (a fresh function each
   // render) doesn't churn the `sampleOne`/`fill` callback identities and
   // re-fire the top-up effect on every render. Refreshed in an effect rather
@@ -336,12 +362,16 @@ export function useSwipeCandidates(opts: UseSwipeCandidatesOpts) {
         }
 
         const setMaxTier = chaseTierForSet(cards)
-        const eligible = remaining.filter((c) =>
-          isEligible(c.rarity, floor, setMaxTier),
+        const excluded = excludedKeysRef.current
+        const eligible = remaining.filter(
+          (c) =>
+            isEligible(c.rarity, floor, setMaxTier) &&
+            !excluded.has(exclusionKey(set.id, c.number)),
         )
-        // Eligible pool empty but cards remain → the floor filtered this
-        // set out for now. Skip it without retiring; a lower floor (or
-        // seeing its chase cards) brings it back.
+        // Eligible pool empty but cards remain → the floor or the library
+        // filter dropped this set out for now. Skip it without retiring
+        // (retirement keys off `seen`/`dealt` only, so toggling a library
+        // exclusion off — or a lower floor — brings the set back).
         if (eligible.length === 0) continue
 
         const weights = eligible.map((c) => rarityWeight(c.rarity))
@@ -445,6 +475,22 @@ export function useSwipeCandidates(opts: UseSwipeCandidatesOpts) {
       setState({ queue: [], loading: true, exhausted: false, error: null })
     }
   }, [rarityFloor])
+
+  // Exclusion set changed (a library toggle flipped, or the persisted seen
+  // set loaded in) → prune any prefetched card that's now excluded and top
+  // the stack back up. Gentler than a full rebuild: no loader flash, and an
+  // incremental `recordSeen` (the common case) prunes nothing because the
+  // just-seen card has already advanced off the queue.
+  useEffect(() => {
+    const pruned = queueRef.current.filter(
+      (c) => !excludedKeys.has(exclusionKey(c.setId, c.card.number)),
+    )
+    if (pruned.length !== queueRef.current.length) {
+      queueRef.current = pruned
+      setState((s) => ({ ...s, queue: pruned }))
+      void fill()
+    }
+  }, [excludedKeys, fill])
 
   const advance = useCallback(() => {
     queueRef.current = queueRef.current.slice(1)

--- a/web/src/components/useSwipeExclusions.test.ts
+++ b/web/src/components/useSwipeExclusions.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import {
+  fetchSwipeExcluded,
+  recordSwipeSeen,
+  resetSwipeSeen,
+} from '../api/client'
+import { exclusionKey, useSwipeExclusions } from './useSwipeExclusions'
+
+vi.mock('../api/client', () => ({
+  fetchSwipeExcluded: vi.fn(),
+  recordSwipeSeen: vi.fn(),
+  resetSwipeSeen: vi.fn(),
+}))
+
+const mockFetch = vi.mocked(fetchSwipeExcluded)
+const mockRecord = vi.mocked(recordSwipeSeen)
+const mockReset = vi.mocked(resetSwipeSeen)
+
+describe('exclusionKey', () => {
+  it('colon-joins set id and number so segments cannot run together', () => {
+    expect(exclusionKey('sv1', '1')).toBe('sv1::1')
+    // A hyphen in the number can't be confused with the card-id form.
+    expect(exclusionKey('swsh12tg', 'TG01')).toBe('swsh12tg::TG01')
+  })
+})
+
+describe('useSwipeExclusions', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+    mockFetch.mockResolvedValue([])
+    mockRecord.mockReset()
+    mockRecord.mockResolvedValue(undefined)
+    mockReset.mockReset()
+    mockReset.mockResolvedValue(undefined)
+  })
+
+  it('loads the persisted exclusion set on mount', async () => {
+    mockFetch.mockResolvedValue([
+      { set_id: 'sv1', number: '1' },
+      { set_id: 'base1', number: '4' },
+    ])
+    const { result } = renderHook(() =>
+      useSwipeExclusions({ excludeOwned: false, excludeChasing: false }),
+    )
+    await waitFor(() => expect(result.current.excludedKeys.size).toBe(2))
+    expect(result.current.excludedKeys.has('sv1::1')).toBe(true)
+    expect(result.current.excludedKeys.has('base1::4')).toBe(true)
+    expect(mockFetch).toHaveBeenCalledWith({ owned: false, chasing: false })
+  })
+
+  it('refetches with the owned / chasing flags when toggles change', async () => {
+    const { rerender } = renderHook(
+      ({ owned, chasing }) =>
+        useSwipeExclusions({ excludeOwned: owned, excludeChasing: chasing }),
+      { initialProps: { owned: false, chasing: false } },
+    )
+    await waitFor(() =>
+      expect(mockFetch).toHaveBeenCalledWith({ owned: false, chasing: false }),
+    )
+    rerender({ owned: true, chasing: true })
+    await waitFor(() =>
+      expect(mockFetch).toHaveBeenCalledWith({ owned: true, chasing: true }),
+    )
+  })
+
+  it('optimistically excludes a recorded card and persists it', async () => {
+    const { result } = renderHook(() =>
+      useSwipeExclusions({ excludeOwned: false, excludeChasing: false }),
+    )
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled())
+
+    act(() => {
+      result.current.recordSeen('sv1', '7', 'save')
+    })
+    expect(result.current.excludedKeys.has('sv1::7')).toBe(true)
+    expect(mockRecord).toHaveBeenCalledWith('sv1', '7', 'save')
+  })
+
+  it('resetDeck clears the keys and calls the server', async () => {
+    mockFetch.mockResolvedValue([{ set_id: 'sv1', number: '1' }])
+    const { result } = renderHook(() =>
+      useSwipeExclusions({ excludeOwned: false, excludeChasing: false }),
+    )
+    await waitFor(() => expect(result.current.excludedKeys.size).toBe(1))
+
+    act(() => {
+      result.current.resetDeck()
+    })
+    expect(result.current.excludedKeys.size).toBe(0)
+    expect(mockReset).toHaveBeenCalled()
+  })
+
+  it('falls back to an empty set when the endpoint is unreachable', async () => {
+    mockFetch.mockRejectedValue(new Error('401'))
+    const { result } = renderHook(() =>
+      useSwipeExclusions({ excludeOwned: false, excludeChasing: false }),
+    )
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled())
+    // No throw, deck still works with an empty exclusion set.
+    expect(result.current.excludedKeys.size).toBe(0)
+  })
+})

--- a/web/src/components/useSwipeExclusions.ts
+++ b/web/src/components/useSwipeExclusions.ts
@@ -1,0 +1,120 @@
+/**
+ * useSwipeExclusions — server-backed "don't show me this card" memory for
+ * the swipe deck (#581).
+ *
+ * Two layers, both keyed on the promoted `(set_id, number)` identity:
+ *
+ *   1. **No-repeat memory** (always on) — every shown card is recorded via
+ *      `recordSeen` and persisted server-side, so a card never resurfaces
+ *      across sessions until the user resets the deck.
+ *   2. **Library-aware exclusion** (opt-in) — when `excludeOwned` /
+ *      `excludeChasing` are set, the server folds the user's collection /
+ *      wishlist cards into the same exclusion set.
+ *
+ * The hook hands back a `Set<string>` of exclusion keys (see {@link
+ * exclusionKey}) that {@link useSwipeCandidates} drops from the pool: new
+ * samples skip excluded identities, and any already-prefetched card that
+ * becomes excluded (a toggle flip, the persisted set loading in) is pruned
+ * from the stack and topped back up — no loader flash.
+ *
+ * Persistence degrades gracefully: when the endpoints are unreachable
+ * (e.g. auth is on and the visitor is anonymous → 401), every call
+ * silently no-ops and the deck falls back to the SPA's session-local
+ * no-repeat set. The swipe surface keeps working; it just doesn't
+ * remember across sessions.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  fetchSwipeExcluded,
+  recordSwipeSeen,
+  resetSwipeSeen,
+} from '../api/client'
+
+/**
+ * Stable exclusion key for a `(set_id, number)` pair. Colon-joined rather
+ * than reusing the `${set}-${number}` card-id form, since a hyphen appears
+ * in both set ids and collector numbers but a colon appears in neither.
+ */
+export function exclusionKey(setId: string, number: string): string {
+  return `${setId}::${number}`
+}
+
+interface UseSwipeExclusionsOpts {
+  /** Fold the user's owned (collection) cards into the exclusion set. */
+  excludeOwned: boolean
+  /** Fold the user's chased (wishlist) cards into the exclusion set. */
+  excludeChasing: boolean
+}
+
+interface UseSwipeExclusionsResult {
+  /** Keys to drop from the candidate pool — see {@link exclusionKey}. */
+  excludedKeys: Set<string>
+  /** Persist one shown card (idempotent). Optimistically excludes it too. */
+  recordSeen: (setId: string, number: string, dir?: string) => void
+  /** Clear the deck — wipe seen memory and surface the full pool again. */
+  resetDeck: () => void
+}
+
+export function useSwipeExclusions({
+  excludeOwned,
+  excludeChasing,
+}: UseSwipeExclusionsOpts): UseSwipeExclusionsResult {
+  const [excludedKeys, setExcludedKeys] = useState<Set<string>>(() => new Set())
+  // Mirror the latest keys so the optimistic `recordSeen` path can extend
+  // the set without depending on the render-time `excludedKeys` closure.
+  // Synced in an effect (never written mid-render); the mutating callbacks
+  // below also update it directly so rapid same-tick swipes compound.
+  const keysRef = useRef(excludedKeys)
+  useEffect(() => {
+    keysRef.current = excludedKeys
+  })
+
+  // Load (and reload on toggle change) the server exclusion set. Failures
+  // resolve to an empty set so an anonymous / offline visitor still gets a
+  // working deck (session-local no-repeat only).
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      let keys: Set<string>
+      try {
+        const cards = await fetchSwipeExcluded({
+          owned: excludeOwned,
+          chasing: excludeChasing,
+        })
+        keys = new Set(cards.map((c) => exclusionKey(c.set_id, c.number)))
+      } catch {
+        keys = new Set()
+      }
+      if (cancelled) return
+      setExcludedKeys(keys)
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [excludeOwned, excludeChasing])
+
+  const recordSeen = useCallback(
+    (setId: string, number: string, dir?: string) => {
+      const key = exclusionKey(setId, number)
+      if (!keysRef.current.has(key)) {
+        const next = new Set(keysRef.current)
+        next.add(key)
+        keysRef.current = next
+        setExcludedKeys(next)
+      }
+      // Fire-and-forget; a failed persist just means this card may return
+      // in a future session. The in-session exclusion above still holds.
+      void recordSwipeSeen(setId, number, dir).catch(() => {})
+    },
+    [],
+  )
+
+  const resetDeck = useCallback(() => {
+    const empty = new Set<string>()
+    keysRef.current = empty
+    setExcludedKeys(empty)
+    void resetSwipeSeen().catch(() => {})
+  }, [])
+
+  return { excludedKeys, recordSeen, resetDeck }
+}

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -43,6 +43,12 @@ const DEFAULT_SETTINGS: Settings = {
   // session feels like flipping chase cards, not walking bulk (#580). The
   // `merge` below backfills this for users with older persisted settings.
   swipeRarityFloor: 'chase',
+  // Library-aware exclusion is opt-in (#581): a fresh deck shows everything
+  // (minus already-seen), and the user turns these on to hide cards they
+  // already own / are already chasing. The `merge` below backfills both for
+  // users with older persisted settings.
+  swipeExcludeOwned: false,
+  swipeExcludeChasing: false,
 }
 
 interface AppState {

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -162,6 +162,15 @@ export interface Settings {
   showEbay: boolean
   /** Swipe-mode rarity floor (swipe-header control; not in the settings drawer). */
   swipeRarityFloor: RarityFloor
+  /**
+   * Swipe-mode library-aware exclusion (#581). Opt-in: when on, the deck
+   * stops serving cards already in any of your collections (`Owned`) or on
+   * any of your wishlists (`Chasing`). Both default off; the no-repeat
+   * memory that excludes already-*seen* cards is always on and isn't a
+   * setting.
+   */
+  swipeExcludeOwned: boolean
+  swipeExcludeChasing: boolean
 }
 
 /** One input line tracked through the bulk lookup lifecycle. */


### PR DESCRIPTION
Closes #581.

## What

Two per-user, durable controls on the swipe deck:

1. **No-repeat memory** (always on) — every card you swipe is recorded server-side, so it never resurfaces across sessions. Previously the "already seen" set lived only in the SPA's `localStorage` and reset whenever the deck did.
2. **Library-aware exclusion** (opt-in) — two checkboxes in the swipe header: **hide owned** (cards already in any of your collections) and **hide chasing** (cards already on any of your want-lists). Both default off, so a fresh deck still shows everything minus what you've seen.

A single "reset" affordance clears the persisted memory and surfaces a genuinely fresh deck.

## Why

The two failure modes of swipe today: the same chase card surfaces across sessions because nothing remembers it, and the deck cheerfully serves cards you've already catalogued. Both kill the chase-reel feel. This is the third piece of the swipe-mode arc (after save-on-swipe #579 and chase weighting #580) and the last "surfaces become collection-aware" item that depends only on the merged #574 data model.

## How

All three exclusion sources share the promoted `(card_set_id, card_number)` identity indexed by the #574 rework, so the exclusion is one union keyed on that pair.

**Backend** (`api/routes/swipe.py`, new `swipe_seen` table):
- `GET /swipe/excluded?owned=&chasing=` — the union of seen ∪ owned? ∪ chasing? over `swipe_seen` / `collection_items` / `wishlist_items`.
- `POST /swipe/seen` — record one shown card; idempotent on `(user_id, card_set_id, card_number)`.
- `DELETE /swipe/seen[?set_id=]` — reset the whole deck, or just one set.

**Frontend**:
- `useSwipeExclusions` loads the persisted set, records each swipe (fire-and-forget), and resets the deck.
- `useSwipeCandidates` drops excluded identities from new samples and prunes already-prefetched cards when a toggle flips — no loader flash.
- The toggles render only with a library (signed in / self-host). Persistence degrades gracefully: an anonymous `401` falls back to the session-local no-repeat set, so the deck keeps working.

**Design note:** #581 sketched a `GET /swipe/candidates` returning the filtered pool, but the deck samples client-side from per-set fetches (the #624/#580 prefetch-stack architecture). An exclusion-set endpoint is the minimal change that fits that architecture and preserves the age-scaled rarity weighting, so I went with `/swipe/excluded` instead.

No `render.yaml` change: the new table rides the existing automigrate, and there are no new env vars / disk / health-check requirements.

## How to verify

1. `make dev-api` + `make dev-web`, open Swipe mode (self-host shows the toggles against the sentinel user).
2. Swipe a few cards, reload — they don't come back (persisted no-repeat).
3. Add a card to a collection, tick **hide owned** — it's dropped from the deck. Same for a want-list + **hide chasing**.
4. Hit reset — the deck refills from scratch.

Verified end-to-end against a live API + SPA: toggling **owned** fires `GET /api/v1/swipe/excluded?owned=true`; a swipe fires `POST /api/v1/swipe/seen → 204` and the card shows up in `/excluded` on the next read; no console errors. (Screenshot of the new toggle row to follow.)

Tests: `tests/test_swipe.py` (migration round-trip, idempotent record, seen/owned/chasing unions, reset all + per-set); `useSwipeExclusions.test.ts`, exclusion + prune cases in `useSwipeCandidates.test.ts`, toggle + record-seen cases in `SwipePanel.test.tsx`.