### PR TITLE
feat(web): aggregate collection insights dashboard (#575)

### DIFF
--- a/api/routes/collections.py
+++ b/api/routes/collections.py
@@ -16,6 +16,7 @@ schema and resolver.
 Endpoints:
 
 - `GET    /collections`                       list user's collections
+- `GET    /collections/insights`              aggregate "at a glance" dashboard (#575)
 - `POST   /collections`                       create (manual, set, or dynamic)
 - `GET    /collections/{id}`                  full collection including items
 - `PATCH  /collections/{id}`                  rename / edit description / rule
@@ -29,6 +30,7 @@ Endpoints:
 
 from __future__ import annotations
 
+from collections import defaultdict
 from datetime import UTC, datetime
 from typing import Annotated, Any
 
@@ -237,6 +239,72 @@ class BulkAddResult(BaseModel):
     items: list[CollectionItemOut]
 
 
+# ---- #575: aggregate insights dashboard ----------------------------------
+
+
+class InsightsTotals(BaseModel):
+    """Headline counters across every collection the user owns."""
+
+    collections: int
+    #: Distinct ``(set_id, number)`` identities, plus each identity-less row.
+    unique_cards: int
+    #: Sum of ``quantity`` — counts vendor multiples.
+    total_quantity: int
+    #: Sum of ``price_snapshot * quantity`` over priced rows. Live per-card
+    #: snapshots, not a ``collection_snapshots`` read — that table's writer
+    #: is #508, so value-over-time stays out of this slice.
+    estimated_value: float
+
+
+class LabeledCount(BaseModel):
+    """One bar in a top-N breakdown — a label and its distinct-card count."""
+
+    label: str
+    count: int
+
+
+class DuplicateCard(BaseModel):
+    """A row a vendor holds in multiples within a single collection."""
+
+    card_name: str | None
+    card_set_id: str | None
+    card_number: str | None
+    quantity: int
+    collection_name: str
+
+
+class CrossCollectionCard(BaseModel):
+    """One card identity that shows up in two or more collections."""
+
+    card_name: str | None
+    card_set_id: str | None
+    card_number: str | None
+    total_quantity: int
+    collections: list[str]
+
+
+class AlreadyOwnedChase(BaseModel):
+    """A want-list card the user already owns in a collection — a cleanup
+    nudge (wishlist ∩ collection)."""
+
+    card_name: str | None
+    card_set_id: str | None
+    card_number: str | None
+    wishlist_id: int
+    wishlist_name: str
+    collections: list[str]
+
+
+class CollectionInsightsOut(BaseModel):
+    totals: InsightsTotals
+    top_types: list[LabeledCount]
+    top_rarities: list[LabeledCount]
+    top_sets: list[LabeledCount]
+    duplicate_multiples: list[DuplicateCard]
+    cross_collection: list[CrossCollectionCard]
+    already_owned_chasing: list[AlreadyOwnedChase]
+
+
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -284,6 +352,175 @@ def list_collections(db: DbSession, current_user: CurrentUser) -> dict:
             )
         )
     return {"items": [item.model_dump() for item in items], "total": len(items)}
