### PR TITLE
chore: split binder._draw_cell into per-block draw helpers (#555)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ fix:  ## Auto-fix safe ruff issues + reformat.
 # file listed here has a D-rank-or-worse function or a B-rank-or-worse
 # maintainability index that pre-dates the gate; the gate stays green on
 # green-field, then tightens as each is brought to A. See issue #387.
-RADON_CC_EXCLUDE := src/mgz_pkmn/spreadsheet.py,src/mgz_pkmn/lookup.py,src/mgz_pkmn/cache.py,src/mgz_pkmn/binder.py,src/mgz_pkmn/report.py
+RADON_CC_EXCLUDE := src/mgz_pkmn/spreadsheet.py,src/mgz_pkmn/lookup.py,src/mgz_pkmn/cache.py,src/mgz_pkmn/report.py
 RADON_MI_EXCLUDE := src/mgz_pkmn/cache.py
 
 .PHONY: complexity

--- a/src/mgz_pkmn/binder.py
+++ b/src/mgz_pkmn/binder.py
@@ -332,7 +332,12 @@ def _draw_cell(
     geom: dict,
     max_price: float | None = None,
 ) -> None:
-    """Render one card cell. (x, y) is the bottom-left of the cell."""
+    """Render one card cell. (x, y) is the bottom-left of the cell.
+
+    A layout coordinator: it computes the cell geometry, then hands each
+    visual block (border, banner, image, caption text, price, comps) to a
+    helper in top-to-bottom order, threading the descending `line_y` cursor
+    through the caption stack."""
     cell_w = geom["cell_w"]
     cell_h = geom["cell_h"]
     image_w = geom["image_w"]
@@ -359,6 +364,27 @@ def _draw_cell(
     if language and language.lower() != "en":
         _draw_lang_banner(c, image_x, banner_top_y, image_w, language, layout)
 
+    _draw_cell_image(c, row, image_x, image_y, image_w, image_h, layout)
+
+    cx = x + cell_w / 2
+    max_w = cell_w - 8
+    line_y = image_y - 6 - layout.caption_leading
+    line_y = _draw_cell_caption_text(c, row.card or {}, language, cx, line_y, max_w, layout)
+    line_y = _draw_cell_price(c, row, cx, line_y, max_w, layout, max_price)
+    _draw_cell_comps(c, row, cx, line_y, max_w, layout)
+
+
+def _draw_cell_image(
+    c: canvas.Canvas,
+    row: Row,
+    image_x: float,
+    image_y: float,
+    image_w: float,
+    image_h: float,
+    layout: BinderLayout,
+) -> None:
+    """Draw the card image, falling back to a placeholder on a missing file
+    or a decode/draw error."""
     if row.image_path and row.image_path.exists():
         try:
             buf = _shrink_for_pdf(row.image_path, layout)
@@ -383,17 +409,23 @@ def _draw_cell(
             "no image" if row.card else "(not found)",
         )
 
-    # Caption block.
-    card = row.card or {}
+
+def _draw_cell_caption_text(
+    c: canvas.Canvas,
+    card: dict,
+    language: str,
+    cx: float,
+    line_y: float,
+    max_w: float,
+    layout: BinderLayout,
+) -> float:
+    """Name (bold), `(#num/total)`, and set name. Returns the cursor below
+    the set-name line, ready for the price block."""
     name = card.get("name") or "(not found)"
     card_set = card.get("set") or {}
     set_name = card_set.get("name") or "?"
     number = card.get("number") or "?"
     total = card_set.get("printedTotal") or card_set.get("total")
-
-    line_y = image_y - 6 - layout.caption_leading
-    cx = x + cell_w / 2
-    max_w = cell_w - 8
 
     # 1. Name (bold).
     c.setFillColorRGB(*palette.rgb01("fg-1"))
@@ -411,8 +443,20 @@ def _draw_cell(
     line_y -= layout.caption_leading
     c.setFont("Helvetica", layout.caption_font_size)
     _draw_truncated(c, cx, line_y, set_name, max_w)
+    return line_y
 
-    # 4. Market price labelled "MP" (slightly emphasized).
+
+def _draw_cell_price(
+    c: canvas.Canvas,
+    row: Row,
+    cx: float,
+    line_y: float,
+    max_w: float,
+    layout: BinderLayout,
+    max_price: float | None,
+) -> float:
+    """Market price labelled "MP". Red `! MP` above cap, green in budget,
+    oblique "no price" when unpriced. Returns the cursor below the line."""
     line_y -= layout.caption_leading + 1
     if row.pricing.market is not None:
         sym = "€" if row.pricing.currency == "EUR" else "$"
@@ -429,8 +473,18 @@ def _draw_cell(
         c.setFont("Helvetica-Oblique", layout.caption_font_size)
         c.setFillColorRGB(*palette.rgb01("fg-3"))
         _draw_truncated(c, cx, line_y, "no price", max_w)
+    return line_y
 
-    # 5-8. Comp tiers, one per line for visibility.
+
+def _draw_cell_comps(
+    c: canvas.Canvas,
+    row: Row,
+    cx: float,
+    line_y: float,
+    max_w: float,
+    layout: BinderLayout,
+) -> None:
+    """Comp tiers, one per line at 80/85/90/95% of market."""
     c.setFillColorRGB(*palette.rgb01("fg-2"))
     c.setFont("Helvetica", layout.comp_font_size)
     if row.pricing.market is not None:


### PR DESCRIPTION
Closes #555

## What

`_draw_cell` rendered the whole cell inline — border, language banner, image-or-placeholder, caption text, market price (with the over-cap red-vs-green branch), and the comp-tier loop — all threading a descending `line_y` cursor, landing it at cyclomatic **D-23** on the radon allowlist. This extracts one helper per visual block:

- `_draw_cell_image` — image with placeholder fallback on missing file / decode error.
- `_draw_cell_caption_text` — name (bold), `(#num/total)`, set name; returns the cursor below.
- `_draw_cell_price` — "MP" line: red `! MP` above cap, green in budget, oblique "no price" when unpriced.
- `_draw_cell_comps` — the 80/85/90/95% comp tiers.

`_draw_cell` becomes a layout coordinator that issues the blocks top-to-bottom, threading `line_y` through the caption stack. The worst function drops from **D-23 to B-6**, so `src/mgz_pkmn/binder.py` comes off `RADON_CC_EXCLUDE` in the [Makefile](Makefile) — one of the eight child issues under [epic #551](https://github.com/mgzwarrior/mgz-pkmn/issues/551).

## Why

Each visual block is a separate concern, but they were fused by the shared `line_y` cursor. Having the caption helpers return the updated cursor keeps the parent a readable top-to-bottom layout, while the exact sequence and arguments of every canvas operation stay put — so the rendered PDF is unchanged.

## How to verify

The "done when" asks for byte-stable PDF output. Rather than eyeball it, I recorded the **full canvas drawing-call stream** (every `rect` / `setFont` / `drawCentredString` / `drawImage` / … with args) before and after the refactor, across **both layout presets** and every cell branch — in-budget, over-cap, no-price, euro symbol, language banner, and the missing-image placeholder. The two sequences are **identical** (410 calls, no diff), which proves the PDF content stream is unchanged.

```bash
# Complexity: worst-offender check empty, file off the allowlist:
uv run radon cc src/mgz_pkmn/binder.py -n D -s   # no output
make complexity                                  # ✓ complexity gate passed

# Existing binder suite (both layouts) + full gate:
uv run python -m pytest tests/test_binder.py -q
make check                                       # green
```

## Done when (from #555)

- [x] `uv run radon cc src/mgz_pkmn/binder.py -n D -s` is empty
- [x] `src/mgz_pkmn/binder.py` removed from `RADON_CC_EXCLUDE`
- [x] `make complexity` is green with the file removed from the allowlist
- [x] Existing tests still pass; PDF output byte-stable (canvas call stream identical before/after, incl. the over-cap red border)