### PR TITLE
feat(web): move swipe-mode wishlist nudge above the card image, and only nudge after 3 saved cards

### DIFF
--- a/web/src/components/SwipePanel.test.tsx
+++ b/web/src/components/SwipePanel.test.tsx
@@ -93,6 +93,23 @@ async function swipeKey(key: 'ArrowLeft' | 'ArrowRight' | 'ArrowUp') {
   }
 }
 
+// Save the PREP_LIST_NUDGE_THRESHOLD (3) cards needed to surface the
+// build-prep-list nudge, waiting on the header chip after each so the next
+// card has mounted before the following swipe. Callers must supply at least
+// three candidate cards via mockFetchSetCards.
+async function saveThreeCards() {
+  for (const n of [1, 2, 3]) {
+    await swipeKey('ArrowRight')
+    await waitFor(
+      () =>
+        expect(
+          screen.getByRole('button', { name: new RegExp(`${n} saved · reset`, 'i') }),
+        ).toBeInTheDocument(),
+      POST_SWIPE_WAIT,
+    )
+  }
+}
+
 describe('SwipePanel', () => {
   let randomSpy: ReturnType<typeof vi.spyOn>
 
@@ -332,10 +349,19 @@ describe('SwipePanel', () => {
 
   it('surfaces a Build prep list error when wishlist creation fails', async () => {
     mockCreateWishlist.mockRejectedValue(new Error('quota exceeded'))
+    mockFetchSets.mockResolvedValue([
+      { id: 'sv1', name: 'Scarlet & Violet', series: 'SV', total: 3, releaseDate: '2023/03/31' },
+    ])
+    mockFetchSetCards.mockResolvedValue([
+      card({ id: 'sv1-1', name: 'Pikachu', number: '1', market: 5 }),
+      card({ id: 'sv1-2', name: 'Charizard', number: '2', market: 50 }),
+      card({ id: 'sv1-3', name: 'Blastoise', number: '3', market: 40 }),
+    ])
 
     render(<SwipePanel active />)
     await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
-    fireEvent.keyDown(window, { key: 'ArrowRight' })
+    // The nudge only appears once PREP_LIST_NUDGE_THRESHOLD (3) cards are saved.
+    await saveThreeCards()
     await waitFor(
       () =>
         expect(screen.getByLabelText('Prep list name')).toBeInTheDocument(),
@@ -367,13 +393,23 @@ describe('SwipePanel', () => {
       added_at: '2026-06-06T00:00:00',
     })
 
+    mockFetchSets.mockResolvedValue([
+      { id: 'sv1', name: 'Scarlet & Violet', series: 'SV', total: 3, releaseDate: '2023/03/31' },
+    ])
+    mockFetchSetCards.mockResolvedValue([
+      card({ id: 'sv1-1', name: 'Pikachu', number: '1', market: 5 }),
+      card({ id: 'sv1-2', name: 'Charizard', number: '2', market: 50 }),
+      card({ id: 'sv1-3', name: 'Blastoise', number: '3', market: 40 }),
+    ])
+
     render(<SwipePanel active />)
     await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
-    fireEvent.keyDown(window, { key: 'ArrowRight' })
+    // The nudge only appears once PREP_LIST_NUDGE_THRESHOLD (3) cards are saved.
+    await saveThreeCards()
     await waitFor(
       () =>
         expect(
-          screen.getByRole('button', { name: /1 saved · reset/i }),
+          screen.getByRole('button', { name: /3 saved · reset/i }),
         ).toBeInTheDocument(),
       POST_SWIPE_WAIT,
     )
@@ -389,7 +425,7 @@ describe('SwipePanel', () => {
     await waitFor(() =>
       expect(screen.queryByText(/Build a prep list/i)).not.toBeInTheDocument(),
     )
-    expect(mockAddCardToWishlist).toHaveBeenCalledTimes(1)
+    expect(mockAddCardToWishlist).toHaveBeenCalledTimes(3)
   })
 
   it('tapping the card (no drag) opens the same detail modal Search rows use', async () => {

--- a/web/src/components/SwipePanel.tsx
+++ b/web/src/components/SwipePanel.tsx
@@ -51,6 +51,10 @@ const SWIPE_THRESHOLD_Y = 110
 /** Pointer movement (px) past which a gesture counts as a drag, not a tap.
  *  Below it, releasing opens the detail modal instead. */
 const CLICK_SLOP = 6
+/** Saved-card count that has to accrue before the build-prep-list nudge
+ *  appears — casual swipers aren't pestered before they have a haul worth
+ *  turning into a wishlist. */
+const PREP_LIST_NUDGE_THRESHOLD = 3
 
 interface Drag {
   startX: number
@@ -244,6 +248,10 @@ export function SwipePanel({ active }: SwipePanelProps) {
         }
       />
 
+      {profile.saved.length >= PREP_LIST_NUDGE_THRESHOLD && (
+        <BuildPrepList saved={profile.saved} onCleared={clearSaved} />
+      )}
+
       <div className="flex flex-col items-center gap-3">
         {error && (
           <p
@@ -337,10 +345,6 @@ export function SwipePanel({ active }: SwipePanelProps) {
 
         <KeyboardHint />
       </div>
-
-      {profile.saved.length > 0 && (
-        <BuildPrepList saved={profile.saved} onCleared={clearSaved} />
-      )}
 
       <CardDetailModal
         rows={detailRows}
@@ -795,8 +799,9 @@ function ExhaustedState({ onReset }: { onReset: () => void }) {
 }
 
 /**
- * BuildPrepList — bottom-of-panel CTA. Inline form that creates a new
- * wishlist from the user's saved cards and adds each one in order. On
+ * BuildPrepList — nudge above the card stack, in the swiper's eye line.
+ * Inline form that creates a new wishlist from the user's saved cards and
+ * adds each one in order. Gated on PREP_LIST_NUDGE_THRESHOLD saves. On
  * success it clears the local saved list so the user starts fresh on
  * the next swipe session; the new wishlist is visible immediately in
  * the Library because both surfaces share the


### PR DESCRIPTION
Closes #510 

## What

Swipe mode nudge was below card stack and invisible to the user. Moving to above and only showing when 3 positive reactions are received.

## Why

To make the nudge effective.

## How to verify

View preview deployment.