+
+
+#: How many bars each top-N breakdown returns, and how many cards the
+#: duplicate / cleanup lists cap at, so the payload stays bounded.
+_TOP_N = 8
+_LIST_CAP = 25
+
+
+def _identity(set_id: str | None, number: str | None) -> tuple[str, str] | None:
+    """The ``(set_id, number)`` handle, or None when the row predates the
+    promoted-identity backfill and can't be grouped."""
+    if set_id is None or number is None:
+        return None
+    return (set_id, number)
+
+
+def _top_labels(buckets: dict[str, set]) -> list[LabeledCount]:
+    """Top-N labels by distinct-card count, ties broken alphabetically."""
+    ranked = sorted(buckets.items(), key=lambda kv: (-len(kv[1]), kv[0]))
+    return [LabeledCount(label=label, count=len(cards)) for label, cards in ranked[:_TOP_N]]
+
+
+def _aggregate_items(rows: list) -> dict[str, Any]:
+    """Roll the user's materialized collection items up into the dashboard's
+    breakdowns. Dynamic collections own no rows, so they never appear here —
+    their owned-scope membership is just a filtered view of cards already
+    counted, and double-counting them would inflate every total."""
+    total_quantity = 0
+    unique_extra = 0  # identity-less rows, each its own "unique" card
+    estimated_value = 0.0
+    type_cards: dict[str, set] = defaultdict(set)
+    rarity_cards: dict[str, set] = defaultdict(set)
+    set_cards: dict[str, set] = defaultdict(set)
+    owned_collections: dict[tuple, set] = defaultdict(set)
+    owned_quantity: dict[tuple, int] = defaultdict(int)
+    owned_meta: dict[tuple, dict] = {}
+    multiples: list[DuplicateCard] = []
+
+    for set_id, number, name, rarity, types, quantity, price, coll_name in rows:
+        qty = quantity or 0
+        total_quantity += qty
+        if price is not None:
+            estimated_value += float(price) * qty
+        ident = _identity(set_id, number)
+        if ident is None:
+            unique_extra += 1
+        else:
+            owned_collections[ident].add(coll_name)
+            owned_quantity[ident] += qty
+            owned_meta[ident] = {"card_name": name, "card_set_id": set_id, "card_number": number}
+            if set_id:
+                set_cards[set_id].add(ident)
+            if rarity:
+                rarity_cards[rarity].add(ident)
+            for t in types or []:
+                type_cards[t].add(ident)
+        if qty > 1:
+            multiples.append(
+                DuplicateCard(
+                    card_name=name,
+                    card_set_id=set_id,
+                    card_number=number,
+                    quantity=qty,
+                    collection_name=coll_name,
+                )
+            )
+
+    multiples.sort(key=lambda d: (-d.quantity, d.card_name or ""))
+    cross = [
+        CrossCollectionCard(
+            total_quantity=owned_quantity[ident],
+            collections=sorted(names),
+            **owned_meta[ident],
+        )
+        for ident, names in owned_collections.items()
+        if len(names) >= 2
+    ]
+    cross.sort(key=lambda c: (-len(c.collections), -c.total_quantity, c.card_name or ""))
+
+    return {
+        "total_quantity": total_quantity,
+        "unique_cards": len(owned_meta) + unique_extra,
+        "estimated_value": round(estimated_value, 2),
+        "top_types": _top_labels(type_cards),
+        "top_rarities": _top_labels(rarity_cards),
+        "top_sets": _top_labels(set_cards),
+        "duplicate_multiples": multiples[:_LIST_CAP],
+        "cross_collection": cross[:_LIST_CAP],
+        "owned_collections": owned_collections,
+    }
+
+
+def _already_owned_chasing(
+    db: Session, user_id: int, owned_collections: dict[tuple, set]
+) -> list[AlreadyOwnedChase]:
+    """Want-list cards the user already owns — the quiet cleanup nudge.
+    Acquired (``got it``) rows are excluded: they're intentionally kept as a
+    retrospective, not stale chases."""
+    rows = db.execute(
+        select(
+            WishlistItem.card_set_id,
+            WishlistItem.card_number,
+            WishlistItem.card_name,
+            Wishlist.id,
+            Wishlist.name,
+        )
+        .join(Wishlist, WishlistItem.wishlist_id == Wishlist.id)
+        .where(Wishlist.user_id == user_id, WishlistItem.acquired_at.is_(None))
+    ).all()
+    out: list[AlreadyOwnedChase] = []
+    for set_id, number, name, wl_id, wl_name in rows:
+        ident = _identity(set_id, number)
+        if ident is None or ident not in owned_collections:
+            continue
+        out.append(
+            AlreadyOwnedChase(
+                card_name=name,
+                card_set_id=set_id,
+                card_number=number,
+                wishlist_id=wl_id,
+                wishlist_name=wl_name,
+                collections=sorted(owned_collections[ident]),
+            )
+        )
+    return out[:_LIST_CAP]
+
+
+@router.get("/collections/insights")
+def collection_insights(db: DbSession, current_user: CurrentUser) -> dict:
+    """Aggregate "your collection at a glance" across all of a user's
+    collections (#575): totals, top types / rarities / sets, vendor
+    duplicates, and the wishlist ∩ collection cleanup nudge. Computed live
+    from the promoted card-identity columns — every breakdown is indexed SQL
+    + a small in-Python rollup, not a ``card_json`` scan."""
+    collection_count = (
+        db.scalar(select(func.count(Collection.id)).where(Collection.user_id == current_user.id))
+        or 0
+    )
+    rows = db.execute(
+        select(
+            CollectionItem.card_set_id,
+            CollectionItem.card_number,
+            CollectionItem.card_name,
+            CollectionItem.card_rarity,
+            CollectionItem.card_types_json,
+            CollectionItem.quantity,
+            CollectionItem.price_snapshot,
+            Collection.name,
+        )
+        .join(Collection, CollectionItem.collection_id == Collection.id)
+        .where(Collection.user_id == current_user.id)
+    ).all()
+
+    agg = _aggregate_items(rows)
+    out = CollectionInsightsOut(
+        totals=InsightsTotals(
+            collections=int(collection_count),
+            unique_cards=agg["unique_cards"],
+            total_quantity=agg["total_quantity"],
+            estimated_value=agg["estimated_value"],
+        ),
+        top_types=agg["top_types"],
+        top_rarities=agg["top_rarities"],
+        top_sets=agg["top_sets"],
+        duplicate_multiples=agg["duplicate_multiples"],
+        cross_collection=agg["cross_collection"],
+        already_owned_chasing=_already_owned_chasing(db, current_user.id, agg["owned_collections"]),
+    )
+    return out.model_dump()
 
 
 @router.post("/collections", status_code=201)

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -981,5 +981,112 @@ class CollectionsAuthGateTests(_IsolatedDbMixin):
                 )
 
 
