### PR TITLE
feat(web): cross-collection ownership badges on search, browse, and swipe

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -53,6 +53,7 @@ from .routes import (
     export,
     lookup,
     overrides,
+    ownership,
     parse,
     pokedex,
     runs,
@@ -542,6 +543,7 @@ app.include_router(runs.router, prefix="/api/v1", tags=["runs"])
 app.include_router(collections.router, prefix="/api/v1", tags=["collections"])
 app.include_router(wishlists.router, prefix="/api/v1", tags=["wishlists"])
 app.include_router(swipe.router, prefix="/api/v1", tags=["swipe"])
+app.include_router(ownership.router, prefix="/api/v1", tags=["ownership"])
 app.include_router(cache_route.router, prefix="/api/v1", tags=["cache"])
 app.include_router(ebay.router, prefix="/api/v1", tags=["ebay"])
 app.include_router(auth_routes.router, prefix="/api/v1", tags=["auth"])

--- a/api/routes/ownership.py
+++ b/api/routes/ownership.py
@@ -1,0 +1,171 @@
+"""`/api/v1/cards/ownership` — cross-collection ownership lookup (#576).
+
+The collections-rethink RFC (#501) turns durable inventory into something
+the rest of the product can see: every card shown in search / browse /
+swipe results carries an inline badge — "owned 2x in Show Binder · 1x in
+Trade Stock", "chasing on Allentown want-list" — so a vendor pricing comps
+doesn't re-add a card they already own and a collector doesn't chase the
+same card twice.
+
+This is the read side of that. The SPA batches the identities on a page
+into one `POST`, and gets back the per-card occupancy across the user's
+collections + wishlists. Keyed on the promoted ``(card_set_id,
+card_number)`` identity from the #574 rework — the sibling of the
+library-aware swipe exclusion (#581), which unions the same shape.
+
+Endpoint:
+
+- ``POST /cards/ownership``  per-card occupancy for a batch of identities
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..auth.session import current_user_or_default
+from ..db.models import Collection, CollectionItem, User, Wishlist, WishlistItem
+from ..db.session import get_db
+
+router = APIRouter()
+
+DbSession = Annotated[Session, Depends(get_db)]
+CurrentUser = Annotated[User, Depends(current_user_or_default)]
+
+#: Upper bound on the batch — a single results page is well under this.
+#: Caps the work a single request can ask for.
+MAX_CARDS = 500
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class CardIdentity(BaseModel):
+    set_id: str
+    number: str
+
+
+class OwnershipQuery(BaseModel):
+    cards: list[CardIdentity] = Field(default_factory=list, max_length=MAX_CARDS)
+
+
+class CollectionOccupancy(BaseModel):
+    id: int
+    name: str
+    quantity: int
+
+
+class WishlistOccupancy(BaseModel):
+    id: int
+    name: str
+
+
+class CardOwnership(BaseModel):
+    collections: list[CollectionOccupancy]
+    wishlists: list[WishlistOccupancy]
+
+
+class OwnershipOut(BaseModel):
+    #: Sparse map keyed by ``"<set_id>::<number>"``. Cards with no
+    #: occupancy are omitted, so the SPA renders a badge only when the key
+    #: is present.
+    ownership: dict[str, CardOwnership]
+
+
+# ---------------------------------------------------------------------------
+# Route
+# ---------------------------------------------------------------------------
+
+
+def _key(set_id: str, number: str) -> str:
+    """Stable map key for a ``(set_id, number)`` pair. Colon-joined so the
+    two segments can't run together ambiguously — mirrors the SPA's
+    ``exclusionKey`` from the swipe surface (#581)."""
+    return f"{set_id}::{number}"
+
+
+@router.post("/cards/ownership")
+def card_ownership(
+    req: OwnershipQuery,
+    db: DbSession,
+    current_user: CurrentUser,
+) -> dict:
+    """Per-card occupancy across the user's collections + wishlists.
+
+    Returns a sparse map: only cards the user owns or is chasing appear.
+    Quantities are summed across a collection's items, so a card added
+    twice to one binder reports ``quantity: 2`` rather than two rows.
+
+    The query is scoped to the set ids present in the request, then matched
+    exactly on ``(card_set_id, card_number)`` in Python — bounded work that
+    stays portable across SQLite / Postgres without a tuple-``IN``."""
+    requested = {(c.set_id, c.number) for c in req.cards}
+    if not requested:
+        return OwnershipOut(ownership={}).model_dump()
+
+    set_ids = {set_id for set_id, _ in requested}
+
+    # (key, collection_id) -> [name, summed quantity]; insertion order
+    # preserved so the badge lists collections in a stable order.
+    collections: dict[str, dict[int, CollectionOccupancy]] = {}
+    coll_rows = db.execute(
+        select(
+            CollectionItem.card_set_id,
+            CollectionItem.card_number,
+            Collection.id,
+            Collection.name,
+            CollectionItem.quantity,
+        )
+        .join(Collection, CollectionItem.collection_id == Collection.id)
+        .where(
+            Collection.user_id == current_user.id,
+            CollectionItem.card_set_id.in_(set_ids),
+        )
+    ).all()
+    for set_id, number, coll_id, coll_name, quantity in coll_rows:
+        if (set_id, number) not in requested:
+            continue
+        key = _key(set_id, number)
+        per_collection = collections.setdefault(key, {})
+        existing = per_collection.get(coll_id)
+        if existing is None:
+            per_collection[coll_id] = CollectionOccupancy(
+                id=coll_id, name=coll_name, quantity=quantity or 0
+            )
+        else:
+            existing.quantity += quantity or 0
+
+    wishlists: dict[str, dict[int, WishlistOccupancy]] = {}
+    wish_rows = db.execute(
+        select(
+            WishlistItem.card_set_id,
+            WishlistItem.card_number,
+            Wishlist.id,
+            Wishlist.name,
+        )
+        .join(Wishlist, WishlistItem.wishlist_id == Wishlist.id)
+        .where(
+            Wishlist.user_id == current_user.id,
+            WishlistItem.card_set_id.in_(set_ids),
+        )
+    ).all()
+    for set_id, number, wish_id, wish_name in wish_rows:
+        if (set_id, number) not in requested:
+            continue
+        key = _key(set_id, number)
+        per_wishlist = wishlists.setdefault(key, {})
+        per_wishlist.setdefault(wish_id, WishlistOccupancy(id=wish_id, name=wish_name))
+
+    ownership: dict[str, CardOwnership] = {}
+    for key in set(collections) | set(wishlists):
+        ownership[key] = CardOwnership(
+            collections=list(collections.get(key, {}).values()),
+            wishlists=list(wishlists.get(key, {}).values()),
+        )
+    return OwnershipOut(ownership=ownership).model_dump()

--- a/tests/test_ownership.py
+++ b/tests/test_ownership.py
@@ -1,0 +1,194 @@
+"""Tests for `/api/v1/cards/ownership` — cross-collection ownership (#576).
+
+Covers:
+
+- Empty / no-occupancy requests return an empty map.
+- Owned cards report their collection + summed quantity.
+- Quantity sums across duplicate rows in one collection.
+- A card in two collections lists both.
+- Chased cards report their wishlist.
+- A card both owned and chasing reports both sides.
+- Only requested identities come back (scoping to the batch).
+
+Mirrors the isolation pattern from `tests/test_swipe.py`.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+
+from api.db import session as session_mod
+
+
+class _IsolatedDbMixin(unittest.TestCase):
+    """Point MGZ_PKMN_DATABASE_URL at a fresh sqlite file per test."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._db_path = Path(self._tmp.name) / "test.db"
+        self._old_url = os.environ.get("MGZ_PKMN_DATABASE_URL")
+        os.environ["MGZ_PKMN_DATABASE_URL"] = f"sqlite:///{self._db_path}"
+        session_mod.reset_engine()
+
+    def tearDown(self) -> None:
+        session_mod.reset_engine()
+        if self._old_url is None:
+            os.environ.pop("MGZ_PKMN_DATABASE_URL", None)
+        else:
+            os.environ["MGZ_PKMN_DATABASE_URL"] = self._old_url
+        self._tmp.cleanup()
+
+
+def _card(set_id: str, number: str, name: str) -> dict:
+    return {
+        "id": f"{set_id}-{number}",
+        "name": name,
+        "set": {"id": set_id, "name": set_id.upper()},
+        "number": number,
+        "rarity": "Rare Holo",
+    }
+
+
+CHARIZARD = _card("base1", "4", "Charizard")
+BLASTOISE = _card("base1", "2", "Blastoise")
+PIKACHU = _card("base1", "58", "Pikachu")
+
+
+class OwnershipEndpointTests(_IsolatedDbMixin):
+    def _client(self) -> TestClient:
+        from api.main import app
+
+        return TestClient(app)
+
+    def _collection(self, c: TestClient, name: str) -> int:
+        return c.post("/api/v1/collections", json={"name": name}).json()["id"]
+
+    def _wishlist(self, c: TestClient, name: str) -> int:
+        return c.post("/api/v1/wishlists", json={"name": name}).json()["id"]
+
+    def _add_to_collection(self, c: TestClient, cid: int, card: dict) -> None:
+        c.post(f"/api/v1/collections/{cid}/items", json={"card": card})
+
+    def test_empty_request(self) -> None:
+        with self._client() as c:
+            resp = c.post("/api/v1/cards/ownership", json={"cards": []})
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.json(), {"ownership": {}})
+
+    def test_owned_card_reports_collection(self) -> None:
+        with self._client() as c:
+            cid = self._collection(c, "Show Binder")
+            self._add_to_collection(c, cid, BLASTOISE)
+
+            resp = c.post(
+                "/api/v1/cards/ownership",
+                json={"cards": [{"set_id": "base1", "number": "2"}]},
+            )
+            body = resp.json()["ownership"]
+            self.assertIn("base1::2", body)
+            entry = body["base1::2"]
+            self.assertEqual(entry["wishlists"], [])
+            self.assertEqual(len(entry["collections"]), 1)
+            self.assertEqual(entry["collections"][0]["name"], "Show Binder")
+            self.assertEqual(entry["collections"][0]["id"], cid)
+            self.assertEqual(entry["collections"][0]["quantity"], 1)
+
+    def test_quantity_sums_across_duplicate_rows(self) -> None:
+        with self._client() as c:
+            cid = self._collection(c, "Trade Stock")
+            # Same card added three times to one collection → quantity 3.
+            for _ in range(3):
+                self._add_to_collection(c, cid, CHARIZARD)
+
+            body = c.post(
+                "/api/v1/cards/ownership",
+                json={"cards": [{"set_id": "base1", "number": "4"}]},
+            ).json()["ownership"]
+            self.assertEqual(len(body["base1::4"]["collections"]), 1)
+            self.assertEqual(body["base1::4"]["collections"][0]["quantity"], 3)
+
+    def test_card_in_two_collections_lists_both(self) -> None:
+        with self._client() as c:
+            a = self._collection(c, "Show Binder")
+            b = self._collection(c, "Trade Stock")
+            self._add_to_collection(c, a, CHARIZARD)
+            self._add_to_collection(c, b, CHARIZARD)
+
+            body = c.post(
+                "/api/v1/cards/ownership",
+                json={"cards": [{"set_id": "base1", "number": "4"}]},
+            ).json()["ownership"]
+            names = {x["name"] for x in body["base1::4"]["collections"]}
+            self.assertEqual(names, {"Show Binder", "Trade Stock"})
+
+    def test_chasing_card_reports_wishlist(self) -> None:
+        with self._client() as c:
+            wid = self._wishlist(c, "Allentown Show")
+            c.post(f"/api/v1/wishlists/{wid}/items", json={"card": PIKACHU})
+
+            body = c.post(
+                "/api/v1/cards/ownership",
+                json={"cards": [{"set_id": "base1", "number": "58"}]},
+            ).json()["ownership"]
+            self.assertEqual(body["base1::58"]["collections"], [])
+            self.assertEqual(len(body["base1::58"]["wishlists"]), 1)
+            self.assertEqual(body["base1::58"]["wishlists"][0]["name"], "Allentown Show")
+
+    def test_owned_and_chasing_reports_both(self) -> None:
+        with self._client() as c:
+            cid = self._collection(c, "Show Binder")
+            self._add_to_collection(c, cid, CHARIZARD)
+            wid = self._wishlist(c, "Upgrade list")
+            c.post(f"/api/v1/wishlists/{wid}/items", json={"card": CHARIZARD})
+
+            body = c.post(
+                "/api/v1/cards/ownership",
+                json={"cards": [{"set_id": "base1", "number": "4"}]},
+            ).json()["ownership"]
+            self.assertEqual(len(body["base1::4"]["collections"]), 1)
+            self.assertEqual(len(body["base1::4"]["wishlists"]), 1)
+
+    def test_unowned_card_is_omitted(self) -> None:
+        with self._client() as c:
+            cid = self._collection(c, "Show Binder")
+            self._add_to_collection(c, cid, CHARIZARD)
+
+            # Ask about a card we don't own; it must not appear.
+            body = c.post(
+                "/api/v1/cards/ownership",
+                json={
+                    "cards": [
+                        {"set_id": "base1", "number": "4"},
+                        {"set_id": "base1", "number": "999"},
+                    ]
+                },
+            ).json()["ownership"]
+            self.assertIn("base1::4", body)
+            self.assertNotIn("base1::999", body)
+
+    def test_scoped_to_requested_identities(self) -> None:
+        with self._client() as c:
+            cid = self._collection(c, "Show Binder")
+            self._add_to_collection(c, cid, CHARIZARD)  # base1-4
+            self._add_to_collection(c, cid, BLASTOISE)  # base1-2
+
+            # Same set, but only ask about Charizard — Blastoise stays out
+            # even though it shares the set id used to scope the query.
+            body = c.post(
+                "/api/v1/cards/ownership",
+                json={"cards": [{"set_id": "base1", "number": "4"}]},
+            ).json()["ownership"]
+            self.assertEqual(set(body.keys()), {"base1::4"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -702,3 +702,42 @@ export async function resetSwipeSeen(setId?: string): Promise<void> {
     throw new Error(`reset swipe seen failed: ${res.status}`)
   }
 }
+
+// ---------------------------------------------------------------------------
+// card ownership (cross-collection badges, #576)
+// ---------------------------------------------------------------------------
+
+export interface CollectionOccupancy {
+  id: number
+  name: string
+  quantity: number
+}
+
+export interface WishlistOccupancy {
+  id: number
+  name: string
+}
+
+export interface CardOwnership {
+  collections: CollectionOccupancy[]
+  wishlists: WishlistOccupancy[]
+}
+
+/**
+ * Per-card occupancy across the user's collections + wishlists, for a batch
+ * of `(set_id, number)` identities. The response is a sparse map keyed by
+ * `${set_id}::${number}` — only cards the user owns or is chasing appear, so
+ * the SPA renders a badge exactly when the key is present.
+ */
+export async function fetchCardOwnership(
+  cards: { set_id: string; number: string }[],
+): Promise<Record<string, CardOwnership>> {
+  const res = await fetch(`${BASE}/cards/ownership`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ cards }),
+  })
+  if (!res.ok) throw new Error(`card ownership failed: ${res.status}`)
+  const data = await res.json()
+  return data.ownership as Record<string, CardOwnership>
+}

