### PR TITLE
web: bulk row actions in the results table (multi-select → add to binder / retag / export / delete)

### DIFF
--- a/api/routes/collections.py
+++ b/api/routes/collections.py
@@ -21,6 +21,7 @@ Endpoints:
 - `PATCH  /collections/{id}`                  rename / edit description / rule
 - `DELETE /collections/{id}`                  cascade-delete items
 - `POST   /collections/{id}/items`            add a card (manual/set only)
+- `POST   /collections/{id}/items/bulk`       add many cards at once (#268/#509)
 - `DELETE /collections/{id}/items/{item_id}`  remove a card (manual/set only)
 - `GET    /collections/{id}/target`           catalog-backed membership + ownership overlay (#631)
 - `POST   /collections/{id}/chase`            push the un-owned matches onto a want-list (#631)
@@ -215,6 +216,27 @@ class CollectionItemCreate(BaseModel):
     added_via: str | None = None
 
 
+class BulkItemsCreate(BaseModel):
+    """Add a set of matched cards to a manual/set collection in one call.
+
+    Backs the results-table "add selected to binder (owned)" bulk action
+    (#268) and the haul mode (#509). Each card lands as its own quantity-1
+    row, mirroring the single-card :class:`CollectionItemCreate` insert; the
+    optional ``notes`` / ``added_via`` apply to every row in the batch."""
+
+    cards: list[dict[str, Any]] = Field(min_length=1, max_length=500)
+    notes: str | None = None
+    added_via: str | None = None
+
+
+class BulkAddResult(BaseModel):
+    """Count plus the created rows, so the SPA can bump item counts and
+    invalidate the cross-surface ownership cache (#576) in one round-trip."""
+
+    added: int
+    items: list[CollectionItemOut]
+
+
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -354,6 +376,47 @@ def add_collection_item(
     db.commit()
     db.refresh(item)
     return serialize_collection_item(item)
+
+
+@router.post("/collections/{collection_id}/items/bulk", status_code=201)
+def add_collection_items_bulk(
+    collection_id: int,
+    req: BulkItemsCreate,
+    db: DbSession,
+    current_user: CurrentUser,
+) -> dict:
+    """Add every card in ``req.cards`` to the collection in one transaction.
+
+    Same per-card handling as the single :func:`add_collection_item` (identity
+    + price-snapshot extraction, ``manual`` provenance by default); dynamic
+    collections are rejected for the same reason."""
+    collection = _load_collection(db, collection_id, current_user.id)
+    _reject_if_dynamic(collection)
+    now = datetime.now(UTC)
+    items: list[CollectionItem] = []
+    for card in req.cards:
+        promoted = extract_card_identity(card)
+        price = extract_price_snapshot(card)
+        items.append(
+            CollectionItem(
+                collection_id=collection.id,
+                card_json=card,
+                notes=req.notes,
+                quantity=1,
+                added_via=req.added_via or ADDED_VIA_MANUAL,
+                price_snapshot=price,
+                priced_at=now if price is not None else None,
+                **promoted,
+            )
+        )
+    db.add_all(items)
+    db.commit()
+    for item in items:
+        db.refresh(item)
+    return BulkAddResult(
+        added=len(items),
+        items=[CollectionItemOut(**serialize_collection_item(i)) for i in items],
+    ).model_dump()
 
 
 @router.delete("/collections/{collection_id}/items/{item_id}", status_code=204)

--- a/api/routes/wishlists.py
+++ b/api/routes/wishlists.py
@@ -15,6 +15,7 @@ Endpoints:
 - `PATCH  /wishlists/{id}`                  rename / edit description
 - `DELETE /wishlists/{id}`                  cascade-delete items
 - `POST   /wishlists/{id}/items`            add a card (optional max_price)
+- `POST   /wishlists/{id}/items/bulk`       add many cards at once (#268)
 - `DELETE /wishlists/{id}/items/{item_id}`  remove a card
 - `POST   /wishlists/{id}/items/{item_id}/promote`  acquire → collection (#504)
 """
@@ -110,6 +111,24 @@ class WishlistItemCreate(BaseModel):
     notes: str | None = None
     # Optional alert threshold — persisted but not yet wired to alerting.
     max_price: float | None = Field(default=None, ge=0)
+
+
+class BulkWishlistItemsCreate(BaseModel):
+    """Add a set of matched cards to a want-list in one call — the
+    results-table "add selected to binder (chasing)" bulk action (#268).
+    ``notes`` / ``max_price`` apply to every row in the batch."""
+
+    cards: list[dict[str, Any]] = Field(min_length=1, max_length=500)
+    notes: str | None = None
+    max_price: float | None = Field(default=None, ge=0)
+
+
+class BulkAddResult(BaseModel):
+    """Count plus the created rows, so the SPA can bump item counts and
+    invalidate the cross-surface ownership cache (#576) in one round-trip."""
+
+    added: int
+    items: list[WishlistItemOut]
 
 
 class PromoteRequest(BaseModel):
@@ -238,6 +257,42 @@ def add_wishlist_item(
     db.commit()
     db.refresh(item)
     return _serialize_item(item)
+
+
+@router.post("/wishlists/{wishlist_id}/items/bulk", status_code=201)
+def add_wishlist_items_bulk(
+    wishlist_id: int,
+    req: BulkWishlistItemsCreate,
+    db: DbSession,
+    current_user: CurrentUser,
+) -> dict:
+    """Add every card in ``req.cards`` to the want-list in one transaction —
+    same per-card handling as the single :func:`add_wishlist_item`."""
+    wishlist = _load_wishlist(db, wishlist_id, current_user.id)
+    now = datetime.now(UTC)
+    items: list[WishlistItem] = []
+    for card in req.cards:
+        promoted = extract_card_identity(card)
+        price = extract_price_snapshot(card)
+        items.append(
+            WishlistItem(
+                wishlist_id=wishlist.id,
+                card_json=card,
+                notes=req.notes,
+                max_price=req.max_price,
+                price_snapshot=price,
+                priced_at=now if price is not None else None,
+                **promoted,
+            )
+        )
+    db.add_all(items)
+    db.commit()
+    for item in items:
+        db.refresh(item)
+    return BulkAddResult(
+        added=len(items),
+        items=[WishlistItemOut(**_serialize_item(i)) for i in items],
+    ).model_dump()
 
 
 @router.delete("/wishlists/{wishlist_id}/items/{item_id}", status_code=204)

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -437,6 +437,49 @@ class CollectionsEndpointTests(_IsolatedDbMixin):
             resp = c.delete(f"/api/v1/collections/{cid_b}/items/{item_id}")
             self.assertEqual(resp.status_code, 404)
 
+    def test_bulk_add_items_round_trip(self) -> None:
+        # #268 — drop a multi-select of matched rows into a collection in one
+        # call. Each card lands as its own row and the response carries them.
+        second = {**SAMPLE_CARD, "id": "base1-2", "name": "Blastoise", "number": "2"}
+        with self._client() as c:
+            cid = c.post("/api/v1/collections", json={"name": "Show haul"}).json()["id"]
+
+            resp = c.post(
+                f"/api/v1/collections/{cid}/items/bulk",
+                json={"cards": [SAMPLE_CARD, second], "added_via": "bulk"},
+            )
+            self.assertEqual(resp.status_code, 201)
+            body = resp.json()
+            self.assertEqual(body["added"], 2)
+            self.assertEqual({i["card"]["name"] for i in body["items"]}, {"Charizard", "Blastoise"})
+            self.assertTrue(all(i["added_via"] == "bulk" for i in body["items"]))
+
+            detail = c.get(f"/api/v1/collections/{cid}").json()
+            self.assertEqual(len(detail["items"]), 2)
+            self.assertEqual(c.get("/api/v1/collections").json()["items"][0]["item_count"], 2)
+
+    def test_bulk_add_rejects_empty_list(self) -> None:
+        with self._client() as c:
+            cid = c.post("/api/v1/collections", json={"name": "k"}).json()["id"]
+            resp = c.post(f"/api/v1/collections/{cid}/items/bulk", json={"cards": []})
+            self.assertEqual(resp.status_code, 422)
+
+    def test_bulk_add_404_for_missing_collection(self) -> None:
+        with self._client() as c:
+            resp = c.post("/api/v1/collections/9999/items/bulk", json={"cards": [SAMPLE_CARD]})
+            self.assertEqual(resp.status_code, 404)
+
+    def test_bulk_add_rejects_dynamic_collection(self) -> None:
+        # A dynamic collection's membership is its rule — direct adds are 409,
+        # same as the single-item endpoint.
+        with self._client() as c:
+            cid = c.post(
+                "/api/v1/collections",
+                json={"name": "All Eevees", "kind": "dynamic", "rule": {"name": "eevee"}},
+            ).json()["id"]
+            resp = c.post(f"/api/v1/collections/{cid}/items/bulk", json={"cards": [SAMPLE_CARD]})
+            self.assertEqual(resp.status_code, 409)
+
 
 # ---------------------------------------------------------------------------
 # Dynamic (rule-based) collections (#506)

--- a/tests/test_wishlists.py
+++ b/tests/test_wishlists.py
@@ -255,6 +255,36 @@ class WishlistsEndpointTests(_IsolatedDbMixin):
             resp = c.delete(f"/api/v1/wishlists/{wid_b}/items/{item_id}")
             self.assertEqual(resp.status_code, 404)
 
+    def test_bulk_add_items_round_trip(self) -> None:
+        # #268 — add a multi-select of matched rows to a want-list at once,
+        # with a shared price cap stamped on every row.
+        second = {**SAMPLE_CARD, "id": "base1-2", "name": "Blastoise", "number": "2"}
+        with self._client() as c:
+            wid = c.post("/api/v1/wishlists", json={"name": "Chase board"}).json()["id"]
+
+            resp = c.post(
+                f"/api/v1/wishlists/{wid}/items/bulk",
+                json={"cards": [SAMPLE_CARD, second], "max_price": 50},
+            )
+            self.assertEqual(resp.status_code, 201)
+            body = resp.json()
+            self.assertEqual(body["added"], 2)
+            self.assertEqual({i["card"]["name"] for i in body["items"]}, {"Charizard", "Blastoise"})
+            self.assertTrue(all(i["max_price"] == 50 for i in body["items"]))
+
+            self.assertEqual(len(c.get(f"/api/v1/wishlists/{wid}").json()["items"]), 2)
+
+    def test_bulk_add_rejects_empty_list(self) -> None:
+        with self._client() as c:
+            wid = c.post("/api/v1/wishlists", json={"name": "k"}).json()["id"]
+            resp = c.post(f"/api/v1/wishlists/{wid}/items/bulk", json={"cards": []})
+            self.assertEqual(resp.status_code, 422)
+
+    def test_bulk_add_404_for_missing_wishlist(self) -> None:
+        with self._client() as c:
+            resp = c.post("/api/v1/wishlists/9999/items/bulk", json={"cards": [SAMPLE_CARD]})
+            self.assertEqual(resp.status_code, 404)
+
 
 # ---------------------------------------------------------------------------
 # Promote: wishlist item → collection (#504)

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -692,6 +692,32 @@ export async function addCardToCollection(
   return (await res.json()) as CollectionItem
 }
 
+/** Result of a bulk add: the created rows plus their count (#268). */
+export interface BulkAddResult<T> {
+  added: number
+  items: T[]
+}
+
+/** Add many cards to a collection in one call — the results-table
+ * "add selected to binder (owned)" action (#268). */
+export async function bulkAddToCollection(
+  collectionId: number,
+  cards: Record<string, unknown>[],
+  opts?: { notes?: string | null; addedVia?: string },
+): Promise<BulkAddResult<CollectionItem>> {
+  const res = await fetch(`${BASE}/collections/${collectionId}/items/bulk`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      cards,
+      notes: opts?.notes ?? null,
+      added_via: opts?.addedVia ?? null,
+    }),
+  })
+  if (!res.ok) throw new Error(`bulk add to collection failed: ${res.status}`)
+  return (await res.json()) as BulkAddResult<CollectionItem>
+}
+
 // ---------------------------------------------------------------------------
 // wishlists
 // ---------------------------------------------------------------------------
@@ -807,6 +833,26 @@ export async function addCardToWishlist(
   })
   if (!res.ok) throw new Error(`add to wishlist failed: ${res.status}`)
   return (await res.json()) as WishlistItem
+}
+
+/** Add many cards to a want-list in one call — the results-table
+ * "add selected to binder (chasing)" action (#268). */
+export async function bulkAddToWishlist(
+  wishlistId: number,
+  cards: Record<string, unknown>[],
+  opts?: { notes?: string | null; maxPrice?: number | null },
+): Promise<BulkAddResult<WishlistItem>> {
+  const res = await fetch(`${BASE}/wishlists/${wishlistId}/items/bulk`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      cards,
+      notes: opts?.notes ?? null,
+      max_price: opts?.maxPrice ?? null,
+    }),
+  })
+  if (!res.ok) throw new Error(`bulk add to want-list failed: ${res.status}`)
+  return (await res.json()) as BulkAddResult<WishlistItem>
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/components/BulkActionBar.tsx
+++ b/web/src/components/BulkActionBar.tsx
@@ -1,0 +1,422 @@
+/**
+ * BulkActionBar — floating action bar for the results-table multi-select
+ * (#268). Slides up from the bottom when ≥1 row is selected and offers:
+ *
+ * - **Binder actions** — add the selected matched cards to a binder as
+ *   *owned* (a collection) or *chasing* (a want-list), backed by the bulk
+ *   endpoints (`bulkAdd` on [useCollections](./useCollections.ts) /
+ *   [useWishlists](./useWishlists.ts)). A picker lists existing binders and
+ *   can spin up a new one inline.
+ * - **View actions** — drop the selected rows from the current results
+ *   view, retag them (the export source tag), or export only the selection.
+ *
+ * Delete and retag mutate the ephemeral results rows in the store via the
+ * parent's callbacks; the parent keeps the removed rows so Undo can restore
+ * the last delete. Binder/Export tones follow the owned=palm / chasing=sun
+ * read (#576).
+ */
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
+import {
+  BookOpen,
+  Check,
+  Download,
+  Heart,
+  Loader2,
+  Plus,
+  RotateCcw,
+  Tags,
+  Trash2,
+  X,
+} from 'lucide-react'
+import { useState } from 'react'
+import { exportFile, type CollectionSummary, type WishlistSummary } from '../api/client'
+import { useAppStore } from '../store'
+import type { ExportFormat, Row } from '../types'
+import { useCollections } from './useCollections'
+import { useWishlists } from './useWishlists'
+
+const EXPORT_FORMATS: { format: ExportFormat; label: string }[] = [
+  { format: 'xlsx', label: 'Download .xlsx' },
+  { format: 'pdf', label: 'PDF binder' },
+  { format: 'condensed-pdf', label: 'Condensed PDF' },
+  { format: 'checklist', label: 'Checklist' },
+]
+
+interface Props {
+  selectedRows: Row[]
+  onClear: () => void
+  onDelete: () => void
+  onRetag: (tag: string) => void
+  canUndo: boolean
+  onUndo: () => void
+  /** Show the add-to-binder pickers. Signed-out users have no library, so
+   *  the parent passes false and only the view actions (retag / export /
+   *  delete) render. */
+  showBinderActions: boolean
+}
+
+export function BulkActionBar({
+  selectedRows,
+  onClear,
+  onDelete,
+  onRetag,
+  canUndo,
+  onUndo,
+  showBinderActions,
+}: Props) {
+  const settings = useAppStore((s) => s.settings)
+  const cards = selectedRows
+    .filter((r) => r.matched && r.card)
+    .map((r) => r.card as unknown as Record<string, unknown>)
+  const count = selectedRows.length
+
+  const [retagOpen, setRetagOpen] = useState(false)
+  const [tag, setTag] = useState('')
+  const [exporting, setExporting] = useState<ExportFormat | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  function submitRetag() {
+    onRetag(tag.trim())
+    setTag('')
+    setRetagOpen(false)
+  }
+
+  async function handleExport(format: ExportFormat) {
+    setExporting(format)
+    setError(null)
+    try {
+      await exportFile(selectedRows, format, {
+        maxPrice: settings.maxPrice,
+        title: settings.tag || 'cards',
+        sort: settings.sort,
+        noImages: settings.noImages,
+        dedupe: settings.dedupe,
+      })
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setExporting(null)
+    }
+  }
+
+  return (
+    <div
+      role="region"
+      aria-label="Bulk actions"
+      className="fixed inset-x-0 bottom-4 z-40 mx-auto flex w-fit max-w-[95vw] flex-col items-center gap-1"
+    >
+      <div className="flex flex-wrap items-center gap-2 rounded-full border border-sand-300 bg-sand-50/95 px-3 py-2 shadow-xl shadow-coconut-700/20 backdrop-blur dark:border-husk-50 dark:bg-husk-200/95">
+        <span className="px-1 text-xs font-medium text-coconut-600 tabular-nums dark:text-sand-200">
+          {count > 0 ? `${count} selected` : 'Rows removed'}
+        </span>
+
+        {count > 0 && (
+          <>
+            {showBinderActions && (
+              <>
+                <BinderPicker kind="owned" cards={cards} onClear={onClear} onError={setError} />
+                <BinderPicker kind="chasing" cards={cards} onClear={onClear} onError={setError} />
+
+                <span className="h-5 w-px bg-sand-300 dark:bg-husk-100" aria-hidden />
+              </>
+            )}
+
+            {retagOpen ? (
+              <div className="flex items-center gap-1">
+                <input
+                  autoFocus
+                  value={tag}
+                  onChange={(e) => setTag(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault()
+                      submitRetag()
+                    } else if (e.key === 'Escape') {
+                      e.preventDefault()
+                      setRetagOpen(false)
+                      setTag('')
+                    }
+                  }}
+                  placeholder="tag…"
+                  aria-label="New tag for selected rows"
+                  className="w-24 rounded border border-sand-300 bg-coconut-50 px-2 py-1 text-xs text-coconut-700 placeholder:text-coconut-400 dark:border-husk-100 dark:bg-husk-100 dark:text-sand-50"
+                />
+                <button
+                  type="button"
+                  onClick={submitRetag}
+                  className="rounded bg-palm-500 px-2 py-1 text-[11px] font-medium text-coconut-50 hover:bg-palm-600 dark:text-husk-300"
+                >
+                  Set
+                </button>
+              </div>
+            ) : (
+              <BarButton onClick={() => setRetagOpen(true)} icon={<Tags size={13} />} label="Retag" />
+            )}
+
+            <DropdownMenu.Root>
+              <DropdownMenu.Trigger asChild>
+                <button
+                  type="button"
+                  className="flex items-center gap-1 rounded px-2 py-1 text-xs font-medium text-coconut-600 hover:bg-sand-200 dark:text-sand-200 dark:hover:bg-husk-100"
+                >
+                  {exporting ? <Loader2 size={13} className="animate-spin" /> : <Download size={13} />}
+                  Export
+                </button>
+              </DropdownMenu.Trigger>
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content
+                  align="center"
+                  sideOffset={6}
+                  className="z-50 min-w-[180px] rounded-md border border-sand-300 bg-sand-50 p-1 shadow-lg dark:border-husk-50 dark:bg-husk-200"
+                >
+                  <DropdownMenu.Label className="px-2 py-1 text-xs font-semibold uppercase tracking-wider text-coconut-400 dark:text-sand-300">
+                    Export {count} selected
+                  </DropdownMenu.Label>
+                  {EXPORT_FORMATS.map((f) => (
+                    <DropdownMenu.Item
+                      key={f.format}
+                      onSelect={() => void handleExport(f.format)}
+                      className="flex cursor-pointer items-center rounded px-2 py-1.5 text-sm text-coconut-700 outline-none data-[highlighted]:bg-sand-200 dark:text-sand-50 dark:data-[highlighted]:bg-husk-100"
+                    >
+                      {f.label}
+                    </DropdownMenu.Item>
+                  ))}
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
+            </DropdownMenu.Root>
+
+            <BarButton
+              onClick={onDelete}
+              icon={<Trash2 size={13} />}
+              label="Delete"
+              tone="danger"
+            />
+          </>
+        )}
+
+        {canUndo && (
+          <BarButton onClick={onUndo} icon={<RotateCcw size={13} />} label="Undo" />
+        )}
+
+        <span className="h-5 w-px bg-sand-300 dark:bg-husk-100" aria-hidden />
+
+        <button
+          type="button"
+          onClick={onClear}
+          aria-label="Clear selection"
+          className="rounded p-1 text-coconut-400 hover:bg-sand-200 hover:text-coconut-700 dark:text-sand-300 dark:hover:bg-husk-100 dark:hover:text-sand-50"
+        >
+          <X size={14} />
+        </button>
+      </div>
+      {error && <span className="text-xs text-ember-500 dark:text-ember-300">{error}</span>}
+    </div>
+  )
+}
+
+function BarButton({
+  onClick,
+  icon,
+  label,
+  tone = 'default',
+}: {
+  onClick: () => void
+  icon: React.ReactNode
+  label: string
+  tone?: 'default' | 'danger'
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex items-center gap-1 rounded px-2 py-1 text-xs font-medium ${
+        tone === 'danger'
+          ? 'text-ember-600 hover:bg-ember-500/10 dark:text-ember-300'
+          : 'text-coconut-600 hover:bg-sand-200 dark:text-sand-200 dark:hover:bg-husk-100'
+      }`}
+    >
+      {icon}
+      {label}
+    </button>
+  )
+}
+
+/** Add-to-binder picker, parameterised by owned (collection) vs chasing
+ * (want-list). Lists the user's binders of that kind and can create a new
+ * one inline, then bulk-adds the selected matched cards. */
+function BinderPicker({
+  kind,
+  cards,
+  onClear,
+  onError,
+}: {
+  kind: 'owned' | 'chasing'
+  cards: Record<string, unknown>[]
+  onClear: () => void
+  onError: (msg: string | null) => void
+}) {
+  const collections = useCollections()
+  const wishlists = useWishlists()
+  const [open, setOpen] = useState(false)
+  const [busyId, setBusyId] = useState<number | null>(null)
+  const [justAdded, setJustAdded] = useState(false)
+  const [newOpen, setNewOpen] = useState(false)
+  const [newName, setNewName] = useState('')
+
+  const owned = kind === 'owned'
+  // Owned-scope dynamic collections are rule-defined — you can't hand-add to
+  // them, so keep them out of the picker.
+  const binders: (CollectionSummary | WishlistSummary)[] = owned
+    ? collections.collections.filter((c) => !('kind' in c) || c.kind === 'manual' || c.kind === 'set')
+    : wishlists.wishlists
+  const disabled = cards.length === 0
+
+  async function addTo(binderId: number) {
+    setBusyId(binderId)
+    onError(null)
+    try {
+      if (owned) await collections.bulkAdd(binderId, cards, { addedVia: 'bulk' })
+      else await wishlists.bulkAdd(binderId, cards)
+      setJustAdded(true)
+      setTimeout(() => {
+        setJustAdded(false)
+        setOpen(false)
+        onClear()
+      }, 700)
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  async function createAndAdd() {
+    const name = newName.trim()
+    if (!name) return
+    setBusyId(-1)
+    onError(null)
+    try {
+      const created = owned
+        ? await collections.create(name)
+        : await wishlists.create(name)
+      if (owned) await collections.bulkAdd(created.id, cards, { addedVia: 'bulk' })
+      else await wishlists.bulkAdd(created.id, cards)
+      setNewName('')
+      setNewOpen(false)
+      setJustAdded(true)
+      setTimeout(() => {
+        setJustAdded(false)
+        setOpen(false)
+        onClear()
+      }, 700)
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusyId(null)
+    }
+  }
+
+  return (
+    <DropdownMenu.Root open={open} onOpenChange={setOpen}>
+      <DropdownMenu.Trigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          title={disabled ? 'Select at least one matched card' : undefined}
+          className={`flex items-center gap-1 rounded px-2 py-1 text-xs font-medium disabled:opacity-40 ${
+            owned
+              ? 'text-palm-600 hover:bg-palm-500/10 dark:text-palm-200'
+              : 'text-husk-500 hover:bg-sun-400/15 dark:text-sun-200'
+          }`}
+        >
+          {owned ? <BookOpen size={13} /> : <Heart size={13} />}
+          {owned ? 'Add as owned' : 'Add as chasing'}
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="center"
+          sideOffset={6}
+          className="z-50 w-56 rounded-md border border-sand-300 bg-sand-50 p-1 shadow-lg dark:border-husk-50 dark:bg-husk-200"
+        >
+          <DropdownMenu.Label className="px-2 py-1 text-xs font-semibold uppercase tracking-wider text-coconut-400 dark:text-sand-300">
+            {owned ? 'Add to collection' : 'Add to want-list'}
+          </DropdownMenu.Label>
+          {justAdded && (
+            <div className="flex items-center gap-2 px-2 py-2 text-xs text-palm-600 dark:text-palm-200">
+              <Check size={12} /> Added {cards.length} {cards.length === 1 ? 'card' : 'cards'}
+            </div>
+          )}
+          {!justAdded && binders.length === 0 && (
+            <div className="px-2 py-2 text-xs text-coconut-400 dark:text-sand-300">
+              {owned ? 'No collections yet.' : 'No want-lists yet.'}
+            </div>
+          )}
+          {!justAdded &&
+            binders.map((b) => (
+              <DropdownMenu.Item
+                key={b.id}
+                onSelect={(e) => {
+                  e.preventDefault()
+                  void addTo(b.id)
+                }}
+                className="flex cursor-pointer items-center justify-between rounded px-2 py-1.5 text-sm text-coconut-700 outline-none data-[highlighted]:bg-sand-200 dark:text-sand-50 dark:data-[highlighted]:bg-husk-100"
+              >
+                <span className="truncate">{b.name}</span>
+                {busyId === b.id ? (
+                  <Loader2 size={12} className="animate-spin text-coconut-400 dark:text-sand-300" />
+                ) : (
+                  <span className="text-xs text-coconut-400 dark:text-sand-300">{b.item_count}</span>
+                )}
+              </DropdownMenu.Item>
+            ))}
+          {!justAdded && (
+            <>
+              <DropdownMenu.Separator className="my-1 h-px bg-sand-200 dark:bg-husk-100" />
+              {newOpen ? (
+                <div className="flex items-center gap-1 px-1 py-1">
+                  <input
+                    autoFocus
+                    value={newName}
+                    onChange={(e) => setNewName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault()
+                        void createAndAdd()
+                      } else if (e.key === 'Escape') {
+                        e.preventDefault()
+                        setNewOpen(false)
+                        setNewName('')
+                      }
+                    }}
+                    placeholder={owned ? 'Collection name' : 'Want-list name'}
+                    aria-label={owned ? 'New collection name' : 'New want-list name'}
+                    className="flex-1 rounded border border-sand-300 bg-sand-50 px-2 py-1 text-xs text-coconut-700 placeholder:text-coconut-300 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:border-coconut-500 dark:bg-husk-100 dark:text-sand-50"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => void createAndAdd()}
+                    disabled={busyId === -1 || !newName.trim()}
+                    className="rounded bg-palm-400 px-2 py-1 text-xs font-medium text-sand-50 hover:bg-palm-300 disabled:opacity-50 dark:bg-sun-300 dark:text-husk-500"
+                  >
+                    {busyId === -1 ? <Loader2 size={12} className="animate-spin" /> : 'Add'}
+                  </button>
+                </div>
+              ) : (
+                <DropdownMenu.Item
+                  onSelect={(e) => {
+                    e.preventDefault()
+                    setNewOpen(true)
+                  }}
+                  className="flex cursor-pointer items-center gap-1.5 rounded px-2 py-1.5 text-sm text-palm-500 outline-none data-[highlighted]:bg-sand-200 dark:text-sun-300 dark:data-[highlighted]:bg-husk-100"
+                >
+                  <Plus size={13} /> {owned ? 'New collection…' : 'New want-list…'}
+                </DropdownMenu.Item>
+              )}
+            </>
+          )}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
+}

--- a/web/src/components/ResultsTable.test.tsx
+++ b/web/src/components/ResultsTable.test.tsx
@@ -1,11 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { ResultsTable } from './ResultsTable'
 import { applyFilters, applySort } from './resultsTableFilter'
 import { EMPTY_VIEW_STATE, useAppStore } from '../store'
 import { _resetAuthStoreForTests } from '../hooks/useAuth'
-import { fetchCardOwnership } from '../api/client'
+import {
+  bulkAddToCollection,
+  exportFile,
+  fetchCardOwnership,
+  fetchCollections,
+} from '../api/client'
 import { _resetCardOwnershipForTests } from './useCardOwnership'
+import { _resetCollectionsCacheForTests } from './useCollections'
+import { _resetWishlistsCacheForTests } from './useWishlists'
 import type { Row } from '../types'
 
 const { fetchMeMock } = vi.hoisted(() => ({ fetchMeMock: vi.fn() }))
@@ -21,6 +28,17 @@ vi.mock('../api/client', () => ({
   // The matched rows trigger a cross-collection ownership lookup (#576);
   // default to "nothing owned" so no badge renders in existing tests.
   fetchCardOwnership: vi.fn(async () => ({})),
+  // The bulk action bar (#268) mounts on selection and reads the binder
+  // lists; default to empty so the pickers render their no-binders state.
+  fetchCollections: vi.fn(async () => []),
+  fetchWishlists: vi.fn(async () => []),
+  createCollection: vi.fn(),
+  createWishlist: vi.fn(),
+  addCardToCollection: vi.fn(),
+  addCardToWishlist: vi.fn(),
+  bulkAddToCollection: vi.fn(async () => ({ added: 0, items: [] })),
+  bulkAddToWishlist: vi.fn(async () => ({ added: 0, items: [] })),
+  exportFile: vi.fn(async () => undefined),
 }))
 
 beforeEach(() => {
@@ -42,8 +60,11 @@ beforeEach(() => {
     currentRunId: null,
   })
   _resetCardOwnershipForTests()
+  _resetCollectionsCacheForTests()
+  _resetWishlistsCacheForTests()
   vi.mocked(fetchCardOwnership).mockReset()
   vi.mocked(fetchCardOwnership).mockResolvedValue({})
+  vi.mocked(exportFile).mockClear()
 })
 
 function makeRow(over: Partial<Row> = {}): Row {
@@ -305,15 +326,19 @@ describe('ResultsTable', () => {
     })
     const bodyRow = container.querySelector('tbody tr')!
     const cells = bodyRow.querySelectorAll(':scope > td')
-    const firstCell = cells[0]
-    expect(firstCell.querySelector('button[aria-label="Save to collection"]')).not.toBeNull()
-    expect(firstCell.querySelector('button[aria-label="Save to wishlist"]')).not.toBeNull()
+    // The selection checkbox (#268) is pinned leftmost, so the save-actions
+    // cell is the one holding the buttons — find it rather than assume index.
+    const actionsCell = Array.from(cells).find((td) =>
+      td.querySelector('button[aria-label="Save to collection"]'),
+    )!
+    expect(actionsCell).toBeTruthy()
+    expect(actionsCell.querySelector('button[aria-label="Save to wishlist"]')).not.toBeNull()
     const nameCell = Array.from(cells).find((td) =>
       td.textContent?.includes('Charizard'),
     )
     expect(nameCell).toBeTruthy()
     expect(
-      firstCell.compareDocumentPosition(nameCell!) & Node.DOCUMENT_POSITION_FOLLOWING,
+      actionsCell.compareDocumentPosition(nameCell!) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy()
     useAppStore.setState({ rows: [] })
   })
@@ -734,6 +759,228 @@ describe('ResultsTable: hide owned (#339)', () => {
     expect(await screen.findByText('owned ×2')).toBeInTheDocument()
     expect(screen.getByText('Charizard')).toBeInTheDocument()
     expect(screen.queryByText(/owned hidden/)).toBeNull()
+
+    useAppStore.setState({ rows: [] })
+  })
+})
+
+describe('ResultsTable: bulk row actions (#268)', () => {
+  function matched(name: string, number: string, market = 100): Row {
+    return makeRow({
+      card: { id: `base1-${number}`, name, number, set: { id: 'base1', name: 'Base Set' } },
+      pricing: { market, currency: 'USD', variant: null, source: 'TCGPlayer', url: null },
+    })
+  }
+
+  // Sign out so the binder pickers (which need a library) stay hidden — the
+  // view actions under test (select / delete / retag / export) don't need a
+  // user, and this keeps the bar free of async collection fetches.
+  function signOut() {
+    fetchMeMock.mockReset()
+    fetchMeMock.mockResolvedValue({ user: null, authEnabled: true })
+    _resetAuthStoreForTests()
+  }
+
+  function bar() {
+    return screen.getByRole('region', { name: /bulk actions/i })
+  }
+
+  it('shows the action bar with a count once a row is selected', () => {
+    signOut()
+    useAppStore.setState({
+      rows: [matched('Charizard', '4'), matched('Pikachu', '58')],
+      isRunning: false,
+      progress: null,
+    })
+    render(<ResultsTable />)
+
+    expect(screen.queryByRole('region', { name: /bulk actions/i })).toBeNull()
+    fireEvent.click(screen.getByLabelText('Select Charizard'))
+    expect(within(bar()).getByText('1 selected')).toBeInTheDocument()
+
+    useAppStore.setState({ rows: [] })
+  })
+
+  it('select-all selects every visible row, then clears them', () => {
+    signOut()
+    useAppStore.setState({
+      rows: [matched('Charizard', '4'), matched('Pikachu', '58'), matched('Squirtle', '63')],
+      isRunning: false,
+      progress: null,
+    })
+    render(<ResultsTable />)
+
+    fireEvent.click(screen.getByLabelText('Select all rows'))
+    expect(within(bar()).getByText('3 selected')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByLabelText('Select all rows'))
+    expect(screen.queryByRole('region', { name: /bulk actions/i })).toBeNull()
+
+    useAppStore.setState({ rows: [] })
+  })
+
+  it('shift-click selects the contiguous range from the anchor', () => {
+    signOut()
+    useAppStore.setState({
+      rows: [matched('A', '1'), matched('B', '2'), matched('C', '3'), matched('D', '4')],
+      isRunning: false,
+      progress: null,
+    })
+    render(<ResultsTable />)
+
+    fireEvent.click(screen.getByLabelText('Select A')) // anchor
+    fireEvent.click(screen.getByLabelText('Select C'), { shiftKey: true })
+    // A, B, C are now selected; D is not.
+    expect(within(bar()).getByText('3 selected')).toBeInTheDocument()
+
+    useAppStore.setState({ rows: [] })
+  })
+
+  it('Delete drops the selected rows and Undo restores them', () => {
+    signOut()
+    useAppStore.setState({
+      rows: [matched('Charizard', '4'), matched('Pikachu', '58')],
+      isRunning: false,
+      progress: null,
+    })
+    render(<ResultsTable />)
+
+    fireEvent.click(screen.getByLabelText('Select Charizard'))
+    fireEvent.click(within(bar()).getByRole('button', { name: /delete/i }))
+
+    expect(useAppStore.getState().rows.map((r) => r.card?.name)).toEqual(['Pikachu'])
+    // The bar stays up in its "Rows removed" state so Undo is reachable.
+    expect(within(bar()).getByText(/rows removed/i)).toBeInTheDocument()
+
+    fireEvent.click(within(bar()).getByRole('button', { name: /undo/i }))
+    expect(useAppStore.getState().rows.map((r) => r.card?.name)).toEqual([
+      'Charizard',
+      'Pikachu',
+    ])
+
+    useAppStore.setState({ rows: [] })
+  })
+
+  it('Retag applies the tag to only the selected rows', () => {
+    signOut()
+    useAppStore.setState({
+      rows: [matched('Charizard', '4'), matched('Pikachu', '58')],
+      isRunning: false,
+      progress: null,
+    })
+    render(<ResultsTable />)
+
+    fireEvent.click(screen.getByLabelText('Select Charizard'))
+    fireEvent.click(within(bar()).getByRole('button', { name: /retag/i }))
+    fireEvent.change(screen.getByLabelText(/new tag for selected rows/i), {
+      target: { value: 'show-a' },
+    })
+    fireEvent.click(within(bar()).getByRole('button', { name: /^set$/i }))
+
+    const rows = useAppStore.getState().rows
+    expect(rows.find((r) => r.card?.name === 'Charizard')?.tag).toBe('show-a')
+    expect(rows.find((r) => r.card?.name === 'Pikachu')?.tag).toBe('')
+
+    useAppStore.setState({ rows: [] })
+  })
+
+  it('Export selected sends only the selected rows to exportFile', async () => {
+    signOut()
+    useAppStore.setState({
+      rows: [matched('Charizard', '4'), matched('Pikachu', '58')],
+      isRunning: false,
+      progress: null,
+    })
+    render(<ResultsTable />)
+
+    fireEvent.click(screen.getByLabelText('Select Pikachu'))
+    // Radix DropdownMenu opens on the keyboard activation path under jsdom.
+    const trigger = within(bar()).getByRole('button', { name: /export/i })
+    trigger.focus()
+    fireEvent.keyDown(trigger, { key: 'Enter', code: 'Enter' })
+    fireEvent.click(await screen.findByText('Download .xlsx'))
+
+    await waitFor(() => expect(vi.mocked(exportFile)).toHaveBeenCalled())
+    const [rowsArg, format] = vi.mocked(exportFile).mock.calls[0]
+    expect(format).toBe('xlsx')
+    expect(rowsArg.map((r) => r.card?.name)).toEqual(['Pikachu'])
+
+    useAppStore.setState({ rows: [] })
+  })
+
+  it('clears the selection on sort by default, keeps it when "preserve" is on', () => {
+    signOut()
+    useAppStore.setState({
+      rows: [matched('Charizard', '4'), matched('Abra', '1')],
+      isRunning: false,
+      progress: null,
+    })
+    render(<ResultsTable />)
+
+    // Select, then sort — selection clears because preserve is off.
+    fireEvent.click(screen.getByLabelText('Select Charizard'))
+    expect(within(bar()).getByText('1 selected')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /sort by name/i }))
+    expect(screen.queryByRole('region', { name: /bulk actions/i })).toBeNull()
+
+    // Re-select, flip preserve on, then sort again — selection survives.
+    fireEvent.click(screen.getByLabelText('Select Charizard'))
+    fireEvent.click(screen.getByLabelText(/keep selection across sort/i))
+    fireEvent.click(screen.getByRole('button', { name: /sort by name/i }))
+    expect(within(bar()).getByText('1 selected')).toBeInTheDocument()
+
+    useAppStore.setState({ rows: [] })
+  })
+
+  it('hides the add-to-binder pickers for a signed-out user', () => {
+    signOut()
+    useAppStore.setState({
+      rows: [matched('Charizard', '4')],
+      isRunning: false,
+      progress: null,
+    })
+    render(<ResultsTable />)
+
+    fireEvent.click(screen.getByLabelText('Select Charizard'))
+    // View actions are present; binder pickers are not.
+    expect(within(bar()).getByRole('button', { name: /retag/i })).toBeInTheDocument()
+    expect(within(bar()).queryByRole('button', { name: /add as owned/i })).toBeNull()
+    expect(within(bar()).queryByRole('button', { name: /add as chasing/i })).toBeNull()
+
+    useAppStore.setState({ rows: [] })
+  })
+
+  it('adds the selected matched cards to a collection via the binder picker', async () => {
+    // Signed-in default mock → binder pickers render. Seed one collection.
+    vi.mocked(fetchCollections).mockResolvedValue([
+      {
+        id: 7,
+        name: 'Show Binder',
+        description: null,
+        created_at: '2026-06-06T00:00:00',
+        item_count: 0,
+      },
+    ])
+    vi.mocked(bulkAddToCollection).mockResolvedValue({ added: 2, items: [] })
+    useAppStore.setState({
+      rows: [matched('Charizard', '4'), matched('Pikachu', '58')],
+      isRunning: false,
+      progress: null,
+    })
+    render(<ResultsTable />)
+
+    fireEvent.click(screen.getByLabelText('Select all rows'))
+    const owned = await within(bar()).findByRole('button', { name: /add as owned/i })
+    owned.focus()
+    fireEvent.keyDown(owned, { key: 'Enter', code: 'Enter' })
+
+    const item = (await screen.findByText('Show Binder')).closest('[role="menuitem"]')!
+    fireEvent.click(item)
+
+    await waitFor(() => expect(vi.mocked(bulkAddToCollection)).toHaveBeenCalled())
+    const [collectionId, cards] = vi.mocked(bulkAddToCollection).mock.calls[0]
+    expect(collectionId).toBe(7)
+    expect(cards).toHaveLength(2)
 
     useAppStore.setState({ rows: [] })
   })

--- a/web/src/components/ResultsTable.tsx
+++ b/web/src/components/ResultsTable.tsx
@@ -14,6 +14,7 @@
 import { useCallback, useMemo, useState } from 'react'
 import { ArrowDown, ArrowUp, ArrowUpDown, ExternalLink, AlertCircle, Filter } from 'lucide-react'
 import { addOverride } from '../api/client'
+import { BulkActionBar } from './BulkActionBar'
 import { useAuth } from '../hooks/useAuth'
 import { useAppStore } from '../store'
 import type { ResultsFilters, Row } from '../types'
@@ -73,7 +74,7 @@ interface Props {
 }
 
 export function ResultsTable({ onRerunLine }: Props) {
-  const { rows, progress, isRunning, settings, viewState, setViewState, resetViewState } =
+  const { rows, setRows, progress, isRunning, settings, viewState, setViewState, resetViewState } =
     useAppStore()
   const { sortColumn, sortDir, showFilters, filters } = viewState
   // Hoist the auth read here (not in ResultRow) so we don't fire one
@@ -155,6 +156,135 @@ export function ResultsTable({ onRerunLine }: Props) {
   )
   const hiddenOwnedCount = displayedRows.length - visibleRows.length
 
+  // ---- Multi-select (#268) -------------------------------------------------
+  // Selection is tracked by Row object reference: it rides along through
+  // sort/filter re-ordering, and a fresh lookup (new Row objects) drops it
+  // for free. Ephemeral by design — never persisted.
+  const [selected, setSelected] = useState<Set<Row>>(() => new Set())
+  // Index into `visibleRows` of the last toggled row, the anchor for a
+  // shift-click range.
+  const [anchorIdx, setAnchorIdx] = useState<number | null>(null)
+  // Power-user opt-in: keep the selection when the sort or filter changes.
+  // Off by default so selection clears on any view change.
+  const [preserveAcrossSort, setPreserveAcrossSort] = useState(false)
+  // Snapshot of `rows` taken just before a bulk delete so Undo can restore it.
+  const [undoSnapshot, setUndoSnapshot] = useState<Row[] | null>(null)
+
+  // Selection intersected with the current view, in view order — this is
+  // what the action bar operates on, so delete/retag/export all naturally
+  // honor the active sort + filter.
+  const selectedRows = useMemo(
+    () => visibleRows.filter((r) => selected.has(r)),
+    [visibleRows, selected],
+  )
+
+  // Clear the selection when the sort or filter changes (unless the
+  // power-user "preserve across sort" toggle is on), and when a fresh
+  // lookup starts. Done during render via React's "adjust state on a
+  // change" pattern rather than an effect, so there's no extra commit.
+  const viewSig = `${sortColumn}|${sortDir}|${JSON.stringify(filters)}`
+  const [prevViewSig, setPrevViewSig] = useState(viewSig)
+  if (viewSig !== prevViewSig) {
+    setPrevViewSig(viewSig)
+    if (!preserveAcrossSort && (selected.size > 0 || anchorIdx !== null)) {
+      setSelected(new Set())
+      setAnchorIdx(null)
+    }
+  }
+
+  const [prevRunning, setPrevRunning] = useState(isRunning)
+  if (isRunning !== prevRunning) {
+    setPrevRunning(isRunning)
+    // A fresh lookup just started — drop selection + undo from the old run.
+    // (Keyed on the run, not rows.length, so deleting every row still leaves
+    // Undo reachable.)
+    if (isRunning) {
+      if (selected.size > 0 || anchorIdx !== null) {
+        setSelected(new Set())
+        setAnchorIdx(null)
+      }
+      if (undoSnapshot !== null) setUndoSnapshot(null)
+    }
+  }
+
+  const toggleRow = useCallback(
+    (displayedIdx: number, shiftKey: boolean) => {
+      setSelected((prev) => {
+        const next = new Set(prev)
+        if (shiftKey && anchorIdx !== null) {
+          // Shift-click selects the whole range between the anchor and the
+          // clicked row (inclusive).
+          const lo = Math.min(anchorIdx, displayedIdx)
+          const hi = Math.max(anchorIdx, displayedIdx)
+          for (let i = lo; i <= hi; i++) next.add(visibleRows[i])
+        } else {
+          const row = visibleRows[displayedIdx]
+          if (next.has(row)) next.delete(row)
+          else next.add(row)
+        }
+        return next
+      })
+      setAnchorIdx(displayedIdx)
+    },
+    [visibleRows, anchorIdx],
+  )
+
+  const allSelected = visibleRows.length > 0 && visibleRows.every((r) => selected.has(r))
+  const someSelected = visibleRows.some((r) => selected.has(r))
+
+  const toggleAll = useCallback(() => {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      const everyVisibleSelected =
+        visibleRows.length > 0 && visibleRows.every((r) => next.has(r))
+      if (everyVisibleSelected) visibleRows.forEach((r) => next.delete(r))
+      else visibleRows.forEach((r) => next.add(r))
+      return next
+    })
+    setAnchorIdx(null)
+  }, [visibleRows])
+
+  const clearSelection = useCallback(() => {
+    setSelected(new Set())
+    setAnchorIdx(null)
+  }, [])
+
+  // Delete the selected rows from the results view, snapshotting the prior
+  // `rows` so Undo can put them back. Selection clears — the rows are gone.
+  const handleDelete = useCallback(() => {
+    const toRemove = selected
+    if (toRemove.size === 0) return
+    setUndoSnapshot(rows)
+    setRows(rows.filter((r) => !toRemove.has(r)))
+    setSelected(new Set())
+    setAnchorIdx(null)
+  }, [rows, selected, setRows])
+
+  const handleUndo = useCallback(() => {
+    if (!undoSnapshot) return
+    setRows(undoSnapshot)
+    setUndoSnapshot(null)
+  }, [undoSnapshot, setRows])
+
+  // Retag the selected rows in place, remapping the selection onto the new
+  // Row objects so the bar's count stays put after the action.
+  const handleRetag = useCallback(
+    (tag: string) => {
+      const sel = selected
+      if (sel.size === 0) return
+      const next = new Set<Row>()
+      const newRows = rows.map((r) => {
+        if (!sel.has(r)) return r
+        const retagged = { ...r, tag }
+        next.add(retagged)
+        return retagged
+      })
+      setRows(newRows)
+      setSelected(next)
+    },
+    [rows, selected, setRows],
+  )
+
   if (rows.length === 0 && !isRunning) {
     return (
       <div className="flex items-center justify-center rounded-md border border-sand-300 dark:border-husk-50 bg-sand-50 dark:bg-husk-200 py-16 text-coconut-400 dark:text-sand-300 text-sm">
@@ -200,6 +330,17 @@ export function ResultsTable({ onRerunLine }: Props) {
           {showFilters ? 'Hide filters' : 'Filter'}
         </button>
         <div className="flex items-center gap-3">
+          {selectedRows.length > 0 && (
+            <label className="flex items-center gap-1.5 text-xs text-coconut-400 dark:text-sand-300 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={preserveAcrossSort}
+                onChange={(e) => setPreserveAcrossSort(e.target.checked)}
+                className="h-3.5 w-3.5 rounded border-sand-300 text-palm-500 focus:ring-palm-400 dark:border-husk-50 dark:text-sun-300"
+              />
+              Keep selection across sort
+            </label>
+          )}
           <SaveSearchButton auth={auth} />
           {(sortColumn || hasActiveFilters(filters)) && (
             <button
@@ -229,6 +370,18 @@ export function ResultsTable({ onRerunLine }: Props) {
         <table className="w-full text-sm border-collapse">
           <thead>
             <tr className="border-b border-sand-300 dark:border-husk-50 bg-sand-100 dark:bg-husk-200 text-left">
+              <th className="px-3 py-2 w-8">
+                <input
+                  type="checkbox"
+                  aria-label="Select all rows"
+                  checked={allSelected}
+                  ref={(el) => {
+                    if (el) el.indeterminate = someSelected && !allSelected
+                  }}
+                  onChange={toggleAll}
+                  className="h-3.5 w-3.5 rounded border-sand-300 text-palm-500 focus:ring-palm-400 dark:border-husk-50 dark:text-sun-300"
+                />
+              </th>
               {showSavedActions && (
                 <th className="px-3 py-2 text-xs font-medium text-coconut-400 dark:text-sand-300 w-20">
                   <span className="sr-only">Save actions</span>
@@ -291,6 +444,9 @@ export function ResultsTable({ onRerunLine }: Props) {
             </tr>
             {showFilters && (
               <tr className="border-b border-sand-300 dark:border-husk-50 bg-sand-50 dark:bg-husk-200">
+                <th>
+                  <span className="sr-only">Select (no filter)</span>
+                </th>
                 {showSavedActions && (
                   <th>
                     <span className="sr-only">Save actions (no filter)</span>
@@ -387,11 +543,13 @@ export function ResultsTable({ onRerunLine }: Props) {
                 ownership={ownershipForRow(row, lookupOwnership)}
                 onRerunLine={onRerunLine}
                 onOpenDetail={() => setDetailIndex(displayedIdx)}
+                selected={selected.has(row)}
+                onSelect={(shiftKey) => toggleRow(displayedIdx, shiftKey)}
               />
             ))}
             {isRunning && (
               <tr>
-                <td colSpan={13} className="py-2 px-3">
+                <td colSpan={14} className="py-2 px-3">
                   <div className="h-1 w-24 rounded animate-pulse bg-sand-200 dark:bg-husk-100" />
                 </td>
               </tr>
@@ -399,6 +557,18 @@ export function ResultsTable({ onRerunLine }: Props) {
           </tbody>
         </table>
       </div>
+
+      {(selectedRows.length > 0 || undoSnapshot !== null) && (
+        <BulkActionBar
+          selectedRows={selectedRows}
+          onClear={clearSelection}
+          onDelete={handleDelete}
+          onRetag={handleRetag}
+          canUndo={undoSnapshot !== null}
+          onUndo={handleUndo}
+          showBinderActions={showSavedActions}
+        />
+      )}
 
       <CardDetailModal
         rows={visibleRows}
@@ -498,6 +668,8 @@ function ResultRow({
   ownership,
   onRerunLine,
   onOpenDetail,
+  selected,
+  onSelect,
 }: {
   row: Row
   showImage: boolean
@@ -506,6 +678,8 @@ function ResultRow({
   ownership: CardOwnership | null | undefined
   onRerunLine?: (line: string) => void
   onOpenDetail?: () => void
+  selected: boolean
+  onSelect: (shiftKey: boolean) => void
 }) {
   const card = row.card
   const p = row.pricing
@@ -574,6 +748,19 @@ function ResultRow({
             : undefined
         }
       >
+        {/* Selection checkbox — onClick carries shiftKey for range select;
+            a no-op onChange keeps the input controlled without a warning. */}
+        <td className="px-3 py-1.5 w-8">
+          <input
+            type="checkbox"
+            aria-label={`Select ${(card?.name as string) ?? row.query.raw}`}
+            checked={selected}
+            onClick={(e) => onSelect(e.shiftKey)}
+            onChange={() => {}}
+            className="h-3.5 w-3.5 rounded border-sand-300 text-palm-500 focus:ring-palm-400 dark:border-husk-50 dark:text-sun-300"
+          />
+        </td>
+
         {/* Row actions — pinned left so they stay visible on narrow
             viewports where the table overflows horizontally. */}
         {showSavedActions && (
@@ -712,7 +899,7 @@ function ResultRow({
       {/* Override URL form (inline, expands below row) */}
       {showOverrideForm && (
         <tr className="border-b border-sand-200 dark:border-husk-100 bg-sand-100 dark:bg-husk-200/60">
-          <td colSpan={13} className="px-3 py-2">
+          <td colSpan={14} className="px-3 py-2">
             <div className="flex items-center gap-2">
               <input
                 type="url"

--- a/web/src/components/useCollections.ts
+++ b/web/src/components/useCollections.ts
@@ -8,6 +8,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import {
   addCardToCollection,
+  bulkAddToCollection,
   createCollection,
   fetchCollections,
   type CollectionSummary,
@@ -110,11 +111,32 @@ export function useCollections() {
     [],
   )
 
+  const bulkAdd = useCallback(
+    async (
+      collectionId: number,
+      cards: Record<string, unknown>[],
+      opts?: { notes?: string | null; addedVia?: string },
+    ) => {
+      const result = await bulkAddToCollection(collectionId, cards, opts)
+      // Every added card's ownership badge (#576) is now stale — drop the
+      // shared cache so it re-fetches.
+      invalidateOwnership()
+      set({
+        collections: state.collections.map((c) =>
+          c.id === collectionId ? { ...c, item_count: c.item_count + result.added } : c,
+        ),
+      })
+      return result
+    },
+    [],
+  )
+
   return {
     ...snapshot,
     refresh,
     create,
     addCard,
+    bulkAdd,
   }
 }
 

--- a/web/src/components/useWishlists.ts
+++ b/web/src/components/useWishlists.ts
@@ -8,6 +8,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import {
   addCardToWishlist,
+  bulkAddToWishlist,
   createWishlist,
   fetchWishlists,
   type WishlistSummary,
@@ -99,11 +100,30 @@ export function useWishlists() {
     [],
   )
 
+  const bulkAdd = useCallback(
+    async (
+      wishlistId: number,
+      cards: Record<string, unknown>[],
+      opts?: { notes?: string | null; maxPrice?: number | null },
+    ) => {
+      const result = await bulkAddToWishlist(wishlistId, cards, opts)
+      invalidateOwnership()
+      set({
+        wishlists: state.wishlists.map((w) =>
+          w.id === wishlistId ? { ...w, item_count: w.item_count + result.added } : w,
+        ),
+      })
+      return result
+    },
+    [],
+  )
+
   return {
     ...snapshot,
     refresh,
     create,
     addCard,
+    bulkAdd,
   }
 }
 


### PR DESCRIPTION
Closes #268

## What

Adds multi-select to the results table and a floating bulk-action bar.

- A left-edge checkbox column: per-row checkboxes, a header **select-all** (with an indeterminate state when only some rows are selected), and **shift-click** to select a contiguous range from the last-clicked anchor.
- A floating action bar slides in when ≥1 row is selected, offering **add to binder** (owned / chasing), **Retag…**, **Export selected**, and **Delete** with **Undo**.
- A **"Keep selection across sort"** toggle for power users.

## Why

A 50-row results table was a row-at-a-time interaction. This lets you say "drop these five, retag those eight, add the rest to a binder" in a few clicks.

## How it works

- Selection is **ephemeral** and tracked by `Row` reference, so it rides through sort/filter re-ordering and drops on its own when a fresh lookup replaces the rows. It clears on any sort/filter change by default; the preserve toggle opts out.
- Delete / retag / export operate on the selection **intersected with the current view**, so export-selected honors the active sort + filter (acceptance criterion). Delete snapshots the prior rows so Undo can restore them — keyed on the run, not on row count, so deleting *every* row still leaves Undo reachable.
- The add-to-binder pickers are gated on a signed-in user (they need a library); signed-out users still get the view actions. This reuses the bulk endpoints from 833cab7 via the new `bulkAddToCollection` / `bulkAddToWishlist` client calls and the `bulkAdd` hooks on `useCollections` / `useWishlists`.

## How to verify

1. Run a lookup, then tick a couple of rows — the bar appears with an N-selected count.
2. Shift-click a row below to select the range; use the header checkbox to select/clear all.
3. **Retag** the selection and confirm only those rows pick up the tag; **Export** and confirm only the selected rows are sent; **Delete** then **Undo**.
4. Turn on **Keep selection across sort**, sort a column, and confirm the selection survives (off by default, it clears).
5. Signed in: **Add as owned / Add as chasing** lists your binders and bulk-adds the selected matched cards.

Verified live (signed-out view, view actions + select-all + preserve toggle), and covered by the component-test suite: `web/src/components/ResultsTable.test.tsx` exercises selection mechanics, every bulk action, the binder picker, and the preserve toggle.

## Tests

`make check` green (900 Python tests, web ESLint, oxlint, site build); `cd web && npm run build` green. The `useSwipeCandidates` "no extra fetch" full-suite flake (#387) passes in isolation.