### PR TITLE
perf(api): run /bulk SSE lookups with bounded concurrency

### DIFF
--- a/api/routes/lookup.py
+++ b/api/routes/lookup.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import time
 from collections.abc import Callable
 from functools import lru_cache
@@ -345,18 +346,28 @@ async def lookup(req: LookupRequest, current_user: CurrentUserOptional) -> JSONR
     )
 
 
-def _stage_frame(index: int, total: int, stage: str) -> str:
-    """Serialize a progress-only SSE frame (no row payload).
-
-    Distinguishable from a resolved-row frame by the absence of `matched` /
-    `query` — the SPA branches on that to update a line's current stage
-    without appending a result row."""
-    return f"data: {json.dumps({'index': index, 'total': total, 'stage': stage})}\n\n"
+_BULK_CONCURRENCY_ENV = "MGZ_PKMN_BULK_CONCURRENCY"
+_DEFAULT_BULK_CONCURRENCY = 8
 
 
-# Sentinel pushed onto a line's stage queue once its threadpool lookup
-# resolves, so the async drain loop knows to stop waiting for more stages.
-_STAGE_DONE = object()
+def _bulk_concurrency() -> int:
+    """Max number of /bulk lines looked up at once (#303).
+
+    Bounded by `MGZ_PKMN_BULK_CONCURRENCY` (default 8) — high enough to mask
+    upstream latency, low enough that a burst stays within pokemontcg.io's
+    30 rpm free tier. The upstream client's 429 backoff (`pokemontcg.py`)
+    absorbs any transient overshoot. A value below 1 (or unparseable) falls
+    back to the default."""
+    try:
+        n = int(os.environ.get(_BULK_CONCURRENCY_ENV, "").strip())
+    except ValueError:
+        return _DEFAULT_BULK_CONCURRENCY
+    return n if n >= 1 else _DEFAULT_BULK_CONCURRENCY
+
+
+# Sentinel pushed onto the shared frame queue once every line's lookup has
+# resolved, so the async drain loop knows the stream is complete.
+_STREAM_DONE = object()
 
 
 @router.post("/bulk")
@@ -391,40 +402,51 @@ async def bulk(req: BulkRequest, current_user: CurrentUserOptional) -> Streaming
 
     async def event_stream():
         loop = asyncio.get_running_loop()
-        # Accumulate the Rows we yield so we can persist them after the
-        # stream completes. ADR-0013: failures-during-stream don't write —
-        # the persistence call is the last thing in the generator, so a
-        # client disconnect stops iteration before the commit.
-        resolved: list[Row] = []
         started = time.monotonic()
-        for stream_idx, (_orig_idx, line) in enumerate(indexed):
-            q = parse_line(line)
-            if q is None:
-                row = _unparseable_row(line, req.settings.tag)
-                resolved.append(row)
-                payload = {
-                    "index": stream_idx,
-                    "total": total,
-                    **_row_to_dict(row, "unparseable"),
-                }
-                yield f"data: {json.dumps(payload)}\n\n"
-                continue
 
-            # The line is in the pipeline before any upstream call goes out.
-            yield _stage_frame(stream_idx, total, "parsed")
+        # Fan the lines out with bounded concurrency (#303): each line runs as
+        # its own task gated by a semaphore, so at most `_bulk_concurrency()`
+        # lookups hit upstream at once instead of walking the list strictly
+        # serially. Every frame (progress + resolved row) is pushed onto one
+        # shared queue that the generator drains and yields as events complete
+        # — *not* in input order. Clients key on `index`, so arrival order
+        # doesn't matter to the SPA's per-line `ProcessingQueue`.
+        sem = asyncio.Semaphore(_bulk_concurrency())
+        frames: asyncio.Queue = asyncio.Queue()
+        # Per-line resolved Rows keyed by stream index, so we can persist in
+        # input order even though lookups finish out of order.
+        resolved_by_idx: dict[int, list[Row]] = {}
 
