### PR TITLE
feat(web): collector golden path — promote a wishlist into a collection

### DIFF
--- a/api/routes/collections.py
+++ b/api/routes/collections.py
@@ -353,7 +353,7 @@ def add_collection_item(
     db.add(item)
     db.commit()
     db.refresh(item)
-    return _serialize_item(item)
+    return serialize_collection_item(item)
 
 
 @router.delete("/collections/{collection_id}/items/{item_id}", status_code=204)
@@ -631,7 +631,9 @@ def _serialize_collection(db: Session, collection: Collection, user_id: int) -> 
     ).model_dump()
 
 
-def _serialize_item(item: CollectionItem) -> dict:
+def serialize_collection_item(item: CollectionItem) -> dict:
+    """Public so the wishlist promote endpoint (#504) can return the created
+    collection item in the same shape ``POST /collections/{id}/items`` does."""
     return _item_out(item).model_dump()
 
 

--- a/api/routes/wishlists.py
+++ b/api/routes/wishlists.py
@@ -16,6 +16,7 @@ Endpoints:
 - `DELETE /wishlists/{id}`                  cascade-delete items
 - `POST   /wishlists/{id}/items`            add a card (optional max_price)
 - `DELETE /wishlists/{id}/items/{item_id}`  remove a card
+- `POST   /wishlists/{id}/items/{item_id}/promote`  acquire → collection (#504)
 """
 
 from __future__ import annotations
@@ -30,8 +31,17 @@ from sqlalchemy.orm import Session, selectinload
 
 from ..auth.session import current_user_or_default
 from ..db.card_payload import extract_card_identity, extract_price_snapshot
-from ..db.models import User, Wishlist, WishlistItem
+from ..db.models import (
+    ADDED_VIA_WISHLIST_PROMOTE,
+    COLLECTION_KIND_DYNAMIC,
+    Collection,
+    CollectionItem,
+    User,
+    Wishlist,
+    WishlistItem,
+)
 from ..db.session import get_db
+from .collections import serialize_collection_item
 
 router = APIRouter()
 
@@ -100,6 +110,25 @@ class WishlistItemCreate(BaseModel):
     notes: str | None = None
     # Optional alert threshold — persisted but not yet wired to alerting.
     max_price: float | None = Field(default=None, ge=0)
+
+
+class PromoteRequest(BaseModel):
+    """Mark a chased card acquired and land it in a collection (#504)."""
+
+    collection_id: int
+    #: Vendor multiples on the resulting collection row. Default 1.
+    quantity: int = Field(default=1, ge=1)
+    #: Optional note stamped on the new collection item — a fresh
+    #: annotation, not inherited from the wishlist row.
+    notes: str | None = None
+
+
+class PromoteResult(BaseModel):
+    """Both sides of the transition: the now-acquired wishlist row and the
+    collection row it produced."""
+
+    wishlist_item: WishlistItemOut
+    collection_item: dict[str, Any]
 
 
 # ---------------------------------------------------------------------------
@@ -234,6 +263,85 @@ def delete_wishlist_item(
         )
     db.delete(item)
     db.commit()
+
+
+@router.post("/wishlists/{wishlist_id}/items/{item_id}/promote", status_code=201)
+def promote_wishlist_item(
+    wishlist_id: int,
+    item_id: int,
+    req: PromoteRequest,
+    db: DbSession,
+    current_user: CurrentUser,
+) -> dict:
+    """Close the chase: mark a wishlist item acquired and mint the owned
+    collection row it becomes (#504).
+
+    The wishlist row is *not* deleted — it's stamped with ``acquired_at`` and
+    a back-pointer to the new ``collection_items`` row, so the want-list keeps
+    doubling as a show retrospective ("here's what I was hunting, and here's
+    what I landed"). Re-promoting an already-acquired item is a 409 rather than
+    a second collection row."""
+    # Scope the item lookup through the parent wishlist so a guess-the-id
+    # attack on another user's items 404s instead of leaking existence.
+    wishlist = _load_wishlist(db, wishlist_id, current_user.id)
+    item = db.scalar(
+        select(WishlistItem).where(
+            WishlistItem.id == item_id,
+            WishlistItem.wishlist_id == wishlist.id,
+        )
+    )
+    if item is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"item {item_id} not found in wishlist {wishlist_id}",
+        )
+    if item.acquired_at is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=f"item {item_id} is already acquired",
+        )
+
+    collection = db.scalar(
+        select(Collection).where(
+            Collection.id == req.collection_id,
+            Collection.user_id == current_user.id,
+        )
+    )
+    if collection is None:
+        raise HTTPException(status_code=404, detail=f"collection {req.collection_id} not found")
+    if collection.kind == COLLECTION_KIND_DYNAMIC:
+        raise HTTPException(
+            status_code=409,
+            detail="dynamic collections are rule-defined; promote into a manual or set collection",
+        )
+
+    # Re-extract identity/price from the verbatim payload so the collection
+    # row goes through the same single extractor as a manual add.
+    promoted = extract_card_identity(item.card_json)
+    price = extract_price_snapshot(item.card_json)
+    collection_item = CollectionItem(
+        collection_id=collection.id,
+        card_json=item.card_json,
+        notes=req.notes,
+        quantity=req.quantity,
+        added_via=ADDED_VIA_WISHLIST_PROMOTE,
+        price_snapshot=price,
+        priced_at=datetime.now(UTC) if price is not None else None,
+        **promoted,
+    )
+    db.add(collection_item)
+    db.flush()  # assign the id without ending the transaction
+
+    item.acquired_at = datetime.now(UTC)
+    item.acquired_collection_item_id = collection_item.id
+
+    db.commit()
+    db.refresh(item)
+    db.refresh(collection_item)
+    return PromoteResult(
+        wishlist_item=_item_out(item),
+        collection_item=serialize_collection_item(collection_item),
+    ).model_dump()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_wishlists.py
+++ b/tests/test_wishlists.py
@@ -257,6 +257,135 @@ class WishlistsEndpointTests(_IsolatedDbMixin):
 
 
 # ---------------------------------------------------------------------------
