### PR TITLE
perf(api): cancel queued /bulk lookups on disconnect; keep SPA progress monotonic

### DIFF
--- a/api/routes/lookup.py
+++ b/api/routes/lookup.py
@@ -483,12 +483,26 @@ async def bulk(req: BulkRequest, current_user: CurrentUserOptional) -> Streaming
         # Drain frames as they land and stream them out. ADR-0013:
         # failures-during-stream don't write — the persistence call is after
         # this loop, so a client disconnect stops iteration before the commit.
-        while True:
-            item = await frames.get()
-            if item is _STREAM_DONE:
-                break
-            yield f"data: {json.dumps(item)}\n\n"
-        await runner  # surface bookkeeping errors from the done-signal task
+        try:
+            while True:
+                item = await frames.get()
+                if item is _STREAM_DONE:
+                    break
+                yield f"data: {json.dumps(item)}\n\n"
+            await runner  # surface bookkeeping errors from the done-signal task
+        except BaseException:
+            # Client disconnect (the Stop button aborts the fetch, raising
+            # GeneratorExit here) or a mid-stream error: cancel the fan-out so
+            # queued lookups stop hitting upstream into a queue nobody reads
+            # (#303). In-flight threadpool calls can't be force-killed, but on
+            # a large pasted list the bulk of the work is still parked on the
+            # semaphore and cancels immediately. Persistence below is skipped —
+            # the re-raise exits the generator before the commit (ADR-0013).
+            for task in tasks:
+                task.cancel()
+            runner.cancel()
+            await asyncio.gather(*tasks, runner, return_exceptions=True)
+            raise
 
         resolved: list[Row] = [
             row for idx in sorted(resolved_by_idx) for row in resolved_by_idx[idx]

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -215,6 +215,32 @@ describe('App: bulk-run timestamp lifecycle', () => {
     expect(useAppStore.getState().runEndedAt).toBe(4_200)
   })
 
+  it('progress counts resolved lines so out-of-order events never make it regress', async () => {
+    // The server streams results in completion order, not input order (#303),
+    // so a late-finishing early line must not rewind the progress bar.
+    useAppStore.setState({ inputText: 'a\nb\nc' })
+
+    let captured: { onEvent: (e: BulkEvent) => void } | null = null
+    mockBulkLookup.mockImplementation(
+      (_lines: string[], _settings: unknown, onEvent: (e: BulkEvent) => void) => {
+        captured = { onEvent }
+        return new Promise<void>(() => {})
+      },
+    )
+
+    render(<App />)
+    fireEvent.click(screen.getByRole('button', { name: /look up/i }))
+    await waitFor(() => expect(captured).not.toBeNull())
+
+    // Arrive out of order: line 2 resolves first, then 0, then 1.
+    act(() => captured!.onEvent(makeEvent(2, 3)))
+    expect(useAppStore.getState().progress).toEqual({ done: 1, total: 3 })
+    act(() => captured!.onEvent(makeEvent(0, 3)))
+    expect(useAppStore.getState().progress).toEqual({ done: 2, total: 3 })
+    act(() => captured!.onEvent(makeEvent(1, 3)))
+    expect(useAppStore.getState().progress).toEqual({ done: 3, total: 3 })
+  })
+
   it('a bulkLookup network rejection without onDone still stamps runEndedAt via the App-level catch', async () => {
     // Mirrors the real path where `fetch` itself rejects before
     // bulkLookup gets a chance to call onDone — the only case the

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -241,6 +241,35 @@ describe('App: bulk-run timestamp lifecycle', () => {
     expect(useAppStore.getState().progress).toEqual({ done: 3, total: 3 })
   })
 
+  it('progress counts a deduped line so a duplicate card ID still reaches total', async () => {
+    // With dedupe on, a line resolving to an already-seen card ID is skipped
+    // from the table but still resolved its input line — it must count toward
+    // progress, otherwise the bar strands below total (e.g. 2 / 3).
+    useAppStore.setState({ inputText: 'Pikachu\nPikachu\nMew' })
+    useAppStore.getState().updateSettings({ dedupe: true })
+
+    let captured: { onEvent: (e: BulkEvent) => void } | null = null
+    mockBulkLookup.mockImplementation(
+      (_lines: string[], _settings: unknown, onEvent: (e: BulkEvent) => void) => {
+        captured = { onEvent }
+        return new Promise<void>(() => {})
+      },
+    )
+
+    render(<App />)
+    fireEvent.click(screen.getByRole('button', { name: /look up/i }))
+    await waitFor(() => expect(captured).not.toBeNull())
+
+    // Lines 0 and 1 resolve to the same card ID; line 1 is the duplicate.
+    const dup = (index: number) => ({ ...makeEvent(index, 3), card: { id: 'pika', name: 'Pikachu' } })
+    act(() => captured!.onEvent(dup(0)))
+    expect(useAppStore.getState().progress).toEqual({ done: 1, total: 3 })
+    act(() => captured!.onEvent(dup(1)))
+    expect(useAppStore.getState().progress).toEqual({ done: 2, total: 3 })
+    act(() => captured!.onEvent(makeEvent(2, 3)))
+    expect(useAppStore.getState().progress).toEqual({ done: 3, total: 3 })
+  })
+
   it('a bulkLookup network rejection without onDone still stamps runEndedAt via the App-level catch', async () => {
     // Mirrors the real path where `fetch` itself rejects before
     // bulkLookup gets a chance to call onDone — the only case the

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -164,6 +164,11 @@ function App() {
 
     // Track unique card IDs for client-side deduplication.
     const seenIds = new Set<string>()
+    // Distinct input lines that have produced a terminal row. The server now
+    // streams results out of completion order (#303), so progress counts
+    // resolved lines rather than reading the latest event's index — otherwise
+    // a late-finishing early line would make the bar regress.
+    const resolvedLines = new Set<number>()
     let firstEventSeen = false
 
     function onEvent(event: BulkEvent) {
@@ -209,7 +214,8 @@ function App() {
         reason: event.reason,
       })
 
-      setProgress({ done: event.index + 1, total: event.total })
+      resolvedLines.add(event.index)
+      setProgress({ done: resolvedLines.size, total: event.total })
     }
 
     // `bulkLookup` calls `onDone` on every normal exit path (non-OK

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -197,6 +197,12 @@ function App() {
       // Subsequent events (top:N expansions) leave the status alone.
       markLineStatus(event.index, event.matched ? 'resolved' : 'error')
 
+      // Count the line toward progress before any dedupe skip — a duplicate
+      // card ID still resolved its line, so omitting it here would strand the
+      // bar below total (e.g. `Pikachu\nPikachu\nMew` finishing at 2 / 3).
+      resolvedLines.add(event.index)
+      setProgress({ done: resolvedLines.size, total: event.total })
+
       if (settings.dedupe && event.matched && event.card) {
         const cid = event.card.id as string | undefined
         if (cid) {
@@ -213,9 +219,6 @@ function App() {
         matched: event.matched,
         reason: event.reason,
       })
-
-      resolvedLines.add(event.index)
-      setProgress({ done: resolvedLines.size, total: event.total })
     }
 
     // `bulkLookup` calls `onDone` on every normal exit path (non-OK


### PR DESCRIPTION
Follow-up to #674, which an automation squash-merged on its first commit before the Codex review fixes landed. This carries the two P2 fixes from that review into main.

## What

- **Cancellation on disconnect** (`api/routes/lookup.py`) — #674 fanned `/bulk` lines out as independent tasks, but nothing cancelled them when the stream closed. The drain loop now wraps in `try/except BaseException`: on a client disconnect (the Stop button aborting the fetch raises `GeneratorExit`) or a mid-stream error, it cancels the still-queued line tasks and the done-signal task before re-raising. In-flight threadpool calls can't be force-killed, but on a large pasted list the bulk of the work is still parked on the semaphore and cancels immediately — so aborting actually stops upstream traffic instead of letting queued lookups drain into a queue nobody reads.
- **Monotonic SPA progress** (`web/src/App.tsx`) — because results now stream in completion order rather than input order, the client can no longer derive overall progress from `event.index + 1` (a late-finishing early line would rewind the bar). It now counts distinct resolved line indices.

## Why

Both were flagged P2 in Codex's review of #674 but the PR merged before they could be applied. The progress regression is user-visible; the missing cancellation wastes API quota and threadpool capacity after a user hits Stop on a long run.

## How to verify

- `make check` green; `cd web && npm run build` clean.
- `web/src/App.test.tsx`: new case drives events out of order (2, 0, 1) and asserts progress only advances.
- Existing `BulkConcurrencyTests` / `BulkStageStreamTests` still pass.