### PR TITLE
fix(devops): make release finalize immutable-safe and stop bot-PR-body overwrites

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -41,9 +41,9 @@ instead of this skill.
 
 ## Step 2 — CHANGELOG consolidation pass
 
-release-please rotated `[Unreleased]` into a versioned section with one bullet
-per Conventional Commit — terse subject literals in its own header format. Reshape
-that section into the project's curated style. The marketing site and the
+release-please inserts a new versioned section at the top of `CHANGELOG.md`, one
+bullet per Conventional Commit — terse subject literals in its own header format.
+Reshape that section into the project's curated style. The marketing site and the
 live-demo "what's new" surface render `CHANGELOG.md` verbatim, so the version
 section you ship is exactly what every visitor reads.
 
@@ -52,8 +52,11 @@ section you ship is exactly what every visitor reads.
 1. **Normalize the header + footer to Keep-a-Changelog style.** release-please
    emits `## [X.Y.Z](compare-link) (YYYY-MM-DD)`; the project uses
    `## [X.Y.Z] - YYYY-MM-DD` with the compare link in the footer at the bottom
-   of the file. Match the existing `## [1.5.0] - …` sections and update the
-   `[Unreleased]` / `[X.Y.Z]` compare links in the footer.
+   of the file. Match the existing `## [1.5.0] - …` sections and add an
+   `[X.Y.Z]: …/compare/vPREV...vX.Y.Z` link to the footer. There is **no
+   `[Unreleased]` section or footer link** — the project retired that placeholder
+   (see [docs/contributing.md → Changelog](../../docs/contributing.md#changelog));
+   the top of the file starts at the latest shipped release.
 2. **Dedupe subsection headings.** One `### Added` / `### Changed` / `### Fixed`
    block per release. Collapse duplicates — multiple blocks break the marketing
    site's table of contents.
@@ -101,7 +104,7 @@ print('Latest shipped:', shipped[0].version, shipped[0].date)
 
 Should print `Latest shipped: $VERSION <today>`.
 
-## Step 5 — Push back + refresh the PR body
+## Step 5 — Push back + sync PR metadata
 
 Push to the **bot's branch** (don't rename it; `gh pr checkout` set the upstream).
 Sign off the commit (DCO is enforced) with a Conventional Commits subject:
@@ -112,16 +115,24 @@ git commit -s -m "chore(release): consolidate v$VERSION changelog"
 git push
 ```
 
-Then refresh the bot PR's body and metadata in place — don't open a competing PR
+Then sync **labels + milestone only** on the bot PR — don't open a competing PR
 (release-please reuses the branch on the next `main` push, so a parallel PR breaks
 its loop):
 
 ```bash
 gh pr edit "$BOT_PR" --repo mgzwarrior/mgz-pkmn \
   --add-label "area:devops" --add-label "version:v1.x" --add-label "agent:claude" \
-  --milestone "v$MILESTONE" \
-  --body "<summary of the release + the consolidation pass>"
+  --milestone "v$MILESTONE"
 ```
+
+> ⚠️ **Never touch the bot PR body** (`--body` / `--body-file`). release-please
+> embeds machine-readable release metadata there and re-parses it at merge time to
+> create the tag + Release. Overwriting it makes release-please log `could not parse
+> pull request body as a release PR` → no tag → no `release: published` event →
+> nothing publishes, and the *next* release PR re-lists the same notes. This broke
+> the v1.6.0 release (issue #651). The curated changelog already ships in
+> `CHANGELOG.md`; if you want a human summary on the PR, post a separate
+> `gh pr comment` instead.
 
 ## Step 6 — Wait for CI; do NOT merge
 
@@ -139,7 +150,10 @@ publishes from there.
 - Don't re-bump the version surfaces by hand — release-please already did, and
   the lock workflow already synced the lockfiles. Your only edits are the
   CHANGELOG prose and the `CITATION.cff` date.
-- Don't add `### Added/Changed/Fixed` subheadings to the empty `[Unreleased]`
-  block; they appear when the first entry lands.
+- Don't overwrite the bot PR body (`gh pr edit --body`) — it carries release-please's
+  machine-readable release metadata; clobbering it blocks tagging + publish (issue #651).
+  Edit labels/milestone only; put any human summary in a `gh pr comment`.
+- Don't re-add an empty `[Unreleased]` section to `CHANGELOG.md` — the project retired
+  that placeholder; release-please drafts the next version's section from commits.
 - Don't suggest a separate admin button, manual PyPI upload, or PAT — the merge
   is the trigger; everything downstream is automatic.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,9 @@ name: Release
 # release-please owns tagging + cutting the GitHub Release (it creates both with
 # RELEASE_PAT, so the `release` event fires downstream workflows). This workflow
 # runs on that event to build, publish to PyPI (trusted publishing + PEP 740
-# attestation), attach the dist to release-please's Release, close the milestone,
-# and rebuild the marketing site. The Sigstore identity stays this workflow in
-# the `pypi` environment, so the existing PyPI trusted publisher needs no change.
+# attestation), close the milestone, and rebuild the marketing site. The
+# Sigstore identity stays this workflow in the `pypi` environment, so the
+# existing PyPI trusted publisher needs no change.
 on:
   release:
     types: [published]
@@ -69,21 +69,10 @@ jobs:
       contents: write
       issues: write
     steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v8
-        with:
-          name: dist
-          path: dist/
-
-      # release-please already cut the Release (with its changelog body); just
-      # attach the built sdist + wheel so they show up on the Release page.
-      # `--clobber` overwrites assets on a re-run without touching the notes.
-      - name: Attach dist to the GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.event.release.tag_name }}
-        run: gh release upload "$TAG" dist/* --clobber --repo "$GITHUB_REPOSITORY"
-
+      # The built sdist + wheel are deliberately not attached to the GitHub
+      # Release: PyPI is the canonical channel and carries the PEP 740
+      # attestation, GitHub already attaches the source archives, and immutable
+      # releases reject post-hoc asset uploads (HTTP 422). See issue #651.
       - name: Close matching milestone
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,14 @@ No other format is acceptable. Keep the description short (2–4 words, kebab-ca
   design (use these for dependency bumps, CI tweaks, internal refactors, test-only PRs) —
   and (2) a rich PR body the editorial pass can pull detail from. See
   [docs/contributing.md → Changelog](docs/contributing.md#changelog).
+- **No empty `[Unreleased]` placeholder section.** release-please now drafts the next
+  version's section straight from the accumulated Conventional Commits, so the old
+  Keep-a-Changelog ritual of carrying a stub `## [Unreleased]` header (and its
+  `compare/...HEAD` footer link) at the top of [CHANGELOG.md](CHANGELOG.md) is retired.
+  Don't re-add it during a release consolidation or in a feature PR — the public surfaces
+  (marketing site, live-demo "what's new") already filter Unreleased out, so the stub only
+  invites drift. The footer keeps versioned compare links; the top of the file starts at the
+  latest shipped release.
 - For **deployment-affecting** changes, update [render.yaml](render.yaml) in the
   same PR so the hosted-demo blueprint stays in sync with the code. The blueprint
   is the canonical declaration of what the deployed API needs — keeping it in the

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -572,25 +572,23 @@ SPA). Thresholds will be revisited once we have a stable baseline.
 
 [CHANGELOG.md](../CHANGELOG.md) follows the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format.
 
-**Don't add `[Unreleased]` entries by hand in your PR.** release-please reads the Conventional Commits between releases and drafts the next release's bullets automatically — adding a hand-written entry on top of that produces a duplicate that ships to the marketing site and the live-demo "what's new" surface as the same change listed twice. The cut-release editorial consolidation pass (`.claude/skills/cut-release/SKILL.md` Step 5a) then rewrites release-please's terse bullets into the project's rich-paragraph style, pulling detail from PR bodies — so the things that matter for the final CHANGELOG are:
+**Don't hand-write changelog entries in your PR.** release-please reads the Conventional Commits between releases and drafts the next release's bullets automatically — adding a hand-written entry on top of that produces a duplicate that ships to the marketing site and the live-demo "what's new" surface as the same change listed twice. (There is no `[Unreleased]` placeholder section to add to, either — release-please drafts the next version's section straight from commits at release time.) The cut-release editorial consolidation pass (`.claude/skills/cut-release/SKILL.md` Step 2) then rewrites release-please's terse bullets into the project's rich-paragraph style, pulling detail from PR bodies — so the things that matter for the final CHANGELOG are:
 
 - **Your Conventional Commits subject** (`<type>(<scope>): <subject>`) — release-please uses it verbatim as the seed bullet. `feat:` lands under `### Added`, `fix:` under `### Fixed`, `perf:` / `refactor:` / `docs:` / `revert:` under `### Changed`. `chore:` / `ci:` / `test:` / `build:` / `style:` are hidden from the changelog by design — that's how you mark "changes users never see" (dependency bumps, CI config, internal refactors, test-only PRs).
 - **Your PR body** — the cut-release editorial pass reads it when rewriting bullets into the rich style. Include the **why**, the user-visible impact, and the files / surfaces touched. The richer your PR description, the richer the final changelog entry.
 
 If your change really has no user-visible impact, use a hidden type (`chore:`, `ci:`, `refactor:` for internal-only restructures, `test:`, `build:`, `style:`) and nothing ships to the changelog. No manual `### Hidden` block, no opt-out flag — the commit type is the contract.
 
-This rule is forward-looking: existing hand-written `[Unreleased]` entries that predate release-please stay until the next release's editorial pass folds or rewrites them.
-
 ## Releasing
 
-release-please owns the release end to end. A version-bump PR **is** the release — once it merges to `main`, release-please tags the commit and cuts the GitHub Release. That `release` event triggers `release.yml`, which builds the package, runs the test suite, publishes to [PyPI](https://pypi.org/project/mgz-pkmn/) via trusted publishing (with PEP 740 attestations), and attaches the built distribution to the Release.
+release-please owns the release end to end. A version-bump PR **is** the release — once it merges to `main`, release-please tags the commit and cuts the GitHub Release. That `release` event triggers `release.yml`, which builds the package, runs the test suite, and publishes to [PyPI](https://pypi.org/project/mgz-pkmn/) via trusted publishing (with PEP 740 attestations). PyPI is the canonical distribution; the built sdist + wheel are not attached to the GitHub Release (GitHub already attaches the source archives, and immutable releases reject post-hoc asset uploads).
 
 ### The release PR is drafted by release-please
 
 `.github/workflows/release-please.yml` watches `main` and opens a version-bump PR whenever release-worthy Conventional Commits (`feat:`, `fix:`, `perf:`, `refactor:`, `docs:`, `revert:`) accumulate. The bot's PR is the **canonical release PR** — don't open a competing one. The bot:
 
 - Bumps **every** version surface in one commit — root `pyproject.toml` (via the `python` release type) plus `api/pyproject.toml`, `web/package.json`, `site/package.json`, `CITATION.cff` (`version`), and `src/mgz_pkmn/__init__.py` (via the `extra-files` config in `release-please-config.json`).
-- Rotates `[Unreleased]` in `CHANGELOG.md` into a new versioned section with bullets generated from the commit subjects.
+- Inserts a new versioned section at the top of `CHANGELOG.md` with bullets generated from the commit subjects (no `[Unreleased]` placeholder — the file starts at the latest shipped release).
 - Signs the commit with `Signed-off-by: github-actions[bot] …` so the DCO check passes.
 
 release-please can't run `uv lock` or `npm install`, so [`release-please-lock.yml`](../.github/workflows/release-please-lock.yml) watches the bot branch and re-syncs `uv.lock`, `web/package-lock.json`, and `site/package-lock.json` after the bump — without this the `web` / `site` CI jobs (which run `npm ci`) would fail on the version mismatch. The PR's checks may flash red until that re-sync commit lands; that's expected.
@@ -635,9 +633,9 @@ unavailable (misconfigured, or an emergency release off-cycle), you can
 cut a release yourself:
 
 1. Open a single PR that bumps the version string in **every** surface
-   so the artifacts ship the same number, and rotates the changelog
-   (rename `[Unreleased]` to the new version with today's date, add a
-   fresh empty `[Unreleased]` above it, update the compare links):
+   so the artifacts ship the same number, and updates the changelog
+   (add a new `## [X.Y.Z] - <today>` section at the top and a matching
+   `[X.Y.Z]` compare link in the footer — no `[Unreleased]` placeholder):
    - **CLI** — `pyproject.toml` (root) and `src/mgz_pkmn/__init__.py`.
      Run `uv lock` afterwards to refresh `uv.lock`.
    - **API** — `api/pyproject.toml`. Served as `{"version": "..."}` by


### PR DESCRIPTION
Closes #651

## What

Fixes the two release-pipeline failures the v1.6.0 release exposed, and retires the vestigial `[Unreleased]` changelog placeholder.

- **cut-release skill (Step 5):** edit labels + milestone only — **never** overwrite the bot PR body. release-please embeds machine-readable release metadata there and re-parses it at merge time to create the tag + Release; clobbering it blocks the whole release. Any human summary goes in a `gh pr comment`.
- **`release.yml` finalize:** drop the post-hoc "attach dist to the Release" step. It fails under immutable releases (`HTTP 422`) and, because it wasn't best-effort, sank the milestone-close + site-rebuild steps with it. PyPI is canonical and carries the PEP 740 attestation; GitHub already attaches the source archives; immutable releases stay enabled.
- **`[Unreleased]` placeholder retired** across `CLAUDE.md`, `docs/contributing.md`, and the cut-release skill — release-please drafts the next version's section straight from commits, so the empty stub was vestigial.

## Why

On v1.6.0 (PR #610), release-please logged `could not parse pull request body as a release PR` → no `v1.6.0` tag → no `release: published` event → nothing published, and the next PR re-listed the old notes as 1.7.0. The finalize `422` then skipped milestone-close + site-rebuild. 1.6.0 was recovered by cutting the tag/Release manually; this PR stops both failures recurring.

## How to verify

- `release.yml` no longer references `gh release upload`; finalize is just the milestone close. `make check` green; `release.yml` parses as valid YAML.
- Skill Step 5 and "Behaviours to avoid" now forbid `--body` edits to the bot PR.
- No remaining `[Unreleased]`-ritual or dist-attach references in `docs/` or `.github/` (grep clean).
- Next release: the bot PR merges → release-please tags + publishes with no manual body edit; the GitHub Release carries notes but no attached wheel/sdist.