+class CollectionInsightsTests(_IsolatedDbMixin):
+    """`GET /api/v1/collections/insights` — the aggregate dashboard (#575)."""
+
+    def _client(self) -> TestClient:
+        from api.main import app
+
+        return TestClient(app)
+
+    def test_insights_empty_when_no_collections(self) -> None:
+        with self._client() as c:
+            body = c.get("/api/v1/collections/insights").json()
+            self.assertEqual(
+                body["totals"],
+                {"collections": 0, "unique_cards": 0, "total_quantity": 0, "estimated_value": 0.0},
+            )
+            self.assertEqual(body["top_types"], [])
+            self.assertEqual(body["duplicate_multiples"], [])
+            self.assertEqual(body["cross_collection"], [])
+            self.assertEqual(body["already_owned_chasing"], [])
+
+    def test_insights_totals_and_breakdowns(self) -> None:
+        priced = {**SAMPLE_CARD, "market_price": 250.0}  # Charizard, Fire, base1, Rare Holo
+        with self._client() as c:
+            owned = c.post("/api/v1/collections", json={"name": "Owned"}).json()["id"]
+            trade = c.post("/api/v1/collections", json={"name": "Trade Stock"}).json()["id"]
+            c.post(f"/api/v1/collections/{owned}/items", json={"card": priced, "quantity": 2})
+            c.post(f"/api/v1/collections/{owned}/items", json={"card": EEVEE_CARD})
+            c.post(f"/api/v1/collections/{trade}/items", json={"card": VAPOREON_CARD})
+
+            body = c.get("/api/v1/collections/insights").json()
+            self.assertEqual(
+                body["totals"],
+                {
+                    "collections": 2,
+                    "unique_cards": 3,  # three distinct (set, number) identities
+                    "total_quantity": 4,  # 2 + 1 + 1
+                    "estimated_value": 500.0,  # 250 * 2; only the Charizard is priced
+                },
+            )
+            sets = {b["label"]: b["count"] for b in body["top_sets"]}
+            self.assertEqual(sets["sv1"], 2)  # Eevee + Vaporeon
+            self.assertEqual(sets["base1"], 1)
+            types = {b["label"]: b["count"] for b in body["top_types"]}
+            self.assertEqual(types, {"Fire": 1, "Colorless": 1, "Water": 1})
+            rarities = {b["label"]: b["count"] for b in body["top_rarities"]}
+            self.assertEqual(rarities["Rare Holo"], 1)
+
+    def test_insights_flags_vendor_multiples(self) -> None:
+        with self._client() as c:
+            cid = c.post("/api/v1/collections", json={"name": "Trade Stock"}).json()["id"]
+            c.post(f"/api/v1/collections/{cid}/items", json={"card": SAMPLE_CARD, "quantity": 3})
+            c.post(
+                f"/api/v1/collections/{cid}/items", json={"card": EEVEE_CARD}
+            )  # qty 1, not a dup
+
+            dups = c.get("/api/v1/collections/insights").json()["duplicate_multiples"]
+            self.assertEqual(len(dups), 1)
+            self.assertEqual(dups[0]["card_name"], "Charizard")
+            self.assertEqual(dups[0]["quantity"], 3)
+            self.assertEqual(dups[0]["collection_name"], "Trade Stock")
+
+    def test_insights_flags_cross_collection_cards(self) -> None:
+        with self._client() as c:
+            a = c.post("/api/v1/collections", json={"name": "Show Binder"}).json()["id"]
+            b = c.post("/api/v1/collections", json={"name": "Trade Stock"}).json()["id"]
+            c.post(f"/api/v1/collections/{a}/items", json={"card": SAMPLE_CARD})
+            c.post(f"/api/v1/collections/{b}/items", json={"card": SAMPLE_CARD, "quantity": 2})
+            c.post(f"/api/v1/collections/{a}/items", json={"card": EEVEE_CARD})  # single collection
+
+            cross = c.get("/api/v1/collections/insights").json()["cross_collection"]
+            self.assertEqual(len(cross), 1)
+            self.assertEqual(cross[0]["card_name"], "Charizard")
+            self.assertEqual(cross[0]["total_quantity"], 3)  # 1 + 2
+            self.assertEqual(sorted(cross[0]["collections"]), ["Show Binder", "Trade Stock"])
+
+    def test_insights_nudges_cards_you_own_but_still_chase(self) -> None:
+        with self._client() as c:
+            cid = c.post("/api/v1/collections", json={"name": "Show Binder"}).json()["id"]
+            c.post(f"/api/v1/collections/{cid}/items", json={"card": SAMPLE_CARD})
+            wid = c.post("/api/v1/wishlists", json={"name": "Chase"}).json()["id"]
+            c.post(f"/api/v1/wishlists/{wid}/items", json={"card": SAMPLE_CARD})  # already own it
+            c.post(f"/api/v1/wishlists/{wid}/items", json={"card": EEVEE_CARD})  # don't own it
+
+            nudge = c.get("/api/v1/collections/insights").json()["already_owned_chasing"]
+            self.assertEqual(len(nudge), 1)
+            self.assertEqual(nudge[0]["card_name"], "Charizard")
+            self.assertEqual(nudge[0]["wishlist_name"], "Chase")
+            self.assertEqual(nudge[0]["collections"], ["Show Binder"])
+
+    def test_insights_excludes_acquired_wishlist_cards(self) -> None:
+        with self._client() as c:
+            cid = c.post("/api/v1/collections", json={"name": "Show Binder"}).json()["id"]
+            c.post(f"/api/v1/collections/{cid}/items", json={"card": SAMPLE_CARD})
+            wid = c.post("/api/v1/wishlists", json={"name": "Chase"}).json()["id"]
+            item_id = c.post(f"/api/v1/wishlists/{wid}/items", json={"card": SAMPLE_CARD}).json()[
+                "id"
+            ]
+            # Marking the chase complete makes it a retrospective, not a stale
+            # want — it should drop out of the cleanup nudge.
+            c.post(
+                f"/api/v1/wishlists/{wid}/items/{item_id}/promote",
+                json={"collection_id": cid},
+            )
+            nudge = c.get("/api/v1/collections/insights").json()["already_owned_chasing"]
+            self.assertEqual(nudge, [])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -727,6 +727,66 @@ export async function deleteCollection(collectionId: number): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
+// #575 — aggregate insights dashboard
+// ---------------------------------------------------------------------------
+
+export interface InsightsTotals {
+  collections: number
+  unique_cards: number
+  total_quantity: number
+  estimated_value: number
+}
+
+/** One bar in a top-N breakdown — a label and its distinct-card count. */
+export interface LabeledCount {
+  label: string
+  count: number
+}
+
+export interface DuplicateCard {
+  card_name: string | null
+  card_set_id: string | null
+  card_number: string | null
+  quantity: number
+  collection_name: string
+}
+
+export interface CrossCollectionCard {
+  card_name: string | null
+  card_set_id: string | null
+  card_number: string | null
+  total_quantity: number
+  collections: string[]
+}
+
+export interface AlreadyOwnedChase {
+  card_name: string | null
+  card_set_id: string | null
+  card_number: string | null
+  wishlist_id: number
+  wishlist_name: string
+  collections: string[]
+}
+
+/** Aggregate "your collection at a glance" across all of the user's
+ * collections (#575). */
+export interface CollectionInsights {
+  totals: InsightsTotals
+  top_types: LabeledCount[]
+  top_rarities: LabeledCount[]
+  top_sets: LabeledCount[]
+  duplicate_multiples: DuplicateCard[]
+  cross_collection: CrossCollectionCard[]
+  already_owned_chasing: AlreadyOwnedChase[]
+}
+
+export async function fetchCollectionInsights(): Promise<CollectionInsights> {
+  const res = await fetch(`${BASE}/collections/insights`)
+  if (!res.ok) throw new Error(`collection insights failed: ${res.status}`)
+  return (await res.json()) as CollectionInsights
+}
+
+// ---------------------------------------------------------------------------
 // wishlists
 // ---------------------------------------------------------------------------
 

