### PR TITLE
feat(web): delete buttons for binders — remove a collection, want-list, or want-list card

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -718,6 +718,14 @@ export async function bulkAddToCollection(
   return (await res.json()) as BulkAddResult<CollectionItem>
 }
 
+/** Delete a collection and cascade-remove its items. */
+export async function deleteCollection(collectionId: number): Promise<void> {
+  const res = await fetch(`${BASE}/collections/${collectionId}`, { method: 'DELETE' })
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`delete collection failed: ${res.status}`)
+  }
+}
+
 // ---------------------------------------------------------------------------
 // wishlists
 // ---------------------------------------------------------------------------
@@ -853,6 +861,27 @@ export async function bulkAddToWishlist(
   })
   if (!res.ok) throw new Error(`bulk add to want-list failed: ${res.status}`)
   return (await res.json()) as BulkAddResult<WishlistItem>
+}
+
+/** Delete a want-list and cascade-remove its items. */
+export async function deleteWishlist(wishlistId: number): Promise<void> {
+  const res = await fetch(`${BASE}/wishlists/${wishlistId}`, { method: 'DELETE' })
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`delete want-list failed: ${res.status}`)
+  }
+}
+
+/** Remove a single card from a want-list. */
+export async function deleteWishlistItem(
+  wishlistId: number,
+  itemId: number,
+): Promise<void> {
+  const res = await fetch(`${BASE}/wishlists/${wishlistId}/items/${itemId}`, {
+    method: 'DELETE',
+  })
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`remove want-list card failed: ${res.status}`)
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/components/LibraryBindersTab.test.tsx
+++ b/web/src/components/LibraryBindersTab.test.tsx
@@ -6,8 +6,10 @@ import { _resetWishlistsCacheForTests } from './useWishlists'
 import {
   fetchCollections,
   createCollection,
+  deleteCollection,
   fetchWishlists,
   fetchWishlist,
+  deleteWishlist,
   fetchCollectionTarget,
 } from '../api/client'
 
