### PR TITLE
chore: remove the radon complexity allowlist mechanism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,32 +127,29 @@ fix:  ## Auto-fix safe ruff issues + reformat.
 	uv run ruff check --fix $(PY_PATHS)
 	uv run ruff format $(PY_PATHS)
 
-# Files that radon's complexity gate allowlists. Tracked in one place so each
-# refactor can shrink the list — and as of #557 both are empty: every file in
-# `src/` and `api/` now clears the D-rank cyclomatic and A-rank maintainability
-# bars with no exceptions. Keep these empty; if a new hotspot lands, refactor it
-# rather than re-growing the allowlist. See issue #387 / epic #551.
-RADON_CC_EXCLUDE :=
-RADON_MI_EXCLUDE :=
-
+# The radon complexity gate has no allowlist. Epic #551 cleared every
+# pre-existing offender, so as of #670 every file in `src/` and `api/` clears the
+# D-rank cyclomatic and B-rank maintainability bars with no exceptions. A new D+
+# function or B+ file must be refactored — there is deliberately no knob to
+# exclude it. See issue #387 (gate) / epic #551 (cleanup) / issue #670 (this).
 .PHONY: complexity
 complexity:  ## Maintainability gate: fail on D+ cyclomatic complexity or B+ maintainability index.
-	@out=$$(uv run radon cc src/ api/ -n D --exclude '$(RADON_CC_EXCLUDE)') \
+	@out=$$(uv run radon cc src/ api/ -n D) \
 	  || { echo "✗ radon cc invocation failed (uv / radon could not run)" >&2; exit 1; }; \
 	  if [ -n "$$out" ]; then \
 	    echo "$$out" >&2; \
 	    echo >&2; \
 	    echo "✗ Cyclomatic complexity gate failed: D-rank or worse function above." >&2; \
-	    echo "  Either refactor it, or (if it pre-dates the gate) add the file to RADON_CC_EXCLUDE in Makefile." >&2; \
+	    echo "  Refactor it — the gate has no allowlist (every file in src/ and api/ clears the bar)." >&2; \
 	    exit 1; \
 	  fi
-	@out=$$(uv run radon mi src/ api/ -n B --exclude '$(RADON_MI_EXCLUDE)') \
+	@out=$$(uv run radon mi src/ api/ -n B) \
 	  || { echo "✗ radon mi invocation failed (uv / radon could not run)" >&2; exit 1; }; \
 	  if [ -n "$$out" ]; then \
 	    echo "$$out" >&2; \
 	    echo >&2; \
 	    echo "✗ Maintainability index gate failed: B-rank or worse file above." >&2; \
-	    echo "  Either refactor it, or (if it pre-dates the gate) add the file to RADON_MI_EXCLUDE in Makefile." >&2; \
+	    echo "  Refactor it — the gate has no allowlist (every file in src/ and api/ clears the bar)." >&2; \
 	    exit 1; \
 	  fi
 	@echo "✓ complexity gate passed"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -322,7 +322,7 @@ make coverage           # python tests under coverage; emits htmlcov/ + coverage
 make lint               # ruff + eslint
 make format             # ruff format in-place
 make fix                # ruff --fix + ruff format
-make complexity         # radon CC + MI gate — fails on D+ functions or B+ files (see Makefile RADON_*_EXCLUDE for the shrink-as-we-refactor allowlist; pair with the [`repo-analysis`](../.claude/skills/repo-analysis/SKILL.md) skill to find the next refactor target)
+make complexity         # radon CC + MI gate — fails on D+ functions or B+ files (no allowlist: a new offender must be refactored, not excluded; pair with the [`repo-analysis`](../.claude/skills/repo-analysis/SKILL.md) skill to find the next refactor target)
 make check              # CI-equivalent: lint + format-check + complexity gate + tests + web lint
 make precommit          # run all pre-commit hooks against every file
 ```


### PR DESCRIPTION
Closes #670

## What

Removes the `RADON_CC_EXCLUDE` / `RADON_MI_EXCLUDE` variables and the `--exclude` flags from the `complexity` target in the [Makefile](Makefile), and drops the "or add the file to RADON_*_EXCLUDE" escape hatch from both failure messages. [docs/contributing.md](docs/contributing.md) is updated to describe the gate as having no allowlist.

## Why

The allowlist existed so the gate (#387) could land green-field while pre-existing offenders were carried as debt. Epic #551 cleared that debt to zero — PR #669 emptied both variables when the last file (`cache.py`) came off the list. Keeping the mechanism around is a footgun: a future PR could quietly re-grow the allowlist instead of refactoring. Deleting the knob makes the standard non-negotiable — a new D+ cyclomatic function or B+ maintainability file must be refactored to pass.

The gate logic itself is unchanged (`radon cc -n D`, `radon mi -n B` over `src/` and `api/`); only the bypass is gone.

## How to verify

- `make complexity` prints `✓ complexity gate passed` on this branch.
- `grep RADON Makefile docs/` returns nothing.
- Temporarily add a deeply-nested throwaway function and confirm the gate fails with the "Refactor it — the gate has no allowlist" message, then revert.