### PR TITLE
feat(site): header nav rework — Demo CTA, icon-only GitHub, mobile hamburger menu

### DIFF
--- a/site/src/components/Header.astro
+++ b/site/src/components/Header.astro
@@ -4,6 +4,25 @@ import logoLightUrl from "../../../assets/logo.svg?url";
 import logoDarkUrl from "../../../assets/logo-dark.svg?url";
 
 const repoUrl = "https://github.com/mgzwarrior/mgz-pkmn";
+const demoUrl = "https://mgz-pkmn.onrender.com";
+
+// Links that live inline on desktop and collapse into the mobile menu.
+const navLinks = [
+  { href: "/#features", label: "Features", accent: false },
+  { href: "/#how-it-works", label: "How it works", accent: false },
+  { href: "/#signup", label: "Subscribe", accent: true },
+  { href: "/contribute", label: "Contribute", accent: true },
+];
+
+const linkClass =
+  "px-3 py-2 rounded-md text-coconut-500 hover:text-coconut-700 hover:bg-sand-100 dark:text-sand-200 dark:hover:text-sand-50 dark:hover:bg-husk-100 transition";
+const accentLinkClass =
+  "px-3 py-2 rounded-md text-palm-500 hover:text-palm-400 hover:bg-sand-100 dark:text-sun-300 dark:hover:text-sun-200 dark:hover:bg-husk-100 transition";
+// Octocat mark, reused inline (desktop) and in the mobile menu.
+const octocatPath =
+  "M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z";
+const demoClass =
+  "inline-flex items-center rounded-md bg-sun-300 px-4 py-2 text-sm font-semibold text-coconut-700 shadow-sm hover:bg-sun-400 dark:text-husk-500 dark:hover:bg-sun-200 transition";
 ---
 
 <header
@@ -13,7 +32,11 @@ const repoUrl = "https://github.com/mgzwarrior/mgz-pkmn";
     class="mx-auto max-w-6xl px-6 py-4 flex items-center justify-between"
     aria-label="Primary"
   >
-    <a href="/" class="flex items-center gap-2" aria-label="mgz-pkmn home">
+    <a
+      href="/"
+      class="flex shrink-0 items-center gap-2"
+      aria-label="mgz-pkmn home"
+    >
       <img
         src={logoLightUrl}
         alt=""
@@ -29,52 +52,144 @@ const repoUrl = "https://github.com/mgzwarrior/mgz-pkmn";
         class="hidden h-8 w-auto dark:block"
       />
     </a>
-    <ul class="flex items-center gap-1 sm:gap-2 text-sm">
+    <ul class="flex items-center gap-1 md:gap-2 text-sm">
+      {
+        navLinks.map((link) => (
+          <li class="hidden md:list-item">
+            <a href={link.href} class={link.accent ? accentLinkClass : linkClass}>
+              {link.label}
+            </a>
+          </li>
+        ))
+      }
       <li>
-        <a
-          href="/#features"
-          class="px-3 py-2 rounded-md text-coconut-500 hover:text-coconut-700 hover:bg-sand-100 dark:text-sand-200 dark:hover:text-sand-50 dark:hover:bg-husk-100 transition"
-          >Features</a
-        >
+        <a href={demoUrl} class={demoClass}>Demo</a>
       </li>
-      <li class="hidden sm:list-item">
-        <a
-          href="/#how-it-works"
-          class="px-3 py-2 rounded-md text-coconut-500 hover:text-coconut-700 hover:bg-sand-100 dark:text-sand-200 dark:hover:text-sand-50 dark:hover:bg-husk-100 transition"
-          >How it works</a
-        >
-      </li>
-      <li class="hidden sm:list-item">
-        <a
-          href="/#roadmap"
-          class="px-3 py-2 rounded-md text-coconut-500 hover:text-coconut-700 hover:bg-sand-100 dark:text-sand-200 dark:hover:text-sand-50 dark:hover:bg-husk-100 transition"
-          >Roadmap</a
-        >
-      </li>
-      <li>
-        <a
-          href="/#signup"
-          class="px-3 py-2 rounded-md text-palm-500 hover:text-palm-400 hover:bg-sand-100 dark:text-sun-300 dark:hover:text-sun-200 dark:hover:bg-husk-100 transition"
-          >Subscribe</a
-        >
-      </li>
-      <li class="hidden sm:list-item">
-        <a
-          href="/contribute"
-          class="px-3 py-2 rounded-md text-palm-500 hover:text-palm-400 hover:bg-sand-100 dark:text-sun-300 dark:hover:text-sun-200 dark:hover:bg-husk-100 transition"
-          >Contribute</a
-        >
-      </li>
-      <li>
+      <li class="hidden md:list-item">
         <a
           href={repoUrl}
-          class="px-3 py-2 rounded-md text-coconut-500 hover:text-coconut-700 hover:bg-sand-100 dark:text-sand-200 dark:hover:text-sand-50 dark:hover:bg-husk-100 transition"
-          >GitHub</a
+          aria-label="GitHub"
+          class="inline-flex items-center px-3 py-2 rounded-md text-coconut-500 hover:text-coconut-700 hover:bg-sand-100 dark:text-sand-200 dark:hover:text-sand-50 dark:hover:bg-husk-100 transition"
         >