--- a/web/src/components/BrowsePanel.tsx
+++ b/web/src/components/BrowsePanel.tsx
@@ -14,7 +14,10 @@ import { useAuth } from '../hooks/useAuth'
 import type { PokedexCard, PokedexEntry, Row, SetCard, SetInfo } from '../types'
 import { browseCardToPayload, browseCardToRow, type BrowseSetContext } from './browseCard'
 import { CardDetailModal } from './CardDetailModal'
+import { useCardOwnership } from './useCardOwnership'
+import { OwnershipBadge } from './OwnershipBadge'
 import { SaveCardActions } from './SaveCardActions'
+import type { CardOwnership } from '../api/client'
 import type {
   BrowseController,
   BrowseViewMode,
@@ -341,6 +344,15 @@ function SetDetailView({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [cards, setInfo.id],
   )
+  // Cross-collection ownership badges (#576), signed-in only.
+  const ownershipIds = useMemo(
+    () =>
+      showSavedActions
+        ? cards.map((c) => ({ setId: setInfo.id, number: c.number }))
+        : [],
+    [showSavedActions, cards, setInfo.id],
+  )
+  const { lookup: lookupOwnership } = useCardOwnership(ownershipIds)
   return (
     <>
       <div className="flex flex-wrap items-center gap-2 border-b border-sand-200 dark:border-husk-100 px-5 py-3">
@@ -421,6 +433,7 @@ function SetDetailView({
                 card={c}
                 setCtx={setCtx}
                 showSavedActions={showSavedActions}
+                ownership={lookupOwnership(setInfo.id, c.number)}
                 onOpenDetail={() => setDetailIndex(i)}
               />
             ))}
@@ -553,6 +566,16 @@ function PokedexDetailView({
     () => (cards ?? []).map((c) => browseCardToRow(c)),
     [cards],
   )
+  // Cross-collection ownership badges (#576), signed-in only. PokedexCard
+  // carries its own set id per printing.
+  const ownershipIds = useMemo(
+    () =>
+      showSavedActions
+        ? (cards ?? []).map((c) => ({ setId: c.setId, number: c.number }))
+        : [],
+    [showSavedActions, cards],
+  )
+  const { lookup: lookupOwnership } = useCardOwnership(ownershipIds)
   return (
     <>
       <div className="flex flex-wrap items-center gap-2 border-b border-sand-200 dark:border-husk-100 px-5 py-2 text-xs text-coconut-400 dark:text-sand-300">
@@ -594,6 +617,7 @@ function PokedexDetailView({
                 key={c.id}
                 card={c}
                 showSavedActions={showSavedActions}
+                ownership={lookupOwnership(c.setId, c.number)}
                 onOpenDetail={() => setDetailIndex(i)}
               />
             ))}
@@ -610,11 +634,13 @@ function CardTile({
   card,
   setCtx,
   showSavedActions,
+  ownership,
   onOpenDetail,
 }: {
   card: SetCard
   setCtx: BrowseSetContext
   showSavedActions: boolean
+  ownership: CardOwnership | null | undefined
   onOpenDetail: () => void
 }) {
   const [thumbFailed, setThumbFailed] = useState(false)
@@ -656,6 +682,7 @@ function CardTile({
           )}
         </div>
       </button>
+      <OwnershipBadge ownership={ownership} className="mt-1.5 justify-center" />
       <SaveCardActions
         show={showSavedActions}
         card={browseCardToPayload(card, setCtx)}
@@ -668,10 +695,12 @@ function CardTile({
 function PokedexCardTile({
   card,
   showSavedActions,
+  ownership,
   onOpenDetail,
 }: {
   card: PokedexCard
   showSavedActions: boolean
+  ownership: CardOwnership | null | undefined
   onOpenDetail: () => void
 }) {
   const [thumbFailed, setThumbFailed] = useState(false)
@@ -717,6 +746,7 @@ function PokedexCardTile({
           )}
         </div>
       </button>
+      <OwnershipBadge ownership={ownership} className="mt-1.5 justify-center" />
       <SaveCardActions
         show={showSavedActions}
         card={browseCardToPayload(card)}

--- a/web/src/components/OwnershipBadge.test.tsx
+++ b/web/src/components/OwnershipBadge.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { OwnershipBadge } from './OwnershipBadge'
+import type { CardOwnership } from '../api/client'
+
+function own(o: Partial<CardOwnership>): CardOwnership {
+  return { collections: [], wishlists: [], ...o }
+}
+
+describe('OwnershipBadge', () => {
+  it('renders nothing when ownership is unknown or empty', () => {
+    const { container: a } = render(<OwnershipBadge ownership={undefined} />)
+    expect(a).toBeEmptyDOMElement()
+    const { container: b } = render(<OwnershipBadge ownership={null} />)
+    expect(b).toBeEmptyDOMElement()
+    const { container: c } = render(<OwnershipBadge ownership={own({})} />)
+    expect(c).toBeEmptyDOMElement()
+  })
+
+  it('shows "owned" with the collections in the tooltip', () => {
+    render(
+      <OwnershipBadge
+        ownership={own({
+          collections: [{ id: 1, name: 'Show Binder', quantity: 1 }],
+        })}
+      />,
+    )
+    const badge = screen.getByText('owned')
+    expect(badge).toBeInTheDocument()
+    expect(badge).toHaveAttribute('title', 'Owned in Show Binder')
+  })
+
+  it('sums quantity across collections into "owned ×N"', () => {
+    render(
+      <OwnershipBadge
+        ownership={own({
+          collections: [
+            { id: 1, name: 'Show Binder', quantity: 2 },
+            { id: 2, name: 'Trade Stock', quantity: 1 },
+          ],
+        })}
+      />,
+    )
+    const badge = screen.getByText('owned ×3')
+    expect(badge).toHaveAttribute('title', 'Owned in Show Binder (2), Trade Stock')
+  })
+
+  it('shows "chasing" with the want-lists in the tooltip', () => {
+    render(
+      <OwnershipBadge
+        ownership={own({ wishlists: [{ id: 7, name: 'Allentown Show' }] })}
+      />,
+    )
+    const badge = screen.getByText('chasing')
+    expect(badge).toHaveAttribute('title', 'Chasing on Allentown Show')
+  })
+
+  it('shows both badges when owned and chasing', () => {
+    render(
+      <OwnershipBadge
+        ownership={own({
+          collections: [{ id: 1, name: 'Binder', quantity: 1 }],
+          wishlists: [{ id: 2, name: 'Upgrade list' }],
+        })}
+      />,
+    )
+    expect(screen.getByText('owned')).toBeInTheDocument()
+    expect(screen.getByText('chasing')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/OwnershipBadge.tsx
+++ b/web/src/components/OwnershipBadge.tsx
@@ -1,0 +1,52 @@
+/**
+ * OwnershipBadge — the inline "owned / chasing" chip on a card (#576).
+ *
+ * Renders nothing until ownership is known and non-empty, so it's safe to
+ * drop next to any card across search / browse / swipe. When the user owns
+ * the card it shows "owned" (with a quantity when they hold multiples) and
+ * lists the collections in the tooltip; when they're chasing it, "chasing"
+ * with the want-lists in the tooltip. Both can show at once.
+ *
+ * Tone follows the design system's read: palm (have it) for owned, sun
+ * (want it) for chasing — the same pairing the swipe deck uses.
+ */
+import type { CardOwnership } from '../api/client'
+
+export function OwnershipBadge({
+  ownership,
+  className = '',
+}: {
+  ownership: CardOwnership | null | undefined
+  className?: string
+}) {
+  if (!ownership) return null
+  const { collections, wishlists } = ownership
+  if (collections.length === 0 && wishlists.length === 0) return null
+
+  const ownedQty = collections.reduce((sum, c) => sum + c.quantity, 0)
+  const ownedTitle = collections
+    .map((c) => (c.quantity > 1 ? `${c.name} (${c.quantity})` : c.name))
+    .join(', ')
+  const chasingTitle = wishlists.map((w) => w.name).join(', ')
+
+  return (
+    <span className={`flex flex-wrap items-center gap-1 ${className}`}>
+      {collections.length > 0 && (
+        <span
+          title={`Owned in ${ownedTitle}`}
+          className="inline-flex items-center rounded-full bg-palm-500/15 px-1.5 py-0.5 text-[11px] font-medium text-palm-600 dark:bg-palm-400/20 dark:text-palm-200"
+        >
+          owned{ownedQty > 1 ? ` ×${ownedQty}` : ''}
+        </span>
+      )}
+      {wishlists.length > 0 && (
+        <span
+          title={`Chasing on ${chasingTitle}`}
+          className="inline-flex items-center rounded-full bg-sun-400/20 px-1.5 py-0.5 text-[11px] font-medium text-husk-500 dark:bg-sun-400/25 dark:text-sun-200"
+        >
+          chasing
+        </span>
+      )}
+    </span>
+  )
+}

--- a/web/src/components/ResultsTable.test.tsx
+++ b/web/src/components/ResultsTable.test.tsx
@@ -4,6 +4,8 @@ import { ResultsTable } from './ResultsTable'
 import { applyFilters, applySort } from './resultsTableFilter'
 import { EMPTY_VIEW_STATE, useAppStore } from '../store'
 import { _resetAuthStoreForTests } from '../hooks/useAuth'
+import { fetchCardOwnership } from '../api/client'
+import { _resetCardOwnershipForTests } from './useCardOwnership'
 import type { Row } from '../types'
 
 const { fetchMeMock } = vi.hoisted(() => ({ fetchMeMock: vi.fn() }))
@@ -16,6 +18,9 @@ vi.mock('../api/client', () => ({
   // signed-out test below overrides via mockResolvedValueOnce.
   fetchMe: fetchMeMock,
   logout: vi.fn(),
+  // The matched rows trigger a cross-collection ownership lookup (#576);
+  // default to "nothing owned" so no badge renders in existing tests.
+  fetchCardOwnership: vi.fn(async () => ({})),
 }))
 
 beforeEach(() => {
@@ -36,6 +41,9 @@ beforeEach(() => {
     viewState: { ...EMPTY_VIEW_STATE, filters: { ...EMPTY_VIEW_STATE.filters } },
     currentRunId: null,
   })
+  _resetCardOwnershipForTests()
+  vi.mocked(fetchCardOwnership).mockReset()
+  vi.mocked(fetchCardOwnership).mockResolvedValue({})
 })
 
 function makeRow(over: Partial<Row> = {}): Row {
@@ -82,6 +90,37 @@ describe('ResultsTable', () => {
     expect(screen.getByRole('dialog')).toBeInTheDocument()
     // The 1/N counter confirms we landed on the right row.
     expect(screen.getByText('1 / 1')).toBeInTheDocument()
+    useAppStore.setState({ rows: [] })
+  })
+
+  it('renders the cross-collection ownership badge on a matched row (#576)', async () => {
+    vi.mocked(fetchCardOwnership).mockResolvedValue({
+      'base1::4': {
+        collections: [{ id: 1, name: 'Show Binder', quantity: 2 }],
+        wishlists: [],
+      },
+    })
+    useAppStore.setState({
+      rows: [
+        makeRow({
+          card: {
+            id: 'base1-4',
+            name: 'Charizard',
+            number: '4',
+            rarity: 'Rare Holo',
+            set: { id: 'base1', name: 'Base Set' },
+          },
+        }),
+      ],
+      isRunning: false,
+      progress: null,
+    })
+    render(<ResultsTable />)
+    // The lookup is keyed on (set_id, number); the badge appears once it resolves.
+    expect(await screen.findByText('owned ×2')).toBeInTheDocument()
+    expect(vi.mocked(fetchCardOwnership)).toHaveBeenCalledWith([
+      { set_id: 'base1', number: '4' },
+    ])
     useAppStore.setState({ rows: [] })
   })
 

--- a/web/src/components/ResultsTable.tsx
+++ b/web/src/components/ResultsTable.tsx
@@ -21,6 +21,9 @@ import { formatComp, formatMoney } from '../utils/format'
 import { AddToCollectionButton } from './AddToCollectionButton'
 import { AddToWishlistButton } from './AddToWishlistButton'
 import { CardDetailModal } from './CardDetailModal'
+import { useCardOwnership } from './useCardOwnership'
+import { OwnershipBadge } from './OwnershipBadge'
+import type { CardOwnership } from '../api/client'
 import { EbaySparkline } from './EbaySparkline'
 import { soldPriceSeries } from './ebayComps'
 import { SaveSearchButton } from './SaveSearchButton'
@@ -31,6 +34,28 @@ import {
   type SortColumn,
   type SortDir,
 } from './resultsTableFilter'
+
+/**
+ * Pull the promoted `(set_id, number)` identity off a matched row for the
+ * ownership lookup (#576). Returns null for unmatched rows or rows missing
+ * either half of the identity.
+ */
+function rowIdentity(row: Row): { setId: string; number: string } | null {
+  if (!row.matched || !row.card) return null
+  const setId = (row.card.set as { id?: string } | undefined)?.id
+  const number = row.card.number as string | undefined
+  if (!setId || !number) return null
+  return { setId, number }
+}
+
+/** Resolve a row's ownership through the shared lookup, or undefined. */
+function ownershipForRow(
+  row: Row,
+  lookup: (setId: string, number: string) => CardOwnership | null | undefined,
+): CardOwnership | null | undefined {
+  const id = rowIdentity(row)
+  return id ? lookup(id.setId, id.number) : undefined
+}
 
 interface Props {
   onRerunLine?: (line: string) => void
@@ -91,6 +116,19 @@ export function ResultsTable({ onRerunLine }: Props) {
     rows.forEach((r, i) => map.set(r, i))
     return map
   }, [rows])
+
+  // Cross-collection ownership badges (#576). Batch the matched rows'
+  // identities into one lookup; signed-out users get no library, so skip it.
+  const ownershipIds = useMemo(
+    () =>
+      showSavedActions
+        ? displayedRows
+            .map(rowIdentity)
+            .filter((id): id is { setId: string; number: string } => id !== null)
+        : [],
+    [showSavedActions, displayedRows],
+  )
+  const { lookup: lookupOwnership } = useCardOwnership(ownershipIds)
 
   if (rows.length === 0 && !isRunning) {
     return (
@@ -318,6 +356,7 @@ export function ResultsTable({ onRerunLine }: Props) {
                 showImage={!settings.noImages}
                 showSavedActions={showSavedActions}
                 showEbay={settings.showEbay}
+                ownership={ownershipForRow(row, lookupOwnership)}
                 onRerunLine={onRerunLine}
                 onOpenDetail={() => setDetailIndex(displayedIdx)}
               />
@@ -428,6 +467,7 @@ function ResultRow({
   showImage,
   showSavedActions,
   showEbay,
+  ownership,
   onRerunLine,
   onOpenDetail,
 }: {
@@ -435,6 +475,7 @@ function ResultRow({
   showImage: boolean
   showSavedActions: boolean
   showEbay: boolean
+  ownership: CardOwnership | null | undefined
   onRerunLine?: (line: string) => void
   onOpenDetail?: () => void
 }) {
@@ -544,6 +585,7 @@ function ResultRow({
             <div>
               <div className="font-medium text-coconut-700 dark:text-sand-50 truncate">{card?.name as string}</div>
               <div className="text-xs text-coconut-400 dark:text-sand-300 truncate">{row.query.raw}</div>
+              <OwnershipBadge ownership={ownership} className="mt-0.5" />
             </div>
           ) : (
             <div>

--- a/web/src/components/SwipePanel.test.tsx
+++ b/web/src/components/SwipePanel.test.tsx
@@ -38,6 +38,8 @@ vi.mock('../api/client', () => ({
   fetchSwipeExcluded: vi.fn(),
   recordSwipeSeen: vi.fn(),
   resetSwipeSeen: vi.fn(),
+  // Cross-collection ownership badge (#576): default to "nothing owned".
+  fetchCardOwnership: vi.fn(async () => ({})),
 }))
 
 const mockFetchSets = vi.mocked(fetchSets)

--- a/web/src/components/SwipePanel.tsx
+++ b/web/src/components/SwipePanel.tsx
@@ -32,6 +32,8 @@ import { useAppStore } from '../store'
 import type { RarityFloor, Row, SetCard } from '../types'
 import { browseCardToPayload, browseCardToRow } from './browseCard'
 import { CardDetailModal } from './CardDetailModal'
+import { useCardOwnership } from './useCardOwnership'
+import { OwnershipBadge } from './OwnershipBadge'
 import { SaveCardActions } from './SaveCardActions'
 import {
   useSwipeProfile,
@@ -79,6 +81,20 @@ export function SwipePanel({ active }: SwipePanelProps) {
     })
   const { user } = useAuth()
   const showSavedActions = user !== null
+
+  // Cross-collection ownership badge (#576). Prefetch the current card plus
+  // the peeks beneath it so the badge is ready as each rises to the top.
+  // Only signed-in users have a library to check, matching the save buttons.
+  const ownershipIds = useMemo(
+    () =>
+      showSavedActions
+        ? [current, ...upcoming]
+            .filter((c): c is NonNullable<typeof c> => c != null)
+            .map((c) => ({ setId: c.setId, number: c.card.number }))
+        : [],
+    [showSavedActions, current, upcoming],
+  )
+  const { lookup: lookupOwnership } = useCardOwnership(ownershipIds)
 
   // Reset both the local taste profile (session-local seen + saved) and the
   // server-persisted deck memory, so "reset" surfaces a genuinely fresh deck.
@@ -298,6 +314,13 @@ export function SwipePanel({ active }: SwipePanelProps) {
             onSave={() => commit('save')}
             onLove={() => commit('love')}
             disabled={!!outgoing}
+          />
+        )}
+
+        {current && showSavedActions && (
+          <OwnershipBadge
+            ownership={lookupOwnership(current.setId, current.card.number)}
+            className="justify-center"
           />
         )}
 

--- a/web/src/components/useCardOwnership.test.ts
+++ b/web/src/components/useCardOwnership.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { fetchCardOwnership, type CardOwnership } from '../api/client'
+import {
+  ownershipKey,
+  useCardOwnership,
+  invalidateOwnership,
+  _resetCardOwnershipForTests,
+} from './useCardOwnership'
+
+vi.mock('../api/client', () => ({
+  fetchCardOwnership: vi.fn(),
+}))
+
+const mockFetch = vi.mocked(fetchCardOwnership)
+
+const OWNED: CardOwnership = {
+  collections: [{ id: 1, name: 'Show Binder', quantity: 2 }],
+  wishlists: [],
+}
+
+describe('ownershipKey', () => {
+  it('colon-joins set id and number', () => {
+    expect(ownershipKey('base1', '4')).toBe('base1::4')
+  })
+})
+
+describe('useCardOwnership', () => {
+  beforeEach(() => {
+    _resetCardOwnershipForTests()
+    mockFetch.mockReset()
+    mockFetch.mockResolvedValue({})
+  })
+
+  it('returns undefined until fetched, then the occupancy', async () => {
+    mockFetch.mockResolvedValue({ 'base1::4': OWNED })
+    const { result } = renderHook(() =>
+      useCardOwnership([{ setId: 'base1', number: '4' }]),
+    )
+    // First render: not yet known.
+    expect(result.current.lookup('base1', '4')).toBeUndefined()
+    await waitFor(() =>
+      expect(result.current.lookup('base1', '4')).toEqual(OWNED),
+    )
+  })
+
+  it('marks an unowned card null (fetched, no occupancy)', async () => {
+    mockFetch.mockResolvedValue({}) // sparse: absent = not owned
+    const { result } = renderHook(() =>
+      useCardOwnership([{ setId: 'base1', number: '99' }]),
+    )
+    await waitFor(() =>
+      expect(result.current.lookup('base1', '99')).toBeNull(),
+    )
+  })
+
+  it('batches and dedupes — one fetch for a repeated identity', async () => {
+    mockFetch.mockResolvedValue({ 'base1::4': OWNED })
+    const ids = [{ setId: 'base1', number: '4' }]
+    const { rerender } = renderHook((p: typeof ids) => useCardOwnership(p), {
+      initialProps: ids,
+    })
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
+    // Re-render with the same identity → cache hit, no second fetch.
+    rerender([{ setId: 'base1', number: '4' }])
+    rerender([{ setId: 'base1', number: '4' }])
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('refetches after invalidateOwnership', async () => {
+    mockFetch.mockResolvedValue({ 'base1::4': OWNED })
+    const { result } = renderHook(() =>
+      useCardOwnership([{ setId: 'base1', number: '4' }]),
+    )
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1))
+
+    invalidateOwnership()
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2))
+    expect(result.current.lookup('base1', '4')).toEqual(OWNED)
+  })
+
+  it('degrades to null when the fetch fails (anonymous / offline)', async () => {
+    mockFetch.mockRejectedValue(new Error('401'))
+    const { result } = renderHook(() =>
+      useCardOwnership([{ setId: 'base1', number: '4' }]),
+    )
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled())
+    expect(result.current.lookup('base1', '4')).toBeNull()
+  })
+
+  it('does not fetch for an empty identity list', () => {
+    renderHook(() => useCardOwnership([]))
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/components/useCardOwnership.ts
+++ b/web/src/components/useCardOwnership.ts
@@ -1,0 +1,134 @@
+/**
+ * useCardOwnership — cross-collection ownership lookup for the inline badge
+ * (#576), shared across the search / browse / swipe surfaces.
+ *
+ * Each surface hands the hook the `(set_id, number)` identities currently on
+ * screen; the hook batches the *uncached* ones into a single
+ * `POST /cards/ownership` and returns a `lookup(setId, number)` that reads
+ * the result. A module-level cache dedupes across surfaces and across
+ * re-fetches, so paging through Browse or swiping never re-asks about a card
+ * it already knows.
+ *
+ * Cache entries are three-valued: `CardOwnership` (owned / chasing — render
+ * a badge), `null` (fetched, no occupancy — render nothing), or `undefined`
+ * (not yet known). After a save, {@link invalidateOwnership} clears the
+ * cache so every mounted surface re-fetches its visible identities and the
+ * badge reflects the new state.
+ *
+ * Degrades gracefully: a failed fetch (e.g. auth on + anonymous → 401)
+ * marks the requested identities as "no occupancy", so the surfaces render
+ * without badges instead of throwing.
+ */
+import { useCallback, useEffect, useReducer } from 'react'
+import { fetchCardOwnership, type CardOwnership } from '../api/client'
+
+export interface CardIdentity {
+  setId: string
+  number: string
+}
+
+/** Map key for a `(set_id, number)` pair — mirrors the server's `_key`. */
+export function ownershipKey(setId: string, number: string): string {
+  return `${setId}::${number}`
+}
+
+// ---- module-level shared cache ----
+
+const cache = new Map<string, CardOwnership | null>()
+const inflight = new Set<string>()
+const listeners = new Set<() => void>()
+let version = 0
+
+function notify() {
+  version += 1
+  for (const fn of listeners) fn()
+}
+
+/**
+ * Fetch occupancy for any of `identities` not already cached or in flight.
+ * No-ops when everything is known. Merges the sparse response back into the
+ * cache (requested-but-absent keys become `null`).
+ */
+async function ensureOwnership(identities: CardIdentity[]): Promise<void> {
+  const missing = identities.filter((c) => {
+    const key = ownershipKey(c.setId, c.number)
+    return !cache.has(key) && !inflight.has(key)
+  })
+  if (missing.length === 0) return
+
+  for (const c of missing) inflight.add(ownershipKey(c.setId, c.number))
+  try {
+    const result = await fetchCardOwnership(
+      missing.map((c) => ({ set_id: c.setId, number: c.number })),
+    )
+    for (const c of missing) {
+      const key = ownershipKey(c.setId, c.number)
+      cache.set(key, result[key] ?? null)
+    }
+  } catch {
+    // Anonymous / offline → no badges. Mark absent so we don't refetch on
+    // every render; an explicit invalidate (e.g. after sign-in + save)
+    // clears this.
+    for (const c of missing) cache.set(ownershipKey(c.setId, c.number), null)
+  } finally {
+    for (const c of missing) inflight.delete(ownershipKey(c.setId, c.number))
+    notify()
+  }
+}
+
+/**
+ * Drop every cached ownership entry and re-notify. Mounted surfaces
+ * re-fetch their visible identities on the next render. Call after a card
+ * is added to / removed from a collection or wishlist.
+ */
+export function invalidateOwnership(): void {
+  cache.clear()
+  inflight.clear()
+  notify()
+}
+
+/**
+ * Subscribe to the shared cache for the given on-screen identities. Returns
+ * a `lookup` reading current occupancy: `CardOwnership` when owned / chasing,
+ * `null` when known-empty, `undefined` until first known.
+ */
+export function useCardOwnership(identities: CardIdentity[]) {
+  const [, force] = useReducer((n: number) => n + 1, 0)
+
+  useEffect(() => {
+    listeners.add(force)
+    return () => {
+      listeners.delete(force)
+    }
+  }, [])
+
+  // Re-key on the identity set so the effect refires when the visible cards
+  // change. `version` is in the dep list so an `invalidateOwnership` (which
+  // bumps it) re-runs the fetch against the freshly-cleared cache.
+  const idsKey = identities
+    .map((c) => ownershipKey(c.setId, c.number))
+    .sort()
+    .join(',')
+  useEffect(() => {
+    if (identities.length > 0) void ensureOwnership(identities)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [idsKey, version])
+
+  const lookup = useCallback(
+    (setId: string, number: string): CardOwnership | null | undefined =>
+      cache.get(ownershipKey(setId, number)),
+    // Re-derive on every cache change so consumers see fresh values.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [version],
+  )
+
+  return { lookup }
+}
+
+// Test-only: reset the shared cache + listeners between cases.
+export function _resetCardOwnershipForTests() {
+  cache.clear()
+  inflight.clear()
+  listeners.clear()
+  version = 0
+}

--- a/web/src/components/useCollections.ts
+++ b/web/src/components/useCollections.ts
@@ -12,6 +12,7 @@ import {
   fetchCollections,
   type CollectionSummary,
 } from '../api/client'
+import { invalidateOwnership } from './useCardOwnership'
 
 interface State {
   collections: CollectionSummary[]
@@ -85,6 +86,9 @@ export function useCollections() {
       notes?: string,
     ) => {
       await addCardToCollection(collectionId, card, notes)
+      // The card's ownership badge (#576) is now stale across every
+      // surface — drop the shared cache so it re-fetches.
+      invalidateOwnership()
       set({
         collections: state.collections.map((c) =>
           c.id === collectionId

--- a/web/src/components/useWishlists.ts
+++ b/web/src/components/useWishlists.ts
@@ -12,6 +12,7 @@ import {
   fetchWishlists,
   type WishlistSummary,
 } from '../api/client'
+import { invalidateOwnership } from './useCardOwnership'
 
 interface State {
   wishlists: WishlistSummary[]
@@ -84,6 +85,9 @@ export function useWishlists() {
       opts?: { notes?: string; maxPrice?: number | null },
     ) => {
       await addCardToWishlist(wishlistId, card, opts)
+      // Refresh the cross-surface ownership badge (#576) — this card is now
+      // chased.
+      invalidateOwnership()
       set({
         wishlists: state.wishlists.map((w) =>
           w.id === wishlistId


### PR DESCRIPTION
Closes #576.

## What

Every card in a search result, browse-mode tile, or swipe card now carries an inline badge showing which of your collections contain it (with quantity) and which want-lists are chasing it:

- **owned ×2** — listing the collections in the tooltip ("Owned in Show Binder (2)")
- **chasing** — listing the want-lists in the tooltip ("Chasing on Allentown Show")

Both can show at once; nothing renders when you neither own nor chase the card.

## Why

The point of treating collections as durable inventory is that the rest of the product becomes aware of it. Without this, a vendor pricing comps accidentally re-adds a card they already own, and a collector keeps adding the same Charizard to multiple want-lists. This is the read-side complement to the library-aware swipe exclusion (#581): #581 *hides* owned/chasing cards from the swipe deck; this *surfaces* them as badges everywhere.

## How

All three surfaces share one identity shape — the promoted `(card_set_id, card_number)` columns from the #574 rework.

**Backend** — new `POST /api/v1/cards/ownership`: takes a batch of `{set_id, number}` and returns a sparse map keyed by `${set_id}::${number}`, each entry listing the collections (id, name, summed quantity) and want-lists (id, name) that hold the card. Only cards with occupancy appear. Scoped to the request's set ids then matched exactly, so it stays a bounded index scan — no tuple-`IN`, portable across SQLite/Postgres.

**Frontend**:
- `useCardOwnership` — a shared module-level cache that batches the *uncached* identities on a page into a single request and dedupes across surfaces and re-fetches. Three-valued (`CardOwnership` / `null` known-empty / `undefined` unknown).
- `OwnershipBadge` — the chip (palm for owned, sun for chasing), renders nothing until occupancy is known and non-empty.
- A save into any collection / want-list calls `invalidateOwnership()` (wired into the shared `useCollections` / `useWishlists` `addCard`), so the badge updates live after a save.
- Wired into `ResultsTable` (search), `BrowsePanel` (set + pokedex-# tiles), and `SwipePanel`.
- Signed-out users skip the lookup (no library to check); a failed fetch degrades to no badge.

No `render.yaml` change — no new env vars, and it reuses the existing tables (no migration).

## How to verify

1. `make dev-api` + `make dev-web`. Add a card to a collection and another to a want-list.
2. **Browse** that card's set → the owned card shows "owned ×N", the chased card shows "chasing".
3. **Search** the same card → the row shows the badge under the name.
4. **Swipe** → the badge appears under the current card.
5. Save a fresh card → its badge appears without a reload.

Verified end-to-end against a live API + SPA — Browse / Base Set renders "owned ×2" on Charizard (held twice in Show Binder) and "chasing" on Pikachu (on the Allentown want-list), no console errors. (Screenshot of the badged Browse tile to follow.)

Tests: `tests/test_ownership.py` (occupancy, summed quantity, multi-collection, chasing, owned+chasing, scoping); `useCardOwnership.test.ts` (cache / dedupe / invalidation / graceful failure), `OwnershipBadge.test.tsx`, and a search-row wiring case in `ResultsTable.test.tsx`.