### PR TITLE
fix(cli): forward unknown root options to the lookup fallback

### DIFF
--- a/src/mgz_pkmn/cli/__init__.py
+++ b/src/mgz_pkmn/cli/__init__.py
@@ -19,7 +19,24 @@ class FallbackGroup(click.Group):
 
     Lets `pkmn cards.txt` keep working alongside `pkmn lookup cards.txt`
     and `pkmn set-cards` — preserves the historical, no-subcommand CLI
-    while still surfacing real subcommands in `--help`."""
+    while still surfacing real subcommands in `--help`.
+
+    Two parser stages need the fallback. An unknown *first positional*
+    (`pkmn cards.txt`) trips `resolve_command`; an unknown *option*
+    (`pkmn --no-images cards.txt`) trips `parse_args` on the root group
+    before `resolve_command` ever runs, so both are caught."""
+
+    def parse_args(self, ctx: click.Context, args: list[str]) -> list[str]:
+        try:
+            return super().parse_args(ctx, list(args))
+        except click.NoSuchOption:
+            if "lookup" not in self.commands:
+                raise
+            # An option meant for `lookup` hit the root group's parser.
+            # Re-parse with an explicit subcommand so the option lands on
+            # lookup's parser instead. `list(args)` above keeps the
+            # original `args` intact for this retry.
+            return super().parse_args(ctx, ["lookup", *args])
 
     def resolve_command(
         self, ctx: click.Context, args: list[str]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -562,6 +562,41 @@ class WarnIfCacheLargeTests(unittest.TestCase):
         self.assertEqual(result.stderr, "")
 
 
+class FallbackGroupTests(unittest.TestCase):
+    """The no-subcommand `pkmn …` form routes to `lookup`, whether the user
+    leads with a positional (`pkmn cards.txt`) or an option
+    (`pkmn --no-images cards.txt`). The option case used to error at the root
+    group's parser before the fallback could kick in (#550)."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self._input = Path(self._tmp.name) / "cards.txt"
+        self._input.write_text("Mew\n", encoding="utf-8")
+
+    @staticmethod
+    def _stub(pkmn, tcgdex, pc, q, default_lang=None) -> MatchResult:
+        card = {"id": q.name, "name": q.name, "number": "1", "set": {"name": "S"}}
+        return MatchResult(card, "matched")
+
+    def _invoke(self, args: list[str]):
+        with patch("mgz_pkmn.cli.lookup.find_card", side_effect=self._stub):
+            return CliRunner().invoke(cli, args)
+
+    def test_option_before_positional_routes_to_lookup(self) -> None:
+        result = self._invoke(["--no-images", "--print-summary-only", str(self._input)])
+        self.assertEqual(result.exit_code, 0, result.output)
+
+    def test_positional_only_still_routes_to_lookup(self) -> None:
+        result = self._invoke(["--print-summary-only", str(self._input)])
+        self.assertEqual(result.exit_code, 0, result.output)
+
+    def test_unknown_option_surfaces_lookup_error(self) -> None:
+        result = self._invoke(["--definitely-not-a-flag", str(self._input)])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("No such option", result.output)
+
+
 class LookupSummaryCacheTests(unittest.TestCase):
     """End-to-end check that `· N cached / M fetched` appears in the summary
     when the run produced cache hits — and is suppressed when it didn't.


### PR DESCRIPTION
Closes #550

## What

The no-subcommand form `pkmn --no-images cards.txt` (or `pkmn -o out.xlsx cards.txt`) errored at the root group's option parser before the `lookup` fallback could kick in:

```
Usage: pkmn [OPTIONS] COMMAND [ARGS]...
No such option: --no-images
```

`FallbackGroup.resolve_command` already forwards an unknown *first positional* (`pkmn cards.txt`) to `lookup`, but Click parses the root group's own option list before `resolve_command` ever runs, so an unknown *option* failed outright. This overrides `FallbackGroup.parse_args` to catch `click.NoSuchOption` and re-parse with an explicit `lookup` subcommand, so the option lands on lookup's parser instead.

## Why

A long-standing limitation since #76 turned the root `@click.command` into a `@click.group`. The legacy single-command form is intentionally supported (muscle memory from pre-#76, simpler `pkmn cards.txt` invocations in docs/examples), so leading with a lookup flag should work the same as leading with the positional. Approach (1) from the issue — the click-idiomatic one.

Genuinely unknown options still surface lookup's own usage error (with its "did you mean" suggestion) rather than failing silently, so typos aren't swallowed.

## How to verify

```bash
printf 'Mew\n' > /tmp/foo.txt

# Was: "No such option: --no-images". Now: runs lookup, exits 0.
uv run pkmn --no-images --print-summary-only /tmp/foo.txt

# Positional fallback unchanged.
uv run pkmn --print-summary-only /tmp/foo.txt

# set-cards subcommand unaffected.
uv run pkmn set-cards --help

# Typos still error (against lookup, not the root group).
uv run pkmn --bogus-flag /tmp/foo.txt
```

New `FallbackGroupTests` in `tests/test_cli.py` lock in all three paths: option-before-positional exits 0, positional-only still routes to lookup, and an unknown option surfaces a "No such option" error. `make check` green (915 tests).