### PR TITLE
feat(web): surface cache-hit vs upstream signal in the lookup timer

### DIFF
--- a/api/routes/lookup.py
+++ b/api/routes/lookup.py
@@ -425,6 +425,13 @@ async def bulk(req: BulkRequest, current_user: CurrentUserOptional) -> Streaming
             async with sem:
                 q = parse_line(line)
                 if q is None:
+                    # Deliberately *not* appended to `cache_statuses`: an
+                    # unparseable line performs no cache read, so it can't be
+                    # graded HIT/STALE/MISS. The run-level chip reports where the
+                    # actual results came from, and folding a synthetic MISS in
+                    # here would make an all-cache-hit run with one typo claim it
+                    # went upstream. An all-unparseable run still reports MISS via
+                    # the empty-list default below, matching the /lookup route.
                     row = _unparseable_row(line, req.settings.tag)
                     resolved_by_idx[stream_idx] = [row]
                     await frames.put(

--- a/api/routes/lookup.py
+++ b/api/routes/lookup.py
@@ -416,6 +416,10 @@ async def bulk(req: BulkRequest, current_user: CurrentUserOptional) -> Streaming
         # Per-line resolved Rows keyed by stream index, so we can persist in
         # input order even though lookups finish out of order.
         resolved_by_idx: dict[int, list[Row]] = {}
+        # Per-line split-cache outcomes, aggregated into the `done` event so the
+        # SPA can render a single run-level source chip (#310). Appended from the
+        # loop thread once each `run_in_threadpool` resolves — no lock needed.
+        cache_statuses: list[str] = []
 
         async def process_line(stream_idx: int, line: str) -> None:
             async with sem:
@@ -441,12 +445,10 @@ async def bulk(req: BulkRequest, current_user: CurrentUserOptional) -> Streaming
                         {"index": _idx, "total": total, "stage": name},
                     )
 