@@ -15,9 +17,11 @@ vi.mock('../api/client', () => ({
   fetchCollections: vi.fn(),
   createCollection: vi.fn(),
   addCardToCollection: vi.fn(),
+  deleteCollection: vi.fn(),
   fetchWishlists: vi.fn(),
   createWishlist: vi.fn(),
   addCardToWishlist: vi.fn(),
+  deleteWishlist: vi.fn(),
   fetchWishlist: vi.fn(),
   promoteWishlistItem: vi.fn(),
   fetchCollectionTarget: vi.fn(),
@@ -27,6 +31,8 @@ vi.mock('../api/client', () => ({
 const mockCollections = vi.mocked(fetchCollections)
 const mockWishlists = vi.mocked(fetchWishlists)
 const mockCreate = vi.mocked(createCollection)
+const mockDeleteCollection = vi.mocked(deleteCollection)
+const mockDeleteWishlist = vi.mocked(deleteWishlist)
 const mockFetchWishlist = vi.mocked(fetchWishlist)
 const mockTarget = vi.mocked(fetchCollectionTarget)
 
@@ -37,6 +43,8 @@ describe('LibraryBindersTab', () => {
     mockCollections.mockReset()
     mockWishlists.mockReset()
     mockCreate.mockReset()
+    mockDeleteCollection.mockReset()
+    mockDeleteWishlist.mockReset()
     mockFetchWishlist.mockReset()
     mockTarget.mockReset()
     mockCollections.mockResolvedValue([])
@@ -302,5 +310,51 @@ describe('LibraryBindersTab', () => {
     // The card name renders inside the opened detail dialog.
     const dialog = screen.getByRole('dialog')
     expect(within(dialog).getByText('Charizard')).toBeInTheDocument()
+  })
+
+  it('deletes a collection after the inline confirm', async () => {
+    mockCollections.mockResolvedValue([
+      { id: 1, name: 'Charizard masters', description: null, created_at: '2026-06-04T00:00:00', item_count: 4 },
+    ])
+    mockDeleteCollection.mockResolvedValue(undefined)
+    render(<LibraryBindersTab />)
+    await waitFor(() => expect(screen.getByText('Charizard masters')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: /delete collection "Charizard masters"/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+
+    await waitFor(() => expect(mockDeleteCollection).toHaveBeenCalledWith(1))
+    await waitFor(() =>
+      expect(screen.queryByText('Charizard masters')).not.toBeInTheDocument(),
+    )
+  })
+
+  it('deletes a want-list after the inline confirm', async () => {
+    mockWishlists.mockResolvedValue([
+      { id: 2, name: 'Mew hunt', description: null, created_at: '2026-06-06T00:00:00', item_count: 3 },
+    ])
+    mockDeleteWishlist.mockResolvedValue(undefined)
+    render(<LibraryBindersTab />)
+    await waitFor(() => expect(screen.getByText('Mew hunt')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: /delete want-list "Mew hunt"/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+
+    await waitFor(() => expect(mockDeleteWishlist).toHaveBeenCalledWith(2))
+    await waitFor(() => expect(screen.queryByText('Mew hunt')).not.toBeInTheDocument())
+  })
+
+  it('keeps the binder when the delete confirm is cancelled', async () => {
+    mockCollections.mockResolvedValue([
+      { id: 1, name: 'Charizard masters', description: null, created_at: '2026-06-04T00:00:00', item_count: 4 },
+    ])
+    render(<LibraryBindersTab />)
+    await waitFor(() => expect(screen.getByText('Charizard masters')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole('button', { name: /delete collection "Charizard masters"/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }))
+
+    expect(mockDeleteCollection).not.toHaveBeenCalled()
+    expect(screen.getByText('Charizard masters')).toBeInTheDocument()
   })
 })

--- a/web/src/components/LibraryBindersTab.tsx
+++ b/web/src/components/LibraryBindersTab.tsx
@@ -17,7 +17,7 @@
  * [OwnershipBadge](./OwnershipBadge.tsx) chip (#576): palm for owned,
  * sun for chasing.
  */
-import { Loader2, Sparkles } from 'lucide-react'
+import { Loader2, Sparkles, Trash2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import type {
   CollectionRule,
@@ -100,12 +100,14 @@ export function LibraryBindersTab() {
     error: cError,
     refresh: refreshCollections,
     create,
+    remove: removeCollection,
   } = useCollections()
   const {
     wishlists,
     loading: wLoading,
     error: wError,
     refresh: refreshWishlists,
+    remove: removeWishlist,
   } = useWishlists()
 
   const [filter, setFilter] = useState<BinderFilter>('all')
@@ -296,9 +298,15 @@ export function LibraryBindersTab() {
                 key={row.key}
                 collection={row.collection}
                 onOpenTarget={setTargetCollection}
+                onDelete={removeCollection}
               />
             ) : (
-              <WishlistRow key={row.key} wishlist={row.wishlist} onOpen={setOpenWishlist} />
+              <WishlistRow
+                key={row.key}
+                wishlist={row.wishlist}
+                onOpen={setOpenWishlist}
+                onDelete={removeWishlist}
+              />
             ),
           )}
         </ul>
@@ -346,9 +354,11 @@ function CardCount({ count }: { count: number }) {
 function CollectionRow({
   collection: c,
   onOpenTarget,
+  onDelete,
 }: {
   collection: CollectionSummary
   onOpenTarget: (c: CollectionSummary) => void
+  onDelete: (id: number) => Promise<void>
 }) {
   const pill = kindPill(c)
   // A catalog-scope target opens its progress detail; everything else is
@@ -378,18 +388,19 @@ function CollectionRow({
     </>
   )
   return (
-    <li>
+    <li className="group flex items-center gap-1">
       {openable ? (
         <button
           type="button"
           onClick={() => onOpenTarget(c)}
-          className="flex w-full items-center justify-between rounded py-2 text-left hover:bg-sand-100 dark:hover:bg-husk-100"
+          className="flex flex-1 items-center justify-between rounded py-2 text-left hover:bg-sand-100 dark:hover:bg-husk-100"
         >
           {body}
         </button>
       ) : (
-        <div className="flex items-center justify-between py-2">{body}</div>
+        <div className="flex flex-1 items-center justify-between py-2">{body}</div>
       )}
+      <DeleteBinderControl label={`collection "${c.name}"`} onDelete={() => onDelete(c.id)} />
     </li>
   )
 }
@@ -397,16 +408,18 @@ function CollectionRow({
 function WishlistRow({
   wishlist: w,
   onOpen,
+  onDelete,
 }: {
   wishlist: WishlistSummary
   onOpen: (w: WishlistSummary) => void
+  onDelete: (id: number) => Promise<void>
 }) {
   return (
-    <li>
+    <li className="group flex items-center gap-1">
       <button
         type="button"
         onClick={() => onOpen(w)}
-        className="flex w-full items-center justify-between rounded py-2 text-left hover:bg-sand-100 dark:hover:bg-husk-100"
+        className="flex flex-1 items-center justify-between rounded py-2 text-left hover:bg-sand-100 dark:hover:bg-husk-100"
       >
         <div className="min-w-0">
           <div className="flex items-center gap-1.5">
@@ -423,6 +436,80 @@ function WishlistRow({
         </div>
         <CardCount count={w.item_count} />
       </button>
+      <DeleteBinderControl label={`want-list "${w.name}"`} onDelete={() => onDelete(w.id)} />
     </li>
+  )
+}
+
+/**
+ * Two-step delete affordance for a binder row. The trash icon reveals on
+ * hover/focus (mirrors the Recent tab); clicking it swaps in an inline
+ * "Delete / Cancel" confirm, since removing a binder cascade-deletes its
+ * cards and can't be undone.
+ */
+function DeleteBinderControl({
+  label,
+  onDelete,
+}: {
+  label: string
+  onDelete: () => Promise<void>
+}) {
+  const [confirming, setConfirming] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [failed, setFailed] = useState(false)
+
+  async function handleConfirm() {
+    setBusy(true)
+    setFailed(false)
+    try {
+      // On success the row unmounts, so there's nothing to reset here.
+      await onDelete()
+    } catch {
+      setFailed(true)
+      setBusy(false)
+    }
+  }
+
+  if (confirming) {
+    return (
+      <div className="flex shrink-0 items-center gap-1">
+        {failed && (
+          <span role="alert" className="text-[10px] text-ember-500 dark:text-ember-300">
+            Couldn&apos;t delete
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={() => void handleConfirm()}
+          disabled={busy}
+          className="inline-flex items-center gap-1 rounded bg-ember-500 px-2 py-1 text-[11px] font-medium text-coconut-50 hover:bg-ember-600 disabled:opacity-50"
+        >
+          {busy && <Loader2 size={11} className="animate-spin" />}
+          Delete
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setConfirming(false)
+            setFailed(false)
+          }}
+          disabled={busy}
+          className="rounded px-2 py-1 text-[11px] font-medium text-coconut-500 hover:bg-sand-200 disabled:opacity-50 dark:text-sand-300 dark:hover:bg-husk-100"
+        >
+          Cancel
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => setConfirming(true)}
+      aria-label={`Delete ${label}`}
+      className="shrink-0 rounded p-1.5 text-coconut-400 opacity-100 transition-opacity hover:bg-sand-200 hover:text-ember-500 focus-visible:opacity-100 dark:text-sand-400 dark:hover:bg-husk-100 dark:hover:text-ember-300 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
+    >
+      <Trash2 size={14} />
+    </button>
   )
 }

--- a/web/src/components/WishlistDetail.test.tsx
+++ b/web/src/components/WishlistDetail.test.tsx
@@ -2,23 +2,33 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { WishlistDetail } from './WishlistDetail'
 import { _resetCollectionsCacheForTests } from './useCollections'
+import { _resetWishlistsCacheForTests } from './useWishlists'
 import {
   fetchWishlist,
   fetchCollections,
+  fetchWishlists,
   promoteWishlistItem,
+  deleteWishlistItem,
 } from '../api/client'
 
 vi.mock('../api/client', () => ({
   fetchWishlist: vi.fn(),
   promoteWishlistItem: vi.fn(),
+  deleteWishlistItem: vi.fn(),
   fetchCollections: vi.fn(),
   createCollection: vi.fn(),
   addCardToCollection: vi.fn(),
+  fetchWishlists: vi.fn(),
+  createWishlist: vi.fn(),
+  addCardToWishlist: vi.fn(),
+  deleteWishlist: vi.fn(),
 }))
 
 const mockFetchWishlist = vi.mocked(fetchWishlist)
 const mockFetchCollections = vi.mocked(fetchCollections)
+const mockFetchWishlists = vi.mocked(fetchWishlists)
 const mockPromote = vi.mocked(promoteWishlistItem)
+const mockDeleteItem = vi.mocked(deleteWishlistItem)
 
 const WISHLIST = {
   id: 7,
@@ -52,10 +62,14 @@ function item(overrides: Record<string, unknown>) {
 describe('WishlistDetail', () => {
   beforeEach(() => {
     _resetCollectionsCacheForTests()
+    _resetWishlistsCacheForTests()
     mockFetchWishlist.mockReset()
     mockFetchCollections.mockReset()
+    mockFetchWishlists.mockReset()
     mockPromote.mockReset()
+    mockDeleteItem.mockReset()
     mockFetchCollections.mockResolvedValue([])
+    mockFetchWishlists.mockResolvedValue([])
   })
 
   it('lists items with an outstanding / landed count', async () => {
@@ -120,5 +134,28 @@ describe('WishlistDetail', () => {
     await waitFor(() =>
       expect(screen.getByText('0 still chasing · 1 landed')).toBeInTheDocument(),
     )
+  })
+
+  it('removes a card from the want-list', async () => {
+    mockFetchWishlist.mockResolvedValue({
+      ...WISHLIST,
+      items: [
+        item({ id: 1, card_name: 'Charizard' }),
+        item({ id: 2, card_name: 'Blastoise' }),
+      ],
+    })
+    mockDeleteItem.mockResolvedValue(undefined)
+    render(<WishlistDetail wishlist={WISHLIST} open onOpenChange={() => {}} />)
+
+    await waitFor(() => expect(screen.getByText('Charizard')).toBeInTheDocument())
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /remove Charizard from this want-list/i }),
+    )
+
+    await waitFor(() => expect(mockDeleteItem).toHaveBeenCalledWith(7, 1))
+    await waitFor(() => expect(screen.queryByText('Charizard')).not.toBeInTheDocument())
+    // The other card stays.
+    expect(screen.getByText('Blastoise')).toBeInTheDocument()
   })
 })

--- a/web/src/components/WishlistDetail.tsx
+++ b/web/src/components/WishlistDetail.tsx
@@ -10,9 +10,10 @@
  */
 import * as Dialog from '@radix-ui/react-dialog'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
-import { Check, Heart, ImageOff, Loader2, Plus, X } from 'lucide-react'
+import { Check, Heart, ImageOff, Loader2, Plus, Trash2, X } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import {
+  deleteWishlistItem,
   fetchWishlist,
   promoteWishlistItem,
   type WishlistItem,
@@ -20,6 +21,7 @@ import {
 } from '../api/client'
 import { invalidateOwnership } from './useCardOwnership'
 import { useCollections } from './useCollections'
+import { useWishlists } from './useWishlists'
 
 interface Props {
   wishlist: WishlistSummary | null
@@ -171,17 +173,20 @@ function GotItPicker({
 function ItemRow({
   item,
   onPromote,
+  onRemove,
 }: {
   item: WishlistItem
   onPromote: (itemId: number, collectionId: number) => Promise<void>
+  onRemove: (itemId: number) => Promise<void>
 }) {
   const [broken, setBroken] = useState(false)
   const [busy, setBusy] = useState(false)
+  const [removing, setRemoving] = useState(false)
   const acquired = item.acquired_at != null
   const img = cardImage(item)
 
   return (
-    <li className="flex items-center gap-3 py-2">
+    <li className="group flex items-center gap-3 py-2">
       <div className="flex h-12 w-9 shrink-0 items-center justify-center overflow-hidden rounded bg-sand-200 dark:bg-husk-100">
         {img && !broken ? (
           <img
@@ -227,12 +232,30 @@ function ItemRow({
           }}
         />
       )}
+      <button
+        type="button"
+        disabled={removing}
+        aria-label={`Remove ${cardLabel(item)} from this want-list`}
+        onClick={async () => {
+          setRemoving(true)
+          try {
+            await onRemove(item.id)
+          } finally {
+            // On success the row unmounts; this only matters if the call failed.
+            setRemoving(false)
+          }
+        }}
+        className="shrink-0 rounded p-1.5 text-coconut-400 opacity-100 transition-opacity hover:bg-sand-200 hover:text-ember-500 disabled:opacity-50 dark:text-sand-400 dark:hover:bg-husk-100 dark:hover:text-ember-300 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
+      >
+        {removing ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />}
+      </button>
     </li>
   )
 }
 
 export function WishlistDetail({ wishlist, open, onOpenChange }: Props) {
   const collections = useCollections()
+  const wishlists = useWishlists()
   const [items, setItems] = useState<WishlistItem[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -267,6 +290,16 @@ export function WishlistDetail({ wishlist, open, onOpenChange }: Props) {
     // The card is now owned: refresh the collection counts and drop the
     // cross-surface ownership badge cache (#576).
     void collections.refresh()
+    invalidateOwnership()
+  }
+
+  async function handleRemove(itemId: number) {
+    if (!wishlist) return
+    await deleteWishlistItem(wishlist.id, itemId)
+    setItems((prev) => prev.filter((i) => i.id !== itemId))
+    // Keep the binder row's card count in sync and drop the stale ownership
+    // badge — the card is no longer on this want-list (#576).
+    void wishlists.refresh()
     invalidateOwnership()
   }
 
@@ -326,7 +359,12 @@ export function WishlistDetail({ wishlist, open, onOpenChange }: Props) {
                 </div>
                 <ul className="divide-y divide-sand-200 dark:divide-husk-100">
                   {sorted.map((item) => (
-                    <ItemRow key={item.id} item={item} onPromote={handlePromote} />
+                    <ItemRow
+                      key={item.id}
+                      item={item}
+                      onPromote={handlePromote}
+                      onRemove={handleRemove}
+                    />
                   ))}
                 </ul>
               </>

--- a/web/src/components/useCollections.ts
+++ b/web/src/components/useCollections.ts
@@ -10,6 +10,7 @@ import {
   addCardToCollection,
   bulkAddToCollection,
   createCollection,
+  deleteCollection,
   fetchCollections,
   type CollectionSummary,
   type CreateCollectionOptions,
@@ -131,12 +132,21 @@ export function useCollections() {
     [],
   )
 
+  const remove = useCallback(async (collectionId: number) => {
+    await deleteCollection(collectionId)
+    // Cascade-removed items drop the cards' ownership badges (#576) — bust
+    // the shared cache so they re-fetch.
+    invalidateOwnership()
+    set({ collections: state.collections.filter((c) => c.id !== collectionId) })
+  }, [])
+
   return {
     ...snapshot,
     refresh,
     create,
     addCard,
     bulkAdd,
+    remove,
   }
 }
 

--- a/web/src/components/useWishlists.ts
+++ b/web/src/components/useWishlists.ts
@@ -10,6 +10,7 @@ import {
   addCardToWishlist,
   bulkAddToWishlist,
   createWishlist,
+  deleteWishlist,
   fetchWishlists,
   type WishlistSummary,
 } from '../api/client'
@@ -118,12 +119,21 @@ export function useWishlists() {
     [],
   )
 
+  const remove = useCallback(async (wishlistId: number) => {
+    await deleteWishlist(wishlistId)
+    // Cascade-removed chases drop the cards' ownership badges (#576) — bust
+    // the shared cache so they re-fetch.
+    invalidateOwnership()
+    set({ wishlists: state.wishlists.filter((w) => w.id !== wishlistId) })
+  }, [])
+
   return {
     ...snapshot,
     refresh,
     create,
     addCard,
     bulkAdd,
+    remove,
   }
 }
 


### PR DESCRIPTION
Closes #646

## What

Wire up the three binder `DELETE` endpoints that had no SPA affordance:

- **Delete a collection** — a trash control on each owned row in the Binders tab. It reveals on hover (mirroring the Recent tab) and swaps into an inline **Delete / Cancel** confirm, since removing a binder cascade-deletes its cards and can't be undone.
- **Delete a want-list** — the same control on each chasing row.
- **Remove a card from a want-list** — a per-card trash button in the want-list detail modal, next to "Got it". No confirm here: it's a single card and cheap to re-add.

Plumbing: `deleteCollection` / `deleteWishlist` / `deleteWishlistItem` land in the API client, and `useCollections` / `useWishlists` each grow a `remove()` that drops the row from the shared cache and busts the ownership-badge cache (#576) so cross-surface badges re-fetch.

## Why

Once you created a binder or added a card to a want-list, the SPA gave you no way back out — the endpoints existed but nothing called them. Identity-disconnect and the swipe deck-reset already had delete affordances; binders were the gap. This is the delete half of the broader "your data" management story (#450).

Out of scope: per-card removal from a *collection* — there's no collection detail view to host it yet.

## How to verify

1. `make dev-api` and `make dev-web`, open the SPA, and create a collection ("New smart collection") and a want-list (heart icon on a looked-up card).
2. Open the **Binders** tab in the Library panel. Hover a row → trash icon appears → click it → confirm with **Delete**. The row disappears; **Cancel** leaves it untouched.
3. Open a want-list, hover a card → trash icon → click. The card is removed immediately and the count updates.

Verified locally end-to-end against the real API (auth-off self-host mode): both binder-row deletes and the per-card removal hit the endpoints and update the UI; removing a card dropped the want-list's server-side item count to 0. New vitest coverage in `LibraryBindersTab.test.tsx` (delete collection, delete want-list, cancel keeps the row) and `WishlistDetail.test.tsx` (remove a card). `npm run lint`, `npm run build`, and the web test suite are green.