### PR TITLE
test(web): stabilize Codecov-flagged flaky swipe/browse tests

### DIFF
--- a/web/src/components/SwipePanel.test.tsx
+++ b/web/src/components/SwipePanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { SwipePanel } from './SwipePanel'
 import {
   fetchSets,
@@ -68,10 +68,30 @@ function card(overrides: Partial<SetCard> = {}): SetCard {
 }
 
 // Each keystroke / drag commit kicks off a 180ms exit-animation timeout in
-// SwipePanel before `advance()` runs and renders the next card. The default
-// 1s waitFor budget gets tight when CI runs the whole suite under contention
-// (#387); give the post-swipe assertions 3s of headroom from one place.
-const POST_SWIPE_WAIT = { timeout: 3000 } as const
+// SwipePanel before `advance()` runs and renders the next card. That's a real
+// timer, so under full-suite CI contention (#387, #653) the saturated event
+// loop fires it well past the old 3s budget — and 3s was *under* the 5s test
+// timeout, so the assertion lost the race first. Give post-swipe assertions a
+// wide budget from one place; on success the wait still resolves in ~200ms.
+const POST_SWIPE_WAIT = { timeout: 10000 } as const
+
+// Commit a keyboard swipe and deterministically flush the 180ms exit-animation
+// timer. SwipePanel schedules the save/advance behind a real `setTimeout`, so a
+// widened waitFor budget still loses to a CI event loop starved past it (#387,
+// #653) — worst on tests that chain two swipes. Faking just that timer lands
+// the swipe on a controlled clock instead of the loaded loop. Real timers are
+// restored immediately so surrounding waitFor calls poll normally.
+async function swipeKey(key: 'ArrowLeft' | 'ArrowRight' | 'ArrowUp') {
+  vi.useFakeTimers()
+  try {
+    fireEvent.keyDown(window, { key })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200)
+    })
+  } finally {
+    vi.useRealTimers()
+  }
+}
 
 describe('SwipePanel', () => {
   let randomSpy: ReturnType<typeof vi.spyOn>
@@ -261,15 +281,17 @@ describe('SwipePanel', () => {
     // A single set with two cards — after two swipes the catalog is empty.
     render(<SwipePanel active />)
     await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
-    fireEvent.keyDown(window, { key: 'ArrowLeft' })
-    // Wait for the first pass to fully commit (Pikachu leaves the stack)
-    // before the next keystroke — while the exit animation is in flight the
-    // handler ignores input, so an instant peek must not race it.
+    // Chaining two swipes compounds the exit-animation timer race, so drive
+    // each commit on a faked clock. The first pass must fully commit (Pikachu
+    // leaves the stack) before the next keystroke — while the exit animation
+    // is in flight the handler ignores input, so an instant peek must not race
+    // it.
+    await swipeKey('ArrowLeft')
     await waitFor(
       () => expect(screen.queryByText('Pikachu')).not.toBeInTheDocument(),
       POST_SWIPE_WAIT,
     )
-    fireEvent.keyDown(window, { key: 'ArrowLeft' })
+    await swipeKey('ArrowLeft')
     await waitFor(
       () =>
         expect(
@@ -292,10 +314,12 @@ describe('SwipePanel', () => {
     render(<SwipePanel active />)
     await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
     fireEvent.keyDown(window, { key: 'ArrowRight' })
-    await waitFor(() =>
-      expect(
-        screen.getByRole('button', { name: /1 saved · reset/i }),
-      ).toBeInTheDocument(),
+    await waitFor(
+      () =>
+        expect(
+          screen.getByRole('button', { name: /1 saved · reset/i }),
+        ).toBeInTheDocument(),
+      POST_SWIPE_WAIT,
     )
     fireEvent.click(screen.getByRole('button', { name: /1 saved · reset/i }))
     await waitFor(() =>
@@ -312,8 +336,10 @@ describe('SwipePanel', () => {
     render(<SwipePanel active />)
     await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
     fireEvent.keyDown(window, { key: 'ArrowRight' })
-    await waitFor(() =>
-      expect(screen.getByLabelText('Prep list name')).toBeInTheDocument(),
+    await waitFor(
+      () =>
+        expect(screen.getByLabelText('Prep list name')).toBeInTheDocument(),
+      POST_SWIPE_WAIT,
     )
 
     fireEvent.click(screen.getByRole('button', { name: /build prep list/i }))
@@ -344,10 +370,12 @@ describe('SwipePanel', () => {
     render(<SwipePanel active />)
     await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
     fireEvent.keyDown(window, { key: 'ArrowRight' })
-    await waitFor(() =>
-      expect(
-        screen.getByRole('button', { name: /1 saved · reset/i }),
-      ).toBeInTheDocument(),
+    await waitFor(
+      () =>
+        expect(
+          screen.getByRole('button', { name: /1 saved · reset/i }),
+        ).toBeInTheDocument(),
+      POST_SWIPE_WAIT,
     )
 
     const input = screen.getByLabelText('Prep list name') as HTMLInputElement

--- a/web/src/components/useSwipeCandidates.test.ts
+++ b/web/src/components/useSwipeCandidates.test.ts
@@ -158,9 +158,14 @@ describe('useSwipeCandidates — prefetched stack', () => {
     })
 
     // The former peek is the new top immediately — no loader, and the
-    // background top-up reuses the cached card list (still one fetch).
+    // background top-up reuses the cached card list (still one fetch). The
+    // top-up is async, so wait for the stack to refill rather than reading it
+    // synchronously — under full-suite contention the fill hasn't always
+    // landed by the time `current` flips to 'b' (#387, #653).
     await waitFor(() => expect(result.current.current!.card.id).toBe('b'))
-    expect(result.current.upcoming.map((c) => c.card.id)).toEqual(['c', 'd'])
+    await waitFor(() =>
+      expect(result.current.upcoming.map((c) => c.card.id)).toEqual(['c', 'd']),
+    )
     expect(mockFetchSetCards).toHaveBeenCalledTimes(1)
   })
 

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -6,6 +6,12 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
+    // The full suite runs across parallel workers in CI; under that
+    // contention the event loop is saturated, so real timers fire late and
+    // heavy renders (e.g. the baked national dex) overrun the stock 5s
+    // budget. Give every test generous headroom — this only costs wall-clock
+    // time when a test genuinely fails, which should be ~never (#387, #653).
+    testTimeout: 15000,
     reporters: [
       'default',
       ['junit', { outputFile: 'junit.xml' }],


### PR DESCRIPTION
Resolves #653

## What

Stabilizes the recurring cluster of flaky web tests that Codecov Test Analytics flags, all rooted in full-suite CI contention (#387) where parallel vitest workers saturate the event loop — starving real timers and slowing heavy renders past their budgets.

- **SwipePanel** post-swipe assertions: the `/N saved · reset/` header chip is gated behind a real 180ms exit-animation `setTimeout`. The old 3s `POST_SWIPE_WAIT` was *under* the 5s test timeout, so the assertion lost the race first. Widened it to 10s, and added the budget to the assertions that were still on the bare 1s default ("Reset profile…", the two "Build prep list" tests).
- **SwipePanel "exhausted state"** chains two swipes, compounding the timer race — it failed even at a 10s budget. This one now flushes the 180ms commit timer on a faked clock via a small `swipeKey` helper, so the swipe lands on a deterministic clock instead of the loaded loop. Real timers are restored immediately so surrounding `waitFor` calls poll normally.
- **BrowsePanel** pokedex view ("filters the species list by name", "shows the collection / wishlist save buttons…") hit the stock **5000ms** test timeout rendering the full national dex under load. Raised the global vitest `testTimeout` to 15s.
- **useSwipeCandidates** "advance() promotes the next card with no extra fetch" read `upcoming` synchronously, racing the async background top-up. Wrapped it in `waitFor`.

## Why

These pass in isolation but fail intermittently in CI's `web` job, eroding trust in the suite and blocking unrelated PRs. The fix follows the maintainer's established #387 approach (widen timing budgets) and adds a deterministic faked-clock flush for the one test where a widened budget wasn't enough.

The other tests in Codecov's failure history — App "switching to Swipe", a11y SettingsDrawer, SetPickerModal ×2, and the Python auth/logging tests — were dev-time failures on the feature branches that introduced them; they're green on `main` and need no change.

## How to verify

```
cd web && for i in $(seq 1 8); do npm test --silent | grep "Tests "; done
```

All 415 web tests passed across 8 consecutive full-suite runs locally (the flakes reproduced ~1-in-3 to 1-in-5 before). `make check` and `cd web && npm run build` are green.