-                # `_do_lookup` now returns (pairs, cache_status); the SSE
-                # stream consumes per-row pairs and drops the aggregate status
-                # — `X-Cache` is set at response-header level by the /lookup
-                # route, not per-event in the stream. SSE coverage is deferred
-                # to the #310 follow-up.
-                pairs, _ = await run_in_threadpool(
+                # `_do_lookup` returns (pairs, cache_status). The per-row pairs
+                # stream out as events; the aggregate status feeds the run-level
+                # source chip carried on the `done` event (#310).
+                pairs, line_status = await run_in_threadpool(
                     _do_lookup,
                     pkmn,
                     tcgdex,
@@ -457,6 +459,7 @@ async def bulk(req: BulkRequest, current_user: CurrentUserOptional) -> Streaming
                     cache_only=cache_only,
                     ebay=ebay,
                 )
+                cache_statuses.append(line_status)
                 resolved_by_idx[stream_idx] = [row for row, _reason in pairs]
                 for row, reason in pairs:
                     await frames.put(
@@ -519,9 +522,25 @@ async def bulk(req: BulkRequest, current_user: CurrentUserOptional) -> Streaming
         except Exception:  # pragma: no cover — defensive, persistence is best-effort
             logger.exception("Failed to persist run after /bulk completion")
 
+        # Aggregate the per-line outcomes into one run-level signal (MISS
+        # dominates STALE dominates HIT). No real lookup ran (all lines blank
+        # or unparseable) → MISS, matching the /lookup route's default.
+        run_cache_status = worse_cache_status(*cache_statuses) if cache_statuses else "MISS"
         # `run_id` surfaces so the SPA can offer a "Save this search" action
-        # against the just-completed run without re-querying the list.
-        yield f"data: {json.dumps({'done': True, 'total': total, 'run_id': run_id})}\n\n"
+        # against the just-completed run without re-querying the list;
+        # `cache_status` feeds the lookup-timer source chip (#310).
+        yield (
+            "data: "
+            + json.dumps(
+                {
+                    "done": True,
+                    "total": total,
+                    "run_id": run_id,
+                    "cache_status": run_cache_status,
+                }
+            )
+            + "\n\n"
+        )
 
     return StreamingResponse(
         event_stream(),

--- a/api/routes/sets.py
+++ b/api/routes/sets.py
@@ -189,7 +189,7 @@ def _trim_card(card: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _fetch_set_cards(set_id: str, api_key: str | None) -> list[dict[str, Any]]:
+def _fetch_set_cards(set_id: str, api_key: str | None) -> tuple[list[dict[str, Any]], str]:
     """Fetch every card in `set_id` via pokemontcg.io and return slim shapes.
 
     Uses `TCGClient.search_all` so the request flows through the existing
@@ -197,13 +197,15 @@ def _fetch_set_cards(set_id: str, api_key: str | None) -> list[dict[str, Any]]:
     Browse open of that set is a disk-cache hit upstream, plus the trim
     is microseconds. `q=set.id:{id}` is the canonical pokemontcg.io
     filter; ids are short alnum so quoting isn't strictly needed but
-    we include it for defence against future ids with special chars."""
+    we include it for defence against future ids with special chars.
+
+    Returns `(cards, cache_status)`; the status is the worst split-cache
+    outcome across the paged walk (#372), surfaced as `X-Cache` by the
+    route handler so a contributor can tell a warm-cache open from an
+    upstream round-trip (#310)."""
     client = TCGClient(api_key=api_key)
-    # `search_all` returns (cards, cache_status) post-#372; the cache_status
-    # is unused here. Surfacing it on `/sets/{set_id}/cards` is the
-    # remaining slice of #310 (follow-up to this PR).
-    cards, _status = client.search_all(f'set.id:"{set_id}"')
-    return [_trim_card(c) for c in cards]
+    cards, status = client.search_all(f'set.id:"{set_id}"')
+    return [_trim_card(c) for c in cards], status
 
 
 @router.get("/sets/{set_id}/cards")
@@ -222,14 +224,18 @@ async def get_set_cards(
     404 when the set is unknown / empty (the upstream catalog returned
     nothing for `set.id:{set_id}`). The SPA surfaces the detail message
     to the user.
+
+    Sets an `X-Cache` header (`HIT` / `STALE` / `MISS`) mirroring the disk
+    cache freshness of the underlying pokemontcg.io read (#310).
     """
-    cards = await run_in_threadpool(_fetch_set_cards, set_id, api_key)
+    cards, cache_status = await run_in_threadpool(_fetch_set_cards, set_id, api_key)
     if not cards:
         raise HTTPException(
             status_code=404,
             detail=f"no cards found for set '{set_id}'",
         )
     response.headers["Cache-Control"] = f"public, max-age={_SET_CARDS_BROWSER_TTL}"
+    response.headers["X-Cache"] = cache_status
     return {"set_id": set_id, "cards": cards}
 
 

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -402,6 +402,48 @@ class BulkStageStreamTests(unittest.TestCase):
         self.assertFalse(rows[0]["matched"])
         self.assertEqual(rows[0]["stage"], "no_match")
 
+    def test_done_event_carries_aggregated_cache_status(self) -> None:
+        """The done frame reports the worst per-line cache outcome (#310):
+        one upstream read in the batch makes the whole run MISS."""
+        from mgz_pkmn.pricing import Pricing
+        from mgz_pkmn.spreadsheet import Row
+
+        # First line is a cache HIT, second a MISS — aggregate must be MISS.
+        statuses = iter(["HIT", "MISS"])
+
+        def fake(pkmn, tcgdex, pc, q, settings, on_stage=None, *, cache_only=False, ebay=None):
+            card = {"id": "base1-4", "name": q.name}
+            return [
+                (Row(query=q, card=card, pricing=Pricing(market=1.0), tag=""), "matched")
+            ], next(statuses)
+
+        with (
+            patch("api.routes.lookup._do_lookup", side_effect=fake),
+            # Serialize so the iterator order maps to line order deterministically.
+            patch("api.routes.lookup._bulk_concurrency", return_value=1),
+        ):
+            resp = client.post("/api/v1/bulk", json={"lines": ["Pikachu", "Charizard"]})
+
+        frames = _parse_sse(resp.text)
+        self.assertTrue(frames[-1].get("done"))
+        self.assertEqual(frames[-1]["cache_status"], "MISS")
+
+    def test_done_event_reports_hit_when_every_line_is_a_cache_hit(self) -> None:
+        from mgz_pkmn.pricing import Pricing
+        from mgz_pkmn.spreadsheet import Row
+
+        def fake(pkmn, tcgdex, pc, q, settings, on_stage=None, *, cache_only=False, ebay=None):
+            card = {"id": "base1-4", "name": q.name}
+            return [
+                (Row(query=q, card=card, pricing=Pricing(market=1.0), tag=""), "matched")
+            ], "HIT"
+
+        with patch("api.routes.lookup._do_lookup", side_effect=fake):
+            resp = client.post("/api/v1/bulk", json={"lines": ["Pikachu", "Charizard"]})
+
+        frames = _parse_sse(resp.text)
+        self.assertEqual(frames[-1]["cache_status"], "HIT")
+
 
 class BulkConcurrencyTests(unittest.TestCase):
     """The /bulk stream fans lines out with bounded concurrency (#303) rather
@@ -458,6 +500,8 @@ class BulkConcurrencyTests(unittest.TestCase):
         self.assertEqual(len(frames), 1)
         self.assertTrue(frames[0].get("done"))
         self.assertEqual(frames[0]["total"], 0)
+        # No real lookup ran → MISS, matching the /lookup route's default.
+        self.assertEqual(frames[0]["cache_status"], "MISS")
 
 
 class BulkConcurrencyEnvTests(unittest.TestCase):
@@ -591,20 +635,23 @@ class SetCardsRouteTests(unittest.TestCase):
 
         with patch(
             "api.routes.sets._fetch_set_cards",
-            return_value=[
+            return_value=(
                 # _fetch_set_cards is the trimmer entry point; bypass it and
                 # verify the route hands the slim shape straight through.
-                {
-                    "id": "sv8-1",
-                    "name": "Pikachu",
-                    "number": "1",
-                    "rarity": "Common",
-                    "supertype": "Pokémon",
-                    "subtypes": ["Basic"],
-                    "thumb": "https://images.example/sv8-1-small.png",
-                    "market": 1.23,
-                }
-            ],
+                [
+                    {
+                        "id": "sv8-1",
+                        "name": "Pikachu",
+                        "number": "1",
+                        "rarity": "Common",
+                        "supertype": "Pokémon",
+                        "subtypes": ["Basic"],
+                        "thumb": "https://images.example/sv8-1-small.png",
+                        "market": 1.23,
+                    }
+                ],
+                "HIT",
+            ),
         ) as fetch_mock:
             resp = client.get("/api/v1/sets/sv8/cards")
 
@@ -669,7 +716,7 @@ class SetCardsRouteTests(unittest.TestCase):
         self.assertEqual(slim["subtypes"], [])
 
     def test_404_when_set_has_no_cards(self) -> None:
-        with patch("api.routes.sets._fetch_set_cards", return_value=[]):
+        with patch("api.routes.sets._fetch_set_cards", return_value=([], "MISS")):
             resp = client.get("/api/v1/sets/bogus/cards")
         self.assertEqual(resp.status_code, 404)
         self.assertIn("bogus", resp.json()["detail"])
@@ -677,24 +724,48 @@ class SetCardsRouteTests(unittest.TestCase):
     def test_browser_cache_control_header(self) -> None:
         with patch(
             "api.routes.sets._fetch_set_cards",
-            return_value=[
-                {
-                    "id": "sv8-1",
-                    "name": "Pikachu",
-                    "number": "1",
-                    "rarity": "Common",
-                    "supertype": "Pokémon",
-                    "subtypes": [],
-                    "thumb": None,
-                    "market": None,
-                }
-            ],
+            return_value=(
+                [
+                    {
+                        "id": "sv8-1",
+                        "name": "Pikachu",
+                        "number": "1",
+                        "rarity": "Common",
+                        "supertype": "Pokémon",
+                        "subtypes": [],
+                        "thumb": None,
+                        "market": None,
+                    }
+                ],
+                "HIT",
+            ),
         ):
             resp = client.get("/api/v1/sets/sv8/cards")
         self.assertEqual(resp.status_code, 200)
         cache_control = resp.headers.get("cache-control", "")
         self.assertIn("public", cache_control)
         self.assertIn("max-age=", cache_control)
+
+    def test_x_cache_header_mirrors_disk_cache_status(self) -> None:
+        """`X-Cache` reflects the split-cache freshness of the set read (#310)."""
+        card = {
+            "id": "sv8-1",
+            "name": "Pikachu",
+            "number": "1",
+            "rarity": "Common",
+            "supertype": "Pokémon",
+            "subtypes": [],
+            "thumb": None,
+            "market": None,
+        }
+        for status in ("HIT", "STALE", "MISS"):
+            with patch(
+                "api.routes.sets._fetch_set_cards",
+                return_value=([card], status),
+            ):
+                resp = client.get("/api/v1/sets/sv8/cards")
+            self.assertEqual(resp.status_code, 200, msg=f"status={status}")
+            self.assertEqual(resp.headers["X-Cache"], status, msg=f"status={status}")
 
     def test_rejects_malformed_set_ids(self) -> None:
         # Mirrors the logo route's defence — the same `_SET_ID_PATH`
@@ -734,18 +805,21 @@ class SetCardsRouteTests(unittest.TestCase):
         # because the upstream catalog ids are case-sensitive.
         with patch(
             "api.routes.sets._fetch_set_cards",
-            return_value=[
-                {
-                    "id": "x",
-                    "name": "x",
-                    "number": "1",
-                    "rarity": None,
-                    "supertype": None,
-                    "subtypes": [],
-                    "thumb": None,
-                    "market": None,
-                }
-            ],
+            return_value=(
+                [
+                    {
+                        "id": "x",
+                        "name": "x",
+                        "number": "1",
+                        "rarity": None,
+                        "supertype": None,
+                        "subtypes": [],
+                        "thumb": None,
+                        "market": None,
+                    }
+                ],
+                "MISS",
+            ),
         ) as fetch_mock:
             client.get("/api/v1/sets/MixedCaseId-9/cards?api_key=abc")
         fetch_mock.assert_called_once_with("MixedCaseId-9", "abc")

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -60,6 +60,7 @@ function App() {
     setRunEndedAt,
     pushRecentRun,
     setCurrentRunId,
+    setCacheStatus,
     resetViewState,
     setRuns,
   } = useAppStore()
@@ -156,6 +157,9 @@ function App() {
     // rows aren't a saved search yet. The done frame surfaces the
     // freshly-persisted `run_id` so the Save button has a target.
     setCurrentRunId(null)
+    // Clear the prior run's cache-source signal so the chip doesn't linger
+    // with a stale value while the new run streams in (#310).
+    setCacheStatus(null)
     // Fresh stream → reset the view state so a saved search's sort or
     // filters don't bleed onto the new run.
     resetViewState()
@@ -178,6 +182,8 @@ function App() {
         // a legitimate value when persistence fell through server-side
         // (best-effort) — leave currentRunId unset in that case.
         if (event.run_id != null) setCurrentRunId(event.run_id)
+        // Surface the run's disk-cache freshness for the lookup-timer chip.
+        setCacheStatus(event.cache_status)
         return
       }
       if (!firstEventSeen) {
@@ -254,6 +260,7 @@ function App() {
     setRunEndedAt,
     pushRecentRun,
     setCurrentRunId,
+    setCacheStatus,
     resetViewState,
   ])
 

--- a/web/src/components/CacheSourceChip.test.tsx
+++ b/web/src/components/CacheSourceChip.test.tsx
@@ -59,9 +59,12 @@ describe('CacheSourceChip', () => {
     expect(screen.getByText('from upstream')).toBeInTheDocument()
   })
 
-  it('treats the anonymous cache-only miss as an upstream read', () => {
+  it('labels the anonymous cache-only miss as not-in-cache, not upstream', () => {
+    // cache_only mode skips upstream on a miss, so "from upstream" would be a
+    // lie — the card simply wasn't warmed.
     useAppStore.setState({ cacheStatus: 'MISS-CACHE-ONLY' })
     render(<CacheSourceChip />)
-    expect(screen.getByText('from upstream')).toBeInTheDocument()
+    expect(screen.getByText('not in cache')).toBeInTheDocument()
+    expect(screen.queryByText('from upstream')).not.toBeInTheDocument()
   })
 })

--- a/web/src/components/CacheSourceChip.test.tsx
+++ b/web/src/components/CacheSourceChip.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { CacheSourceChip } from './CacheSourceChip'
+import { useAppStore } from '../store'
+
+const DEFAULT_SETTINGS = {
+  apiKey: '',
+  maxPrice: null,
+  noImages: true,
+  tag: '',
+  dedupe: false,
+  sort: 'number' as const,
+  showTimer: false,
+  showEbay: false,
+  hideOwned: false,
+  swipeRarityFloor: 'chase' as const,
+  swipeExcludeOwned: false,
+  swipeExcludeChasing: false,
+}
+
+describe('CacheSourceChip', () => {
+  beforeEach(() => {
+    useAppStore.setState({
+      settings: { ...DEFAULT_SETTINGS, showTimer: true },
+      cacheStatus: null,
+    })
+  })
+
+  it('renders nothing when showTimer is off', () => {
+    useAppStore.setState({
+      settings: { ...DEFAULT_SETTINGS, showTimer: false },
+      cacheStatus: 'HIT',
+    })
+    const { container } = render(<CacheSourceChip />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders nothing before a run reports a cache status', () => {
+    useAppStore.setState({ cacheStatus: null })
+    const { container } = render(<CacheSourceChip />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows "from cache" on a HIT', () => {
+    useAppStore.setState({ cacheStatus: 'HIT' })
+    render(<CacheSourceChip />)
+    expect(screen.getByText('from cache')).toBeInTheDocument()
+  })
+
+  it('flags the background refresh on a STALE read', () => {
+    useAppStore.setState({ cacheStatus: 'STALE' })
+    render(<CacheSourceChip />)
+    expect(screen.getByText('from cache · refreshing')).toBeInTheDocument()
+  })
+
+  it('shows "from upstream" on a MISS', () => {
+    useAppStore.setState({ cacheStatus: 'MISS' })
+    render(<CacheSourceChip />)
+    expect(screen.getByText('from upstream')).toBeInTheDocument()
+  })
+
+  it('treats the anonymous cache-only miss as an upstream read', () => {
+    useAppStore.setState({ cacheStatus: 'MISS-CACHE-ONLY' })
+    render(<CacheSourceChip />)
+    expect(screen.getByText('from upstream')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/CacheSourceChip.tsx
+++ b/web/src/components/CacheSourceChip.tsx
@@ -1,0 +1,40 @@
+/**
+ * CacheSourceChip — shows whether the last run's results came from the disk
+ * cache or a fresh upstream fetch (#310).
+ *
+ * A dev-leaning signal for spotting cache regressions and confirming a
+ * `warm-*` subcommand actually populated what you expected. Gated by the same
+ * `showTimer` setting as the {@link LookupTimer} and rendered beside it, so it
+ * stays out of the default user's way. Renders nothing until a run has
+ * reported a `cache_status` on its SSE done frame.
+ */
+import { Database, CloudDownload } from 'lucide-react'
+import { useAppStore } from '../store'
+
+export function CacheSourceChip() {
+  const { settings, cacheStatus } = useAppStore()
+
+  if (!settings.showTimer) return null
+  if (cacheStatus == null) return null
+
+  // STALE served from cache too — it just kicked off a background pricing
+  // refresh, so it still counts as a cache read for the source label.
+  const fromCache = cacheStatus === 'HIT' || cacheStatus === 'STALE'
+  const Icon = fromCache ? Database : CloudDownload
+  const label =
+    cacheStatus === 'HIT'
+      ? 'from cache'
+      : cacheStatus === 'STALE'
+        ? 'from cache · refreshing'
+        : 'from upstream'
+
+  return (
+    <div
+      aria-label={`Lookup source: ${label}`}
+      className="flex items-center gap-1.5 text-xs tabular-nums text-coconut-400 dark:text-sand-300"
+    >
+      <Icon size={12} className="text-palm-500 dark:text-sun-300" />
+      <span>{label}</span>
+    </div>
+  )
+}

--- a/web/src/components/CacheSourceChip.tsx
+++ b/web/src/components/CacheSourceChip.tsx
@@ -8,7 +8,7 @@
  * stays out of the default user's way. Renders nothing until a run has
  * reported a `cache_status` on its SSE done frame.
  */
-import { Database, CloudDownload } from 'lucide-react'
+import { Database, CloudDownload, CloudOff } from 'lucide-react'
 import { useAppStore } from '../store'
 
 export function CacheSourceChip() {
@@ -17,16 +17,21 @@ export function CacheSourceChip() {
   if (!settings.showTimer) return null
   if (cacheStatus == null) return null
 
-  // STALE served from cache too — it just kicked off a background pricing
-  // refresh, so it still counts as a cache read for the source label.
-  const fromCache = cacheStatus === 'HIT' || cacheStatus === 'STALE'
-  const Icon = fromCache ? Database : CloudDownload
-  const label =
+  // Four distinct outcomes:
+  //   HIT / STALE         — served from cache (STALE also kicked off a
+  //                          background pricing refresh, but still a cache read)
+  //   MISS                — a real upstream fetch happened
+  //   MISS-CACHE-ONLY     — anonymous cache-only mode: a disk miss that
+  //                          *skips* upstream entirely, so it's neither cache
+  //                          nor upstream — the data simply wasn't warmed.
+  const { Icon, label } =
     cacheStatus === 'HIT'
-      ? 'from cache'
+      ? { Icon: Database, label: 'from cache' }
       : cacheStatus === 'STALE'
-        ? 'from cache · refreshing'
-        : 'from upstream'
+        ? { Icon: Database, label: 'from cache · refreshing' }
+        : cacheStatus === 'MISS-CACHE-ONLY'
+          ? { Icon: CloudOff, label: 'not in cache' }
+          : { Icon: CloudDownload, label: 'from upstream' }
 
   return (
     <div

--- a/web/src/components/InputEditor.tsx
+++ b/web/src/components/InputEditor.tsx
@@ -13,6 +13,7 @@ import { parseLine } from '../api/client'
 import { useAppStore } from '../store'
 import type { CardQuery } from '../types'
 import { LookupTimer } from './LookupTimer'
+import { CacheSourceChip } from './CacheSourceChip'
 
 interface Props {
   onRun: (overrideText?: string) => void
@@ -139,9 +140,10 @@ export function InputEditor({ onRun, onStop }: Props) {
         </div>
       </div>
 
-      {/* Optional lookup-timer readout (settings-gated). Sits under the
-          toolbar so it's adjacent to the Look up / Stop button. */}
-      <div className="flex justify-end">
+      {/* Optional lookup-timer readout + cache-source chip (settings-gated).
+          Sits under the toolbar so it's adjacent to the Look up / Stop button. */}
+      <div className="flex items-center justify-end gap-3">
+        <CacheSourceChip />
         <LookupTimer />
       </div>
 

--- a/web/src/store/index.ts
+++ b/web/src/store/index.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 import type {
+  CacheStatus,
   ProcessingLine,
   RecentRun,
   Row,
@@ -100,6 +101,14 @@ interface AppState {
   runEndedAt: number | null
   setRunStartedAt: (t: number | null) => void
   setRunEndedAt: (t: number | null) => void
+
+  /**
+   * Disk-cache freshness of the most recent run, from the SSE done frame.
+   * `null` while a run is in flight or before any run this session; the
+   * lookup-timer reads it to show a cache-vs-upstream source chip (#310).
+   */
+  cacheStatus: CacheStatus | null
+  setCacheStatus: (s: CacheStatus | null) => void
 
   /** Per-input-line status tracked across the current bulk lookup. */
   processingLines: ProcessingLine[]
@@ -222,6 +231,9 @@ export const useAppStore = create<AppState>()(
       runEndedAt: null,
       setRunStartedAt: (runStartedAt) => set({ runStartedAt }),
       setRunEndedAt: (runEndedAt) => set({ runEndedAt }),
+
+      cacheStatus: null,
+      setCacheStatus: (cacheStatus) => set({ cacheStatus }),
 
       processingLines: [],
       setProcessingLines: (processingLines) => set({ processingLines }),

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -114,16 +114,24 @@ export interface RowEvent extends Row {
   done?: false
 }
 
+/** Split-cache freshness for a run, as reported on the SSE done frame and the
+ * `X-Cache` response header. `MISS-CACHE-ONLY` is the anonymous cache-only
+ * variant of a miss; the SPA treats it like any other upstream read. */
+export type CacheStatus = 'HIT' | 'STALE' | 'MISS' | 'MISS-CACHE-ONLY'
+
 /** The single terminating SSE frame emitted once all lines are done.
  *
  * `run_id` carries the id of the run the backend just persisted, or
  * `null` if persistence fell through. The SPA reads it so a "Save this
- * search" action can target the just-completed run without re-listing. */
+ * search" action can target the just-completed run without re-listing.
+ * `cache_status` aggregates the run's disk-cache freshness so the
+ * lookup-timer can show whether results came from cache or upstream (#310). */
 export interface DoneEvent {
   index?: undefined
   total: number
   done: true
   run_id: number | null
+  cache_status: CacheStatus
 }
 
 /** Any frame emitted by POST /api/v1/bulk. */


### PR DESCRIPTION
Closes #310

## What

Surfaces whether a lookup's results came from the disk cache or a fresh upstream fetch, in two places:

- **Backend** — `GET /api/v1/sets/{set_id}/cards` now sets an `X-Cache` header (`HIT` / `STALE` / `MISS`) mirroring the split-cache freshness of the underlying pokemontcg.io read. `/api/v1/lookup` already grew its `X-Cache` header in #372; this fills in the set-cards endpoint the issue called out. The `/bulk` SSE stream also aggregates each line's cache outcome onto its `done` frame as `cache_status` (MISS dominates STALE dominates HIT), so the SPA has a single run-level signal to read.
- **Frontend** — a compact source chip renders beside the existing lookup timer, gated by the same **Show lookup timer** toggle so it stays out of the default user's way. It reads the aggregate `cache_status` off the done frame (clearing on each new run) and maps it to one of: `from cache` (HIT), `from cache · refreshing` (STALE — served from cache while a background pricing refresh runs), `from upstream` (a real MISS fetch), or `not in cache` (`MISS-CACHE-ONLY` — an anonymous cache-only miss that skips upstream entirely).

## Why

The lookup timer reports *how fast* a run was, but a 40 ms response could be a warm-cache hit or a fast network day. This signal lets a contributor (or future-me) tell the two apart — spotting cache regressions, and confirming a `warm-*` subcommand actually populated what was expected. It reuses an existing, settings-gated surface rather than adding an always-on indicator.

The plumbing already existed: `TCGClient._fetch_page` threads a `(data, status)` pair up through `MatchResult.cache_status` and `_do_lookup`. This change just stops dropping that status at the set-cards route and the bulk-stream boundary, and renders it.

## How to verify

1. `make check` (939 Python tests) + `cd web && npm run build` + `npx vitest run` — all green.
2. **Backend, live** (`uv run uvicorn api.main:app`):
   - `curl -s .../api/v1/sets/base1/cards -o /dev/null -w '%header{x-cache}'` → `STALE`
   - `curl -s -X POST .../api/v1/bulk -d '{"lines":["Pikachu","Charizard | Base Set"]}'` → done frame `{"done": true, ..., "cache_status": "STALE"}`
3. **Frontend, live** (Settings → Show lookup timer on, run a lookup): the chip renders next to the timer, e.g. `from cache · 43ms · 2 cards · 22 ms/card` on a warm-cache run.

### Tests

- `tests/test_api_routes.py`: `X-Cache` on `/sets/{set_id}/cards` across HIT/STALE/MISS; `/bulk` done-event `cache_status` aggregation (HIT-only → HIT, mixed → MISS) and the no-parseable-lines MISS default.
- `web/src/components/CacheSourceChip.test.tsx`: label/icon per status, gated by `showTimer`, hidden until a run reports.
