### PR TITLE
chore: split extract_pricing into per-source resolvers (#553)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ fix:  ## Auto-fix safe ruff issues + reformat.
 # file listed here has a D-rank-or-worse function or a B-rank-or-worse
 # maintainability index that pre-dates the gate; the gate stays green on
 # green-field, then tightens as each is brought to A. See issue #387.
-RADON_CC_EXCLUDE := src/mgz_pkmn/spreadsheet.py,src/mgz_pkmn/lookup.py,src/mgz_pkmn/cache.py,src/mgz_pkmn/card_images.py,src/mgz_pkmn/parser.py,src/mgz_pkmn/pricing.py,src/mgz_pkmn/binder.py,src/mgz_pkmn/report.py
+RADON_CC_EXCLUDE := src/mgz_pkmn/spreadsheet.py,src/mgz_pkmn/lookup.py,src/mgz_pkmn/cache.py,src/mgz_pkmn/card_images.py,src/mgz_pkmn/parser.py,src/mgz_pkmn/binder.py,src/mgz_pkmn/report.py
 RADON_MI_EXCLUDE := src/mgz_pkmn/cache.py
 
 .PHONY: complexity

--- a/src/mgz_pkmn/pricing.py
+++ b/src/mgz_pkmn/pricing.py
@@ -65,28 +65,28 @@ def summarize_ebay_comps(comps: Iterable[Pricing]) -> tuple[float | None, float 
     return median_sold, active_floor
 
 
-def extract_pricing(card: dict[str, Any], variant_hint: str | None) -> Pricing:
+def _pricing_from_pricecharting(card: dict[str, Any]) -> Pricing | None:
     # PriceCharting (when matched via a URL hint) takes priority since the
     # user explicitly chose that page. "Loose" / used is the negotiation tier.
     pc_prices = card.get("_pc_prices") or {}
+    if not pc_prices:
+        return None
     pc_url = card.get("_pc_url")
-    if pc_prices:
-        for label in ("used", "new", "graded"):
-            value = pc_prices.get(label)
-            if value:
-                return Pricing(
-                    market=float(value),
-                    variant=label,
-                    source="pricecharting",
-                    url=pc_url,
-                    currency="USD",
-                )
+    for label in ("used", "new", "graded"):
+        value = pc_prices.get(label)
+        if value:
+            return Pricing(
+                market=float(value),
+                variant=label,
+                source="pricecharting",
+                url=pc_url,
+                currency="USD",
+            )
+    return None
 
-    tcg = card.get("tcgplayer") or {}
-    prices = tcg.get("prices") or {}
-    url = tcg.get("url")
 
-    # Build the variant search order: explicit hint first, then preferences.
+def _tcgplayer_variant_order(prices: dict[str, Any], variant_hint: str | None) -> list[str]:
+    # Explicit hint first, then the preference list, then any remaining variants.
     order: list[str] = []
     if variant_hint and variant_hint in prices:
         order.append(variant_hint)
@@ -96,14 +96,21 @@ def extract_pricing(card: dict[str, Any], variant_hint: str | None) -> Pricing:
     for v in prices:
         if v not in order:
             order.append(v)
+    return order
 
-    for v in order:
+
+def _pricing_from_tcgplayer(tcg: dict[str, Any], variant_hint: str | None) -> Pricing | None:
+    prices = tcg.get("prices") or {}
+    url = tcg.get("url")
+    for v in _tcgplayer_variant_order(prices, variant_hint):
         bucket = prices.get(v) or {}
         market = bucket.get("market") or bucket.get("mid") or bucket.get("low")
         if market:
             return Pricing(market=float(market), variant=v, source="tcgplayer", url=url)
+    return None
 
-    cm = card.get("cardmarket") or {}
+
+def _pricing_from_cardmarket(cm: dict[str, Any], fallback_url: str | None) -> Pricing | None:
     cm_prices = cm.get("prices") or {}
     cm_url = cm.get("url")
     cm_currency = cm.get("_currency", "EUR")
@@ -113,8 +120,23 @@ def extract_pricing(card: dict[str, Any], variant_hint: str | None) -> Pricing:
                 market=float(cm_prices[key]),
                 variant=key,
                 source="cardmarket",
-                url=cm_url or url,
+                url=cm_url or fallback_url,
                 currency=cm_currency,
             )
+    return None
 
-    return Pricing(url=url or cm_url)
+
+def extract_pricing(card: dict[str, Any], variant_hint: str | None) -> Pricing:
+    """Resolve a `Pricing` from a card, walking sources in priority order.
+
+    PriceCharting (explicit URL hint) wins, then TCGPlayer, then Cardmarket;
+    a bare `Pricing` carrying whatever store URL we have is the floor."""
+    tcg = card.get("tcgplayer") or {}
+    cm = card.get("cardmarket") or {}
+    tcg_url = tcg.get("url")
+    return (
+        _pricing_from_pricecharting(card)
+        or _pricing_from_tcgplayer(tcg, variant_hint)
+        or _pricing_from_cardmarket(cm, fallback_url=tcg_url)
+        or Pricing(url=tcg_url or cm.get("url"))
+    )

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from mgz_pkmn.pricing import Pricing, extract_pricing
+
+
+class ExtractPricingTests(unittest.TestCase):
+    """Characterization tests for `extract_pricing`'s source priority and
+    variant resolution, locking the behaviour the per-source resolvers
+    preserve (#553)."""
+
+    def test_pricecharting_wins_over_tcgplayer(self) -> None:
+        card = {
+            "_pc_prices": {"used": 12.5, "new": 20},
+            "_pc_url": "https://pc/mew",
+            "tcgplayer": {"prices": {"normal": {"market": 99}}, "url": "https://tcg/mew"},
+        }
+        pricing = extract_pricing(card, None)
+        self.assertEqual(pricing.market, 12.5)
+        self.assertEqual(pricing.variant, "used")
+        self.assertEqual(pricing.source, "pricecharting")
+        self.assertEqual(pricing.url, "https://pc/mew")
+        self.assertEqual(pricing.currency, "USD")
+
+    def test_pricecharting_label_priority_skips_empty(self) -> None:
+        card = {"_pc_prices": {"used": 0, "new": 0, "graded": 30}}
+        pricing = extract_pricing(card, None)
+        self.assertEqual(pricing.market, 30.0)
+        self.assertEqual(pricing.variant, "graded")
+
+    def test_tcgplayer_variant_hint_takes_precedence(self) -> None:
+        card = {
+            "tcgplayer": {
+                "prices": {
+                    "holofoil": {"market": 10},
+                    "reverseHolofoil": {"market": 5},
+                },
+                "url": "https://tcg/x",
+            }
+        }
+        pricing = extract_pricing(card, "reverseHolofoil")
+        self.assertEqual(pricing.market, 5.0)
+        self.assertEqual(pricing.variant, "reverseHolofoil")
+        self.assertEqual(pricing.source, "tcgplayer")
+
+    def test_tcgplayer_preference_order_when_no_hint(self) -> None:
+        # `holofoil` outranks `normal` in PRICE_VARIANT_PREFERENCE.
+        card = {
+            "tcgplayer": {
+                "prices": {
+                    "normal": {"market": 3},
+                    "holofoil": {"market": 8},
+                }
+            }
+        }
+        pricing = extract_pricing(card, None)
+        self.assertEqual(pricing.variant, "holofoil")
+        self.assertEqual(pricing.market, 8.0)
+
+    def test_tcgplayer_falls_back_market_then_mid_then_low(self) -> None:
+        card = {"tcgplayer": {"prices": {"normal": {"low": 4, "mid": 6}}}}
+        pricing = extract_pricing(card, None)
+        self.assertEqual(pricing.market, 6.0)  # mid chosen over low
+
+    def test_cardmarket_used_when_tcgplayer_absent(self) -> None:
+        card = {
+            "cardmarket": {
+                "prices": {"trendPrice": 7.25},
+                "url": "https://cm/x",
+                "_currency": "EUR",
+            }
+        }
+        pricing = extract_pricing(card, None)
+        self.assertEqual(pricing.market, 7.25)
+        self.assertEqual(pricing.variant, "trendPrice")
+        self.assertEqual(pricing.source, "cardmarket")
+        self.assertEqual(pricing.url, "https://cm/x")
+        self.assertEqual(pricing.currency, "EUR")
+
+    def test_cardmarket_falls_back_to_tcgplayer_url(self) -> None:
+        card = {
+            "tcgplayer": {"prices": {}, "url": "https://tcg/x"},
+            "cardmarket": {"prices": {"avg7": 2.0}},
+        }
+        pricing = extract_pricing(card, None)
+        self.assertEqual(pricing.source, "cardmarket")
+        self.assertEqual(pricing.url, "https://tcg/x")
+
+    def test_no_prices_returns_bare_pricing_with_available_url(self) -> None:
+        card = {"tcgplayer": {"prices": {}, "url": "https://tcg/x"}, "cardmarket": {}}
+        pricing = extract_pricing(card, None)
+        self.assertEqual(pricing, Pricing(url="https://tcg/x"))
+
+    def test_empty_card_returns_empty_pricing(self) -> None:
+        self.assertEqual(extract_pricing({}, None), Pricing())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #553

## What

`extract_pricing` carried the whole PriceCharting → TCGPlayer → Cardmarket → fallback decision tree inline, landing it at cyclomatic **D-25** on the radon allowlist. This pulls each source into its own resolver — `_pricing_from_pricecharting`, `_pricing_from_tcgplayer`, `_pricing_from_cardmarket` — plus a `_tcgplayer_variant_order` helper, and reduces `extract_pricing` to a short priority chain over them:

```python
return (
    _pricing_from_pricecharting(card)
    or _pricing_from_tcgplayer(tcg, variant_hint)
    or _pricing_from_cardmarket(cm, fallback_url=tcg_url)
    or Pricing(url=tcg_url or cm.get("url"))
)
```

The worst function drops from **D-25 to B-7**, so `src/mgz_pkmn/pricing.py` comes off `RADON_CC_EXCLUDE` in the [Makefile](Makefile) and is now actively defended by the complexity gate. This is one of the eight child issues under [epic #551](https://github.com/mgzwarrior/mgz-pkmn/issues/551).

## Why

The branching tree was the entire source of complexity. Per-source resolvers each stay independently testable and well under D, and the coordinator reads as the source-priority policy it encodes — without changing any behaviour.

Behaviour is preserved exactly: same source order, same variant-hint-then-preference resolution, same `market`/`mid`/`low` pick, same currency and URL fallbacks (Cardmarket still falls back to the TCGPlayer URL; the bare `Pricing` floor still carries whichever store URL exists).

`extract_pricing` had **no direct unit coverage** before, so this adds `tests/test_pricing.py` characterizing every source path — the safety net the "behaviour preserved exactly" claim rests on.

## How to verify

```bash
# Worst-offender check is now empty, and the file is off the allowlist:
uv run radon cc src/mgz_pkmn/pricing.py -n D -s   # no output
make complexity                                   # ✓ complexity gate passed

# Behaviour characterization + full suite:
uv run python -m pytest tests/test_pricing.py -q  # 9 passed
make check                                        # green (921 tests)
```

## Done when (from #553)

- [x] `uv run radon cc src/mgz_pkmn/pricing.py -n D -s` is empty
- [x] `src/mgz_pkmn/pricing.py` removed from `RADON_CC_EXCLUDE`
- [x] `make complexity` is green with the file removed from the allowlist
- [x] Existing tests still pass (+ new direct coverage added)