+# Promote: wishlist item → collection (#504)
+# ---------------------------------------------------------------------------
+
+
+class WishlistPromoteTests(_IsolatedDbMixin):
+    def _client(self) -> TestClient:
+        from api.main import app
+
+        return TestClient(app)
+
+    def _seed_item_and_collection(self, c: TestClient) -> tuple[int, int, int]:
+        """Return ``(wishlist_id, item_id, collection_id)`` ready to promote."""
+        wid = c.post("/api/v1/wishlists", json={"name": "hunt"}).json()["id"]
+        item_id = c.post(f"/api/v1/wishlists/{wid}/items", json={"card": SAMPLE_CARD}).json()["id"]
+        cid = c.post("/api/v1/collections", json={"name": "binder"}).json()["id"]
+        return wid, item_id, cid
+
+    def test_promote_marks_acquired_and_creates_collection_item(self) -> None:
+        with self._client() as c:
+            wid, item_id, cid = self._seed_item_and_collection(c)
+            resp = c.post(
+                f"/api/v1/wishlists/{wid}/items/{item_id}/promote",
+                json={"collection_id": cid, "quantity": 2, "notes": "near-mint"},
+            )
+            self.assertEqual(resp.status_code, 201)
+            body = resp.json()
+
+            wl_item = body["wishlist_item"]
+            self.assertEqual(wl_item["id"], item_id)
+            self.assertIsNotNone(wl_item["acquired_at"])
+            self.assertIsNotNone(wl_item["acquired_collection_item_id"])
+
+            coll_item = body["collection_item"]
+            self.assertEqual(coll_item["card"]["id"], "base1-4")
+            self.assertEqual(coll_item["quantity"], 2)
+            self.assertEqual(coll_item["notes"], "near-mint")
+            self.assertEqual(coll_item["added_via"], "wishlist_promote")
+            self.assertEqual(coll_item["card_set_id"], "base1")
+            self.assertEqual(wl_item["acquired_collection_item_id"], coll_item["id"])
+
+    def test_promote_lands_in_collection_listing(self) -> None:
+        with self._client() as c:
+            wid, item_id, cid = self._seed_item_and_collection(c)
+            c.post(
+                f"/api/v1/wishlists/{wid}/items/{item_id}/promote",
+                json={"collection_id": cid},
+            )
+            detail = c.get(f"/api/v1/collections/{cid}").json()
+            self.assertEqual(len(detail["items"]), 1)
+            self.assertEqual(detail["items"][0]["added_via"], "wishlist_promote")
+            # The wishlist row survives — the want-list still doubles as a
+            # retrospective.
+            wl = c.get(f"/api/v1/wishlists/{wid}").json()
+            self.assertEqual(len(wl["items"]), 1)
+            self.assertIsNotNone(wl["items"][0]["acquired_at"])
+
+    def test_promote_defaults_quantity_to_one(self) -> None:
+        with self._client() as c:
+            wid, item_id, cid = self._seed_item_and_collection(c)
+            resp = c.post(
+                f"/api/v1/wishlists/{wid}/items/{item_id}/promote",
+                json={"collection_id": cid},
+            )
+            self.assertEqual(resp.json()["collection_item"]["quantity"], 1)
+
+    def test_promote_twice_is_409(self) -> None:
+        with self._client() as c:
+            wid, item_id, cid = self._seed_item_and_collection(c)
+            first = c.post(
+                f"/api/v1/wishlists/{wid}/items/{item_id}/promote",
+                json={"collection_id": cid},
+            )
+            self.assertEqual(first.status_code, 201)
+            second = c.post(
+                f"/api/v1/wishlists/{wid}/items/{item_id}/promote",
+                json={"collection_id": cid},
+            )
+            self.assertEqual(second.status_code, 409)
+            # No duplicate collection row.
+            self.assertEqual(len(c.get(f"/api/v1/collections/{cid}").json()["items"]), 1)
+
+    def test_promote_404_for_missing_item(self) -> None:
+        with self._client() as c:
+            wid = c.post("/api/v1/wishlists", json={"name": "hunt"}).json()["id"]
+            cid = c.post("/api/v1/collections", json={"name": "binder"}).json()["id"]
+            resp = c.post(
+                f"/api/v1/wishlists/{wid}/items/9999/promote",
+                json={"collection_id": cid},
+            )
+            self.assertEqual(resp.status_code, 404)
+
+    def test_promote_404_for_missing_collection(self) -> None:
+        with self._client() as c:
+            wid, item_id, _ = self._seed_item_and_collection(c)
+            resp = c.post(
+                f"/api/v1/wishlists/{wid}/items/{item_id}/promote",
+                json={"collection_id": 9999},
+            )
+            self.assertEqual(resp.status_code, 404)
+
+    def test_promote_409_into_dynamic_collection(self) -> None:
+        with self._client() as c:
+            wid, item_id, _ = self._seed_item_and_collection(c)
+            cid = c.post(
+                "/api/v1/collections",
+                json={"name": "all fire", "kind": "dynamic", "rule": {"types": ["Fire"]}},
+            ).json()["id"]
+            resp = c.post(
+                f"/api/v1/wishlists/{wid}/items/{item_id}/promote",
+                json={"collection_id": cid},
+            )
+            self.assertEqual(resp.status_code, 409)
+
+    def test_promote_404_when_item_in_other_wishlist(self) -> None:
+        with self._client() as c:
+            wid_a = c.post("/api/v1/wishlists", json={"name": "a"}).json()["id"]
+            wid_b = c.post("/api/v1/wishlists", json={"name": "b"}).json()["id"]
+            item_id = c.post(f"/api/v1/wishlists/{wid_a}/items", json={"card": SAMPLE_CARD}).json()[
+                "id"
+            ]
+            cid = c.post("/api/v1/collections", json={"name": "binder"}).json()["id"]
+            resp = c.post(
+                f"/api/v1/wishlists/{wid_b}/items/{item_id}/promote",
+                json={"collection_id": cid},
+            )
+            self.assertEqual(resp.status_code, 404)
+
+
+# ---------------------------------------------------------------------------
 # Auth gating
 # ---------------------------------------------------------------------------
 