+          <svg
+            class="h-5 w-5"
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path d={octocatPath}></path>
+          </svg>
+        </a>
       </li>
       <li>
         <ThemeToggle />
       </li>
+      <li class="md:hidden">
+        <button
+          id="menu-toggle"
+          type="button"
+          aria-label="Open menu"
+          aria-controls="mobile-menu"
+          aria-expanded="false"
+          class="inline-flex h-9 w-9 items-center justify-center rounded-md text-coconut-500 hover:text-coconut-700 hover:bg-sand-100 dark:text-sand-200 dark:hover:text-sand-50 dark:hover:bg-husk-100 transition"
+        >
+          {/* Hamburger — shown when the menu is closed */}
+          <svg
+            id="menu-open-icon"
+            class="h-5 w-5"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M3 6h18M3 12h18M3 18h18"></path>
+          </svg>
+          {/* Close — shown when the menu is open */}
+          <svg
+            id="menu-close-icon"
+            class="hidden h-5 w-5"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M6 6l12 12M18 6L6 18"></path>
+          </svg>
+        </button>
+      </li>
     </ul>
   </nav>
+
+  {/* Mobile-only dropdown — Demo + theme toggle stay in the bar above */}
+  <div
+    id="mobile-menu"
+    class="hidden md:hidden border-t border-sand-300 dark:border-husk-200/80"
+  >
+    <ul class="mx-auto max-w-6xl px-4 py-2 flex flex-col gap-1 text-sm">
+      {
+        navLinks.map((link) => (
+          <li>
+            <a
+              href={link.href}
+              class={`block ${link.accent ? accentLinkClass : linkClass}`}
+            >
+              {link.label}
+            </a>
+          </li>
+        ))
+      }
+      <li>
+        <a
+          href={repoUrl}
+          class="flex items-center gap-2 px-3 py-2 rounded-md text-coconut-500 hover:text-coconut-700 hover:bg-sand-100 dark:text-sand-200 dark:hover:text-sand-50 dark:hover:bg-husk-100 transition"
+        >
+          <svg
+            class="h-5 w-5"
+            viewBox="0 0 16 16"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path d={octocatPath}></path>
+          </svg>
+          GitHub
+        </a>
+      </li>
+    </ul>
+  </div>
 </header>
+
+<script is:inline>
+  (function () {
+    var btn = document.getElementById("menu-toggle");
+    var menu = document.getElementById("mobile-menu");
+    if (!btn || !menu) return;
+    var openIcon = document.getElementById("menu-open-icon");
+    var closeIcon = document.getElementById("menu-close-icon");
+
+    function setOpen(open) {
+      menu.classList.toggle("hidden", !open);
+      btn.setAttribute("aria-expanded", String(open));
+      btn.setAttribute("aria-label", open ? "Close menu" : "Open menu");
+      openIcon.classList.toggle("hidden", open);
+      closeIcon.classList.toggle("hidden", !open);
+    }
+
+    btn.addEventListener("click", function () {
+      setOpen(menu.classList.contains("hidden"));
+    });
+    menu.querySelectorAll("a").forEach(function (a) {
+      a.addEventListener("click", function () {
+        setOpen(false);
+      });
+    });
+    document.addEventListener("keydown", function (e) {
+      if (e.key === "Escape") setOpen(false);
+    });
+  })();
+</script>


### PR DESCRIPTION
Closes #338

## What

Reworks the marketing-site header (`site/src/components/Header.astro`):

1. Drop the standalone **Roadmap** anchor — the homepage "Where it's going" section already links out to the full roadmap.
2. Promote **Demo** (the live SPA, `https://mgz-pkmn.onrender.com`, gated on #313 which has landed) to a filled sun CTA button so the highest-value external destination stands out from the text links.
3. Render **GitHub** as an icon-only octocat mark (`currentColor`, so it adapts to light/dark with no hardcoded hex).
4. Collapse the nav into a **hamburger menu** below the `md` breakpoint.

## Why

Nav is a CTR-sensitive surface that had stretched as features were added. Dropping a low-value link and elevating Demo to a real button sharpens the hierarchy. The hamburger is what makes it all fit: the full inline nav measures ~733px, so once the Demo link was added the bar overran narrow viewports and flexbox silently squeezed the **logo to zero width**. Collapsing the secondary links into a dropdown restores the logo and keeps the bar comfortable; the inline nav switches in at `md` (768px), where it actually fits.

## Layout

- **Desktop (≥768px):** logo · Features · How it works · Subscribe · Contribute · **[Demo]** · 🐙 · ☼/☾
- **Mobile/tablet-portrait (<768px) — bar:** logo · **[Demo]** · ☼/☾ · ☰
- **Collapsed menu:** Features · How it works · Subscribe · Contribute · GitHub

The toggle manages `aria-expanded`, swaps its icon (☰ ⇄ ✕), and closes on link click or Escape.

## How to verify

`cd site && npm run build` is clean; `make check` passes (including the existing Header z-index tests). Rendered from the dev server:

- Desktop dark + light: Demo reads as a filled CTA, no horizontal overflow.
- Breakpoint boundary: 767px shows the collapsed hamburger bar; 800px shows the full inline nav with the hamburger hidden; neither overflows (`scrollWidth === clientWidth`).
- Mobile (375px): logo no longer collapses; hamburger opens/closes the panel; no console errors.