### PR TITLE
feat(api): catalog-backed smart collections — target view + chase

### DIFF
--- a/api/db/collection_rules.py
+++ b/api/db/collection_rules.py
@@ -150,6 +150,62 @@ def resolve_dynamic_items(db: Session, user_id: int, rule: dict[str, Any]) -> li
     return items
 
 
+def rule_to_lucene(rule: dict[str, Any]) -> str:
+    """Translate a rule into a pokemontcg.io Lucene query (#631, catalog scope).
+
+    Maps each predicate onto the catalog's field syntax and ANDs them with
+    spaces (Lucene's implicit AND). ``name`` becomes a prefix wildcard so
+    "Eevee" catches "Eevee ex" / "Eevee VMAX"; the rest are exact-field
+    matches. Multiple ``types`` AND together — a dual-type match, which is
+    the same semantics the owned-scope resolver uses.
+
+    Forward-compatible with ADR-0022: when the DSL planner lands it can own
+    this translation, but for now the rule maps cleanly enough that a direct
+    builder is simpler than standing up the planner."""
+    parts: list[str] = []
+    name = rule.get("name")
+    if name:
+        token = name.replace('"', "")
+        # Prefix wildcard. Quote multi-word names so the wildcard binds to
+        # the whole value rather than just the last token.
+        parts.append(f'name:"{token}*"' if " " in token else f"name:{token}*")
+    for t in rule.get("types", []) or []:
+        parts.append(f'types:"{t}"' if " " in t else f"types:{t}")
+    if rule.get("set_id"):
+        parts.append(f'set.id:"{rule["set_id"]}"')
+    if rule.get("number"):
+        parts.append(f'number:"{rule["number"]}"')
+    if rule.get("rarity"):
+        parts.append(f'rarity:"{rule["rarity"]}"')
+    return " ".join(parts)
+
+
+def owned_quantity_map(db: Session, user_id: int) -> dict[tuple[str, str], int]:
+    """Map ``(card_set_id, card_number) -> total owned quantity`` for the user.
+
+    The overlay key for catalog-scope resolution: a catalog card is "owned"
+    iff its identity is in this map. Sums ``quantity`` across every binder so
+    two copies in two collections read as quantity 2. Only rows with a full
+    promoted identity participate — a card we couldn't promote can't be
+    matched against the catalog anyway."""
+    rows = db.execute(
+        select(
+            CollectionItem.card_set_id,
+            CollectionItem.card_number,
+            func.coalesce(func.sum(CollectionItem.quantity), 0),
+        )
+        .join(Collection, CollectionItem.collection_id == Collection.id)
+        .where(
+            Collection.user_id == user_id,
+            Collection.kind != COLLECTION_KIND_DYNAMIC,
+            CollectionItem.card_set_id.is_not(None),
+            CollectionItem.card_number.is_not(None),
+        )
+        .group_by(CollectionItem.card_set_id, CollectionItem.card_number)
+    ).all()
+    return {(set_id, number): int(qty) for set_id, number, qty in rows}
+
+
 def count_dynamic_items(db: Session, user_id: int, rule: dict[str, Any]) -> int:
     """Count of resolved members — the badge number for the list view.
 

--- a/api/db/models.py
+++ b/api/db/models.py
@@ -165,6 +165,14 @@ COLLECTION_KIND_MANUAL = "manual"
 COLLECTION_KIND_SET = "set"
 COLLECTION_KIND_DYNAMIC = "dynamic"
 
+#: Allowed values for ``Collection.dynamic_scope`` (#631). ``owned`` matches
+#: the rule against the user's own cards — an inventory view (the #630
+#: default). ``catalog`` resolves the full matching set from pokemontcg.io
+#: and overlays ownership — a goal-with-progress target view. A null column
+#: reads as ``owned``.
+DYNAMIC_SCOPE_OWNED = "owned"
+DYNAMIC_SCOPE_CATALOG = "catalog"
+
 #: Allowed values for ``CollectionItem.added_via`` — provenance tag,
 #: used by the insights dashboard to answer "how do users actually get
 #: cards into their collections."
@@ -199,6 +207,10 @@ class Collection(Base):
     #: (the query DSL from ADR-0022); the membership query is recomputed
     #: lazily and never materialised as ``collection_items`` rows.
     rule_json: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    #: Only meaningful when ``kind == 'dynamic'`` (#631). One of ``owned`` /
+    #: ``catalog``; null reads as ``owned``. ``catalog`` flips the rule from
+    #: an inventory view into a catalog-backed target view with progress.
+    dynamic_scope: Mapped[str | None] = mapped_column(String(16), nullable=True)
 
     items: Mapped[list[CollectionItem]] = relationship(
         back_populates="collection",

--- a/api/migrations/versions/d5e2f7a3c9b1_collection_dynamic_scope.py
+++ b/api/migrations/versions/d5e2f7a3c9b1_collection_dynamic_scope.py
@@ -1,0 +1,41 @@
+"""collections.dynamic_scope — owned vs catalog membership for smart collections
+
+Child slice of the library rethink RFC (#501); see #631, follow-up to #506.
+
+A dynamic collection (``kind='dynamic'``) can resolve its membership two
+ways. ``owned`` (the #630 behavior) matches the rule against the cards the
+user already owns — an inventory view. ``catalog`` resolves the full
+matching set from pokemontcg.io and overlays ownership — a goal-with-progress
+target view, for the case the collector doesn't yet have everything that
+matches.
+
+Nullable with no server default: a null reads as ``owned`` so every row that
+predates this migration (and every manual/set collection, which ignores the
+column) keeps its current behavior untouched.
+
+Revision ID: d5e2f7a3c9b1
+Revises: b3f1a9c2d7e4
+Create Date: 2026-06-11
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d5e2f7a3c9b1"
+down_revision: str | Sequence[str] | None = "b3f1a9c2d7e4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("collections") as batch:
+        batch.add_column(sa.Column("dynamic_scope", sa.String(length=16), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("collections") as batch:
+        batch.drop_column("dynamic_scope")

--- a/api/routes/collections.py
+++ b/api/routes/collections.py
@@ -22,6 +22,8 @@ Endpoints:
 - `DELETE /collections/{id}`                  cascade-delete items
 - `POST   /collections/{id}/items`            add a card (manual/set only)
 - `DELETE /collections/{id}/items/{item_id}`  remove a card (manual/set only)
+- `GET    /collections/{id}/target`           catalog-backed membership + ownership overlay (#631)
+- `POST   /collections/{id}/chase`            push the un-owned matches onto a want-list (#631)
 """
 
 from __future__ import annotations
@@ -30,9 +32,11 @@ from datetime import UTC, datetime
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session, selectinload
+
+from mgz_pkmn.sources import TCGClient
 
 from ..auth.session import current_user_or_default
 from ..db.card_payload import extract_card_identity, extract_price_snapshot
@@ -40,22 +44,30 @@ from ..db.collection_rules import (
     RuleValidationError,
     count_dynamic_items,
     normalize_rule,
+    owned_quantity_map,
     resolve_dynamic_items,
+    rule_to_lucene,
 )
 from ..db.models import (
     ADDED_VIA_MANUAL,
     COLLECTION_KIND_DYNAMIC,
     COLLECTION_KIND_MANUAL,
     COLLECTION_KIND_SET,
+    DYNAMIC_SCOPE_CATALOG,
+    DYNAMIC_SCOPE_OWNED,
     Collection,
     CollectionItem,
     User,
+    Wishlist,
+    WishlistItem,
 )
 from ..db.session import get_db
 
 #: The kinds a caller may create. Mirrors the model constants; kept here so
 #: the create/patch validators reject an unknown kind with a 422.
 _VALID_KINDS = (COLLECTION_KIND_MANUAL, COLLECTION_KIND_SET, COLLECTION_KIND_DYNAMIC)
+#: Allowed ``dynamic_scope`` values on create. Null/owned is the default.
+_VALID_SCOPES = (DYNAMIC_SCOPE_OWNED, DYNAMIC_SCOPE_CATALOG)
 
 router = APIRouter()
 
@@ -80,6 +92,8 @@ class CollectionSummaryOut(BaseModel):
     kind: str
     source_set_id: str | None
     rule: dict[str, Any] | None
+    #: #631 — ``owned`` / ``catalog`` for dynamic collections, else null.
+    dynamic_scope: str | None
 
 
 class CollectionItemOut(BaseModel):
@@ -114,6 +128,8 @@ class CollectionOut(BaseModel):
     #: Membership rule when ``kind == 'dynamic'``, else null. For a dynamic
     #: collection ``items`` is the resolved, non-persisted membership.
     rule: dict[str, Any] | None
+    #: #631 — ``owned`` / ``catalog`` for dynamic collections, else null.
+    dynamic_scope: str | None
 
 
 class CollectionCreate(BaseModel):
@@ -124,6 +140,9 @@ class CollectionCreate(BaseModel):
     kind: str = COLLECTION_KIND_MANUAL
     source_set_id: str | None = Field(default=None, max_length=64)
     rule: dict[str, Any] | None = None
+    #: #631 — only read for ``kind == 'dynamic'``. ``owned`` (default) is the
+    #: inventory view; ``catalog`` is the catalog-backed target view.
+    dynamic_scope: str | None = None
 
 
 class CollectionPatch(BaseModel):
@@ -132,6 +151,54 @@ class CollectionPatch(BaseModel):
     #: Editing a dynamic collection's rule re-points its membership. Only
     #: meaningful on ``kind == 'dynamic'`` collections.
     rule: dict[str, Any] | None = None
+
+
+# ---- #631: catalog-backed target view + chase ----------------------------
+
+
+class TargetCardOut(BaseModel):
+    """One catalog match, annotated with the user's ownership of it."""
+
+    card: dict[str, Any]
+    card_set_id: str | None
+    card_number: str | None
+    owned: bool
+    owned_quantity: int
+
+
+class CollectionTargetOut(BaseModel):
+    """Resolved catalog membership for a ``catalog``-scope dynamic collection,
+    with an ``owned / total`` progress headline and the per-card overlay."""
+
+    id: int
+    name: str
+    rule: dict[str, Any] | None
+    total: int
+    owned_count: int
+    cards: list[TargetCardOut]
+
+
+class ChaseRequest(BaseModel):
+    """Push the un-owned matches onto a want-list. Target either an existing
+    want-list by id, or create a fresh one by name — exactly one of the two."""
+
+    wishlist_id: int | None = None
+    wishlist_name: str | None = Field(default=None, min_length=1, max_length=200)
+    #: Optional alert threshold stamped on every created want-list item.
+    max_price: float | None = Field(default=None, gt=0)
+
+    @model_validator(mode="after")
+    def _exactly_one_target(self) -> ChaseRequest:
+        if (self.wishlist_id is None) == (self.wishlist_name is None):
+            raise ValueError("pass exactly one of wishlist_id or wishlist_name")
+        return self
+
+
+class ChaseResult(BaseModel):
+    wishlist_id: int
+    added: int
+    skipped: int
+    total_missing: int
 
 
 class CollectionItemCreate(BaseModel):
@@ -191,6 +258,7 @@ def list_collections(db: DbSession, current_user: CurrentUser) -> dict:
                 kind=c.kind,
                 source_set_id=c.source_set_id,
                 rule=c.rule_json,
+                dynamic_scope=c.dynamic_scope,
             )
         )
     return {"items": [item.model_dump() for item in items], "total": len(items)}
@@ -203,7 +271,9 @@ def create_collection(req: CollectionCreate, db: DbSession, current_user: Curren
             status_code=422,
             detail=f"unknown kind '{req.kind}'; allowed: {', '.join(_VALID_KINDS)}",
         )
-    source_set_id, rule_json = _validate_kind_fields(req.kind, req.source_set_id, req.rule)
+    source_set_id, rule_json, dynamic_scope = _validate_kind_fields(
+        req.kind, req.source_set_id, req.rule, req.dynamic_scope
+    )
     collection = Collection(
         user_id=current_user.id,
         name=req.name.strip(),
@@ -211,6 +281,7 @@ def create_collection(req: CollectionCreate, db: DbSession, current_user: Curren
         kind=req.kind,
         source_set_id=source_set_id,
         rule_json=rule_json,
+        dynamic_scope=dynamic_scope,
     )
     db.add(collection)
     db.commit()
@@ -312,6 +383,125 @@ def delete_collection_item(
 
 
 # ---------------------------------------------------------------------------
+# #631 — catalog-backed target view + chase
+# ---------------------------------------------------------------------------
+
+
+@router.get("/collections/{collection_id}/target")
+def get_collection_target(
+    collection_id: int,
+    db: DbSession,
+    current_user: CurrentUser,
+    api_key: str | None = None,
+) -> dict:
+    """Resolve a ``catalog``-scope dynamic collection against the catalog and
+    overlay the user's ownership.
+
+    Returns the full matching set from pokemontcg.io (bounded by the client's
+    paginated ``search_all`` cap), each card flagged ``owned`` / not, plus an
+    ``owned / total`` progress headline. The resolution rides the catalog
+    client's on-disk cache, so this stays cheap on a warm cache; the base
+    ``GET /collections/{id}`` is left DB-only and offline. 409 for any
+    collection that isn't a catalog-scope dynamic — owned-scope membership
+    belongs on the base endpoint."""
+    collection = _load_collection(db, collection_id, current_user.id)
+    _require_catalog_dynamic(collection)
+
+    cards = _fetch_catalog_cards(collection.rule_json, api_key)
+    owned = owned_quantity_map(db, current_user.id)
+
+    target_cards: list[TargetCardOut] = []
+    owned_count = 0
+    for card in cards:
+        ident = extract_card_identity(card)
+        set_id, number = ident["card_set_id"], ident["card_number"]
+        qty = owned.get((set_id, number), 0) if set_id and number else 0
+        if qty > 0:
+            owned_count += 1
+        target_cards.append(
+            TargetCardOut(
+                card=card,
+                card_set_id=set_id,
+                card_number=number,
+                owned=qty > 0,
+                owned_quantity=qty,
+            )
+        )
+
+    return CollectionTargetOut(
+        id=collection.id,
+        name=collection.name,
+        rule=collection.rule_json,
+        total=len(target_cards),
+        owned_count=owned_count,
+        cards=target_cards,
+    ).model_dump()
+
+
+@router.post("/collections/{collection_id}/chase", status_code=201)
+def chase_collection(
+    collection_id: int,
+    req: ChaseRequest,
+    db: DbSession,
+    current_user: CurrentUser,
+    api_key: str | None = None,
+) -> dict:
+    """Push the un-owned matches of a catalog-scope dynamic collection onto a
+    want-list — the one-click chase hand-off (#631, #504).
+
+    Resolves the catalog target, subtracts what the user owns, and adds each
+    remaining card to the named (created) or referenced want-list. Idempotent
+    on re-run: a card already on the target want-list is skipped, not
+    duplicated, so chasing twice doesn't double the list."""
+    collection = _load_collection(db, collection_id, current_user.id)
+    _require_catalog_dynamic(collection)
+
+    wishlist = _resolve_chase_wishlist(db, current_user.id, req)
+
+    cards = _fetch_catalog_cards(collection.rule_json, api_key)
+    owned = owned_quantity_map(db, current_user.id)
+    existing = {
+        (i.card_set_id, i.card_number)
+        for i in db.scalars(
+            select(WishlistItem).where(WishlistItem.wishlist_id == wishlist.id)
+        ).all()
+    }
+
+    added = skipped = total_missing = 0
+    for card in cards:
+        ident = extract_card_identity(card)
+        set_id, number = ident["card_set_id"], ident["card_number"]
+        key = (set_id, number)
+        if set_id and number and owned.get(key, 0) > 0:
+            continue  # already owned — not a chase target
+        total_missing += 1
+        if key in existing:
+            skipped += 1
+            continue
+        price = extract_price_snapshot(card)
+        db.add(
+            WishlistItem(
+                wishlist_id=wishlist.id,
+                card_json=card,
+                max_price=req.max_price,
+                price_snapshot=price,
+                priced_at=datetime.now(UTC) if price is not None else None,
+                **ident,
+            )
+        )
+        existing.add(key)
+        added += 1
+
+    db.commit()
+    return ChaseResult(
+        wishlist_id=wishlist.id,
+        added=added,
+        skipped=skipped,
+        total_missing=total_missing,
+    ).model_dump()
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -331,20 +521,30 @@ def _load_collection(db: Session, collection_id: int, user_id: int) -> Collectio
 
 
 def _validate_kind_fields(
-    kind: str, source_set_id: str | None, rule: dict[str, Any] | None
-) -> tuple[str | None, dict[str, Any] | None]:
+    kind: str,
+    source_set_id: str | None,
+    rule: dict[str, Any] | None,
+    dynamic_scope: str | None,
+) -> tuple[str | None, dict[str, Any] | None, str | None]:
     """Cross-check the kind-specific fields, returning the values to persist.
 
     A ``set`` collection needs a ``source_set_id`` anchor; a ``dynamic`` one
-    needs a valid ``rule``. Fields that don't belong to the chosen kind are
-    dropped rather than stored as dead state."""
+    needs a valid ``rule`` and a scope (defaulting to ``owned``). Fields that
+    don't belong to the chosen kind are dropped rather than stored as dead
+    state."""
     if kind == COLLECTION_KIND_SET:
         if not source_set_id:
             raise HTTPException(status_code=422, detail="set collections require a source_set_id")
-        return source_set_id, None
+        return source_set_id, None, None
     if kind == COLLECTION_KIND_DYNAMIC:
-        return None, _normalize_rule_or_422(rule)
-    return None, None
+        scope = dynamic_scope or DYNAMIC_SCOPE_OWNED
+        if scope not in _VALID_SCOPES:
+            raise HTTPException(
+                status_code=422,
+                detail=f"unknown dynamic_scope '{scope}'; allowed: {', '.join(_VALID_SCOPES)}",
+            )
+        return None, _normalize_rule_or_422(rule), scope
+    return None, None, None
 
 
 def _normalize_rule_or_422(rule: dict[str, Any] | None) -> dict[str, Any]:
@@ -365,6 +565,52 @@ def _reject_if_dynamic(collection: Collection) -> None:
         )
 
 
+def _require_catalog_dynamic(collection: Collection) -> None:
+    """Gate the #631 endpoints to catalog-scope dynamic collections.
+
+    Owned-scope membership is served by the base ``GET /collections/{id}``
+    (pure DB, offline); the catalog endpoints only make sense for a
+    target-view collection, so anything else is a 409 with a pointer."""
+    if (
+        collection.kind != COLLECTION_KIND_DYNAMIC
+        or collection.dynamic_scope != DYNAMIC_SCOPE_CATALOG
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail="not a catalog-scope dynamic collection; use GET /collections/{id} instead",
+        )
+
+
+def _fetch_catalog_cards(rule: dict[str, Any] | None, api_key: str | None) -> list[dict[str, Any]]:
+    """Resolve a rule's full matching set from pokemontcg.io.
+
+    Translates the rule to a Lucene query and walks the catalog client's
+    paginated, on-disk-cached ``search_all`` — the same path the set-browse
+    and pokedex routes use, so the request shares their cache. The page cap
+    inside ``search_all`` bounds an over-broad rule ("all Fire")."""
+    query = rule_to_lucene(rule or {})
+    if not query:
+        return []
+    cards, _status = TCGClient(api_key=api_key).search_all(query)
+    return cards
+
+
+def _resolve_chase_wishlist(db: Session, user_id: int, req: ChaseRequest) -> Wishlist:
+    """Return the want-list to chase into — created from ``wishlist_name`` or
+    looked up by ``wishlist_id`` (scoped to the user; a foreign id 404s)."""
+    if req.wishlist_name is not None:
+        wishlist = Wishlist(user_id=user_id, name=req.wishlist_name.strip())
+        db.add(wishlist)
+        db.flush()  # assign id without ending the outer transaction
+        return wishlist
+    wishlist = db.scalar(
+        select(Wishlist).where(Wishlist.id == req.wishlist_id, Wishlist.user_id == user_id)
+    )
+    if wishlist is None:
+        raise HTTPException(status_code=404, detail=f"wishlist {req.wishlist_id} not found")
+    return wishlist
+
+
 def _serialize_collection(db: Session, collection: Collection, user_id: int) -> dict:
     # A dynamic collection owns no rows — resolve its membership live from
     # the rule. Manual/set collections render their stored items.
@@ -381,6 +627,7 @@ def _serialize_collection(db: Session, collection: Collection, user_id: int) -> 
         kind=collection.kind,
         source_set_id=collection.source_set_id,
         rule=collection.rule_json,
+        dynamic_scope=collection.dynamic_scope,
     ).model_dump()
 
 

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -236,6 +236,36 @@ class CollectionsModelReworkMigrationTests(_IsolatedDbMixin):
         self.assertIsNone(row.added_via)
 
 
+class DynamicScopeMigrationTests(_IsolatedDbMixin):
+    """The #631 ``collections.dynamic_scope`` column lands additively and
+    round-trips down/up without disturbing the rest of the schema."""
+
+    def test_dynamic_scope_column_present(self) -> None:
+        engine = session_mod.get_engine()
+        upgrade_head(engine)
+        cols = {c["name"] for c in inspect(engine).get_columns("collections")}
+        self.assertIn("dynamic_scope", cols)
+
+    def test_round_trip_downgrade_then_reupgrade(self) -> None:
+        from alembic import command
+
+        from api.db import migrate as migrate_mod
+
+        engine = session_mod.get_engine()
+        upgrade_head(engine)
+        cfg = migrate_mod._alembic_config()
+        cfg.set_main_option("sqlalchemy.url", str(engine.url))
+
+        # Step back past the dynamic_scope revision to its parent.
+        command.downgrade(cfg, "b3f1a9c2d7e4")
+        cols = {c["name"] for c in inspect(engine).get_columns("collections")}
+        self.assertNotIn("dynamic_scope", cols)
+
+        upgrade_head(engine)
+        cols = {c["name"] for c in inspect(engine).get_columns("collections")}
+        self.assertIn("dynamic_scope", cols)
+
+
 # ---------------------------------------------------------------------------
 # Endpoint behavior
 # ---------------------------------------------------------------------------
@@ -579,6 +609,211 @@ class DynamicCollectionTests(_IsolatedDbMixin):
             self.assertEqual(created["kind"], "manual")
             self.assertIsNone(created["rule"])
             self.assertIsNone(created["source_set_id"])
+
+
+# ---------------------------------------------------------------------------
+# Catalog-scope dynamic collections — target view + chase (#631)
+# ---------------------------------------------------------------------------
+
+
+# Three Eevee printings the fake catalog returns for a `name: eevee` rule.
+CATALOG_EEVEES = [
+    EEVEE_CARD,  # sv1-130
+    {
+        "id": "sv4-167",
+        "name": "Eevee ex",
+        "set": {"id": "sv4", "name": "Paradox Rift"},
+        "number": "167",
+        "rarity": "Double Rare",
+        "images": {"small": "https://example.com/eevee-ex.png"},
+        "types": ["Colorless"],
+    },
+    {
+        "id": "swsh7-186",
+        "name": "Eevee VMAX",
+        "set": {"id": "swsh7", "name": "Evolving Skies"},
+        "number": "186",
+        "rarity": "Rare Rainbow",
+        "images": {"small": "https://example.com/eevee-vmax.png"},
+        "types": ["Colorless"],
+    },
+]
+
+
+class _FakeTCGClient:
+    """Stand-in for the pokemontcg.io client — returns a fixed card list so
+    the catalog-scope tests never touch the network."""
+
+    def __init__(self, cards: list[dict], *, api_key: str | None = None) -> None:
+        self._cards = cards
+
+    def search_all(self, query: str, *args, **kwargs):
+        return list(self._cards), "HIT"
+
+
+class CatalogScopeDynamicTests(_IsolatedDbMixin):
+    """A catalog-scope dynamic collection resolves its membership from the
+    catalog and overlays ownership — a goal-with-progress target view."""
+
+    def _client(self) -> TestClient:
+        from api.main import app
+
+        return TestClient(app)
+
+    def _patch_catalog(self, cards: list[dict]):
+        from unittest.mock import patch
+
+        return patch(
+            "api.routes.collections.TCGClient",
+            lambda api_key=None: _FakeTCGClient(cards, api_key=api_key),
+        )
+
+    def _seed_owned(self, c: TestClient, *cards: dict) -> int:
+        cid = c.post("/api/v1/collections", json={"name": "binder"}).json()["id"]
+        for card in cards:
+            c.post(f"/api/v1/collections/{cid}/items", json={"card": card})
+        return cid
+
+    def _make_catalog_dynamic(self, c: TestClient, rule: dict) -> dict:
+        return c.post(
+            "/api/v1/collections",
+            json={
+                "name": "all Eevees",
+                "kind": "dynamic",
+                "rule": rule,
+                "dynamic_scope": "catalog",
+            },
+        ).json()
+
+    def test_create_catalog_scope_echoes_scope(self) -> None:
+        with self._client() as c:
+            dyn = self._make_catalog_dynamic(c, {"name": "eevee"})
+            self.assertEqual(dyn["kind"], "dynamic")
+            self.assertEqual(dyn["dynamic_scope"], "catalog")
+
+    def test_dynamic_defaults_to_owned_scope(self) -> None:
+        with self._client() as c:
+            dyn = c.post(
+                "/api/v1/collections",
+                json={"name": "x", "kind": "dynamic", "rule": {"name": "eevee"}},
+            ).json()
+            self.assertEqual(dyn["dynamic_scope"], "owned")
+
+    def test_create_rejects_unknown_scope(self) -> None:
+        with self._client() as c:
+            resp = c.post(
+                "/api/v1/collections",
+                json={
+                    "name": "x",
+                    "kind": "dynamic",
+                    "rule": {"name": "eevee"},
+                    "dynamic_scope": "bogus",
+                },
+            )
+            self.assertEqual(resp.status_code, 422)
+
+    def test_target_overlays_ownership_and_progress(self) -> None:
+        with self._client() as c:
+            self._seed_owned(c, EEVEE_CARD)  # owns sv1-130 only
+            dyn = self._make_catalog_dynamic(c, {"name": "eevee"})
+            with self._patch_catalog(CATALOG_EEVEES):
+                target = c.get(f"/api/v1/collections/{dyn['id']}/target").json()
+            self.assertEqual(target["total"], 3)
+            self.assertEqual(target["owned_count"], 1)
+            by_id = {tc["card"]["id"]: tc for tc in target["cards"]}
+            self.assertTrue(by_id["sv1-130"]["owned"])
+            self.assertEqual(by_id["sv1-130"]["owned_quantity"], 1)
+            self.assertFalse(by_id["sv4-167"]["owned"])
+
+    def test_target_409_on_owned_scope(self) -> None:
+        with self._client() as c:
+            dyn = c.post(
+                "/api/v1/collections",
+                json={"name": "x", "kind": "dynamic", "rule": {"name": "eevee"}},
+            ).json()
+            resp = c.get(f"/api/v1/collections/{dyn['id']}/target")
+            self.assertEqual(resp.status_code, 409)
+
+    def test_target_409_on_manual(self) -> None:
+        with self._client() as c:
+            cid = c.post("/api/v1/collections", json={"name": "m"}).json()["id"]
+            self.assertEqual(c.get(f"/api/v1/collections/{cid}/target").status_code, 409)
+
+    def test_chase_adds_only_unowned_to_new_wishlist(self) -> None:
+        with self._client() as c:
+            self._seed_owned(c, EEVEE_CARD)  # owns sv1-130
+            dyn = self._make_catalog_dynamic(c, {"name": "eevee"})
+            with self._patch_catalog(CATALOG_EEVEES):
+                res = c.post(
+                    f"/api/v1/collections/{dyn['id']}/chase",
+                    json={"wishlist_name": "Eevee chase"},
+                ).json()
+            self.assertEqual(res["total_missing"], 2)
+            self.assertEqual(res["added"], 2)
+            self.assertEqual(res["skipped"], 0)
+
+            detail = c.get(f"/api/v1/wishlists/{res['wishlist_id']}").json()
+            names = {i["card_name"] for i in detail["items"]}
+            self.assertEqual(names, {"Eevee ex", "Eevee VMAX"})
+
+    def test_chase_is_idempotent_on_rerun(self) -> None:
+        with self._client() as c:
+            self._seed_owned(c, EEVEE_CARD)
+            dyn = self._make_catalog_dynamic(c, {"name": "eevee"})
+            with self._patch_catalog(CATALOG_EEVEES):
+                first = c.post(
+                    f"/api/v1/collections/{dyn['id']}/chase",
+                    json={"wishlist_name": "Eevee chase"},
+                ).json()
+                again = c.post(
+                    f"/api/v1/collections/{dyn['id']}/chase",
+                    json={"wishlist_id": first["wishlist_id"]},
+                ).json()
+            self.assertEqual(again["added"], 0)
+            self.assertEqual(again["skipped"], 2)
+
+    def test_chase_requires_exactly_one_target(self) -> None:
+        with self._client() as c:
+            dyn = self._make_catalog_dynamic(c, {"name": "eevee"})
+            both = c.post(
+                f"/api/v1/collections/{dyn['id']}/chase",
+                json={"wishlist_id": 1, "wishlist_name": "x"},
+            )
+            self.assertEqual(both.status_code, 422)
+            neither = c.post(f"/api/v1/collections/{dyn['id']}/chase", json={})
+            self.assertEqual(neither.status_code, 422)
+
+    def test_chase_404_for_missing_wishlist_id(self) -> None:
+        with self._client() as c:
+            dyn = self._make_catalog_dynamic(c, {"name": "eevee"})
+            with self._patch_catalog(CATALOG_EEVEES):
+                resp = c.post(
+                    f"/api/v1/collections/{dyn['id']}/chase",
+                    json={"wishlist_id": 9999},
+                )
+            self.assertEqual(resp.status_code, 404)
+
+
+class RuleToLuceneTests(unittest.TestCase):
+    """The rule → pokemontcg.io Lucene translation (#631)."""
+
+    def test_name_becomes_prefix_wildcard(self) -> None:
+        from api.db.collection_rules import rule_to_lucene
+
+        self.assertEqual(rule_to_lucene({"name": "Eevee"}), "name:Eevee*")
+
+    def test_multiword_name_is_quoted(self) -> None:
+        from api.db.collection_rules import rule_to_lucene
+
+        self.assertEqual(rule_to_lucene({"name": "Mr Mime"}), 'name:"Mr Mime*"')
+
+    def test_predicates_and_together(self) -> None:
+        from api.db.collection_rules import rule_to_lucene
+
+        q = rule_to_lucene({"types": ["Fire"], "set_id": "base1", "rarity": "Rare Holo"})
+        self.assertIn("types:Fire", q)
+        self.assertIn('set.id:"base1"', q)
+        self.assertIn('rarity:"Rare Holo"', q)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Part of #631. Backend slice (1 of 2). Builds on #630 (now merged) — the owned-scope dynamic collections.

## What

Adds a **catalog scope** to dynamic collections — the target view that answers "what about the cards I don't own yet?", the open question from #506.

A dynamic collection is now either:
- `owned` scope (#630) — the rule resolved against your own cards, an inventory view
- `catalog` scope (this PR) — the rule resolved against the full pokemontcg.io catalog, with your ownership overlaid as progress

New endpoints:
- `GET /collections/{id}/target` — every catalog match for the rule, each flagged `owned` / not, with an `owned / total` progress headline. The base `GET /collections/{id}` stays DB-only and offline; catalog resolution lives here.
- `POST /collections/{id}/chase` — subtract what you own, push the rest onto a want-list (named → created, or by id). Idempotent on re-run.

## Why

This is the collector-true model: a smart collection as a *goal with progress*, not an inventory bucket. Three states stay distinct — exists (catalog) / owned (your real items) / missing (the chase list) — and the missing set feeds the existing want-list → collection golden path (#504).

Two design calls worth flagging for review:
- **No auto-materialization.** Catalog matches are never inserted as `collection_items`. Doing so would tell the app you own cards you don't, corrupting ownership badges (#576), value-over-time, and set-completion — the same reason ADR-0025 rejected materializing dynamic membership. Ownership stays your real items; the catalog match is an overlay.
- **Cache, not live-every-read.** Catalog resolution rides `TCGClient.search_all`'s paginated on-disk cache (shared with set-browse / pokedex) and is bounded by its page cap, so an over-broad rule ("all Fire") can't run away. A dedicated snapshot table + nightly refresh is a later refinement.

## Data model

One additive, nullable column — `collections.dynamic_scope` (`owned` | `catalog`; null reads as `owned`). Existing rows and manual/set collections are untouched. Migration `d5e2f7a3c9b1` round-trips down/up.

## How to verify

- `make check` — full Python suite green; 18 new tests in `tests/test_collections.py` (target overlay + progress, chase add/skip/idempotency, scope validation, rule→Lucene translation, migration round-trip). The catalog client is mocked, so tests never touch the network.
- The owned-scope behavior from #630 is unchanged — the base endpoints stay DB-only.

> No UI in this slice — it's API + schema only, so there's no screenshot. The SPA scope toggle and the target/progress view (the mockup from the discussion) are the next slice on #631.