### PR TITLE
render: correct buildFilter key from includedPaths to paths

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -27,14 +27,14 @@ services:
     # `CHANGELOG.md` (backs GET /api/v1/changelog) and `README.md` (hatchling
     # package readme), and the `Dockerfile` itself. Docs-, site-, and
     # design-only churn (`docs/`, `site/`, `design/`, `tests/`) no longer
-    # spins up a production deploy or a PR preview. `includedPaths` (rather
+    # spins up a production deploy or a PR preview. `paths` (rather
     # than the inverse `ignoredPaths`) is deliberate: an allowlist of the real
     # build inputs can't silently skip a deploy when a *new* top-level input
     # dir appears — it just won't match until added here, which is the safe
     # failure mode. Glob syntax, relative to the repo root. See
     # https://render.com/docs/blueprint-spec#buildfilter.
     buildFilter:
-      includedPaths:
+      paths:
         - "api/**"
         - "web/**"
         - "src/**"


### PR DESCRIPTION
Resolves #636

## What

Rename the Render blueprint's build-filter allowlist key from `buildFilter.includedPaths` to `buildFilter.paths`, and update the comment that referenced the old name. The glob list is unchanged.

## Why

The [blueprint spec](https://render.com/docs/blueprint-spec#buildfilter) names the field `paths` (its inverse is `ignoredPaths`); there is no `includedPaths`. Render silently ignores the unknown key, so the filter never took effect — docs-, site-, and design-only churn could still spin up a production deploy and a PR preview, which is exactly what the allowlist was added (in #634) to prevent.

## How to verify

- `buildFilter.paths` matches the spec at https://render.com/docs/blueprint-spec#buildfilter.
- With the corrected key, a commit touching only `docs/**` (or `site/**`, `design/**`, `tests/**`) no longer matches the filter, so it won't trigger a deploy or preview; a commit under `api/**`, `web/**`, `src/**`, etc. still does.