### PR TITLE
chore: split warm_card_images into per-image and per-card helpers (#556)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ fix:  ## Auto-fix safe ruff issues + reformat.
 # file listed here has a D-rank-or-worse function or a B-rank-or-worse
 # maintainability index that pre-dates the gate; the gate stays green on
 # green-field, then tightens as each is brought to A. See issue #387.
-RADON_CC_EXCLUDE := src/mgz_pkmn/spreadsheet.py,src/mgz_pkmn/lookup.py,src/mgz_pkmn/cache.py,src/mgz_pkmn/card_images.py,src/mgz_pkmn/parser.py,src/mgz_pkmn/binder.py,src/mgz_pkmn/report.py
+RADON_CC_EXCLUDE := src/mgz_pkmn/spreadsheet.py,src/mgz_pkmn/lookup.py,src/mgz_pkmn/cache.py,src/mgz_pkmn/parser.py,src/mgz_pkmn/binder.py,src/mgz_pkmn/report.py
 RADON_MI_EXCLUDE := src/mgz_pkmn/cache.py
 
 .PHONY: complexity

--- a/src/mgz_pkmn/card_images.py
+++ b/src/mgz_pkmn/card_images.py
@@ -78,6 +78,114 @@ class WarmCardImagesResult:
     sets_failed: list[str] = field(default_factory=list)
 
 
+@dataclass
+class _WarmState:
+    """Running counters threaded through the warm pass.
+
+    A small mutable accumulator so the per-image / per-card helpers can
+    update progress in place while the coordinator keeps the loop flat."""
+
+    images_warmed: int = 0
+    images_failed: int = 0
+    bytes_written: int = 0
+    sets_failed: list[str] = field(default_factory=list)
+
+
+def _throttle(throttle_ms: int) -> None:
+    if throttle_ms > 0:
+        time.sleep(throttle_ms / 1000.0)
+
+
+def _warm_one_image(
+    pkmn: TCGClient,
+    card_id: str,
+    url: str,
+    category: str,
+    state: _WarmState,
+    *,
+    max_bytes: int | None,
+    skip_existing: bool,
+) -> bool:
+    """Warm a single (card, size) image into the cache, mutating `state`.
+
+    Returns False when the `--max-bytes` budget is reached and the whole
+    pass must stop; True to keep going (including the skipped-existing,
+    download-failure, and write-failure paths, which never abort the pass)."""
+    if skip_existing and disk_cache.read_image(category, card_id) is not None:
+        state.images_warmed += 1
+        return True
+
+    # Pre-download budget check: stop cleanly when we're already at the cap.
+    if max_bytes is not None and state.bytes_written >= max_bytes:
+        return False
+
+    content = _download_bytes(pkmn.session, url)
+    if content is None:
+        state.images_failed += 1
+        return True
+
+    # Post-download, pre-write budget check. The pre-check above can't see
+    # *this* download's size — a download larger than the remaining budget
+    # would otherwise push us past the hard cap. This enforces the
+    # docstring's "would the next write push us over?" contract exactly
+    # (caught in Copilot review of #371).
+    if max_bytes is not None and state.bytes_written + len(content) > max_bytes:
+        return False
+
+    path = disk_cache.write_image(category, card_id, content, ext=url)
+    if path is None:
+        state.images_failed += 1
+        return True
+    state.images_warmed += 1
+    state.bytes_written += len(content)
+    return True
+
+
+def _warm_card(
+    pkmn: TCGClient,
+    card: dict,
+    requested_sizes: list[str],
+    state: _WarmState,
+    *,
+    max_bytes: int | None,
+    skip_existing: bool,
+) -> bool:
+    """Warm every requested size for one card. Returns False if the budget
+    was reached partway through (caller must stop the pass)."""
+    card_id = card.get("id")
+    if not card_id:
+        return True
+    images = card.get("images") or {}
+    for size in requested_sizes:
+        url = images.get(size)
+        if not url:
+            continue
+        if not _warm_one_image(
+            pkmn,
+            card_id,
+            url,
+            _CATEGORY_BY_SIZE[size],
+            state,
+            max_bytes=max_bytes,
+            skip_existing=skip_existing,
+        ):
+            return False
+    return True
+
+
+def _build_result(
+    state: _WarmState, *, sets_attempted: int, budget_reached: bool
+) -> WarmCardImagesResult:
+    return WarmCardImagesResult(
+        sets_attempted=sets_attempted,
+        images_warmed=state.images_warmed,
+        images_failed=state.images_failed,
+        bytes_written=state.bytes_written,
+        budget_reached=budget_reached,
+        sets_failed=state.sets_failed,
+    )
+
+
 def warm_card_images(
     pkmn: TCGClient,
     *,
@@ -124,10 +232,7 @@ def warm_card_images(
 
     ids = set_ids if set_ids is not None else fetch_set_ids(pkmn)
     total = len(ids)
-    images_warmed = 0
-    images_failed = 0
-    bytes_written = 0
-    sets_failed: list[str] = []
+    state = _WarmState()
 
     for index, set_id in enumerate(ids, start=1):
         if on_progress is not None:
@@ -140,74 +245,24 @@ def warm_card_images(
         query = f'set.id:"{set_id}"'
         cards, _status = pkmn.search_all(query)
         if not cards:
-            sets_failed.append(set_id)
-            if throttle_ms > 0:
-                time.sleep(throttle_ms / 1000.0)
+            state.sets_failed.append(set_id)
+            _throttle(throttle_ms)
             continue
 
         for card in cards:
-            card_id = card.get("id")
-            if not card_id:
-                continue
-            images = card.get("images") or {}
-            for size in requested_sizes:
-                url = images.get(size)
-                if not url:
-                    continue
-                category = _CATEGORY_BY_SIZE[size]
-                if skip_existing and disk_cache.read_image(category, card_id) is not None:
-                    images_warmed += 1
-                    continue
+            if not _warm_card(
+                pkmn,
+                card,
+                requested_sizes,
+                state,
+                max_bytes=max_bytes,
+                skip_existing=skip_existing,
+            ):
+                return _build_result(state, sets_attempted=index, budget_reached=True)
 
-                if max_bytes is not None and bytes_written >= max_bytes:
-                    return WarmCardImagesResult(
-                        sets_attempted=index,
-                        images_warmed=images_warmed,
-                        images_failed=images_failed,
-                        bytes_written=bytes_written,
-                        budget_reached=True,
-                        sets_failed=sets_failed,
-                    )
+        _throttle(throttle_ms)
 
-                content = _download_bytes(pkmn.session, url)
-                if content is None:
-                    images_failed += 1
-                    continue
-
-                # Post-download, pre-write budget check. The pre-check
-                # above stops cleanly when we're already at the cap, but
-                # it can't see *this* download's size — and a download
-                # larger than the remaining budget would otherwise push
-                # us past the hard cap. This second check enforces the
-                # docstring's "would the next write push us over?"
-                # contract exactly (caught in Copilot review of #371).
-                if max_bytes is not None and bytes_written + len(content) > max_bytes:
-                    return WarmCardImagesResult(
-                        sets_attempted=index,
-                        images_warmed=images_warmed,
-                        images_failed=images_failed,
-                        bytes_written=bytes_written,
-                        budget_reached=True,
-                        sets_failed=sets_failed,
-                    )
-
-                path = disk_cache.write_image(category, card_id, content, ext=url)
-                if path is None:
-                    images_failed += 1
-                    continue
-                images_warmed += 1
-                bytes_written += len(content)
-
-        if throttle_ms > 0:
-            time.sleep(throttle_ms / 1000.0)
-
-    return WarmCardImagesResult(
-        sets_attempted=total,
-        images_warmed=images_warmed,
-        images_failed=images_failed,
-        bytes_written=bytes_written,
-        sets_failed=sets_failed,
-    )
+    return _build_result(state, sets_attempted=total, budget_reached=False)
 
 
 def _download_bytes(session: requests.Session, url: str, *, timeout: float = 30.0) -> bytes | None:


### PR DESCRIPTION
Closes #556

## What

`warm_card_images` carried the whole set → card → size walk inline, with the skip-existing check, both `--max-bytes` budget short-circuits, and the counter bookkeeping nested three loops deep — landing it at cyclomatic **D-22** on the radon allowlist. This extracts:

- `_warm_one_image` — the per-(card, size) state machine; returns `False` to signal the budget was reached and the pass must stop.
- `_warm_card` — walks the requested sizes for one card.
- `_WarmState` — a small mutable accumulator for the running counters.
- `_build_result` — folds state into a `WarmCardImagesResult`.
- `_throttle` — the `if throttle_ms > 0: sleep(...)` that appeared twice.

`warm_card_images` becomes a flat coordinator over the set list. The worst function drops from **D-22 to B-9**, so `src/mgz_pkmn/card_images.py` comes off `RADON_CC_EXCLUDE` in the [Makefile](Makefile) and is now actively defended by the complexity gate — one of the eight child issues under [epic #551](https://github.com/mgzwarrior/mgz-pkmn/issues/551).

## Why

The throttle / skip-existing / budget-reached state machine three loops deep was the entire complexity driver. Pulling the per-image decision into its own function (with a `bool` "keep going?" return) lets the budget short-circuit propagate up cleanly without duplicating the `WarmCardImagesResult(budget_reached=True, ...)` construction at two nesting levels.

Behaviour is preserved exactly: same source order, same pre-download (`bytes_written >= max_bytes`) and post-download (`bytes_written + len(content) > max_bytes`) budget checks, same skip-existing / download-failure / write-failure handling, same per-set throttle placement, and the budget short-circuit still returns with `sets_attempted` at the in-progress set index (not the total).

## How to verify

```bash
# Worst-offender check is now empty, and the file is off the allowlist:
uv run radon cc src/mgz_pkmn/card_images.py -n D -s   # no output
make complexity                                       # ✓ complexity gate passed

# The existing 33-test warm suite covers budget caps, throttle,
# skip-existing, and failure counters — all unchanged:
uv run python -m pytest tests/test_warm_card_images.py -q
make check                                            # green
```

## Done when (from #556)

- [x] `uv run radon cc src/mgz_pkmn/card_images.py -n D -s` is empty
- [x] `src/mgz_pkmn/card_images.py` removed from `RADON_CC_EXCLUDE`
- [x] `make complexity` is green with the file removed from the allowlist
- [x] Existing tests still pass