### PR TITLE
feat(web): smart-collection target view — scope toggle, progress, chase

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -540,6 +540,13 @@ export interface CollectionRule {
 /** One of `manual` (default), `set`, or `dynamic`. */
 export type CollectionKind = 'manual' | 'set' | 'dynamic'
 
+/**
+ * For a `dynamic` collection (#631): `owned` resolves the rule against your
+ * own cards (an inventory view); `catalog` resolves the full matching set
+ * from the catalog and overlays ownership (a target view with progress).
+ */
+export type DynamicScope = 'owned' | 'catalog'
+
 export interface CollectionSummary {
   id: number
   name: string
@@ -551,6 +558,7 @@ export interface CollectionSummary {
   kind?: CollectionKind
   source_set_id?: string | null
   rule?: CollectionRule | null
+  dynamic_scope?: DynamicScope | null
 }
 
 export interface CollectionItem {
@@ -569,6 +577,7 @@ export interface Collection {
   kind?: CollectionKind
   source_set_id?: string | null
   rule?: CollectionRule | null
+  dynamic_scope?: DynamicScope | null
 }
 
 export async function fetchCollections(): Promise<CollectionSummary[]> {
@@ -583,6 +592,7 @@ export interface CreateCollectionOptions {
   kind?: CollectionKind
   source_set_id?: string | null
   rule?: CollectionRule | null
+  dynamic_scope?: DynamicScope | null
 }
 
 export async function createCollection(
@@ -598,10 +608,74 @@ export async function createCollection(
       kind: options?.kind ?? 'manual',
       source_set_id: options?.source_set_id ?? null,
       rule: options?.rule ?? null,
+      dynamic_scope: options?.dynamic_scope ?? null,
     }),
   })
   if (!res.ok) throw new Error(`create collection failed: ${res.status}`)
   return (await res.json()) as Collection
+}
+
+// ---------------------------------------------------------------------------
+// #631 — catalog-backed target view + chase
+// ---------------------------------------------------------------------------
+
+/** One catalog match, annotated with the user's ownership of it. */
+export interface TargetCard {
+  card: Record<string, unknown>
+  card_set_id: string | null
+  card_number: string | null
+  owned: boolean
+  owned_quantity: number
+}
+
+/** Resolved catalog membership for a `catalog`-scope dynamic collection. */
+export interface CollectionTarget {
+  id: number
+  name: string
+  rule: CollectionRule | null
+  total: number
+  owned_count: number
+  cards: TargetCard[]
+}
+
+export async function fetchCollectionTarget(
+  collectionId: number,
+  apiKey?: string,
+): Promise<CollectionTarget> {
+  const params = apiKey ? `?api_key=${encodeURIComponent(apiKey)}` : ''
+  const res = await fetch(`${BASE}/collections/${collectionId}/target${params}`)
+  if (!res.ok) throw new Error(`collection target failed: ${res.status}`)
+  return (await res.json()) as CollectionTarget
+}
+
+export interface ChaseResult {
+  wishlist_id: number
+  added: number
+  skipped: number
+  total_missing: number
+}
+
+/**
+ * Push the un-owned matches onto a want-list. Pass exactly one of
+ * `wishlistName` (creates a fresh list) or `wishlistId` (an existing one).
+ */
+export async function chaseCollection(
+  collectionId: number,
+  target: { wishlistName?: string; wishlistId?: number; maxPrice?: number },
+  apiKey?: string,
+): Promise<ChaseResult> {
+  const params = apiKey ? `?api_key=${encodeURIComponent(apiKey)}` : ''
+  const res = await fetch(`${BASE}/collections/${collectionId}/chase${params}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      wishlist_name: target.wishlistName ?? null,
+      wishlist_id: target.wishlistId ?? null,
+      max_price: target.maxPrice ?? null,
+    }),
+  })
+  if (!res.ok) throw new Error(`chase failed: ${res.status}`)
+  return (await res.json()) as ChaseResult
 }
 
 export async function addCardToCollection(

--- a/web/src/components/LibraryCollectionsTab.test.tsx
+++ b/web/src/components/LibraryCollectionsTab.test.tsx
@@ -2,22 +2,34 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { LibraryCollectionsTab } from './LibraryCollectionsTab'
 import { _resetCollectionsCacheForTests } from './useCollections'
-import { fetchCollections, createCollection } from '../api/client'
+import { _resetWishlistsCacheForTests } from './useWishlists'
+import {
+  fetchCollections,
+  createCollection,
+  fetchCollectionTarget,
+} from '../api/client'
 
 vi.mock('../api/client', () => ({
   fetchCollections: vi.fn(),
   createCollection: vi.fn(),
   addCardToCollection: vi.fn(),
+  // Pulled in by the always-mounted target modal + its want-list hook.
+  fetchWishlists: vi.fn(() => Promise.resolve([])),
+  fetchCollectionTarget: vi.fn(),
+  chaseCollection: vi.fn(),
 }))
 
 const mockFetch = vi.mocked(fetchCollections)
 const mockCreate = vi.mocked(createCollection)
+const mockTarget = vi.mocked(fetchCollectionTarget)
 
 describe('LibraryCollectionsTab', () => {
   beforeEach(() => {
     _resetCollectionsCacheForTests()
+    _resetWishlistsCacheForTests()
     mockFetch.mockReset()
     mockCreate.mockReset()
+    mockTarget.mockReset()
   })
 
   it('shows the empty state when the user has no collections', async () => {
@@ -114,7 +126,86 @@ describe('LibraryCollectionsTab', () => {
       expect(mockCreate).toHaveBeenCalledWith('All Eevees', {
         kind: 'dynamic',
         rule: { name: 'Eevee' },
+        dynamic_scope: 'owned',
       }),
     )
+  })
+
+  it('creates a catalog-scope target when the scope toggle is flipped', async () => {
+    mockFetch.mockResolvedValue([])
+    mockCreate.mockResolvedValue({
+      id: 9,
+      name: 'All Eevees',
+      description: null,
+      created_at: '2026-06-11T00:00:00',
+      items: [],
+      kind: 'dynamic',
+      source_set_id: null,
+      rule: { name: 'Eevee' },
+      dynamic_scope: 'catalog',
+    })
+    render(<LibraryCollectionsTab />)
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled())
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /new smart collection/i }),
+    )
+    fireEvent.change(screen.getByPlaceholderText(/collection name/i), {
+      target: { value: 'All Eevees' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Eevee'), {
+      target: { value: 'Eevee' },
+    })
+    fireEvent.click(screen.getByRole('radio', { name: /whole catalog/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() =>
+      expect(mockCreate).toHaveBeenCalledWith('All Eevees', {
+        kind: 'dynamic',
+        rule: { name: 'Eevee' },
+        dynamic_scope: 'catalog',
+      }),
+    )
+  })
+
+  it('opens the target modal for a catalog-scope collection', async () => {
+    mockFetch.mockResolvedValue([
+      {
+        id: 7,
+        name: 'All Eevees',
+        description: null,
+        created_at: '2026-06-06T00:00:00',
+        item_count: 3,
+        kind: 'dynamic',
+        source_set_id: null,
+        rule: { name: 'eevee' },
+        dynamic_scope: 'catalog',
+      },
+    ])
+    mockTarget.mockResolvedValue({
+      id: 7,
+      name: 'All Eevees',
+      rule: { name: 'eevee' },
+      total: 3,
+      owned_count: 1,
+      cards: [
+        { card: { id: 'sv1-130', name: 'Eevee' }, card_set_id: 'sv1', card_number: '130', owned: true, owned_quantity: 1 },
+        { card: { id: 'sv4-167', name: 'Eevee ex' }, card_set_id: 'sv4', card_number: '167', owned: false, owned_quantity: 0 },
+        { card: { id: 'swsh7-186', name: 'Eevee VMAX' }, card_set_id: 'swsh7', card_number: '186', owned: false, owned_quantity: 0 },
+      ],
+    })
+    render(<LibraryCollectionsTab />)
+    await waitFor(() => expect(screen.getByText('target')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByText('All Eevees'))
+
+    await waitFor(() => expect(mockTarget).toHaveBeenCalledWith(7, undefined))
+    // Progress headline + chase affordance render from the resolved target.
+    await waitFor(() =>
+      expect(screen.getByText(/of 3 owned/)).toBeInTheDocument(),
+    )
+    expect(
+      screen.getByRole('button', { name: /add 2 missing to want-list/i }),
+    ).toBeInTheDocument()
   })
 })

--- a/web/src/components/LibraryCollectionsTab.tsx
+++ b/web/src/components/LibraryCollectionsTab.tsx
@@ -11,7 +11,12 @@
  */
 import { Loader2, Sparkles } from 'lucide-react'
 import { useEffect, useState } from 'react'
-import type { CollectionKind, CollectionRule } from '../api/client'
+import type {
+  CollectionRule,
+  CollectionSummary,
+  DynamicScope,
+} from '../api/client'
+import { SmartCollectionTarget } from './SmartCollectionTarget'
 import { useCollections } from './useCollections'
 
 /** The single-predicate fields the inline rule builder offers. The API
@@ -26,16 +31,30 @@ const RULE_FIELDS = [
 
 type RuleField = (typeof RULE_FIELDS)[number]['key']
 
+/** The two dynamic scopes, framed for the toggle. `owned` is an inventory
+ * view over your own cards; `catalog` is a target view over the whole
+ * catalog with progress (#631). */
+const SCOPE_OPTIONS: { key: DynamicScope; label: string }[] = [
+  { key: 'owned', label: 'My cards' },
+  { key: 'catalog', label: 'Whole catalog' },
+]
+
 function buildRule(field: RuleField, value: string): CollectionRule {
   const v = value.trim()
   // `types` is a list on the wire; every other predicate is a scalar.
   return field === 'types' ? { types: [v] } : { [field]: v }
 }
 
-function kindPill(kind: CollectionKind | undefined): string | null {
-  if (kind === 'dynamic') return 'smart'
-  if (kind === 'set') return 'set'
+/** A catalog-scope smart collection is a target with progress, so it reads
+ * as "target"; an owned-scope one is an inventory view ("smart"). */
+function kindPill(c: CollectionSummary): string | null {
+  if (c.kind === 'dynamic') return c.dynamic_scope === 'catalog' ? 'target' : 'smart'
+  if (c.kind === 'set') return 'set'
   return null
+}
+
+function isCatalogTarget(c: CollectionSummary): boolean {
+  return c.kind === 'dynamic' && c.dynamic_scope === 'catalog'
 }
 
 export function LibraryCollectionsTab() {
@@ -45,8 +64,11 @@ export function LibraryCollectionsTab() {
   const [name, setName] = useState('')
   const [field, setField] = useState<RuleField>('name')
   const [value, setValue] = useState('')
+  const [scope, setScope] = useState<DynamicScope>('owned')
   const [submitting, setSubmitting] = useState(false)
   const [formError, setFormError] = useState<string | null>(null)
+  // The catalog-scope target collection whose detail modal is open.
+  const [targetCollection, setTargetCollection] = useState<CollectionSummary | null>(null)
 
   useEffect(() => {
     void refresh()
@@ -58,7 +80,11 @@ export function LibraryCollectionsTab() {
     setSubmitting(true)
     setFormError(null)
     try {
-      await create(name.trim(), { kind: 'dynamic', rule: buildRule(field, value) })
+      await create(name.trim(), {
+        kind: 'dynamic',
+        rule: buildRule(field, value),
+        dynamic_scope: scope,
+      })
       setName('')
       setValue('')
       setFormOpen(false)
@@ -117,6 +143,35 @@ export function LibraryCollectionsTab() {
               className="min-w-0 flex-1 rounded border border-sand-300 bg-coconut-50 px-2 py-1 text-xs text-coconut-700 placeholder:text-coconut-400 dark:border-husk-100 dark:bg-husk-100 dark:text-sand-50"
             />
           </div>
+          <div>
+            <div
+              role="radiogroup"
+              aria-label="Membership scope"
+              className="inline-flex rounded border border-sand-300 p-0.5 dark:border-husk-100"
+            >
+              {SCOPE_OPTIONS.map((s) => (
+                <button
+                  key={s.key}
+                  type="button"
+                  role="radio"
+                  aria-checked={scope === s.key}
+                  onClick={() => setScope(s.key)}
+                  className={`rounded px-2 py-0.5 text-[11px] font-medium ${
+                    scope === s.key
+                      ? 'bg-palm-500 text-coconut-50 dark:text-husk-300'
+                      : 'text-coconut-500 hover:bg-sand-200 dark:text-sand-300 dark:hover:bg-husk-100'
+                  }`}
+                >
+                  {s.label}
+                </button>
+              ))}
+            </div>
+            <p className="mt-1 text-[10px] text-coconut-400 dark:text-sand-300">
+              {scope === 'owned'
+                ? 'Filters the cards you already own.'
+                : 'Pulls every match from the catalog and tracks your progress.'}
+            </p>
+          </div>
           {formError && (
             <div role="alert" className="text-[11px] text-sun-600 dark:text-sun-300">
               {formError}
@@ -151,9 +206,12 @@ export function LibraryCollectionsTab() {
       ) : (
         <ul className="divide-y divide-sand-200 dark:divide-husk-100">
           {collections.map((c) => {
-            const pill = kindPill(c.kind)
-            return (
-              <li key={c.id} className="flex items-center justify-between py-2">
+            const pill = kindPill(c)
+            // A catalog-scope target opens its progress detail; everything
+            // else is a static row.
+            const openable = isCatalogTarget(c)
+            const body = (
+              <>
                 <div className="min-w-0">
                   <div className="flex items-center gap-1.5">
                     <span className="truncate text-xs font-medium text-coconut-700 dark:text-sand-50">
@@ -174,11 +232,34 @@ export function LibraryCollectionsTab() {
                 <span className="ml-3 shrink-0 rounded bg-sand-200 px-2 py-0.5 text-[11px] text-coconut-600 dark:bg-husk-100 dark:text-sand-200">
                   {c.item_count} {c.item_count === 1 ? 'card' : 'cards'}
                 </span>
+              </>
+            )
+            return (
+              <li key={c.id}>
+                {openable ? (
+                  <button
+                    type="button"
+                    onClick={() => setTargetCollection(c)}
+                    className="flex w-full items-center justify-between rounded py-2 text-left hover:bg-sand-100 dark:hover:bg-husk-100"
+                  >
+                    {body}
+                  </button>
+                ) : (
+                  <div className="flex items-center justify-between py-2">{body}</div>
+                )}
               </li>
             )
           })}
         </ul>
       )}
+
+      <SmartCollectionTarget
+        collection={targetCollection}
+        open={targetCollection !== null}
+        onOpenChange={(o) => {
+          if (!o) setTargetCollection(null)
+        }}
+      />
     </div>
   )
 }

--- a/web/src/components/SmartCollectionTarget.test.tsx
+++ b/web/src/components/SmartCollectionTarget.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { SmartCollectionTarget } from './SmartCollectionTarget'
+import { _resetWishlistsCacheForTests } from './useWishlists'
+import { fetchCollectionTarget, chaseCollection } from '../api/client'
+
+vi.mock('../api/client', () => ({
+  fetchCollectionTarget: vi.fn(),
+  chaseCollection: vi.fn(),
+  fetchWishlists: vi.fn(() => Promise.resolve([])),
+}))
+
+const mockTarget = vi.mocked(fetchCollectionTarget)
+const mockChase = vi.mocked(chaseCollection)
+
+const COLLECTION = {
+  id: 7,
+  name: 'All Eevees',
+  description: null,
+  created_at: '2026-06-06T00:00:00',
+  item_count: 3,
+  kind: 'dynamic' as const,
+  source_set_id: null,
+  rule: { name: 'eevee' },
+  dynamic_scope: 'catalog' as const,
+}
+
+const TARGET = {
+  id: 7,
+  name: 'All Eevees',
+  rule: { name: 'eevee' },
+  total: 3,
+  owned_count: 1,
+  cards: [
+    { card: { id: 'sv1-130', name: 'Eevee' }, card_set_id: 'sv1', card_number: '130', owned: true, owned_quantity: 2 },
+    { card: { id: 'sv4-167', name: 'Eevee ex' }, card_set_id: 'sv4', card_number: '167', owned: false, owned_quantity: 0 },
+    { card: { id: 'swsh7-186', name: 'Eevee VMAX' }, card_set_id: 'swsh7', card_number: '186', owned: false, owned_quantity: 0 },
+  ],
+}
+
+describe('SmartCollectionTarget', () => {
+  beforeEach(() => {
+    _resetWishlistsCacheForTests()
+    mockTarget.mockReset()
+    mockChase.mockReset()
+  })
+
+  it('renders progress and the owned / missing split', async () => {
+    mockTarget.mockResolvedValue(TARGET)
+    render(<SmartCollectionTarget collection={COLLECTION} open onOpenChange={() => {}} />)
+
+    await waitFor(() => expect(screen.getByText(/of 3 owned/)).toBeInTheDocument())
+    expect(screen.getByText('1')).toBeInTheDocument() // owned_count headline
+    expect(screen.getByText(/33% complete/)).toBeInTheDocument()
+    expect(screen.getByText('Owned (1)')).toBeInTheDocument()
+    expect(screen.getByText(/Missing.*\(2\)/)).toBeInTheDocument()
+  })
+
+  it('chases the missing cards onto a new want-list named after the collection', async () => {
+    mockTarget.mockResolvedValue(TARGET)
+    mockChase.mockResolvedValue({ wishlist_id: 3, added: 2, skipped: 0, total_missing: 2 })
+    render(<SmartCollectionTarget collection={COLLECTION} open onOpenChange={() => {}} />)
+
+    await waitFor(() => expect(screen.getByText(/of 3 owned/)).toBeInTheDocument())
+    fireEvent.click(screen.getByRole('button', { name: /add 2 missing to want-list/i }))
+
+    await waitFor(() =>
+      expect(mockChase).toHaveBeenCalledWith(7, { wishlistName: 'All Eevees' }, undefined),
+    )
+    await waitFor(() =>
+      expect(screen.getByText(/added 2 to your want-list/i)).toBeInTheDocument(),
+    )
+  })
+
+  it('tops up the same want-list on a second chase', async () => {
+    mockTarget.mockResolvedValue(TARGET)
+    mockChase
+      .mockResolvedValueOnce({ wishlist_id: 3, added: 2, skipped: 0, total_missing: 2 })
+      .mockResolvedValueOnce({ wishlist_id: 3, added: 0, skipped: 2, total_missing: 2 })
+    render(<SmartCollectionTarget collection={COLLECTION} open onOpenChange={() => {}} />)
+
+    await waitFor(() => expect(screen.getByText(/of 3 owned/)).toBeInTheDocument())
+    const btn = screen.getByRole('button', { name: /add 2 missing to want-list/i })
+    fireEvent.click(btn)
+    await waitFor(() => expect(mockChase).toHaveBeenCalledTimes(1))
+    fireEvent.click(btn)
+
+    await waitFor(() =>
+      expect(mockChase).toHaveBeenLastCalledWith(7, { wishlistId: 3 }, undefined),
+    )
+  })
+})

--- a/web/src/components/SmartCollectionTarget.tsx
+++ b/web/src/components/SmartCollectionTarget.tsx
@@ -1,0 +1,268 @@
+/**
+ * SmartCollectionTarget — the detail view for a catalog-scope smart
+ * collection (#631). Opens from a row in [LibraryCollectionsTab](./LibraryCollectionsTab.tsx).
+ *
+ * A catalog-scope smart collection is a goal, not a bucket: its membership
+ * is the full set of cards matching the rule (resolved from the catalog via
+ * `GET /collections/{id}/target`), with the user's ownership overlaid. The
+ * modal shows an `owned / total` progress bar, the cards you already have,
+ * and the missing ones as chase candidates — with one button to push every
+ * un-owned match onto a want-list (`POST /collections/{id}/chase`).
+ *
+ * Chasing is idempotent: the first click creates a want-list named after the
+ * collection and remembers its id, so re-clicking adds only newly-missing
+ * cards to the same list rather than spawning duplicates.
+ */
+import * as Dialog from '@radix-ui/react-dialog'
+import { ImageOff, Loader2, Plus, Target, X } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import {
+  chaseCollection,
+  fetchCollectionTarget,
+  type CollectionSummary,
+  type CollectionTarget,
+  type TargetCard,
+} from '../api/client'
+import { useAppStore } from '../store'
+import { useWishlists } from './useWishlists'
+
+interface Props {
+  collection: CollectionSummary | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+function cardImage(card: Record<string, unknown>): string | undefined {
+  const images = card.images as { small?: string; large?: string } | undefined
+  return images?.small ?? images?.large
+}
+
+function cardName(card: Record<string, unknown>): string {
+  return (card.name as string | undefined) ?? 'Unknown card'
+}
+
+function CardTile({ tc }: { tc: TargetCard }) {
+  const [broken, setBroken] = useState(false)
+  const img = cardImage(tc.card)
+  return (
+    <div
+      className={`rounded-md border p-1.5 ${
+        tc.owned
+          ? 'border-palm-200 bg-palm-50 dark:border-husk-100 dark:bg-husk-100'
+          : 'border-sand-200 bg-sand-50 opacity-90 dark:border-husk-100 dark:bg-husk-200'
+      }`}
+    >
+      <div className="mb-1 flex aspect-[3/4] items-center justify-center overflow-hidden rounded bg-sand-200 dark:bg-husk-100">
+        {img && !broken ? (
+          <img
+            src={img}
+            alt={cardName(tc.card)}
+            loading="lazy"
+            onError={() => setBroken(true)}
+            className="h-full w-full object-contain"
+          />
+        ) : (
+          <ImageOff size={16} className="text-coconut-400 dark:text-sand-300" />
+        )}
+      </div>
+      <div className="truncate text-[11px] font-medium text-coconut-700 dark:text-sand-50">
+        {cardName(tc.card)}
+      </div>
+      <div className="truncate text-[10px] text-coconut-400 dark:text-sand-300">
+        {tc.card_set_id}
+        {tc.card_number ? `-${tc.card_number}` : ''}
+        {tc.owned && tc.owned_quantity > 1 ? ` · ${tc.owned_quantity}x` : ''}
+      </div>
+    </div>
+  )
+}
+
+export function SmartCollectionTarget({ collection, open, onOpenChange }: Props) {
+  const apiKey = useAppStore((s) => s.settings.apiKey)
+  const wishlists = useWishlists()
+
+  const [target, setTarget] = useState<CollectionTarget | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [chasing, setChasing] = useState(false)
+  const [chaseMsg, setChaseMsg] = useState<string | null>(null)
+  // Remember the want-list created on the first chase so repeat clicks top up
+  // the same list instead of creating a new one each time.
+  const chaseWishlistId = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (!open || !collection) return
+    let cancelled = false
+    const load = async () => {
+      setTarget(null)
+      setError(null)
+      setChaseMsg(null)
+      chaseWishlistId.current = null
+      setLoading(true)
+      try {
+        const resolved = await fetchCollectionTarget(collection.id, apiKey || undefined)
+        if (!cancelled) setTarget(resolved)
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e))
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [open, collection, apiKey])
+
+  async function handleChase() {
+    if (!collection || !target) return
+    setChasing(true)
+    setChaseMsg(null)
+    try {
+      const res = await chaseCollection(
+        collection.id,
+        chaseWishlistId.current
+          ? { wishlistId: chaseWishlistId.current }
+          : { wishlistName: collection.name },
+        apiKey || undefined,
+      )
+      chaseWishlistId.current = res.wishlist_id
+      void wishlists.refresh()
+      setChaseMsg(
+        res.added > 0
+          ? `Added ${res.added} to your want-list.`
+          : res.total_missing === 0
+            ? 'You already own every card here.'
+            : 'All missing cards are already on your want-list.',
+      )
+    } catch (e) {
+      setChaseMsg(e instanceof Error ? e.message : String(e))
+    } finally {
+      setChasing(false)
+    }
+  }
+
+  const owned = target ? target.cards.filter((c) => c.owned) : []
+  const missing = target ? target.cards.filter((c) => !c.owned) : []
+  const pct = target && target.total > 0 ? Math.round((target.owned_count / target.total) * 100) : 0
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-coconut-700/50 backdrop-blur-sm dark:bg-husk-500/70" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-[min(720px,92vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-sand-300 bg-sand-50 shadow-2xl dark:border-husk-50 dark:bg-husk-200">
+          <header className="flex items-center justify-between gap-3 border-b border-sand-200 px-5 py-4 dark:border-husk-100">
+            <div className="flex min-w-0 items-center gap-2">
+              <Target size={18} className="shrink-0 text-coconut-600 dark:text-sand-200" />
+              <Dialog.Title className="truncate text-lg font-semibold text-coconut-700 dark:text-sand-50">
+                {collection?.name ?? 'Smart collection'}
+              </Dialog.Title>
+            </div>
+            <Dialog.Close asChild>
+              <button
+                aria-label="Close"
+                className="rounded p-1 text-coconut-500 hover:bg-sand-200 dark:text-sand-300 dark:hover:bg-husk-100"
+              >
+                <X size={18} />
+              </button>
+            </Dialog.Close>
+          </header>
+          <Dialog.Description className="sr-only">
+            Cards matching this smart collection&apos;s rule, with the ones you
+            own and the ones still to chase.
+          </Dialog.Description>
+
+          <div className="flex-1 overflow-y-auto px-5 py-4">
+            {loading ? (
+              <div className="flex items-center gap-2 text-xs text-coconut-400 dark:text-sand-300">
+                <Loader2 size={14} className="animate-spin" />
+                Resolving from catalog…
+              </div>
+            ) : error ? (
+              <div role="alert" className="text-xs text-sun-600 dark:text-sun-300">
+                {error}
+              </div>
+            ) : target ? (
+              <>
+                <div className="mb-4">
+                  <div className="mb-1 flex items-baseline gap-2">
+                    <span className="text-2xl font-semibold text-coconut-700 dark:text-sand-50">
+                      {target.owned_count}
+                    </span>
+                    <span className="text-xs text-coconut-500 dark:text-sand-300">
+                      of {target.total} owned · {missing.length} to chase
+                    </span>
+                  </div>
+                  <div className="h-2 overflow-hidden rounded-full bg-sand-200 dark:bg-husk-100">
+                    <div
+                      className="h-full rounded-full bg-palm-500"
+                      style={{ width: `${pct}%` }}
+                    />
+                  </div>
+                  <div className="mt-1 text-[11px] text-coconut-400 dark:text-sand-300">
+                    {pct}% complete
+                  </div>
+                </div>
+
+                {missing.length > 0 && (
+                  <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+                    <button
+                      type="button"
+                      onClick={handleChase}
+                      disabled={chasing}
+                      className="inline-flex items-center gap-1.5 rounded bg-palm-500 px-3 py-1.5 text-xs font-medium text-coconut-50 hover:bg-palm-600 disabled:opacity-50 dark:text-husk-300"
+                    >
+                      {chasing ? (
+                        <Loader2 size={13} className="animate-spin" />
+                      ) : (
+                        <Plus size={13} />
+                      )}
+                      Add {missing.length} missing to want-list
+                    </button>
+                    {chaseMsg && (
+                      <span className="text-[11px] text-coconut-500 dark:text-sand-300">
+                        {chaseMsg}
+                      </span>
+                    )}
+                  </div>
+                )}
+
+                {owned.length > 0 && (
+                  <section className="mb-4">
+                    <h3 className="mb-2 text-[11px] font-medium uppercase tracking-wide text-coconut-400 dark:text-sand-300">
+                      Owned ({owned.length})
+                    </h3>
+                    <div className="grid grid-cols-[repeat(auto-fill,minmax(76px,1fr))] gap-2">
+                      {owned.map((tc) => (
+                        <CardTile key={`${tc.card_set_id}-${tc.card_number}`} tc={tc} />
+                      ))}
+                    </div>
+                  </section>
+                )}
+
+                {missing.length > 0 && (
+                  <section>
+                    <h3 className="mb-2 text-[11px] font-medium uppercase tracking-wide text-coconut-400 dark:text-sand-300">
+                      Missing — chase candidates ({missing.length})
+                    </h3>
+                    <div className="grid grid-cols-[repeat(auto-fill,minmax(76px,1fr))] gap-2">
+                      {missing.map((tc) => (
+                        <CardTile key={`${tc.card_set_id}-${tc.card_number}`} tc={tc} />
+                      ))}
+                    </div>
+                  </section>
+                )}
+
+                {target.total === 0 && (
+                  <p className="text-xs text-coconut-500 dark:text-sand-300">
+                    No catalog cards match this rule yet. Try a broader rule.
+                  </p>
+                )}
+              </>
+            ) : null}
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/web/src/components/useCollections.ts
+++ b/web/src/components/useCollections.ts
@@ -79,6 +79,7 @@ export function useCollections() {
             kind: created.kind,
             source_set_id: created.source_set_id,
             rule: created.rule,
+            dynamic_scope: created.dynamic_scope,
           },
           ...state.collections,
         ],


### PR DESCRIPTION
Closes #631. Frontend slice (2 of 2) — the SPA surface for the catalog-backed smart collections whose API landed in #632.

## What

Turns the catalog-scope smart collection into something you can actually use and see:

- **Scope toggle on the create form.** "New smart collection" now offers "My cards" (owned — the #630 inventory view) vs "Whole catalog" (catalog — the target view), wired through `createCollection`'s `dynamic_scope`.
- **Target detail modal** (`SmartCollectionTarget`). Clicking a catalog-scope collection resolves its rule against the catalog (`GET /collections/{id}/target`) and shows an `owned / total` progress bar, the cards you own, and the missing ones as a chase grid.
- **One-click chase.** A button pushes every un-owned match onto a want-list (`POST /collections/{id}/chase`). The created list's id is remembered for the session, so re-clicking tops up the same list instead of spawning duplicates.
- **`target` pill** distinguishes catalog collections from owned-scope (`smart`) and `set` ones in the list.

This is the flow from the mockup in the design discussion: a smart collection as a goal with progress, not an inventory bucket. Owned-scope behavior is unchanged — only catalog-scope rows are clickable, and no catalog match is ever written as an owned card.

## How to verify

- `make check` — full gate green (ESLint + Python). Web build (`tsc -b && vite build`) green.
- `npx vitest run src/components/SmartCollectionTarget.test.tsx src/components/LibraryCollectionsTab.test.tsx` — 10 passing: scope toggle creates a `catalog` collection, the `target` pill renders, the modal resolves + shows progress and the owned/missing split, chase posts to a named want-list and tops up the same list on re-run.
- Manually (needs a signed-in user with some owned cards): create a smart collection, flip the toggle to "Whole catalog", open it — every matching card from the catalog appears with your owned ones marked and an `owned / total` bar; "Add N missing to want-list" populates a want-list with just the cards you don't have.

> Like #630, this needs a seeded signed-in collection + live catalog to populate, which the static preview can't stand up — so there's no standalone screenshot here; the intended UI is the mockup from the discussion thread, and the behavior is covered by the vitest suite above.

## Epic

With this, #631 is complete: #632 (backend — `dynamic_scope`, `/target`, `/chase`) + this PR (the SPA). Together they answer the open question from #506 — what a smart collection does when you don't yet own everything that matches.