--- a/web/src/components/CollectionInsights.test.tsx
+++ b/web/src/components/CollectionInsights.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, within } from '@testing-library/react'
+import { CollectionInsights } from './CollectionInsights'
+import { fetchCollectionInsights, type CollectionInsights as Insights } from '../api/client'
+
+vi.mock('../api/client', () => ({
+  fetchCollectionInsights: vi.fn(),
+}))
+
+const mockFetch = vi.mocked(fetchCollectionInsights)
+
+function insights(overrides: Partial<Insights> = {}): Insights {
+  return {
+    totals: { collections: 2, unique_cards: 3, total_quantity: 5, estimated_value: 500 },
+    top_types: [
+      { label: 'Fire', count: 2 },
+      { label: 'Water', count: 1 },
+    ],
+    top_rarities: [{ label: 'Rare Holo', count: 1 }],
+    top_sets: [{ label: 'base1', count: 2 }],
+    duplicate_multiples: [],
+    cross_collection: [],
+    already_owned_chasing: [],
+    ...overrides,
+  }
+}
+
+describe('CollectionInsights', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+
+  it('renders headline totals and breakdown bars', async () => {
+    mockFetch.mockResolvedValue(insights())
+    render(<CollectionInsights open onOpenChange={() => {}} />)
+
+    await waitFor(() => expect(screen.getByText('Est. value')).toBeInTheDocument())
+    // Totals: collections / unique / copies / value.
+    expect(screen.getByText('$500.00')).toBeInTheDocument()
+    expect(screen.getByText('Unique cards')).toBeInTheDocument()
+    // Breakdown labels render.
+    expect(screen.getByText('Top types')).toBeInTheDocument()
+    expect(screen.getByText('Fire')).toBeInTheDocument()
+    expect(screen.getByText('base1')).toBeInTheDocument()
+  })
+
+  it('shows the empty state when there are no cards', async () => {
+    mockFetch.mockResolvedValue(
+      insights({ totals: { collections: 0, unique_cards: 0, total_quantity: 0, estimated_value: 0 } }),
+    )
+    render(<CollectionInsights open onOpenChange={() => {}} />)
+
+    expect(await screen.findByText(/No collection data yet/i)).toBeInTheDocument()
+  })
+
+  it('lists duplicates and the already-owned cleanup nudge', async () => {
+    mockFetch.mockResolvedValue(
+      insights({
+        duplicate_multiples: [
+          {
+            card_name: 'Charizard',
+            card_set_id: 'base1',
+            card_number: '4',
+            quantity: 3,
+            collection_name: 'Trade Stock',
+          },
+        ],
+        cross_collection: [
+          {
+            card_name: 'Pikachu',
+            card_set_id: 'base1',
+            card_number: '58',
+            total_quantity: 2,
+            collections: ['Show Binder', 'Trade Stock'],
+          },
+        ],
+        already_owned_chasing: [
+          {
+            card_name: 'Blastoise',
+            card_set_id: 'base1',
+            card_number: '2',
+            wishlist_id: 9,
+            wishlist_name: 'Chase',
+            collections: ['Show Binder'],
+          },
+        ],
+      }),
+    )
+    render(<CollectionInsights open onOpenChange={() => {}} />)
+
+    await waitFor(() => expect(screen.getByText('Duplicates')).toBeInTheDocument())
+    expect(screen.getByText('3x')).toBeInTheDocument()
+    expect(screen.getByText('Charizard')).toBeInTheDocument()
+    expect(screen.getByText('Pikachu')).toBeInTheDocument()
+    // Cleanup nudge names the card and its want-list.
+    const nudge = screen.getByText('Already in a binder').closest('section')!
+    expect(within(nudge).getByText('Blastoise')).toBeInTheDocument()
+    expect(within(nudge).getByText('Chase')).toBeInTheDocument()
+  })
+
+  it('does not fetch while closed', () => {
+    render(<CollectionInsights open={false} onOpenChange={() => {}} />)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/components/CollectionInsights.tsx
+++ b/web/src/components/CollectionInsights.tsx
@@ -1,0 +1,266 @@
+/**
+ * CollectionInsights — the aggregate "your collection at a glance"
+ * dashboard (#575). Opens from the header of
+ * [LibraryBindersTab](./LibraryBindersTab.tsx).
+ *
+ * Reads one rollup from `GET /collections/insights`: headline totals, the
+ * top types / rarities / sets as bars, a vendor-facing duplicates view
+ * (multiples + cards spanning more than one binder), and a quiet cleanup
+ * nudge for want-list cards you already own. Value-over-time is deliberately
+ * out — that chart needs the `collection_snapshots` writer (#508), which
+ * hasn't landed.
+ */
+import * as Dialog from '@radix-ui/react-dialog'
+import { BarChart3, Copy, Loader2, Sparkles, X } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import {
+  fetchCollectionInsights,
+  type CollectionInsights as Insights,
+  type LabeledCount,
+} from '../api/client'
+import { formatMoney } from '../utils/format'
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+function cardRef(setId: string | null, number: string | null): string {
+  return `${setId ?? ''}${number ? `-${number}` : ''}`
+}
+
+function StatTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-md border border-sand-200 bg-sand-50 px-3 py-2 dark:border-husk-100 dark:bg-husk-100">
+      <div className="text-xl font-semibold tabular-nums text-coconut-700 dark:text-sand-50">
+        {value}
+      </div>
+      <div className="text-[11px] uppercase tracking-wide text-coconut-400 dark:text-sand-300">
+        {label}
+      </div>
+    </div>
+  )
+}
+
+/** A top-N breakdown as horizontal bars, widths relative to the group max. */
+function BarList({ title, items }: { title: string; items: LabeledCount[] }) {
+  if (items.length === 0) return null
+  const max = Math.max(...items.map((i) => i.count))
+  return (
+    <section>
+      <h3 className="mb-2 text-[11px] font-medium uppercase tracking-wide text-coconut-400 dark:text-sand-300">
+        {title}
+      </h3>
+      <ul className="space-y-1.5">
+        {items.map((i) => (
+          <li
+            key={i.label}
+            className="grid grid-cols-[5.5rem_1fr_1.75rem] items-center gap-2 text-xs"
+          >
+            <span className="truncate text-coconut-600 dark:text-sand-200" title={i.label}>
+              {i.label}
+            </span>
+            <div className="h-2 overflow-hidden rounded-full bg-sand-200 dark:bg-husk-200">
+              <div
+                className="h-full rounded-full bg-palm-500"
+                style={{ width: `${Math.max((i.count / max) * 100, 4)}%` }}
+              />
+            </div>
+            <span className="text-right tabular-nums text-coconut-400 dark:text-sand-300">
+              {i.count}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+function DuplicatesSection({ data }: { data: Insights }) {
+  const { duplicate_multiples: multiples, cross_collection: cross } = data
+  if (multiples.length === 0 && cross.length === 0) return null
+  return (
+    <section className="space-y-3">
+      <h3 className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-coconut-400 dark:text-sand-300">
+        <Copy size={12} /> Duplicates
+      </h3>
+      {multiples.length > 0 && (
+        <div>
+          <div className="mb-1 text-[11px] text-coconut-500 dark:text-sand-300">
+            More than one copy
+          </div>
+          <ul className="divide-y divide-sand-200 dark:divide-husk-100">
+            {multiples.map((d, idx) => (
+              <li
+                key={`${d.card_set_id}-${d.card_number}-${d.collection_name}-${idx}`}
+                className="flex items-center justify-between gap-2 py-1.5 text-xs"
+              >
+                <span className="min-w-0 truncate text-coconut-700 dark:text-sand-50">
+                  {d.card_name ?? cardRef(d.card_set_id, d.card_number)}
+                  <span className="ml-1.5 text-[11px] text-coconut-400 dark:text-sand-300">
+                    {d.collection_name}
+                  </span>
+                </span>
+                <span className="shrink-0 rounded bg-sand-200 px-1.5 py-0.5 text-[11px] font-medium tabular-nums text-coconut-600 dark:bg-husk-100 dark:text-sand-200">
+                  {d.quantity}x
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {cross.length > 0 && (
+        <div>
+          <div className="mb-1 text-[11px] text-coconut-500 dark:text-sand-300">
+            In more than one binder
+          </div>
+          <ul className="divide-y divide-sand-200 dark:divide-husk-100">
+            {cross.map((d, idx) => (
+              <li
+                key={`${d.card_set_id}-${d.card_number}-${idx}`}
+                className="flex items-center justify-between gap-2 py-1.5 text-xs"
+              >
+                <span className="min-w-0 truncate text-coconut-700 dark:text-sand-50">
+                  {d.card_name ?? cardRef(d.card_set_id, d.card_number)}
+                </span>
+                <span className="shrink-0 truncate text-[11px] text-coconut-400 dark:text-sand-300">
+                  {d.collections.join(' · ')}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  )
+}
+
+function AlreadyOwnedSection({ data }: { data: Insights }) {
+  const nudges = data.already_owned_chasing
+  if (nudges.length === 0) return null
+  return (
+    <section>
+      <h3 className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-coconut-400 dark:text-sand-300">
+        <Sparkles size={12} /> Already in a binder
+      </h3>
+      <p className="mb-2 mt-1 text-[11px] text-coconut-500 dark:text-sand-300">
+        These cards are on a want-list but you already own them — clear them off when you get a
+        chance.
+      </p>
+      <ul className="divide-y divide-sand-200 dark:divide-husk-100">
+        {nudges.map((n, idx) => (
+          <li
+            key={`${n.wishlist_id}-${n.card_set_id}-${n.card_number}-${idx}`}
+            className="flex items-center justify-between gap-2 py-1.5 text-xs"
+          >
+            <span className="min-w-0 truncate text-coconut-700 dark:text-sand-50">
+              {n.card_name ?? cardRef(n.card_set_id, n.card_number)}
+              <span className="ml-1.5 text-[11px] text-coconut-400 dark:text-sand-300">
+                {n.wishlist_name}
+              </span>
+            </span>
+            <span className="shrink-0 truncate text-[11px] text-coconut-400 dark:text-sand-300">
+              {n.collections.join(' · ')}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+export function CollectionInsights({ open, onOpenChange }: Props) {
+  const [data, setData] = useState<Insights | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    const load = async () => {
+      setData(null)
+      setError(null)
+      setLoading(true)
+      try {
+        const resolved = await fetchCollectionInsights()
+        if (!cancelled) setData(resolved)
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e))
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [open])
+
+  const empty = data !== null && data.totals.unique_cards === 0
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-coconut-700/50 backdrop-blur-sm dark:bg-husk-500/70" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-[min(760px,94vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-sand-300 bg-sand-50 shadow-2xl dark:border-husk-50 dark:bg-husk-200">
+          <header className="flex items-center justify-between gap-3 border-b border-sand-200 px-5 py-4 dark:border-husk-100">
+            <div className="flex min-w-0 items-center gap-2">
+              <BarChart3 size={18} className="shrink-0 text-coconut-600 dark:text-sand-200" />
+              <Dialog.Title className="truncate text-lg font-semibold text-coconut-700 dark:text-sand-50">
+                Collection insights
+              </Dialog.Title>
+            </div>
+            <Dialog.Close asChild>
+              <button
+                aria-label="Close"
+                className="rounded p-1 text-coconut-500 hover:bg-sand-200 dark:text-sand-300 dark:hover:bg-husk-100"
+              >
+                <X size={18} />
+              </button>
+            </Dialog.Close>
+          </header>
+          <Dialog.Description className="sr-only">
+            Headline totals, top types, rarities and sets, duplicates, and want-list cards you
+            already own, across all your collections.
+          </Dialog.Description>
+
+          <div className="flex-1 space-y-5 overflow-y-auto px-5 py-4">
+            {loading ? (
+              <div className="flex items-center gap-2 text-xs text-coconut-400 dark:text-sand-300">
+                <Loader2 size={14} className="animate-spin" />
+                Crunching your collections…
+              </div>
+            ) : error ? (
+              <div role="alert" className="text-xs text-sun-600 dark:text-sun-300">
+                {error}
+              </div>
+            ) : empty ? (
+              <p className="text-xs text-coconut-500 dark:text-sand-300">
+                No collection data yet. Add cards to a collection — click the bookmark icon on a
+                matched row — and your stats will show up here.
+              </p>
+            ) : data ? (
+              <>
+                <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+                  <StatTile label="Collections" value={String(data.totals.collections)} />
+                  <StatTile label="Unique cards" value={String(data.totals.unique_cards)} />
+                  <StatTile label="Total copies" value={String(data.totals.total_quantity)} />
+                  <StatTile label="Est. value" value={formatMoney(data.totals.estimated_value)} />
+                </div>
+
+                <div className="grid gap-5 sm:grid-cols-3">
+                  <BarList title="Top types" items={data.top_types} />
+                  <BarList title="Top rarities" items={data.top_rarities} />
+                  <BarList title="Top sets" items={data.top_sets} />
+                </div>
+
+                <DuplicatesSection data={data} />
+                <AlreadyOwnedSection data={data} />
+              </>
+            ) : null}
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/web/src/components/LibraryBindersTab.tsx
+++ b/web/src/components/LibraryBindersTab.tsx
@@ -17,7 +17,7 @@
  * [OwnershipBadge](./OwnershipBadge.tsx) chip (#576): palm for owned,
  * sun for chasing.
  */
-import { Loader2, Sparkles, Trash2 } from 'lucide-react'
+import { BarChart3, Loader2, Sparkles, Trash2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import type {
   CollectionRule,
@@ -25,6 +25,7 @@ import type {
   DynamicScope,
   WishlistSummary,
 } from '../api/client'
+import { CollectionInsights } from './CollectionInsights'
 import { SmartCollectionTarget } from './SmartCollectionTarget'
 import { WishlistDetail } from './WishlistDetail'
 import { useCollections } from './useCollections'
@@ -122,6 +123,8 @@ export function LibraryBindersTab() {
   const [targetCollection, setTargetCollection] = useState<CollectionSummary | null>(null)
   // The want-list whose detail modal is open.
   const [openWishlist, setOpenWishlist] = useState<WishlistSummary | null>(null)
+  // The aggregate insights dashboard.
+  const [insightsOpen, setInsightsOpen] = useState(false)
 
   useEffect(() => {
     void refreshCollections()
@@ -169,14 +172,24 @@ export function LibraryBindersTab() {
         <span className="text-[11px] font-medium uppercase tracking-wide text-coconut-400 dark:text-sand-300">
           Binders
         </span>
-        <button
-          type="button"
-          onClick={() => setFormOpen((o) => !o)}
-          className="inline-flex items-center gap-1 rounded px-2 py-1 text-[11px] font-medium text-palm-600 hover:bg-palm-50 dark:text-palm-300 dark:hover:bg-husk-100"
-        >
-          <Sparkles size={12} />
-          New smart collection
-        </button>
+        <div className="flex items-center gap-0.5">
+          <button
+            type="button"
+            onClick={() => setInsightsOpen(true)}
+            className="inline-flex items-center gap-1 rounded px-2 py-1 text-[11px] font-medium text-palm-600 hover:bg-palm-50 dark:text-palm-300 dark:hover:bg-husk-100"
+          >
+            <BarChart3 size={12} />
+            Insights
+          </button>
+          <button
+            type="button"
+            onClick={() => setFormOpen((o) => !o)}
+            className="inline-flex items-center gap-1 rounded px-2 py-1 text-[11px] font-medium text-palm-600 hover:bg-palm-50 dark:text-palm-300 dark:hover:bg-husk-100"
+          >
+            <Sparkles size={12} />
+            New smart collection
+          </button>
+        </div>
       </div>
 
       <div
@@ -326,6 +339,7 @@ export function LibraryBindersTab() {
           if (!o) setOpenWishlist(null)
         }}
       />
+      <CollectionInsights open={insightsOpen} onOpenChange={setInsightsOpen} />
     </div>
   )
 }


### PR DESCRIPTION
Closes #575

## What

An aggregate "your collection at a glance" dashboard across all of a user's collections, opened from a new **Insights** button in the Binders tab header. One `GET /collections/insights` rollup backs the whole modal:

- **Headline totals** — collections, unique cards, total copies (with multiples), estimated value.
- **Top types / rarities / sets** — distinct-card breakdowns rendered as bars.
- **Duplicates** (for vendors) — cards held in multiples, and cards that span more than one binder.
- **Already in a binder** — a quiet cleanup nudge for want-list cards you already own (wishlist ∩ collection), excluding ones you've already marked "got it".

## Why

The model rework (#574) promoted card-identity columns onto `collection_items`, so every one of these is indexed SQL plus a small in-Python rollup — not a `card_json` scan. This turns that model investment into something the serious-collector audience can feel. Dynamic collections own no materialized rows, so they're naturally excluded from the aggregation rather than double-counted.

Scoped deliberately to the **aggregate** half of #575. Two pieces are left for follow-ups:
- **Value over time** — needs the `collection_snapshots` writer (#508), which hasn't landed; the table is never written yet, so there's no series to chart.
- **Per-collection insight cards** — there's no per-collection detail view in the SPA to host them yet; that's its own slice.

## How to verify

1. `make dev-api` + `make dev-web`, sign in (or self-host), and add cards to a couple of collections — vary types/rarities/sets, set a `quantity > 1` on some, and put the same card in two collections. Add a card you own to a want-list.
2. Open the **Binders** tab → click **Insights**.
3. Confirm the totals, the three bar breakdowns, the duplicates lists (multiples + cross-binder), and the "already in a binder" nudge all populate. Empty collections show a friendly empty state.

Verified locally end-to-end against the real API (auth-off self-host): the endpoint returns the expected rollup and the modal renders every section with no console errors. New coverage: 6 endpoint tests in `tests/test_collections.py` (totals, type/rarity/set breakdowns, vendor multiples, cross-collection, the wishlist∩collection nudge, and acquired-card exclusion) and 4 component tests in `CollectionInsights.test.tsx`. `make check` and `cd web && npm run build` are green.