@@ -347,6 +476,14 @@ class WishlistsAuthGateTests(_IsolatedDbMixin):
                 )
                 self.assertEqual(
                     c.delete(f"/api/v1/wishlists/{wid}/items/{item_id}").status_code,
+                    404,
+                )
+                cid = c.post("/api/v1/collections", json={"name": "bob-binder"}).json()["id"]
+                self.assertEqual(
+                    c.post(
+                        f"/api/v1/wishlists/{wid}/items/{item_id}/promote",
+                        json={"collection_id": cid},
+                    ).status_code,
                     404,
                 )
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -710,6 +710,19 @@ export interface WishlistItem {
   notes: string | null
   max_price: number | null
   added_at: string
+  // Promoted identity + lifecycle fields (#574/#504). Optional so partial
+  // fixtures stay valid — the wire always carries them (null when absent).
+  card_set_id?: string | null
+  card_number?: string | null
+  card_name?: string | null
+  card_rarity?: string | null
+  card_types?: string[] | null
+  card_image_url?: string | null
+  price_snapshot?: number | null
+  priced_at?: string | null
+  // Non-null once the chase is closed and the card is owned (#504).
+  acquired_at?: string | null
+  acquired_collection_item_id?: number | null
 }
 
 export interface Wishlist {
@@ -725,6 +738,44 @@ export async function fetchWishlists(): Promise<WishlistSummary[]> {
   if (!res.ok) throw new Error(`wishlists failed: ${res.status}`)
   const data = await res.json()
   return data.items as WishlistSummary[]
+}
+
+export async function fetchWishlist(wishlistId: number): Promise<Wishlist> {
+  const res = await fetch(`${BASE}/wishlists/${wishlistId}`)
+  if (!res.ok) throw new Error(`wishlist failed: ${res.status}`)
+  return (await res.json()) as Wishlist
+}
+
+/** The wishlist row (now acquired) plus the collection row it produced. */
+export interface PromoteResult {
+  wishlist_item: WishlistItem
+  collection_item: CollectionItem
+}
+
+/**
+ * Close a chase: mark a wishlist item acquired and land it in a collection
+ * (#504). The wishlist row survives — stamped `acquired_at` — so the list
+ * doubles as a show retrospective.
+ */
+export async function promoteWishlistItem(
+  wishlistId: number,
+  itemId: number,
+  opts: { collectionId: number; quantity?: number; notes?: string | null },
+): Promise<PromoteResult> {
+  const res = await fetch(
+    `${BASE}/wishlists/${wishlistId}/items/${itemId}/promote`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        collection_id: opts.collectionId,
+        quantity: opts.quantity ?? 1,
+        notes: opts.notes ?? null,
+      }),
+    },
+  )
+  if (!res.ok) throw new Error(`promote failed: ${res.status}`)
+  return (await res.json()) as PromoteResult
 }
 
 export async function createWishlist(

--- a/web/src/components/LibraryWishlistsTab.test.tsx
+++ b/web/src/components/LibraryWishlistsTab.test.tsx
@@ -1,21 +1,33 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { LibraryWishlistsTab } from './LibraryWishlistsTab'
 import { _resetWishlistsCacheForTests } from './useWishlists'
-import { fetchWishlists } from '../api/client'
+import { _resetCollectionsCacheForTests } from './useCollections'
+import { fetchWishlists, fetchWishlist, fetchCollections } from '../api/client'
 
 vi.mock('../api/client', () => ({
   fetchWishlists: vi.fn(),
   createWishlist: vi.fn(),
   addCardToWishlist: vi.fn(),
+  fetchWishlist: vi.fn(),
+  promoteWishlistItem: vi.fn(),
+  fetchCollections: vi.fn(),
+  createCollection: vi.fn(),
+  addCardToCollection: vi.fn(),
 }))
 
 const mockFetch = vi.mocked(fetchWishlists)
+const mockFetchWishlist = vi.mocked(fetchWishlist)
+const mockFetchCollections = vi.mocked(fetchCollections)
 
 describe('LibraryWishlistsTab', () => {
   beforeEach(() => {
     _resetWishlistsCacheForTests()
+    _resetCollectionsCacheForTests()
     mockFetch.mockReset()
+    mockFetchWishlist.mockReset()
+    mockFetchCollections.mockReset()
+    mockFetchCollections.mockResolvedValue([])
   })
 
   it('shows the empty state when the user has no wishlists', async () => {
@@ -60,5 +72,52 @@ describe('LibraryWishlistsTab', () => {
     await waitFor(() =>
       expect(screen.getByRole('alert')).toHaveTextContent(/network down/i),
     )
+  })
+
+  it('opens the detail modal when a wishlist row is clicked', async () => {
+    mockFetch.mockResolvedValue([
+      {
+        id: 7,
+        name: 'Mew hunt',
+        description: null,
+        created_at: '2026-06-06T00:00:00',
+        item_count: 1,
+      },
+    ])
+    mockFetchWishlist.mockResolvedValue({
+      id: 7,
+      name: 'Mew hunt',
+      description: null,
+      created_at: '2026-06-06T00:00:00',
+      items: [
+        {
+          id: 11,
+          card: { id: 'base1-4', name: 'Charizard' },
+          notes: null,
+          max_price: null,
+          added_at: '2026-06-06T00:00:00',
+          card_set_id: 'base1',
+          card_number: '4',
+          card_name: 'Charizard',
+          card_rarity: 'Rare Holo',
+          card_types: null,
+          card_image_url: null,
+          price_snapshot: null,
+          priced_at: null,
+          acquired_at: null,
+          acquired_collection_item_id: null,
+        },
+      ],
+    })
+    render(<LibraryWishlistsTab />)
+    await waitFor(() => expect(screen.getByText('Mew hunt')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByText('Mew hunt'))
+
+    await waitFor(() =>
+      expect(screen.getByText('1 still chasing · 0 landed')).toBeInTheDocument(),
+    )
+    expect(mockFetchWishlist).toHaveBeenCalledWith(7)
+    expect(screen.getByText('Charizard')).toBeInTheDocument()
   })
 })

--- a/web/src/components/LibraryWishlistsTab.tsx
+++ b/web/src/components/LibraryWishlistsTab.tsx
@@ -5,11 +5,14 @@
  * creates entries here, optionally with a price cap.
  */
 import { Loader2 } from 'lucide-react'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
+import type { WishlistSummary } from '../api/client'
 import { useWishlists } from './useWishlists'
+import { WishlistDetail } from './WishlistDetail'
 
 export function LibraryWishlistsTab() {
   const { wishlists, loading, error, refresh } = useWishlists()
+  const [openWishlist, setOpenWishlist] = useState<WishlistSummary | null>(null)
 
   useEffect(() => {
     void refresh()
@@ -38,24 +41,40 @@ export function LibraryWishlistsTab() {
   }
 
   return (
-    <ul className="divide-y divide-sand-200 dark:divide-husk-100">
-      {wishlists.map((w) => (
-        <li key={w.id} className="flex items-center justify-between py-2">
-          <div className="min-w-0">
-            <div className="truncate text-xs font-medium text-coconut-700 dark:text-sand-50">
-              {w.name}
-            </div>
-            {w.description && (
-              <div className="truncate text-[11px] text-coconut-400 dark:text-sand-300">
-                {w.description}
+    <>
+      <ul className="divide-y divide-sand-200 dark:divide-husk-100">
+        {wishlists.map((w) => (
+          <li key={w.id}>
+            <button
+              type="button"
+              onClick={() => setOpenWishlist(w)}
+              className="flex w-full items-center justify-between rounded py-2 text-left hover:bg-sand-100 dark:hover:bg-husk-100"
+            >
+              <div className="min-w-0">
+                <div className="truncate text-xs font-medium text-coconut-700 dark:text-sand-50">
+                  {w.name}
+                </div>
+                {w.description && (
+                  <div className="truncate text-[11px] text-coconut-400 dark:text-sand-300">
+                    {w.description}
+                  </div>
+                )}
               </div>
-            )}
-          </div>
-          <span className="ml-3 shrink-0 rounded bg-sand-200 px-2 py-0.5 text-[11px] text-coconut-600 dark:bg-husk-100 dark:text-sand-200">
-            {w.item_count} {w.item_count === 1 ? 'card' : 'cards'}
-          </span>
-        </li>
-      ))}
-    </ul>
+              <span className="ml-3 shrink-0 rounded bg-sand-200 px-2 py-0.5 text-[11px] text-coconut-600 dark:bg-husk-100 dark:text-sand-200">
+                {w.item_count} {w.item_count === 1 ? 'card' : 'cards'}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      <WishlistDetail
+        wishlist={openWishlist}
+        open={openWishlist !== null}
+        onOpenChange={(o) => {
+          if (!o) setOpenWishlist(null)
+        }}
+      />
+    </>
   )
 }

--- a/web/src/components/WishlistDetail.test.tsx
+++ b/web/src/components/WishlistDetail.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { WishlistDetail } from './WishlistDetail'
+import { _resetCollectionsCacheForTests } from './useCollections'
+import {
+  fetchWishlist,
+  fetchCollections,
+  promoteWishlistItem,
+} from '../api/client'
+
+vi.mock('../api/client', () => ({
+  fetchWishlist: vi.fn(),
+  promoteWishlistItem: vi.fn(),
+  fetchCollections: vi.fn(),
+  createCollection: vi.fn(),
+  addCardToCollection: vi.fn(),
+}))
+
+const mockFetchWishlist = vi.mocked(fetchWishlist)
+const mockFetchCollections = vi.mocked(fetchCollections)
+const mockPromote = vi.mocked(promoteWishlistItem)
+
+const WISHLIST = {
+  id: 7,
+  name: 'Mew hunt',
+  description: null,
+  created_at: '2026-06-06T00:00:00',
+  item_count: 2,
+}
+
+function item(overrides: Record<string, unknown>) {
+  return {
+    id: 1,
+    card: { id: 'base1-4', name: 'Charizard' },
+    notes: null,
+    max_price: null,
+    added_at: '2026-06-06T00:00:00',
+    card_set_id: 'base1',
+    card_number: '4',
+    card_name: 'Charizard',
+    card_rarity: 'Rare Holo',
+    card_types: null,
+    card_image_url: null,
+    price_snapshot: null,
+    priced_at: null,
+    acquired_at: null,
+    acquired_collection_item_id: null,
+    ...overrides,
+  }
+}
+
+describe('WishlistDetail', () => {
+  beforeEach(() => {
+    _resetCollectionsCacheForTests()
+    mockFetchWishlist.mockReset()
+    mockFetchCollections.mockReset()
+    mockPromote.mockReset()
+    mockFetchCollections.mockResolvedValue([])
+  })
+
+  it('lists items with an outstanding / landed count', async () => {
+    mockFetchWishlist.mockResolvedValue({
+      ...WISHLIST,
+      items: [
+        item({ id: 1, card_name: 'Charizard' }),
+        item({ id: 2, card_name: 'Blastoise', acquired_at: '2026-06-07T00:00:00', acquired_collection_item_id: 99 }),
+      ],
+    })
+    render(<WishlistDetail wishlist={WISHLIST} open onOpenChange={() => {}} />)
+
+    await waitFor(() =>
+      expect(screen.getByText('1 still chasing · 1 landed')).toBeInTheDocument(),
+    )
+    expect(screen.getByText('Charizard')).toBeInTheDocument()
+    // The acquired one is struck through.
+    expect(screen.getByText('Blastoise')).toHaveClass('line-through')
+  })
+
+  it('promotes an item into a collection and marks it acquired', async () => {
+    mockFetchWishlist.mockResolvedValue({
+      ...WISHLIST,
+      items: [item({ id: 1, card_name: 'Charizard' })],
+    })
+    mockFetchCollections.mockResolvedValue([
+      {
+        id: 3,
+        name: 'Show Binder',
+        description: null,
+        created_at: '2026-06-06T00:00:00',
+        item_count: 5,
+      },
+    ])
+    mockPromote.mockResolvedValue({
+      wishlist_item: item({
+        id: 1,
+        card_name: 'Charizard',
+        acquired_at: '2026-06-08T00:00:00',
+        acquired_collection_item_id: 42,
+      }),
+      collection_item: {} as never,
+    })
+    render(<WishlistDetail wishlist={WISHLIST} open onOpenChange={() => {}} />)
+
+    await waitFor(() => expect(screen.getByText('Charizard')).toBeInTheDocument())
+
+    // Radix DropdownMenu opens on the keyboard activation path under jsdom.
+    const trigger = screen.getByRole('button', { name: /got it/i })
+    trigger.focus()
+    fireEvent.keyDown(trigger, { key: 'Enter', code: 'Enter' })
+
+    const target = (await screen.findByText('Show Binder')).closest(
+      '[role="menuitem"]',
+    )!
+    fireEvent.click(target)
+
+    await waitFor(() =>
+      expect(mockPromote).toHaveBeenCalledWith(7, 1, { collectionId: 3 }),
+    )
+    // The row flips from "still chasing" to "landed".
+    await waitFor(() =>
+      expect(screen.getByText('0 still chasing · 1 landed')).toBeInTheDocument(),
+    )
+  })
+})

--- a/web/src/components/WishlistDetail.tsx
+++ b/web/src/components/WishlistDetail.tsx
@@ -1,0 +1,339 @@
+/**
+ * WishlistDetail — the detail view for a wishlist (#504). Opens from a row
+ * in [LibraryWishlistsTab](./LibraryWishlistsTab.tsx).
+ *
+ * A wishlist is the chase board: cards you're hunting. This modal lists each
+ * item with a "got it" affordance that promotes it into a collection
+ * (`POST /wishlists/{id}/items/{item_id}/promote`) — the moment a chase
+ * becomes ownership. Acquired items aren't deleted: they sink to the bottom,
+ * struck through, so the want-list keeps doubling as a show retrospective.
+ */
+import * as Dialog from '@radix-ui/react-dialog'
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
+import { Check, Heart, ImageOff, Loader2, Plus, X } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import {
+  fetchWishlist,
+  promoteWishlistItem,
+  type WishlistItem,
+  type WishlistSummary,
+} from '../api/client'
+import { invalidateOwnership } from './useCardOwnership'
+import { useCollections } from './useCollections'
+
+interface Props {
+  wishlist: WishlistSummary | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+function cardImage(item: WishlistItem): string | undefined {
+  if (item.card_image_url) return item.card_image_url
+  const images = item.card.images as { small?: string; large?: string } | undefined
+  return images?.small ?? images?.large
+}
+
+function cardLabel(item: WishlistItem): string {
+  return item.card_name ?? (item.card.name as string | undefined) ?? 'Unknown card'
+}
+
+function cardRef(item: WishlistItem): string {
+  return `${item.card_set_id ?? ''}${item.card_number ? `-${item.card_number}` : ''}`
+}
+
+/** Per-item "got it" → collection picker. Collections come back most-recent
+ * first from the API, so the dropdown already shows recents at the top. */
+function GotItPicker({
+  onPromote,
+  busy,
+}: {
+  onPromote: (collectionId: number) => Promise<void>
+  busy: boolean
+}) {
+  const { collections, loading, error, create } = useCollections()
+  const [open, setOpen] = useState(false)
+  const [newOpen, setNewOpen] = useState(false)
+  const [newName, setNewName] = useState('')
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  async function handleCreateAndPromote() {
+    const name = newName.trim()
+    if (!name) return
+    setSubmitError(null)
+    try {
+      const created = await create(name)
+      await onPromote(created.id)
+      setNewName('')
+      setNewOpen(false)
+      setOpen(false)
+    } catch (e) {
+      setSubmitError(e instanceof Error ? e.message : String(e))
+    }
+  }
+
+  return (
+    <DropdownMenu.Root open={open} onOpenChange={setOpen}>
+      <DropdownMenu.Trigger asChild>
+        <button
+          type="button"
+          disabled={busy}
+          className="inline-flex items-center gap-1 rounded bg-palm-500 px-2 py-1 text-[11px] font-medium text-coconut-50 hover:bg-palm-600 disabled:opacity-50 dark:text-husk-300"
+        >
+          {busy ? <Loader2 size={11} className="animate-spin" /> : <Check size={11} />}
+          Got it
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="end"
+          sideOffset={4}
+          className="z-[60] w-56 rounded-md border border-sand-300 bg-sand-50 p-1 shadow-lg dark:border-husk-50 dark:bg-husk-200"
+        >
+          <DropdownMenu.Label className="px-2 py-1 text-xs font-semibold uppercase tracking-wider text-coconut-400 dark:text-sand-300">
+            Add to collection
+          </DropdownMenu.Label>
+          {loading && (
+            <div className="flex items-center gap-2 px-2 py-2 text-xs text-coconut-400 dark:text-sand-300">
+              <Loader2 size={12} className="animate-spin" /> Loading…
+            </div>
+          )}
+          {error && (
+            <div className="px-2 py-2 text-xs text-sun-600 dark:text-sun-300">{error}</div>
+          )}
+          {!loading && !error && collections.length === 0 && (
+            <div className="px-2 py-2 text-xs text-coconut-400 dark:text-sand-300">
+              No collections yet.
+            </div>
+          )}
+          {collections.map((c) => (
+            <DropdownMenu.Item
+              key={c.id}
+              onSelect={(e) => {
+                e.preventDefault()
+                void onPromote(c.id).then(() => setOpen(false))
+              }}
+              className="flex cursor-pointer items-center justify-between rounded px-2 py-1.5 text-sm text-coconut-700 outline-none hover:bg-sand-200 dark:text-sand-50 dark:hover:bg-husk-100"
+            >
+              <span className="truncate">{c.name}</span>
+              <span className="text-xs text-coconut-400 dark:text-sand-300">{c.item_count}</span>
+            </DropdownMenu.Item>
+          ))}
+          <DropdownMenu.Separator className="my-1 h-px bg-sand-200 dark:bg-husk-100" />
+          {newOpen ? (
+            <div className="flex items-center gap-1 px-1 py-1">
+              <input
+                autoFocus
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    void handleCreateAndPromote()
+                  } else if (e.key === 'Escape') {
+                    e.preventDefault()
+                    setNewOpen(false)
+                    setNewName('')
+                  }
+                }}
+                placeholder="Collection name"
+                className="flex-1 rounded border border-sand-300 bg-sand-50 px-2 py-1 text-xs text-coconut-700 placeholder:text-coconut-300 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:border-coconut-500 dark:bg-husk-100 dark:text-sand-50 dark:placeholder:text-sand-500 dark:focus:ring-sun-300"
+                aria-label="New collection name"
+              />
+              <button
+                type="button"
+                onClick={() => void handleCreateAndPromote()}
+                disabled={!newName.trim()}
+                className="rounded bg-palm-400 px-2 py-1 text-xs font-medium text-sand-50 hover:bg-palm-300 disabled:opacity-50 dark:bg-sun-300 dark:text-husk-500 dark:hover:bg-sun-200"
+              >
+                Save
+              </button>
+            </div>
+          ) : (
+            <DropdownMenu.Item
+              onSelect={(e) => {
+                e.preventDefault()
+                setNewOpen(true)
+              }}
+              className="flex cursor-pointer items-center gap-1.5 rounded px-2 py-1.5 text-sm text-palm-500 outline-none hover:bg-sand-200 dark:text-sun-300 dark:hover:bg-husk-100"
+            >
+              <Plus size={13} /> New collection…
+            </DropdownMenu.Item>
+          )}
+          {submitError && (
+            <div className="px-2 py-1 text-xs text-sun-600 dark:text-sun-300">{submitError}</div>
+          )}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
+}
+
+function ItemRow({
+  item,
+  onPromote,
+}: {
+  item: WishlistItem
+  onPromote: (itemId: number, collectionId: number) => Promise<void>
+}) {
+  const [broken, setBroken] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const acquired = item.acquired_at != null
+  const img = cardImage(item)
+
+  return (
+    <li className="flex items-center gap-3 py-2">
+      <div className="flex h-12 w-9 shrink-0 items-center justify-center overflow-hidden rounded bg-sand-200 dark:bg-husk-100">
+        {img && !broken ? (
+          <img
+            src={img}
+            alt={cardLabel(item)}
+            loading="lazy"
+            onError={() => setBroken(true)}
+            className={`h-full w-full object-contain ${acquired ? 'opacity-50' : ''}`}
+          />
+        ) : (
+          <ImageOff size={14} className="text-coconut-400 dark:text-sand-300" />
+        )}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div
+          className={`truncate text-xs font-medium ${
+            acquired
+              ? 'text-coconut-400 line-through dark:text-sand-300'
+              : 'text-coconut-700 dark:text-sand-50'
+          }`}
+        >
+          {cardLabel(item)}
+        </div>
+        <div className="truncate text-[11px] text-coconut-400 dark:text-sand-300">
+          {cardRef(item)}
+          {item.card_rarity ? ` · ${item.card_rarity}` : ''}
+        </div>
+      </div>
+      {acquired ? (
+        <span className="inline-flex shrink-0 items-center gap-1 rounded bg-palm-100 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-palm-700 dark:bg-husk-100 dark:text-palm-300">
+          <Check size={10} /> Got it
+        </span>
+      ) : (
+        <GotItPicker
+          busy={busy}
+          onPromote={async (collectionId) => {
+            setBusy(true)
+            try {
+              await onPromote(item.id, collectionId)
+            } finally {
+              setBusy(false)
+            }
+          }}
+        />
+      )}
+    </li>
+  )
+}
+
+export function WishlistDetail({ wishlist, open, onOpenChange }: Props) {
+  const collections = useCollections()
+  const [items, setItems] = useState<WishlistItem[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open || !wishlist) return
+    let cancelled = false
+    const load = async () => {
+      setItems([])
+      setError(null)
+      setLoading(true)
+      try {
+        const full = await fetchWishlist(wishlist.id)
+        if (!cancelled) setItems(full.items)
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e))
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [open, wishlist])
+
+  async function handlePromote(itemId: number, collectionId: number) {
+    if (!wishlist) return
+    const res = await promoteWishlistItem(wishlist.id, itemId, { collectionId })
+    // Swap the acquired row in place — it stays in the list, struck through.
+    setItems((prev) => prev.map((i) => (i.id === itemId ? res.wishlist_item : i)))
+    // The card is now owned: refresh the collection counts and drop the
+    // cross-surface ownership badge cache (#576).
+    void collections.refresh()
+    invalidateOwnership()
+  }
+
+  // Outstanding chases first, acquired ones sunk to the bottom.
+  const sorted = [...items].sort((a, b) => {
+    const aDone = a.acquired_at != null ? 1 : 0
+    const bDone = b.acquired_at != null ? 1 : 0
+    return aDone - bDone
+  })
+  const outstanding = items.filter((i) => i.acquired_at == null).length
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-coconut-700/50 backdrop-blur-sm dark:bg-husk-500/70" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-[min(560px,92vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-sand-300 bg-sand-50 shadow-2xl dark:border-husk-50 dark:bg-husk-200">
+          <header className="flex items-center justify-between gap-3 border-b border-sand-200 px-5 py-4 dark:border-husk-100">
+            <div className="flex min-w-0 items-center gap-2">
+              <Heart size={18} className="shrink-0 text-coconut-600 dark:text-sand-200" />
+              <Dialog.Title className="truncate text-lg font-semibold text-coconut-700 dark:text-sand-50">
+                {wishlist?.name ?? 'Wishlist'}
+              </Dialog.Title>
+            </div>
+            <Dialog.Close asChild>
+              <button
+                aria-label="Close"
+                className="rounded p-1 text-coconut-500 hover:bg-sand-200 dark:text-sand-300 dark:hover:bg-husk-100"
+              >
+                <X size={18} />
+              </button>
+            </Dialog.Close>
+          </header>
+          <Dialog.Description className="sr-only">
+            Cards on this want-list. Mark one &ldquo;got it&rdquo; to move it into a
+            collection.
+          </Dialog.Description>
+
+          <div className="flex-1 overflow-y-auto px-5 py-4">
+            {loading ? (
+              <div className="flex items-center gap-2 text-xs text-coconut-400 dark:text-sand-300">
+                <Loader2 size={14} className="animate-spin" />
+                Loading cards…
+              </div>
+            ) : error ? (
+              <div role="alert" className="text-xs text-sun-600 dark:text-sun-300">
+                {error}
+              </div>
+            ) : items.length === 0 ? (
+              <p className="text-xs text-coconut-500 dark:text-sand-300">
+                This want-list is empty. Click the heart icon on a matched row to add a
+                chase.
+              </p>
+            ) : (
+              <>
+                <div className="mb-2 text-[11px] text-coconut-400 dark:text-sand-300">
+                  {outstanding} still chasing · {items.length - outstanding} landed
+                </div>
+                <ul className="divide-y divide-sand-200 dark:divide-husk-100">
+                  {sorted.map((item) => (
+                    <ItemRow key={item.id} item={item} onPromote={handlePromote} />
+                  ))}
+                </ul>
+              </>
+            )}
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}


### PR DESCRIPTION
Closes #504

## What

The lifecycle step that turns a chased want-list card into an owned collection card.

- **New endpoint** `POST /api/v1/wishlists/{id}/items/{item_id}/promote { collection_id, quantity?, notes? }` — marks the wishlist item acquired (stamps `acquired_at` + `acquired_collection_item_id`), inserts a `collection_items` row with `added_via='wishlist_promote'`, and returns both rows. Guards: re-promoting an already-acquired item is a `409`, promoting into a dynamic (rule-defined) collection is a `409`, and the item lookup is scoped through the parent wishlist so a foreign id `404`s instead of leaking existence.
- **SPA affordance** — each wishlist row now opens a detail modal listing its cards. Outstanding chases sort to the top, each with a "got it" button that opens a collection picker (most-recent collections first, plus inline "new collection…"). Acquired cards aren't deleted: they sink to the bottom, struck through, with a "got it" badge — so the want-list keeps doubling as a post-show retrospective.

Built on the `#574`/`#582` data-model rework, which had already added the `acquired_at`, `acquired_collection_item_id`, and `added_via` columns.

## Why

Chasing is the want-list's job; owning is the collection's job. The promote operation is what makes that split load-bearing instead of cosmetic — without it, you either duplicate the card by hand or never close the loop.

## How to verify

1. `make dev-api` + `make dev-web`.
2. Add a few cards to a wishlist (heart icon on a matched row), and create a collection or two.
3. Open the **Library → Wishlists** tab and click a wishlist to open its detail.
4. Click **Got it** on a card → pick a collection. The card flips to a struck-through "got it" row at the bottom, the header count updates (`N still chasing · M landed`), and the card now appears in that collection (`added_via='wishlist_promote'`).
5. The same card can't be promoted twice (the button is gone); the endpoint returns `409` if re-called.

Verified end-to-end locally: promoting Charizard from a 3-card want-list moved it to "1 landed", sank it to the bottom struck through, and incremented the target collection to 1 item.

## Notes

- Deployment-neutral: no new env vars, persistence, or health-check changes, so `render.yaml` is untouched.
- Backend + web tests added (`tests/test_wishlists.py` promote suite, `WishlistDetail.test.tsx`, plus a row-opens-detail case on `LibraryWishlistsTab.test.tsx`). Full `make check` + `npm run build` green.