-            # Bridge the synchronous `on_stage` callback (invoked on the
-            # threadpool worker) to this async generator. The worker pushes
-            # stage names via `call_soon_threadsafe`; a done-callback pushes a
-            # sentinel once the lookup returns. We drain in between, so stage
-            # frames interleave with the blocking lookup in real time.
-            stage_queue: asyncio.Queue = asyncio.Queue()
+        async def process_line(stream_idx: int, line: str) -> None:
+            async with sem:
+                q = parse_line(line)
+                if q is None:
+                    row = _unparseable_row(line, req.settings.tag)
+                    resolved_by_idx[stream_idx] = [row]
+                    await frames.put(
+                        {"index": stream_idx, "total": total, **_row_to_dict(row, "unparseable")}
+                    )
+                    return
 
-            def on_stage(name: str, _q: asyncio.Queue = stage_queue) -> None:
-                loop.call_soon_threadsafe(_q.put_nowait, name)
+                # The line is in the pipeline before any upstream call goes out.
+                await frames.put({"index": stream_idx, "total": total, "stage": "parsed"})
 
-            task = asyncio.ensure_future(
-                run_in_threadpool(
+                # Bridge the synchronous `on_stage` callback (invoked on the
+                # threadpool worker) onto the shared frame queue from the loop
+                # thread, so stage frames interleave with the blocking lookup
+                # in real time.
+                def on_stage(name: str, _idx: int = stream_idx) -> None:
+                    loop.call_soon_threadsafe(
+                        frames.put_nowait,
+                        {"index": _idx, "total": total, "stage": name},
+                    )
+
+                # `_do_lookup` now returns (pairs, cache_status); the SSE
+                # stream consumes per-row pairs and drops the aggregate status
+                # — `X-Cache` is set at response-header level by the /lookup
+                # route, not per-event in the stream. SSE coverage is deferred
+                # to the #310 follow-up.
+                pairs, _ = await run_in_threadpool(
                     _do_lookup,
                     pkmn,
                     tcgdex,
@@ -435,30 +457,42 @@ async def bulk(req: BulkRequest, current_user: CurrentUserOptional) -> Streaming
                     cache_only=cache_only,
                     ebay=ebay,
                 )
-            )
-            task.add_done_callback(lambda _t, _q=stage_queue: _q.put_nowait(_STAGE_DONE))
+                resolved_by_idx[stream_idx] = [row for row, _reason in pairs]
+                for row, reason in pairs:
+                    await frames.put(
+                        {"index": stream_idx, "total": total, **_row_to_dict(row, reason)}
+                    )
 
-            while True:
-                item = await stage_queue.get()
-                if item is _STAGE_DONE:
-                    break
-                yield _stage_frame(stream_idx, total, item)
+        tasks = [
+            asyncio.ensure_future(process_line(stream_idx, line))
+            for stream_idx, (_orig_idx, line) in enumerate(indexed)
+        ]
 
-            # `_do_lookup` now returns (pairs, cache_status); the SSE
-            # stream consumes per-row pairs and drops the aggregate status
-            # — `X-Cache` is set at response-header level by the /lookup
-            # route, not per-event in the stream. SSE coverage is deferred
-            # to the #310 follow-up.
-            pairs, _ = task.result()
-            for row, reason in pairs:
-                resolved.append(row)
-                payload = {
-                    "index": stream_idx,
-                    "total": total,
-                    **_row_to_dict(row, reason),
-                }
-                yield f"data: {json.dumps(payload)}\n\n"
+        async def _signal_when_done() -> None:
+            # `return_exceptions=True` guarantees the done sentinel is always
+            # queued (a raising task can't deadlock the drain loop). `_do_lookup`
+            # already swallows upstream RequestExceptions into error rows, so a
+            # task exception here is unexpected — log it and carry on.
+            for result in await asyncio.gather(*tasks, return_exceptions=True):
+                if isinstance(result, Exception):
+                    logger.error("A /bulk line task failed", exc_info=result)
+            await frames.put(_STREAM_DONE)
 
+        runner = asyncio.ensure_future(_signal_when_done())
+
+        # Drain frames as they land and stream them out. ADR-0013:
+        # failures-during-stream don't write — the persistence call is after
+        # this loop, so a client disconnect stops iteration before the commit.
+        while True:
+            item = await frames.get()
+            if item is _STREAM_DONE:
+                break
+            yield f"data: {json.dumps(item)}\n\n"
+        await runner  # surface bookkeeping errors from the done-signal task
+
+        resolved: list[Row] = [
+            row for idx in sorted(resolved_by_idx) for row in resolved_by_idx[idx]
+        ]
         elapsed = time.monotonic() - started
         run_id: int | None = None
         try:

--- a/render.yaml
+++ b/render.yaml
@@ -136,6 +136,15 @@ services:
       - key: MGZ_PKMN_WARM_CARD_IMAGES_ON_STARTUP
         value: "1"
         previewValue: "0"
+      # Bounded concurrency for /bulk SSE lookups (#303). The route fans each
+      # line out as its own task gated by a semaphore of this size
+      # (api/routes/lookup.py:_bulk_concurrency) instead of walking the list
+      # serially. Pinned to the code default (8) to make the production
+      # posture explicit: high enough to mask upstream latency on a ~200-line
+      # Browse drop, low enough that a burst stays within pokemontcg.io's
+      # 30 rpm free tier (the client's 429 backoff absorbs any overshoot).
+      - key: MGZ_PKMN_BULK_CONCURRENCY
+        value: "8"
       # Hosted-demo auth scaffold (#61 epic, foundation in #407, GitHub
       # provider in #408). Toggle is in-blueprint because it's a
       # reviewable deploy policy decision; the secrets below ride the

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -403,6 +403,83 @@ class BulkStageStreamTests(unittest.TestCase):
         self.assertEqual(rows[0]["stage"], "no_match")
 
 
+class BulkConcurrencyTests(unittest.TestCase):
+    """The /bulk stream fans lines out with bounded concurrency (#303) rather
+    than walking the list strictly serially, while still tagging every frame
+    with `index` / `total` so the SPA can map results back to input lines."""
+
+    def test_lines_run_concurrently_and_frames_carry_index(self) -> None:
+        import threading
+        import time
+
+        from mgz_pkmn.pricing import Pricing
+        from mgz_pkmn.spreadsheet import Row
+
+        active = 0
+        max_active = 0
+        lock = threading.Lock()
+
+        def fake(pkmn, tcgdex, pc, q, settings, on_stage=None, *, cache_only=False, ebay=None):
+            nonlocal active, max_active
+            with lock:
+                active += 1
+                max_active = max(max_active, active)
+            time.sleep(0.05)
+            with lock:
+                active -= 1
+            card = {"id": "base1-4", "name": q.name}
+            return [
+                (Row(query=q, card=card, pricing=Pricing(market=1.0), tag=""), "matched")
+            ], "HIT"
+
+        lines = [f"Card {i}" for i in range(6)]
+        with (
+            patch("api.routes.lookup._do_lookup", side_effect=fake),
+            patch("api.routes.lookup._bulk_concurrency", return_value=4),
+        ):
+            resp = client.post("/api/v1/bulk", json={"lines": lines})
+
+        self.assertEqual(resp.status_code, 200)
+        frames = _parse_sse(resp.text)
+        rows = [f for f in frames if "matched" in f]
+        self.assertEqual(len(rows), 6)
+        self.assertEqual({f["index"] for f in rows}, set(range(6)))
+        self.assertTrue(all(f["total"] == 6 for f in rows))
+        self.assertTrue(frames[-1].get("done"))
+        # Proves the lookups overlapped rather than running one-at-a-time, but
+        # stayed within the configured semaphore bound.
+        self.assertGreater(max_active, 1)
+        self.assertLessEqual(max_active, 4)
+
+    def test_done_terminates_even_with_no_parseable_lines(self) -> None:
+        resp = client.post("/api/v1/bulk", json={"lines": ["", "# comment"]})
+        self.assertEqual(resp.status_code, 200)
+        frames = _parse_sse(resp.text)
+        self.assertEqual(len(frames), 1)
+        self.assertTrue(frames[0].get("done"))
+        self.assertEqual(frames[0]["total"], 0)
+
+
+class BulkConcurrencyEnvTests(unittest.TestCase):
+    """`_bulk_concurrency` reads `MGZ_PKMN_BULK_CONCURRENCY`, defaulting and
+    clamping to a sane value when the var is unset or invalid."""
+
+    def test_env_parsing(self) -> None:
+        from api.routes.lookup import _DEFAULT_BULK_CONCURRENCY, _bulk_concurrency
+
+        cases = {
+            "2": 2,
+            "16": 16,
+            "": _DEFAULT_BULK_CONCURRENCY,
+            "0": _DEFAULT_BULK_CONCURRENCY,
+            "-3": _DEFAULT_BULK_CONCURRENCY,
+            "nonsense": _DEFAULT_BULK_CONCURRENCY,
+        }
+        for raw, expected in cases.items():
+            with patch.dict(os.environ, {"MGZ_PKMN_BULK_CONCURRENCY": raw}):
+                self.assertEqual(_bulk_concurrency(), expected)
+
+
 # ---------------------------------------------------------------------------
 # /sets
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #303

## What

`/bulk`'s SSE generator walked its lines strictly serially — `await run_in_threadpool(_do_lookup, ...)` on each line before starting the next — so wall-clock was roughly `N × per-line latency`. This fans each line out as its own task gated by an `asyncio.Semaphore`, pushing every frame (progress + resolved row) onto one shared queue that the generator drains as events complete.

- **Bounded concurrency** via `asyncio.Semaphore(_bulk_concurrency())`, size from `MGZ_PKMN_BULK_CONCURRENCY` (default 8, clamps to the default for unset/invalid/`<1`).
- **Out-of-order streaming** — frames arrive as lookups finish, not in input order. Every frame still carries `index` / `total`.
- **Input-order persistence** — per-line rows are collected keyed by stream index and flattened in order before `_persist_run`, so the saved run matches submitted intent.
- **Cancellation on disconnect** — the drain loop cancels the still-queued line tasks (and the done-signal task) when the stream closes, so aborting a large run stops queued lookups instead of letting them keep hitting upstream into a queue nobody reads. In-flight threadpool calls can't be force-killed, but the bulk of a large list is still parked on the semaphore and cancels immediately.
- **Monotonic SPA progress** — because results no longer arrive in input order, the web client counts distinct resolved line indices rather than reading the latest event's index, so a late-finishing early line can't rewind the progress bar.
- **`render.yaml`** pins `MGZ_PKMN_BULK_CONCURRENCY=8` to make the production posture explicit (deployment-affecting env var the API reads).

## Why

Split from #267 — Browse pushes users toward dropping a whole set (~200 lines) into the editor, which makes the serial walk extremely visible and the SSE progress feel artificially staggered. Cards are independent, so the work parallelizes cleanly; the semaphore keeps a burst within pokemontcg.io's 30 rpm free tier, and the client's existing 429 backoff absorbs any overshoot. Builds on #302 (warm shared session pool), which compounds the win.

## Microbenchmark

10-line list, simulated 0.3s per-line upstream latency, same code path at `concurrency=1` (serial baseline) vs default `8`:

| | wall clock |
| --- | --- |
| serial (`concurrency=1`) | 3.08s |
| concurrent (`concurrency=8`) | 0.62s |
| **speedup** | **5.0×** |

## How to verify

- `make check` — full Python + lint suite green (936 tests); `cd web && npm run build` clean.
- Backend: `BulkConcurrencyTests` proves lines overlap but stay within the semaphore bound and that every frame carries `index`/`total` with a terminating `done`; `BulkConcurrencyEnvTests` covers env parsing/clamping. Existing `BulkStageStreamTests` (single-line stage ordering) still pass — no SSE regression.
- Web: new `App.test.tsx` case drives events out of order (2, 0, 1) and asserts progress only advances.