### PR TITLE
fix(web): cache-bust the SPA favicon so the tropical rebrand replaces the cached purple bolt (#664)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <!-- ?v= busts the per-URL favicon cache when the asset is rebranded;
+         bump it on any favicon change (the file name stays /favicon.svg). -->
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg?v=2" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>mgz-pkmn — card lookup</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
Closes #664

## What

Appends `?v=2` to the favicon link in [web/index.html](web/index.html) so returning visitors stop seeing the old purple lightning bolt and pick up the tropical palm rebrand:

```html
<link rel="icon" type="image/svg+xml" href="/favicon.svg?v=2" />
```

## Why

The favicon was rebranded from the purple bolt to the tropical palm in #634 (commit bf50fff), reusing the same `/favicon.svg` URL. Browsers cache favicons in a separate per-URL store that ignores normal HTTP cache headers and survives hard refreshes, so any browser that saw the old icon never re-fetches it — the tab keeps showing purple.

Production is already serving the correct icon; this is purely a client-cache bust:

- `curl https://mgz-pkmn.onrender.com/favicon.svg` → new tropical palm (`200`, `image/svg+xml`, no `#863bff`).
- Deployed `index.html` linked `/favicon.svg` (no version), so the cached purple copy was never invalidated.

Changing only the referenced URL (not the filename) is enough to force every browser to re-fetch. Bump the version on any future favicon change.

## How to verify

```bash
cd web && npm run build
grep favicon dist/index.html   # href="/favicon.svg?v=2"
```

After deploy: a previously-purple tab picks up the palm without the visitor having to clear site data. (To confirm the asset itself was always correct, open `/favicon.svg` directly or load the demo in a private window.)

## Out of scope

- The marketing site (`site/`, `/favicon-tropical.svg`) was always tropical — no stale-cache problem there.
- A `/favicon.ico` fallback (browsers auto-request it; it currently falls through the SPA handler to `index.html`). Separate concern.