### PR TITLE
feat(web): printable collection ID card for the binder cover (#507)

### DIFF
--- a/api/routes/collections.py
+++ b/api/routes/collections.py
@@ -26,19 +26,28 @@ Endpoints:
 - `DELETE /collections/{id}/items/{item_id}`  remove a card (manual/set only)
 - `GET    /collections/{id}/target`           catalog-backed membership + ownership overlay (#631)
 - `POST   /collections/{id}/chase`            push the un-owned matches onto a want-list (#631)
+- `GET    /collections/{id}/id-card.pdf`      printable binder cover ID card (#507)
 """
 
 from __future__ import annotations
 
+import hashlib
+import io
+import tempfile
 from collections import defaultdict
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Annotated, Any
 
+import requests
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, model_validator
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session, selectinload
 
+from mgz_pkmn import cache as disk_cache
+from mgz_pkmn.set_cards import fetch_all_sets, write_collection_id_card_pdf
 from mgz_pkmn.sources import TCGClient
 
 from ..auth.session import current_user_or_default
@@ -799,6 +808,114 @@ def chase_collection(
         skipped=skipped,
         total_missing=total_missing,
     ).model_dump()
+
+
+# ---------------------------------------------------------------------------
+# #507 — printable collection ID card
+# ---------------------------------------------------------------------------
+
+#: Disk-image-cache category for auto-picked cover art, keyed by a hash of
+#: the card image URL so repeat prints reuse the download.
+_COVER_CATEGORY = "collection-covers"
+
+
+@router.get("/collections/{collection_id}/id-card.pdf")
+def collection_id_card(
+    collection_id: int,
+    db: DbSession,
+    current_user: CurrentUser,
+    api_key: str | None = None,
+    no_images: bool = False,
+) -> StreamingResponse:
+    """Render a printable collection ID card — the cover cutout for the
+    top-left pocket of a binder (#507): the collection's title, a representative
+    card photo, and an owned / total count.
+
+    The cover is auto-picked: the most valuable card you own in the collection,
+    falling back to the first. ``total`` is the catalog match count for a
+    catalog-scope smart collection and the printed set size for a set
+    collection; manual buckets and owned-scope smart collections have no
+    denominator, so the card shows just the owned count. Pass ``no_images=true``
+    to skip the cover fetch (text-only, fast on a cold cache)."""
+    collection = _load_collection(db, collection_id, current_user.id)
+    owned_items = _id_card_owned_items(db, collection, current_user.id)
+    total = _id_card_total(collection, api_key)
+
+    cover_path: Path | None = None
+    if not no_images:
+        cover_url = _pick_cover_url(owned_items)
+        if cover_url:
+            cover_path = _fetch_cover(cover_url, TCGClient(api_key=api_key).session)
+
+    content = _render_id_card(collection.name, len(owned_items), total, cover_path)
+    return StreamingResponse(
+        io.BytesIO(content),
+        media_type="application/pdf",
+        headers={
+            "Content-Disposition": f'attachment; filename="collection-{collection_id}-id-card.pdf"'
+        },
+    )
+
+
+def _id_card_owned_items(db: Session, collection: Collection, user_id: int) -> list[CollectionItem]:
+    """The owned cards backing the ID card — resolved rule membership for a
+    dynamic collection, stored rows otherwise."""
+    if collection.kind == COLLECTION_KIND_DYNAMIC and collection.rule_json:
+        return resolve_dynamic_items(db, user_id, collection.rule_json)
+    return list(collection.items)
+
+
+def _pick_cover_url(items: list[CollectionItem]) -> str | None:
+    """Auto-pick the cover: the most valuable owned card with an image, else
+    the first with one."""
+    with_image = [i for i in items if i.card_image_url]
+    if not with_image:
+        return None
+    best = max(
+        with_image,
+        key=lambda i: float(i.price_snapshot) if i.price_snapshot is not None else -1.0,
+    )
+    return best.card_image_url
+
+
+def _id_card_total(collection: Collection, api_key: str | None) -> int | None:
+    """The denominator for the owned / total count, or None when the
+    collection has no well-defined total (manual bucket, owned-scope smart)."""
+    if (
+        collection.kind == COLLECTION_KIND_DYNAMIC
+        and collection.dynamic_scope == DYNAMIC_SCOPE_CATALOG
+    ):
+        return len(_fetch_catalog_cards(collection.rule_json, api_key))
+    if collection.kind == COLLECTION_KIND_SET and collection.source_set_id:
+        return _set_total(collection.source_set_id, api_key)
+    return None
+
+
+def _set_total(set_id: str, api_key: str | None) -> int | None:
+    """Printed card count for a set, from the catalog's cached set list."""
+    try:
+        sets = fetch_all_sets(TCGClient(api_key=api_key))
+    except requests.RequestException:
+        return None
+    for s in sets:
+        if s.get("id") == set_id:
+            total = s.get("printedTotal") or s.get("total")
+            return int(total) if total else None
+    return None
+
+
+def _fetch_cover(url: str, session: requests.Session) -> Path | None:
+    key = hashlib.sha256(url.encode()).hexdigest()[:16]
+    return disk_cache.download_and_cache_image(_COVER_CATEGORY, key, url, session)
+
+
+def _render_id_card(title: str, owned: int, total: int | None, cover_path: Path | None) -> bytes:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_path = Path(tmpdir) / "collection-id-card.pdf"
+        write_collection_id_card_pdf(
+            out_path, title=title, owned=owned, total=total, cover_path=cover_path
+        )
+        return out_path.read_bytes()
 
 
 # ---------------------------------------------------------------------------

--- a/src/mgz_pkmn/set_cards.py
+++ b/src/mgz_pkmn/set_cards.py
@@ -457,3 +457,135 @@ def _wrap_two_lines(c: canvas.Canvas, text: str, font: str, size: float, max_w: 
     while c.stringWidth(line2, font, size) > max_w and len(line2) > 3:
         line2 = line2[:-2] + "…"
     return [line1, line2]
+
+
+# ---------------------------------------------------------------------------
+# Collection ID card (#507)
+# ---------------------------------------------------------------------------
+
+#: Share of the cutout's inner height given to the cover card art. Larger
+#: than ``LOGO_BOX_RATIO`` because a card image is portrait — it wants the
+#: vertical room a landscape set logo doesn't.
+COVER_BOX_RATIO = 0.66
+
+
+def write_collection_id_card_pdf(
+    out_path: Path,
+    *,
+    title: str,
+    owned: int,
+    total: int | None,
+    cover_path: Path | None,
+    today: _dt.date | None = None,
+) -> None:
+    """Render a single collection ID card into the top-left binder pocket (#507).
+
+    One cutout — cover card art, the collection's title, and an owned / total
+    count — sized to a 9-pocket pocket and placed in slot 1 of a Letter page,
+    so the user can cut it out and front their binder with it. ``total`` is
+    ``None`` for collections with no well-defined denominator (a manual bucket);
+    the count then reads "N cards" instead of a fraction."""
+    today = today or _dt.date.today()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    c = canvas.Canvas(str(out_path), pagesize=letter)
+    branding.apply_pdf_metadata(c, out_path.stem)
+    tracker = branding.PageTracker(c, letter)
+    _draw_page_one_logo(c)
+    x = MARGIN_X
+    y = PAGE_H - MARGIN_Y - CARD_H
+    _draw_collection_cutout(
+        c,
+        x,
+        y,
+        title=title,
+        owned=owned,
+        total=total,
+        cover_path=cover_path,
+        generated=today.isoformat(),
+    )
+    tracker.finish()
+
+
+def _draw_collection_cutout(
+    c: canvas.Canvas,
+    x: float,
+    y: float,
+    *,
+    title: str,
+    owned: int,
+    total: int | None,
+    cover_path: Path | None,
+    generated: str,
+) -> None:
+    """One collection cutout: dashed cut line, cover art on top, title +
+    count underneath. Mirrors :func:`_draw_cutout`'s frame."""
+    c.saveState()
+    c.setStrokeColorRGB(*palette.rgb01("border-2"))
+    c.setLineWidth(0.4)
+    c.setDash(2, 2)
+    c.rect(x, y, CARD_W, CARD_H, stroke=1, fill=0)
+    c.setDash()
+    c.restoreState()
+
+    inner_x = x + CELL_PADDING
+    inner_y = y + CELL_PADDING
+    inner_w = CARD_W - 2 * CELL_PADDING
+    inner_h = CARD_H - 2 * CELL_PADDING
+
+    cover_h = inner_h * COVER_BOX_RATIO
+    cover_bottom = inner_y + inner_h - cover_h
+    if cover_path is not None and cover_path.exists():
+        _draw_logo(c, cover_path, inner_x, cover_bottom, inner_w, cover_h)
+    else:
+        _draw_placeholder(c, inner_x, cover_bottom, inner_w, cover_h, "no cover")
+
+    text_top = cover_bottom - TEXT_BLOCK_GAP
+    _draw_collection_text(
+        c,
+        inner_x,
+        inner_y,
+        inner_w,
+        text_top - inner_y,
+        title=title,
+        owned=owned,
+        total=total,
+        generated=generated,
+    )
+
+
+def _draw_collection_text(
+    c: canvas.Canvas,
+    x: float,
+    y: float,
+    w: float,
+    h: float,
+    *,
+    title: str,
+    owned: int,
+    total: int | None,
+    generated: str,
+) -> None:
+    """Title (wrapped, up to 2 lines), the owned / total count, gen date."""
+    name_size = 13
+    cur_y = y + h - name_size
+    c.setFont("Helvetica-Bold", name_size)
+    c.setFillColorRGB(*palette.rgb01("fg-1"))
+    for line in _wrap_two_lines(c, title, "Helvetica-Bold", name_size, w):
+        c.drawCentredString(x + w / 2, cur_y, line)
+        cur_y -= name_size + 1
+
+    cur_y -= 5
+    c.setFont("Helvetica-Bold", 12)
+    c.setFillColorRGB(*palette.rgb01("brand-secondary"))
+    if total is not None:
+        c.drawCentredString(x + w / 2, cur_y, f"{owned} / {total}")
+        cur_y -= 10
+        c.setFont("Helvetica", 8)
+        c.setFillColorRGB(*palette.rgb01("fg-3"))
+        c.drawCentredString(x + w / 2, cur_y, "owned")
+    else:
+        c.drawCentredString(x + w / 2, cur_y, f"{owned} {'card' if owned == 1 else 'cards'}")
+
+    c.setFont("Helvetica", 7)
+    c.setFillColorRGB(*palette.rgb01("fg-3"))
+    c.drawCentredString(x + w / 2, y + 2, f"generated {generated}")

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1088,5 +1088,52 @@ class CollectionInsightsTests(_IsolatedDbMixin):
             self.assertEqual(nudge, [])
 
 
+class CollectionIdCardTests(_IsolatedDbMixin):
+    """`GET /api/v1/collections/{id}/id-card.pdf` — printable binder cover (#507)."""
+
+    def _client(self) -> TestClient:
+        from api.main import app
+
+        return TestClient(app)
+
+    def test_id_card_renders_pdf_for_a_manual_collection(self) -> None:
+        with self._client() as c:
+            cid = c.post("/api/v1/collections", json={"name": "Show Binder"}).json()["id"]
+            c.post(f"/api/v1/collections/{cid}/items", json={"card": SAMPLE_CARD})
+            # no_images skips the cover fetch so the test stays offline.
+            resp = c.get(f"/api/v1/collections/{cid}/id-card.pdf?no_images=true")
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.headers["content-type"], "application/pdf")
+            self.assertTrue(resp.content.startswith(b"%PDF"))
+
+    def test_id_card_renders_for_an_empty_collection(self) -> None:
+        with self._client() as c:
+            cid = c.post("/api/v1/collections", json={"name": "Empty"}).json()["id"]
+            resp = c.get(f"/api/v1/collections/{cid}/id-card.pdf?no_images=true")
+            self.assertEqual(resp.status_code, 200)
+            self.assertTrue(resp.content.startswith(b"%PDF"))
+
+    def test_id_card_404_for_missing_collection(self) -> None:
+        with self._client() as c:
+            self.assertEqual(
+                c.get("/api/v1/collections/9999/id-card.pdf?no_images=true").status_code, 404
+            )
+
+    def test_pick_cover_prefers_the_most_valuable_card(self) -> None:
+        from types import SimpleNamespace
+
+        from api.routes.collections import _pick_cover_url
+
+        items = [
+            SimpleNamespace(card_image_url="cheap.png", price_snapshot=2.0),
+            SimpleNamespace(card_image_url="pricey.png", price_snapshot=300.0),
+            SimpleNamespace(card_image_url=None, price_snapshot=999.0),  # no image — skipped
+        ]
+        self.assertEqual(_pick_cover_url(items), "pricey.png")
+        self.assertIsNone(
+            _pick_cover_url([SimpleNamespace(card_image_url=None, price_snapshot=1.0)])
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_set_cards.py
+++ b/tests/test_set_cards.py
@@ -23,6 +23,7 @@ from mgz_pkmn.set_cards import (
     fetch_all_sets,
     filter_sets_by_ids,
     warm_set_images,
+    write_collection_id_card_pdf,
     write_set_cards_pdf,
 )
 
@@ -181,6 +182,24 @@ class WritePdfTests(unittest.TestCase):
             out = Path(tmp) / "set-cards.pdf"
             self.assertEqual(write_set_cards_pdf([], out), 0)
             self.assertFalse(out.exists())
+
+    def test_collection_id_card_renders_with_fraction(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "id-card.pdf"
+            write_collection_id_card_pdf(
+                out, title="Exeggutor line", owned=7, total=24, cover_path=None
+            )
+            self.assertTrue(out.exists())
+            self.assertTrue(out.read_bytes().startswith(b"%PDF"))
+
+    def test_collection_id_card_renders_count_only(self) -> None:
+        # No denominator (a manual bucket) → "N cards", no cover.
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "id-card.pdf"
+            write_collection_id_card_pdf(
+                out, title="Show Binder", owned=1, total=None, cover_path=None
+            )
+            self.assertTrue(out.read_bytes().startswith(b"%PDF"))
 
     def test_paginates_when_more_than_nine_sets(self) -> None:
         sets = [_set(sid=f"set-{i}", name=f"Set {i}") for i in range(11)]

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -726,6 +726,36 @@ export async function deleteCollection(collectionId: number): Promise<void> {
   }
 }
 
+/**
+ * Download the printable collection ID card PDF (#507) — the cover cutout for
+ * the top-left binder pocket (title, a representative card photo, owned/total).
+ * Triggers a browser save; mirrors `downloadSetCardsPdf`.
+ */
+export async function downloadCollectionIdCardPdf(
+  collectionId: number,
+  apiKey?: string,
+): Promise<void> {
+  const params = apiKey ? `?api_key=${encodeURIComponent(apiKey)}` : ''
+  const res = await fetch(`${BASE}/collections/${collectionId}/id-card.pdf${params}`)
+  if (!res.ok) {
+    let detail = `id card failed: ${res.status}`
+    try {
+      const body = await res.json()
+      if (body?.detail) detail = body.detail
+    } catch {
+      /* fall through */
+    }
+    throw new Error(detail)
+  }
+  const blob = await res.blob()
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `collection-${collectionId}-id-card.pdf`
+  a.click()
+  setTimeout(() => URL.revokeObjectURL(url), 0)
+}
+
 // ---------------------------------------------------------------------------
 // #575 — aggregate insights dashboard
 // ---------------------------------------------------------------------------

--- a/web/src/components/LibraryBindersTab.test.tsx
+++ b/web/src/components/LibraryBindersTab.test.tsx
@@ -7,6 +7,7 @@ import {
   fetchCollections,
   createCollection,
   deleteCollection,
+  downloadCollectionIdCardPdf,
   fetchWishlists,
   fetchWishlist,
   deleteWishlist,
@@ -18,6 +19,7 @@ vi.mock('../api/client', () => ({
   createCollection: vi.fn(),
   addCardToCollection: vi.fn(),
   deleteCollection: vi.fn(),
+  downloadCollectionIdCardPdf: vi.fn(),
   fetchWishlists: vi.fn(),
   createWishlist: vi.fn(),
   addCardToWishlist: vi.fn(),
@@ -33,6 +35,7 @@ const mockWishlists = vi.mocked(fetchWishlists)
 const mockCreate = vi.mocked(createCollection)
 const mockDeleteCollection = vi.mocked(deleteCollection)
 const mockDeleteWishlist = vi.mocked(deleteWishlist)
+const mockPrintIdCard = vi.mocked(downloadCollectionIdCardPdf)
 const mockFetchWishlist = vi.mocked(fetchWishlist)
 const mockTarget = vi.mocked(fetchCollectionTarget)
 
@@ -45,6 +48,7 @@ describe('LibraryBindersTab', () => {
     mockCreate.mockReset()
     mockDeleteCollection.mockReset()
     mockDeleteWishlist.mockReset()
+    mockPrintIdCard.mockReset()
     mockFetchWishlist.mockReset()
     mockTarget.mockReset()
     mockCollections.mockResolvedValue([])
@@ -342,6 +346,21 @@ describe('LibraryBindersTab', () => {
 
     await waitFor(() => expect(mockDeleteWishlist).toHaveBeenCalledWith(2))
     await waitFor(() => expect(screen.queryByText('Mew hunt')).not.toBeInTheDocument())
+  })
+
+  it('downloads the ID card for a collection', async () => {
+    mockCollections.mockResolvedValue([
+      { id: 1, name: 'Charizard masters', description: null, created_at: '2026-06-04T00:00:00', item_count: 4 },
+    ])
+    mockPrintIdCard.mockResolvedValue(undefined)
+    render(<LibraryBindersTab />)
+    await waitFor(() => expect(screen.getByText('Charizard masters')).toBeInTheDocument())
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /print ID card for collection "Charizard masters"/i }),
+    )
+
+    await waitFor(() => expect(mockPrintIdCard).toHaveBeenCalledWith(1, undefined))
   })
 
   it('keeps the binder when the delete confirm is cancelled', async () => {

--- a/web/src/components/LibraryBindersTab.tsx
+++ b/web/src/components/LibraryBindersTab.tsx
@@ -17,14 +17,16 @@
  * [OwnershipBadge](./OwnershipBadge.tsx) chip (#576): palm for owned,
  * sun for chasing.
  */
-import { BarChart3, Loader2, Sparkles, Trash2 } from 'lucide-react'
+import { BarChart3, Loader2, Printer, Sparkles, Trash2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
+import { downloadCollectionIdCardPdf } from '../api/client'
 import type {
   CollectionRule,
   CollectionSummary,
   DynamicScope,
   WishlistSummary,
 } from '../api/client'
+import { useAppStore } from '../store'
 import { CollectionInsights } from './CollectionInsights'
 import { SmartCollectionTarget } from './SmartCollectionTarget'
 import { WishlistDetail } from './WishlistDetail'
@@ -414,8 +416,50 @@ function CollectionRow({
       ) : (
         <div className="flex flex-1 items-center justify-between py-2">{body}</div>
       )}
+      <PrintIdCardControl collectionId={c.id} label={`collection "${c.name}"`} />
       <DeleteBinderControl label={`collection "${c.name}"`} onDelete={() => onDelete(c.id)} />
     </li>
+  )
+}
+
+/**
+ * Per-row "print ID card" affordance — downloads the binder-cover PDF (#507)
+ * for the collection. The printer icon reveals on hover like the delete
+ * control; a failed download surfaces a quiet inline note.
+ */
+function PrintIdCardControl({ collectionId, label }: { collectionId: number; label: string }) {
+  const apiKey = useAppStore((s) => s.settings.apiKey)
+  const [busy, setBusy] = useState(false)
+  const [failed, setFailed] = useState(false)
+
+  return (
+    <span className="flex shrink-0 items-center gap-1">
+      {failed && (
+        <span role="alert" className="text-[10px] text-ember-500 dark:text-ember-300">
+          Couldn&apos;t print
+        </span>
+      )}
+      <button
+        type="button"
+        disabled={busy}
+        aria-label={`Print ID card for ${label}`}
+        title="Print ID card"
+        onClick={async () => {
+          setBusy(true)
+          setFailed(false)
+          try {
+            await downloadCollectionIdCardPdf(collectionId, apiKey || undefined)
+          } catch {
+            setFailed(true)
+          } finally {
+            setBusy(false)
+          }
+        }}
+        className="shrink-0 rounded p-1.5 text-coconut-400 opacity-100 transition-opacity hover:bg-sand-200 hover:text-palm-600 disabled:opacity-50 dark:text-sand-400 dark:hover:bg-husk-100 dark:hover:text-palm-300 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
+      >
+        {busy ? <Loader2 size={14} className="animate-spin" /> : <Printer size={14} />}
+      </button>
+    </span>
   )
 }
 


### PR DESCRIPTION
Closes #507

## What

A per-collection **ID card** — a single binder-pocket cutout for the top-left slot of a 9-pocket sheet, the personal-collection analogue of the existing Set ID Cards export. It carries the collection's **title**, a representative **card photo**, and an **owned / total** count, so a collector can cut it out and front their binder with it.

- `GET /collections/{id}/id-card.pdf` resolves the cutout for any collection kind and streams the PDF.
- A printer icon on each collection row in the Binders tab triggers the download.
- The cover photo is **auto-picked**: the most valuable card you own in the collection, falling back to the first.
- The denominator is the catalog match count for a **catalog-scope smart collection** and the printed set size for a **set collection**; **manual buckets** and **owned-scope smart collections** have no total, so the card shows just the owned count ("N cards").

## Why

This is a refinement of #507. Rather than the original ticket's full multi-card preview page with drag-reorder, the design we settled on is the single **cover card** a collector slots into pocket 1 — the same idea as Set ID Cards, but scoped to a personal collection (e.g. an Exeggutor/Exeggcute run). It reuses the existing PDF pipeline (`set_cards.py` cutout primitives + the unified disk image cache) rather than asking users to screenshot a list view.

Deliberately out of this slice (fast-follows): value-over-time, manual drag-reorder, and the full per-card preview page.

## How to verify

1. `make dev-api` + `make dev-web`. Create a collection and add a few cards to it (bookmark icon on matched rows).
2. In the **Binders** tab, hover the collection row → click the **printer** icon. A PDF downloads.
3. Open it: a single binder-pocket cutout in the top-left, with the collection title, the cover photo (your priciest card), the count, and dashed cut lines. For a catalog-scope smart collection the count reads "owned / total"; for a manual bucket it reads "N cards".

Verified locally end-to-end against the real API: the endpoint streams a valid one-page PDF with the cover image embedded, the title, and the count, laid out in pocket 1 with cut lines and the mgz-pkmn footer. New coverage: route + cover-pick tests in `tests/test_collections.py`, renderer tests in `tests/test_set_cards.py`, and a download-trigger test in `LibraryBindersTab.test.tsx`. `make check` and `cd web && npm run build` are green.