### PR TITLE
feat(web): surface eBay + TCGPlayer affiliate links across the web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,13 @@ the FastAPI server. Swagger UI lives at <http://localhost:8000/docs>.
 Prefer not to install anything? The same UI is hosted at
 <https://mgz-pkmn.onrender.com>.
 
+Every matched result — both in the results table and the card detail
+view — carries a "Buy" affordance that links out to eBay and TCGPlayer
+searches for that exact printing, opening in a new tab. The links are
+affiliate-tagged where a code is configured (eBay today; TCGPlayer once
+its affiliate application lands) and fall back to plain searches
+otherwise, so they always work.
+
 The hosted demo can sign users in with GitHub, Google, Discord, or an
 email magic link when auth is enabled. See
 [Deployment](docs/deployment.md#environment-variables) for the provider

--- a/web/src/components/AffiliateLinks.tsx
+++ b/web/src/components/AffiliateLinks.tsx
@@ -1,0 +1,63 @@
+/**
+ * AffiliateLinks — eBay + TCGPlayer "buy" links for a resolved card (#657).
+ *
+ * One link per marketplace, each a keyword search to the card's exact
+ * printing (see `utils/affiliateLinks`). Links open in a new tab and carry
+ * `rel="sponsored noopener"` so the affiliate relationship is declared and
+ * the opener is detached. Renders nothing when the card has no name to search
+ * on — unmatched rows and bare cards just skip the affordance.
+ *
+ * Two layouts share one builder:
+ *   - `inline` (default) — compact text links for the results-table row.
+ *   - `pill` — bordered buttons for the card detail modal's "Buy" block.
+ */
+import { ExternalLink } from 'lucide-react'
+import type { CardData } from '../types'
+import { ebayAffiliateUrl, tcgplayerAffiliateUrl } from '../utils/affiliateLinks'
+
+const REL = 'sponsored noopener'
+
+const INLINE_CLASS =
+  'inline-flex items-center gap-0.5 text-xs font-medium text-coconut-400 hover:text-palm-500 dark:text-sand-300 dark:hover:text-sun-300 transition-colors'
+
+const PILL_CLASS =
+  'inline-flex items-center gap-1 rounded-md border border-sand-300 dark:border-husk-50 bg-sand-50 dark:bg-husk-400 px-2.5 py-1 text-xs font-semibold text-palm-600 hover:border-palm-400 hover:text-palm-500 dark:text-sun-300 dark:hover:border-sun-300/60 dark:hover:text-sun-200 transition-colors'
+
+export function AffiliateLinks({
+  card,
+  variant = 'inline',
+  className = '',
+}: {
+  card: CardData | null
+  variant?: 'inline' | 'pill'
+  className?: string
+}) {
+  const ebay = ebayAffiliateUrl(card)
+  const tcg = tcgplayerAffiliateUrl(card)
+  if (!ebay && !tcg) return null
+
+  const linkClass = variant === 'pill' ? PILL_CLASS : INLINE_CLASS
+
+  return (
+    <div className={`flex items-center gap-2 ${className}`}>
+      {ebay && (
+        <a href={ebay} target="_blank" rel={REL} className={linkClass} title="Find on eBay">
+          eBay
+          <ExternalLink size={11} />
+        </a>
+      )}
+      {tcg && (
+        <a
+          href={tcg}
+          target="_blank"
+          rel={REL}
+          className={linkClass}
+          title="Find on TCGPlayer"
+        >
+          TCGPlayer
+          <ExternalLink size={11} />
+        </a>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/CardDetailModal.test.tsx
+++ b/web/src/components/CardDetailModal.test.tsx
@@ -537,4 +537,24 @@ describe('CardDetailModal', () => {
     render(<CardDetailModal rows={[buildRow()]} index={0} onChangeIndex={() => {}} />)
     expect(screen.queryByText('eBay comps')).toBeNull()
   })
+
+  it('renders Buy links out to eBay and TCGPlayer with the affiliate rel', () => {
+    render(<CardDetailModal rows={[buildRow()]} index={0} onChangeIndex={() => {}} />)
+    expect(screen.getByText('Buy')).toBeInTheDocument()
+    const ebay = screen.getByTitle('Find on eBay')
+    const tcg = screen.getByTitle('Find on TCGPlayer')
+    expect(ebay).toHaveAttribute('href', expect.stringContaining('ebay.com/sch'))
+    expect(ebay).toHaveAttribute('href', expect.stringContaining('Charizard'))
+    expect(ebay).toHaveAttribute('rel', 'sponsored noopener')
+    expect(ebay).toHaveAttribute('target', '_blank')
+    expect(tcg).toHaveAttribute('href', expect.stringContaining('tcgplayer.com/search'))
+    expect(tcg).toHaveAttribute('rel', 'sponsored noopener')
+  })
+
+  it('omits the Buy block when the card has no name to search on', () => {
+    render(
+      <CardDetailModal rows={[buildRow({ card: null })]} index={0} onChangeIndex={() => {}} />,
+    )
+    expect(screen.queryByText('Buy')).toBeNull()
+  })
 })

--- a/web/src/components/CardDetailModal.tsx
+++ b/web/src/components/CardDetailModal.tsx
@@ -19,7 +19,9 @@ import * as Dialog from '@radix-ui/react-dialog'
 import { ChevronLeft, ChevronRight, ExternalLink, X } from 'lucide-react'
 import { useEffect } from 'react'
 import type { CardData, EbaySoldComp, Pricing, Row } from '../types'
+import { ebayAffiliateUrl, tcgplayerAffiliateUrl } from '../utils/affiliateLinks'
 import { formatComp, formatMoney } from '../utils/format'
+import { AffiliateLinks } from './AffiliateLinks'
 import { EbaySparkline } from './EbaySparkline'
 import { hasEbayData, soldPriceSeries } from './ebayComps'
 
@@ -245,6 +247,8 @@ function CardDetailBody({
               </div>
             </div>
 
+            <BuyBlock card={card} />
+
             <EbayCompsBlock pricing={pricing} />
 
             <CardMetadataBlock card={card} />
@@ -252,6 +256,28 @@ function CardDetailBody({
         </div>
       </div>
     </>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// BuyBlock — eBay + TCGPlayer affiliate search links for the card (#657).
+// Omitted entirely when the card has no name to search on, so a sparse or
+// unmatched card doesn't leave an empty "Buy" heading behind.
+// ---------------------------------------------------------------------------
+
+function BuyBlock({ card }: { card: CardData | null }) {
+  const links = <AffiliateLinks card={card} variant="pill" />
+  // AffiliateLinks renders null when there's nothing to link to; mirror that
+  // so the heading never shows up alone.
+  if (!ebayAffiliateUrl(card) && !tcgplayerAffiliateUrl(card)) return null
+
+  return (
+    <div>
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-coconut-400 dark:text-sand-300 mb-2">
+        Buy
+      </h3>
+      {links}
+    </div>
   )
 }
 

--- a/web/src/components/ResultsTable.test.tsx
+++ b/web/src/components/ResultsTable.test.tsx
@@ -177,6 +177,44 @@ describe('ResultsTable', () => {
     useAppStore.setState({ rows: [] })
   })
 
+  it('renders eBay + TCGPlayer affiliate Buy links on a matched row (#657)', () => {
+    useAppStore.setState({
+      rows: [
+        makeRow({
+          card: {
+            id: 'base1-4',
+            name: 'Charizard',
+            number: '4',
+            rarity: 'Rare Holo',
+            set: { name: 'Base Set' },
+          },
+        }),
+      ],
+      isRunning: false,
+      progress: null,
+    })
+    render(<ResultsTable />)
+    const ebay = screen.getByTitle('Find on eBay')
+    const tcg = screen.getByTitle('Find on TCGPlayer')
+    expect(ebay).toHaveAttribute('href', expect.stringContaining('ebay.com/sch'))
+    expect(ebay).toHaveAttribute('rel', 'sponsored noopener')
+    expect(tcg).toHaveAttribute('href', expect.stringContaining('tcgplayer.com/search'))
+    expect(tcg).toHaveAttribute('rel', 'sponsored noopener')
+    useAppStore.setState({ rows: [] })
+  })
+
+  it('omits affiliate Buy links on an unmatched row with no card', () => {
+    useAppStore.setState({
+      rows: [makeRow({ matched: false, card: null, query: { raw: 'whatever', name: 'whatever' } as Row['query'] })],
+      isRunning: false,
+      progress: null,
+    })
+    render(<ResultsTable />)
+    expect(screen.queryByTitle('Find on eBay')).toBeNull()
+    expect(screen.queryByTitle('Find on TCGPlayer')).toBeNull()
+    useAppStore.setState({ rows: [] })
+  })
+
   it('unmatched rows are not clickable and do not get the aria-label', () => {
     useAppStore.setState({
       rows: [

--- a/web/src/components/ResultsTable.tsx
+++ b/web/src/components/ResultsTable.tsx
@@ -21,6 +21,7 @@ import type { ResultsFilters, Row } from '../types'
 import { formatComp, formatMoney } from '../utils/format'
 import { AddToCollectionButton } from './AddToCollectionButton'
 import { AddToWishlistButton } from './AddToWishlistButton'
+import { AffiliateLinks } from './AffiliateLinks'
 import { CardDetailModal } from './CardDetailModal'
 import { useCardOwnership } from './useCardOwnership'
 import { OwnershipBadge } from './OwnershipBadge'
@@ -438,8 +439,8 @@ export function ResultsTable({ onRerunLine }: Props) {
                 onClick={cycleSort}
                 className="hidden sm:table-cell"
               />
-              <th className="px-3 py-2 text-xs font-medium text-coconut-400 dark:text-sand-300 w-8">
-                <span className="sr-only">Listing link</span>
+              <th className="px-3 py-2 text-xs font-medium text-coconut-400 dark:text-sand-300 text-right">
+                Buy
               </th>
             </tr>
             {showFilters && (
@@ -527,7 +528,7 @@ export function ResultsTable({ onRerunLine }: Props) {
                   />
                 </FilterCell>
                 <th>
-                  <span className="sr-only">Listing link (no filter)</span>
+                  <span className="sr-only">Buy (no filter)</span>
                 </th>
               </tr>
             )}
@@ -880,19 +881,24 @@ function ResultRow({
           {p.source ?? '—'}
         </td>
 
-        {/* Listing link */}
-        <td className="px-3 py-2 w-8">
-          {p.url && (
-            <a
-              href={p.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-coconut-400 hover:text-palm-500 dark:text-sand-300 dark:hover:text-sun-300 transition-colors"
-              title="Open listing"
-            >
-              <ExternalLink size={13} />
-            </a>
-          )}
+        {/* Buy — the matched listing (if any) plus eBay + TCGPlayer affiliate
+            search links (#657). Unmatched rows have no card to search, so the
+            affiliate links omit themselves there. */}
+        <td className="px-3 py-2 whitespace-nowrap">
+          <div className="flex items-center justify-end gap-2">
+            {p.url && (
+              <a
+                href={p.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-coconut-400 hover:text-palm-500 dark:text-sand-300 dark:hover:text-sun-300 transition-colors"
+                title="Open listing"
+              >
+                <ExternalLink size={13} />
+              </a>
+            )}
+            <AffiliateLinks card={card} />
+          </div>
         </td>
       </tr>
 

--- a/web/src/utils/affiliateLinks.test.ts
+++ b/web/src/utils/affiliateLinks.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest'
+import {
+  cardSearchQuery,
+  ebayAffiliateUrl,
+  tcgplayerAffiliateUrl,
+  type AffiliateConfig,
+} from './affiliateLinks'
+import type { CardData } from '../types'
+
+function card(over: Partial<CardData> = {}): CardData {
+  return { name: 'Charizard', set: { name: 'Base Set' }, number: '4', ...over }
+}
+
+const WITH_CODES: AffiliateConfig = {
+  ebayCampaignId: '5339000000',
+  tcgplayerAffiliateId: 'mgzpkmn',
+}
+const NO_CODES: AffiliateConfig = { ebayCampaignId: '', tcgplayerAffiliateId: '' }
+
+describe('cardSearchQuery', () => {
+  it('joins name + set + number', () => {
+    expect(cardSearchQuery(card())).toBe('Charizard Base Set 4')
+  })
+
+  it('trims and skips missing parts', () => {
+    expect(cardSearchQuery({ name: '  Pikachu  ' })).toBe('Pikachu')
+    expect(cardSearchQuery({ name: 'Mew', number: '53' })).toBe('Mew 53')
+  })
+
+  it('returns "" for null or a nameless card', () => {
+    expect(cardSearchQuery(null)).toBe('')
+    expect(cardSearchQuery({ set: { name: 'Base Set' } })).toBe('')
+    expect(cardSearchQuery({ name: '   ' })).toBe('')
+  })
+})
+
+describe('ebayAffiliateUrl', () => {
+  it('returns null when there is no query', () => {
+    expect(ebayAffiliateUrl(null, NO_CODES)).toBeNull()
+  })
+
+  it('builds a plain search URL when no campaign id is set', () => {
+    const url = ebayAffiliateUrl(card(), NO_CODES)!
+    expect(url).toContain('https://www.ebay.com/sch/i.html')
+    expect(url).toContain('_nkw=Charizard+Base+Set+4')
+    expect(url).not.toContain('campid')
+    expect(url).not.toContain('mkevt')
+  })
+
+  it('attaches EPN tracking params when a campaign id is set', () => {
+    const url = ebayAffiliateUrl(card(), WITH_CODES)!
+    expect(url).toContain('campid=5339000000')
+    expect(url).toContain('mkevt=1')
+    expect(url).toContain('mkcid=1')
+  })
+})
+
+describe('tcgplayerAffiliateUrl', () => {
+  it('returns null when there is no query', () => {
+    expect(tcgplayerAffiliateUrl(null, NO_CODES)).toBeNull()
+  })
+
+  it('builds a plain search URL when no affiliate id is set', () => {
+    const url = tcgplayerAffiliateUrl(card(), NO_CODES)!
+    expect(url).toContain('https://www.tcgplayer.com/search/pokemon/product')
+    expect(url).toContain('q=Charizard+Base+Set+4')
+    expect(url).toContain('productLineName=pokemon')
+    expect(url).not.toContain('partner')
+  })
+
+  it('tags the URL with the partner id when set', () => {
+    const url = tcgplayerAffiliateUrl(card(), WITH_CODES)!
+    expect(url).toContain('partner=mgzpkmn')
+    expect(url).toContain('utm_campaign=affiliate')
+  })
+})

--- a/web/src/utils/affiliateLinks.ts
+++ b/web/src/utils/affiliateLinks.ts
@@ -23,7 +23,9 @@ export interface AffiliateConfig {
  * links degrade to plain searches until the real codes are filled in.
  */
 export const AFFILIATE: AffiliateConfig = {
-  ebayCampaignId: '',
+  ebayCampaignId: '5339156329',
+  // Empty until the TCGPlayer (Impact) affiliate application is accepted —
+  // links stay plain searches until then.
   tcgplayerAffiliateId: '',
 }
 

--- a/web/src/utils/affiliateLinks.ts
+++ b/web/src/utils/affiliateLinks.ts
@@ -1,0 +1,89 @@
+/**
+ * Affiliate-link builders for the eBay + TCGPlayer "buy" affordances (#657).
+ *
+ * Both links are keyword searches built from the card's name + set + number —
+ * we don't carry a stable per-card product id for either marketplace, so a
+ * search to the exact printing is the closest we get without a resolution
+ * layer. When an affiliate code is configured the tracking params are
+ * attached; when it's blank the link still works, it just points at a plain
+ * (uncredited) search. Drop real codes into `AFFILIATE` to start earning.
+ */
+import type { CardData } from '../types'
+
+export interface AffiliateConfig {
+  /** eBay Partner Network campaign id — the `campid` rover param. */
+  ebayCampaignId: string
+  /** TCGPlayer affiliate / Impact partner id. */
+  tcgplayerAffiliateId: string
+}
+
+/**
+ * Affiliate codes. These are public values (they ride in every outbound URL),
+ * so they live in source rather than a secret store. Both default empty so the
+ * links degrade to plain searches until the real codes are filled in.
+ */
+export const AFFILIATE: AffiliateConfig = {
+  ebayCampaignId: '',
+  tcgplayerAffiliateId: '',
+}
+
+// eBay Partner Network rover constants for the US marketplace. Stable across
+// partners — only `campid` changes — so they stay literals here.
+const EBAY_ROTATION_ID = '711-53200-19255-0'
+
+/** Keyword query for a card: name + set name + collector number. */
+export function cardSearchQuery(card: CardData | null): string {
+  if (!card) return ''
+  const name = (card.name ?? '').trim()
+  if (!name) return ''
+  const setName = (card.set?.name ?? '').trim()
+  const number = String(card.number ?? '').trim()
+  return [name, setName, number].filter(Boolean).join(' ')
+}
+
+/**
+ * eBay search URL for a card, with EPN tracking params when a campaign id is
+ * configured. Returns null when the card has no name to search on.
+ */
+export function ebayAffiliateUrl(
+  card: CardData | null,
+  config: AffiliateConfig = AFFILIATE,
+): string | null {
+  const query = cardSearchQuery(card)
+  if (!query) return null
+  const url = new URL('https://www.ebay.com/sch/i.html')
+  url.searchParams.set('_nkw', query)
+  if (config.ebayCampaignId) {
+    url.searchParams.set('mkcid', '1')
+    url.searchParams.set('mkrid', EBAY_ROTATION_ID)
+    url.searchParams.set('siteid', '0')
+    url.searchParams.set('campid', config.ebayCampaignId)
+    url.searchParams.set('toolid', '10001')
+    url.searchParams.set('mkevt', '1')
+  }
+  return url.toString()
+}
+
+/**
+ * TCGPlayer search URL for a card, tagged with the affiliate partner id when
+ * one is configured. The `partner` + utm shape matches TCGPlayer's affiliate
+ * program; adjust here if your Impact link uses a different format. Returns
+ * null when the card has no name to search on.
+ */
+export function tcgplayerAffiliateUrl(
+  card: CardData | null,
+  config: AffiliateConfig = AFFILIATE,
+): string | null {
+  const query = cardSearchQuery(card)
+  if (!query) return null
+  const url = new URL('https://www.tcgplayer.com/search/pokemon/product')
+  url.searchParams.set('q', query)
+  url.searchParams.set('productLineName', 'pokemon')
+  if (config.tcgplayerAffiliateId) {
+    url.searchParams.set('partner', config.tcgplayerAffiliateId)
+    url.searchParams.set('utm_campaign', 'affiliate')
+    url.searchParams.set('utm_medium', config.tcgplayerAffiliateId)
+    url.searchParams.set('utm_source', config.tcgplayerAffiliateId)
+  }
+  return url.toString()
+}


### PR DESCRIPTION
Closes #657

## What

Adds a "Buy" affordance everywhere a card is shown in the web app:

- **Results table** — each matched row gets compact `eBay` / `TCGPlayer` links alongside the existing listing-link icon, under a new right-aligned "Buy" column.
- **Card detail modal** — a "Buy" block with pill-style `eBay` / `TCGPlayer` links, distinct from the existing "View on …" source link.

Each link is a keyword search to the card's exact printing (name + set + collector number, mirroring the backend's `ebay_query_for_card`), opens in a new tab, and carries `rel="sponsored noopener"` so the affiliate relationship is declared.

Affiliate codes live in a committed config module ([`web/src/utils/affiliateLinks.ts`](web/src/utils/affiliateLinks.ts)) — they're public values that ride in every outbound URL, so they don't belong in a secret store. The **eBay Partner Network campaign id is wired live** (`5339156329`), so eBay links carry full EPN tracking (`campid` + `mkevt`) and earn from day one. **TCGPlayer is intentionally left as a plain search** — its affiliate id stays empty until the Impact application is accepted, at which point the link upgrades automatically. Unmatched rows and nameless cards omit the affordance entirely.

## Why

The deep eBay (#416) / TCGPlayer (#417) API integrations are deferred to v2.0.0 pending high-volume developer access. Affiliate links deliver the user-facing value (one click to live listings) and a revenue path today, with no OAuth or credential surface.

## Follow-up (one-liner)

When the TCGPlayer affiliate application is accepted, set `tcgplayerAffiliateId` in [`affiliateLinks.ts`](web/src/utils/affiliateLinks.ts) to flip its links from plain searches to credited ones. The `partner` + utm shape may need a tweak to match the exact Impact link format — it's isolated to one function.

## How to verify

- `cd web && npx vitest run` — all tests pass, including new coverage in `affiliateLinks.test.ts` (URL builders, empty-code fallback, tracking params when set) and rendering assertions in `ResultsTable.test.tsx` / `CardDetailModal.test.tsx`.
- `cd web && npm run build` — typecheck + production build green.
- Verified end-to-end against a local API + web preview (lookup for Charizard / Pikachu / Squirtle): every matched row and the card modal render both links with `rel="sponsored noopener"`, `target="_blank"`. eBay carries the live EPN params — e.g. `ebay.com/sch/i.html?_nkw=Charizard+Base+Set+2+4&mkcid=1&mkrid=711-53200-19255-0&siteid=0&campid=5339156329&toolid=10001&mkevt=1`. TCGPlayer is a plain `tcgplayer.com/search/...` query until its code lands.

Design system: links use `palm` / `sun` / `sand` tokens (no raw hex/px), sentence-case copy, and Title Case only for the marketplace names.