### PR TITLE
perf(api): memoize the upstream session per api_key to keep connections warm

### DIFF
--- a/api/routes/lookup.py
+++ b/api/routes/lookup.py
@@ -12,6 +12,7 @@ import json
 import logging
 import time
 from collections.abc import Callable
+from functools import lru_cache
 from typing import Any
 
 import requests as req_lib
@@ -65,15 +66,38 @@ class BulkRequest(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def _make_clients(
-    settings: Settings,
+@lru_cache(maxsize=8)
+def _clients_for(
+    api_key: str | None,
 ) -> tuple[TCGClient, TCGDexClient, PriceChartingClient, EbayClient]:
+    """Build the upstream client quartet, memoized per api_key (#302).
+
+    Reusing one instance across requests keeps each client's
+    ``requests.Session`` connection pool warm — saving a TLS handshake per
+    upstream hit — and lets ``TCGClient._cache`` serve repeat queries from
+    memory instead of re-reading + re-decoding the disk cache. Only the
+    api_key affects construction: the other three take no auth-bearing input,
+    and ``lang`` is a per-search argument (``find_card(..., default_lang=…)``),
+    not a constructor input, so it doesn't fragment the cache.
+
+    Thread-safety: ``lru_cache`` itself is thread-safe, and ``Session`` is
+    documented safe for concurrent ``get``/``post``. ``TCGClient._cache`` is a
+    bare dict shared across the FastAPI threadpool, but a racy read is benign
+    — worst case a duplicated upstream fetch and cache overwrite — so it stays
+    lock-free until a benchmark says otherwise.
+    """
     return (
-        TCGClient(api_key=settings.api_key),
+        TCGClient(api_key=api_key),
         TCGDexClient(),
         PriceChartingClient(),
         EbayClient(),
     )
+
+
+def _make_clients(
+    settings: Settings,
+) -> tuple[TCGClient, TCGDexClient, PriceChartingClient, EbayClient]:
+    return _clients_for(settings.api_key)
 
 
 def _query_to_dict(q: CardQuery) -> dict[str, Any]:

--- a/api/routes/lookup.py
+++ b/api/routes/lookup.py
@@ -67,37 +67,46 @@ class BulkRequest(BaseModel):
 
 
 @lru_cache(maxsize=8)
-def _clients_for(
+def _sessions_for(
     api_key: str | None,
-) -> tuple[TCGClient, TCGDexClient, PriceChartingClient, EbayClient]:
-    """Build the upstream client quartet, memoized per api_key (#302).
+) -> tuple[req_lib.Session, req_lib.Session, req_lib.Session, req_lib.Session]:
+    """One warm ``requests.Session`` per upstream, memoized per api_key (#302).
 
-    Reusing one instance across requests keeps each client's
-    ``requests.Session`` connection pool warm — saving a TLS handshake per
-    upstream hit — and lets ``TCGClient._cache`` serve repeat queries from
-    memory instead of re-reading + re-decoding the disk cache. Only the
-    api_key affects construction: the other three take no auth-bearing input,
-    and ``lang`` is a per-search argument (``find_card(..., default_lang=…)``),
-    not a constructor input, so it doesn't fragment the cache.
+    Reusing the session across requests keeps its connection pool warm, so
+    every upstream hit reuses a kept-alive connection instead of paying a
+    fresh TLS handshake. Each upstream gets its *own* session so headers
+    don't cross-contaminate (the pokemontcg.io key must never ride along to
+    TCGdex / PriceCharting). Only the api_key matters — ``lang`` is a
+    per-search argument, not a connection input.
 
-    Thread-safety: ``lru_cache`` itself is thread-safe, and ``Session`` is
-    documented safe for concurrent ``get``/``post``. ``TCGClient._cache`` is a
-    bare dict shared across the FastAPI threadpool, but a racy read is benign
-    — worst case a duplicated upstream fetch and cache overwrite — so it stays
-    lock-free until a benchmark says otherwise.
+    We deliberately memoize the *session*, not the client: the clients carry
+    an instance-local ``_cache`` (L1) with no TTL, written on STALE/MISS reads
+    and keyed without ``cache_only``. Reusing a client across requests would
+    pin those entries process-wide — serving stale or empty results and
+    suppressing the disk SWR refresh until restart. Fresh clients per request
+    keep that L1 cache request-scoped (its original contract) while the shared
+    session still delivers the connection-reuse win. ``lru_cache`` and
+    ``Session.get``/``post`` are both safe for the concurrent FastAPI
+    threadpool.
     """
     return (
-        TCGClient(api_key=api_key),
-        TCGDexClient(),
-        PriceChartingClient(),
-        EbayClient(),
+        req_lib.Session(),
+        req_lib.Session(),
+        req_lib.Session(),
+        req_lib.Session(),
     )
 
 
 def _make_clients(
     settings: Settings,
 ) -> tuple[TCGClient, TCGDexClient, PriceChartingClient, EbayClient]:
-    return _clients_for(settings.api_key)
+    pkmn_s, tcgdex_s, pc_s, ebay_s = _sessions_for(settings.api_key)
+    return (
+        TCGClient(api_key=settings.api_key, session=pkmn_s),
+        TCGDexClient(session=tcgdex_s),
+        PriceChartingClient(session=pc_s),
+        EbayClient(session=ebay_s),
+    )
 
 
 def _query_to_dict(q: CardQuery) -> dict[str, Any]:

--- a/api/routes/lookup.py
+++ b/api/routes/lookup.py
@@ -66,23 +66,25 @@ class BulkRequest(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-@lru_cache(maxsize=8)
-def _sessions_for(
-    api_key: str | None,
-) -> tuple[req_lib.Session, req_lib.Session, req_lib.Session, req_lib.Session]:
-    """One warm ``requests.Session`` per upstream, memoized per api_key (#302).
+@lru_cache(maxsize=1)
+def _sessions_for() -> tuple[req_lib.Session, req_lib.Session, req_lib.Session, req_lib.Session]:
+    """One warm, header-light ``requests.Session`` per upstream (#302).
 
-    Reusing the session across requests keeps its connection pool warm, so
+    Sharing the session across requests keeps its connection pool warm, so
     every upstream hit reuses a kept-alive connection instead of paying a
-    fresh TLS handshake. Each upstream gets its *own* session so headers
-    don't cross-contaminate (the pokemontcg.io key must never ride along to
-    TCGdex / PriceCharting). Only the api_key matters — ``lang`` is a
-    per-search argument, not a connection input.
+    fresh TLS handshake. Each upstream gets its *own* session so connections
+    (and any default headers) don't cross hosts.
 
-    We deliberately memoize the *session*, not the client: the clients carry
-    an instance-local ``_cache`` (L1) with no TTL, written on STALE/MISS reads
-    and keyed without ``cache_only``. Reusing a client across requests would
-    pin those entries process-wide — serving stale or empty results and
+    Crucially the sessions carry **no per-request secret**: a caller-supplied
+    pokemontcg.io api_key is applied per request as an ``X-Api-Key`` header by
+    ``TCGClient`` itself, never stored on the pooled session or used as a
+    cache key — so BYO credentials stay request-scoped rather than lingering
+    in process-global state.
+
+    We also memoize the session, not the client: the clients carry an
+    instance-local L1 ``_cache`` with no TTL, written on STALE/MISS reads and
+    keyed without ``cache_only``. Reusing a client across requests would pin
+    those entries process-wide — serving stale or empty results and
     suppressing the disk SWR refresh until restart. Fresh clients per request
     keep that L1 cache request-scoped (its original contract) while the shared
     session still delivers the connection-reuse win. ``lru_cache`` and
@@ -100,7 +102,7 @@ def _sessions_for(
 def _make_clients(
     settings: Settings,
 ) -> tuple[TCGClient, TCGDexClient, PriceChartingClient, EbayClient]:
-    pkmn_s, tcgdex_s, pc_s, ebay_s = _sessions_for(settings.api_key)
+    pkmn_s, tcgdex_s, pc_s, ebay_s = _sessions_for()
     return (
         TCGClient(api_key=settings.api_key, session=pkmn_s),
         TCGDexClient(session=tcgdex_s),

--- a/src/mgz_pkmn/sources/pokemontcg.py
+++ b/src/mgz_pkmn/sources/pokemontcg.py
@@ -20,8 +20,16 @@ API_BASE = "https://api.pokemontcg.io/v2"
 class TCGClient:
     """Thin wrapper around api.pokemontcg.io with response caching + 429 retry."""
 
-    def __init__(self, api_key: str | None = None, verbose: bool = False) -> None:
-        self.session = requests.Session()
+    def __init__(
+        self,
+        api_key: str | None = None,
+        verbose: bool = False,
+        session: requests.Session | None = None,
+    ) -> None:
+        # Accept an injected session so callers can keep a connection pool warm
+        # across instances (#302); the per-instance `_cache` below stays
+        # instance-local, which the API route relies on for correctness.
+        self.session = session or requests.Session()
         self.session.headers["User-Agent"] = USER_AGENT
         if api_key:
             self.session.headers["X-Api-Key"] = api_key

--- a/src/mgz_pkmn/sources/pokemontcg.py
+++ b/src/mgz_pkmn/sources/pokemontcg.py
@@ -31,8 +31,10 @@ class TCGClient:
         # instance-local, which the API route relies on for correctness.
         self.session = session or requests.Session()
         self.session.headers["User-Agent"] = USER_AGENT
-        if api_key:
-            self.session.headers["X-Api-Key"] = api_key
+        # Applied per request (see `_network_fetch`), not stored on the session:
+        # the session may be shared across requests, and a caller-supplied key
+        # must not linger in a pooled session's headers (#302).
+        self._api_key = api_key
         self.verbose = verbose
         # L1 in-memory cache. Stores (cards, status) — status is the worst
         # disk-cache outcome we observed when first populating this entry,
@@ -138,9 +140,10 @@ class TCGClient:
         error after retries). Raises on persistent non-retryable errors."""
         if cache_only:
             return None
+        headers = {"X-Api-Key": self._api_key} if self._api_key else None
         for attempt in range(4):
             try:
-                resp = self.session.get(url, timeout=60)
+                resp = self.session.get(url, headers=headers, timeout=60)
                 if resp.status_code == 429:
                     time.sleep(2**attempt)
                     continue

--- a/src/mgz_pkmn/sources/pricecharting.py
+++ b/src/mgz_pkmn/sources/pricecharting.py
@@ -38,8 +38,10 @@ class PriceChartingClient:
     """Lightweight scraper for pricecharting.com product pages. We trust the
     user picked the right page and just extract image + prices."""
 
-    def __init__(self, verbose: bool = False) -> None:
-        self.session = requests.Session()
+    def __init__(self, verbose: bool = False, session: requests.Session | None = None) -> None:
+        # Injected session keeps the connection pool warm across instances
+        # (#302); `_cache` stays instance-local.
+        self.session = session or requests.Session()
         self.session.headers["User-Agent"] = USER_AGENT
         self.verbose = verbose
         self._cache: dict[str, str] = {}

--- a/src/mgz_pkmn/sources/tcgdex.py
+++ b/src/mgz_pkmn/sources/tcgdex.py
@@ -20,8 +20,10 @@ class TCGDexClient:
     """Two-step lookup: search by name, then hydrate each hit with full card
     details so we can score on set + rarity."""
 
-    def __init__(self, verbose: bool = False) -> None:
-        self.session = requests.Session()
+    def __init__(self, verbose: bool = False, session: requests.Session | None = None) -> None:
+        # Injected session keeps the connection pool warm across instances
+        # (#302); `_cache` stays instance-local.
+        self.session = session or requests.Session()
         self.session.headers["User-Agent"] = USER_AGENT
         self.verbose = verbose
         self._cache: dict[str, Any] = {}

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -254,7 +254,7 @@ class ClientMemoizationTests(unittest.TestCase):
         )
         return [(row, "no_candidates")], "MISS"
 
-    def test_one_api_key_reuses_sessions_but_rebuilds_clients(self) -> None:
+    def test_clients_are_rebuilt_but_share_the_pooled_session(self) -> None:
         from api.routes.lookup import Settings, _make_clients
 
         first = _make_clients(Settings(api_key="k1"))
@@ -266,16 +266,35 @@ class ClientMemoizationTests(unittest.TestCase):
         for a, b in zip(first, second, strict=True):
             self.assertIs(a.session, b.session)
 
-    def test_a_different_api_key_gets_fresh_sessions(self) -> None:
+    def test_sessions_are_shared_across_api_keys_and_hold_no_key(self) -> None:
+        # The pooled session is api-key-agnostic: a BYO key is applied per
+        # request, never stored on the session or used as a cache key, so it
+        # doesn't linger in process-global state.
         from api.routes.lookup import Settings, _make_clients
 
         a = _make_clients(Settings(api_key="k1"))
         b = _make_clients(Settings(api_key="k2"))
-        self.assertIsNot(a[0].session, b[0].session)
+        self.assertIs(a[0].session, b[0].session)
+        self.assertNotIn("X-Api-Key", a[0].session.headers)
+        self.assertEqual(a[0]._api_key, "k1")
+
+    def test_api_key_is_sent_per_request_not_on_the_session(self) -> None:
+        # The key still authenticates — it rides on each upstream GET.
+        from unittest.mock import MagicMock
+
+        from mgz_pkmn.sources import TCGClient
+
+        session = MagicMock()
+        session.headers = {}
+        session.get.return_value = MagicMock(status_code=200, json=lambda: {"data": []})
+        TCGClient(api_key="secret", session=session)._network_fetch(
+            "https://api.pokemontcg.io/v2/cards?q=x"
+        )
+        self.assertEqual(session.get.call_args.kwargs["headers"], {"X-Api-Key": "secret"})
+        self.assertNotIn("X-Api-Key", session.headers)
 
     def test_distinct_session_per_upstream(self) -> None:
-        # The pokemontcg.io api-key header must never ride along to the other
-        # hosts, so each upstream gets its own session.
+        # Each upstream gets its own session so connections don't cross hosts.
         from api.routes.lookup import Settings, _make_clients
 
         pkmn, tcgdex, pc, ebay = _make_clients(Settings(api_key="k1"))

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -232,15 +232,17 @@ class LookupRouteTests(unittest.TestCase):
 
 
 class ClientMemoizationTests(unittest.TestCase):
-    """The upstream client quartet is memoized per api_key so each client's
-    `requests.Session` pool + in-memory cache survive across requests."""
+    """The upstream `requests.Session` pool is memoized per api_key so the
+    connection stays warm across requests (#302). The clients themselves are
+    rebuilt per request on purpose — their instance-local L1 `_cache` has no
+    TTL, so reusing a client would pin stale/empty results process-wide."""
 
     def setUp(self) -> None:
-        from api.routes.lookup import _clients_for
+        from api.routes.lookup import _sessions_for
 
         # Other tests share the process-wide cache; clear it so these assert
         # against a known-empty starting point.
-        _clients_for.cache_clear()
+        _sessions_for.cache_clear()
 
     def _row(self):
         from mgz_pkmn.parser import CardQuery
@@ -252,23 +254,35 @@ class ClientMemoizationTests(unittest.TestCase):
         )
         return [(row, "no_candidates")], "MISS"
 
-    def test_make_clients_returns_the_same_instances_for_one_api_key(self) -> None:
+    def test_one_api_key_reuses_sessions_but_rebuilds_clients(self) -> None:
         from api.routes.lookup import Settings, _make_clients
 
         first = _make_clients(Settings(api_key="k1"))
         second = _make_clients(Settings(api_key="k1"))
-        # Every member of the quartet is reused, not rebuilt.
+        # Fresh client objects each call — keeps the L1 `_cache` request-scoped.
         for a, b in zip(first, second, strict=True):
-            self.assertIs(a, b)
+            self.assertIsNot(a, b)
+        # ...but every client shares the warm, memoized session.
+        for a, b in zip(first, second, strict=True):
+            self.assertIs(a.session, b.session)
 
-    def test_a_different_api_key_gets_a_fresh_quartet(self) -> None:
+    def test_a_different_api_key_gets_fresh_sessions(self) -> None:
         from api.routes.lookup import Settings, _make_clients
 
         a = _make_clients(Settings(api_key="k1"))
         b = _make_clients(Settings(api_key="k2"))
-        self.assertIsNot(a[0], b[0])
+        self.assertIsNot(a[0].session, b[0].session)
 
-    def test_consecutive_lookups_reuse_the_same_tcgclient(self) -> None:
+    def test_distinct_session_per_upstream(self) -> None:
+        # The pokemontcg.io api-key header must never ride along to the other
+        # hosts, so each upstream gets its own session.
+        from api.routes.lookup import Settings, _make_clients
+
+        pkmn, tcgdex, pc, ebay = _make_clients(Settings(api_key="k1"))
+        sessions = {id(pkmn.session), id(tcgdex.session), id(pc.session), id(ebay.session)}
+        self.assertEqual(len(sessions), 4)
+
+    def test_consecutive_lookups_reuse_the_same_session(self) -> None:
         seen: list[object] = []
 
         def _record(pkmn, *args, **kwargs):
@@ -280,7 +294,9 @@ class ClientMemoizationTests(unittest.TestCase):
             client.post("/api/v1/lookup", json={"line": "Pikachu"})
 
         self.assertEqual(len(seen), 2)
-        self.assertIs(seen[0], seen[1])
+        # Fresh TCGClient per request, same warm session underneath.
+        self.assertIsNot(seen[0], seen[1])
+        self.assertIs(seen[0].session, seen[1].session)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -227,6 +227,63 @@ class LookupRouteTests(unittest.TestCase):
 
 
 # ---------------------------------------------------------------------------
+# Client memoization (#302)
+# ---------------------------------------------------------------------------
+
+
+class ClientMemoizationTests(unittest.TestCase):
+    """The upstream client quartet is memoized per api_key so each client's
+    `requests.Session` pool + in-memory cache survive across requests."""
+
+    def setUp(self) -> None:
+        from api.routes.lookup import _clients_for
+
+        # Other tests share the process-wide cache; clear it so these assert
+        # against a known-empty starting point.
+        _clients_for.cache_clear()
+
+    def _row(self):
+        from mgz_pkmn.parser import CardQuery
+        from mgz_pkmn.pricing import Pricing
+        from mgz_pkmn.spreadsheet import Row
+
+        row = Row(
+            query=CardQuery(raw="Pikachu", name="Pikachu"), card=None, pricing=Pricing(), tag=""
+        )
+        return [(row, "no_candidates")], "MISS"
+
+    def test_make_clients_returns_the_same_instances_for_one_api_key(self) -> None:
+        from api.routes.lookup import Settings, _make_clients
+
+        first = _make_clients(Settings(api_key="k1"))
+        second = _make_clients(Settings(api_key="k1"))
+        # Every member of the quartet is reused, not rebuilt.
+        for a, b in zip(first, second, strict=True):
+            self.assertIs(a, b)
+
+    def test_a_different_api_key_gets_a_fresh_quartet(self) -> None:
+        from api.routes.lookup import Settings, _make_clients
+
+        a = _make_clients(Settings(api_key="k1"))
+        b = _make_clients(Settings(api_key="k2"))
+        self.assertIsNot(a[0], b[0])
+
+    def test_consecutive_lookups_reuse_the_same_tcgclient(self) -> None:
+        seen: list[object] = []
+
+        def _record(pkmn, *args, **kwargs):
+            seen.append(pkmn)
+            return self._row()
+
+        with patch("api.routes.lookup._do_lookup", side_effect=_record):
+            client.post("/api/v1/lookup", json={"line": "Pikachu"})
+            client.post("/api/v1/lookup", json={"line": "Pikachu"})
+
+        self.assertEqual(len(seen), 2)
+        self.assertIs(seen[0], seen[1])
+
+
+# ---------------------------------------------------------------------------
 # /bulk (SSE) — stage streaming
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #302

## What

`api/routes/lookup.py:_make_clients` built a fresh `TCGClient`, `TCGDexClient`, `PriceChartingClient`, and `EbayClient` — each with its own `requests.Session` — on **every** `/lookup` and `/bulk` request, discarding the connection pool each time. This shares **one header-light `requests.Session` per upstream** (`_sessions_for`, backed by `lru_cache`) across requests and injects them into freshly-built clients, so the connection pool survives across requests while the clients stay request-scoped.

## Why memoize the session, not the client

The first cut memoized the whole client. Codex flagged that as a P1: each client carries an instance-local L1 `_cache` with **no TTL**, written on STALE/MISS reads and keyed **without `cache_only`**. A process-lived client would pin those entries — serving a stale card payload or a cached empty `no_candidates` indefinitely, never re-reading disk or re-arming the SWR refresh, and even letting an anonymous cache-only read poison a later authenticated request. Request-local client lifetime was load-bearing for correctness.

Memoizing only the session keeps the **primary** win — a warm connection pool, i.e. a saved TLS handshake per upstream hit — while the L1 `_cache` returns to its original per-request contract.

## BYO api keys stay request-scoped

A second Codex pass (P2) noted that keying the pooled session by `api_key` retained caller-supplied keys in process-global state (the `lru_cache` key + the `X-Api-Key` header on the pooled session). Fixed: the pooled session is now api-key-agnostic, and `TCGClient` applies `X-Api-Key` **per request** on each upstream GET rather than storing it on the shared session. A BYO credential never lands in the cache key or a pooled session header — it stays request-scoped — while the connection pool still stays warm. `lru_cache` and `Session.get`/`post` are both safe for the concurrent FastAPI threadpool.

## Benchmark

Construction cost removed per request (2000 iterations, warm process):

```
fresh sessions/request : 36.37 us/call
memoized sessions      : 10.59 us/call
construction saved     : 25.77 us/call
```

That's allocation only — it excludes the larger, network-bound win this targets: reusing a kept-alive connection instead of a fresh TLS handshake on every upstream call.

## How to verify

- `uv run python -m pytest tests/test_api_routes.py -k Memoization` — five tests: clients are rebuilt but share the pooled session, the session is shared across api_keys and holds no key, the api_key rides on each per-request GET (and is absent from session headers), each upstream gets a distinct session, and two consecutive `/lookup` calls share the same session.
- `uv run python -m pytest tests/` — full suite green (933 passed).
- `make lint-py format-check complexity` — all green.