### PR TITLE
feat(web): set-name autocomplete in the binder modal + quick binder-create from Browse

### DIFF
--- a/web/src/components/BinderModal.test.tsx
+++ b/web/src/components/BinderModal.test.tsx
@@ -163,4 +163,36 @@ describe('BinderModal', () => {
       ),
     )
   })
+
+  it('seeds a fresh binder from a prefill (e.g. opened from Browse)', async () => {
+    mockCreate.mockResolvedValue({
+      id: 9,
+      name: 'Jungle binder',
+      description: null,
+      created_at: '2026-06-15T00:00:00',
+      items: [],
+      kind: 'binder',
+      source_set_id: 'base2',
+    } as never)
+    render(
+      <BinderModal
+        open
+        onOpenChange={() => {}}
+        prefill={{ name: 'Jungle binder', sourceSetId: 'base2' }}
+      />,
+    )
+
+    // Name + set anchor arrive prefilled, and the details are auto-expanded so
+    // the set shows its name ('Jungle' for base2) rather than the bare ID.
+    expect(screen.getByDisplayValue('Jungle binder')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Jungle')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() =>
+      expect(mockCreate).toHaveBeenCalledWith(
+        'Jungle binder',
+        expect.objectContaining({ kind: 'binder', source_set_id: 'base2' }),
+      ),
+    )
+  })
 })

--- a/web/src/components/BinderModal.tsx
+++ b/web/src/components/BinderModal.tsx
@@ -33,7 +33,16 @@ import {
   BINDER_TYPE_OPTIONS,
   SWATCH_BG,
 } from './binderIdentity'
+import { SetCombobox } from './SetCombobox'
 import { useCollections } from './useCollections'
+
+/** Seed values for a fresh binder created from another surface (e.g. the
+ * Browse set view, #682). Applied only on create, not when editing. */
+export interface BinderPrefill {
+  name?: string
+  sourceSetId?: string
+  isMasterSet?: boolean
+}
 
 /** The single-predicate fields the smart-binder rule builder offers. */
 const RULE_FIELDS = [
@@ -71,9 +80,11 @@ interface Props {
   onOpenChange: (open: boolean) => void
   /** When set, edit this binder's identity; otherwise create a new one. */
   editing?: CollectionSummary | null
+  /** Seed a fresh binder's fields (create only) — e.g. opened from Browse. */
+  prefill?: BinderPrefill
 }
 
-export function BinderModal({ open, onOpenChange, editing }: Props) {
+export function BinderModal({ open, onOpenChange, editing, prefill }: Props) {
   const { create, update } = useCollections()
   const isEdit = editing != null
   // A dynamic collection edits as a smart binder; everything else as physical.
@@ -83,7 +94,7 @@ export function BinderModal({ open, onOpenChange, editing }: Props) {
   // a create). The parent remounts this modal with a fresh `key` on each
   // open, so these lazy initializers stand in for a reset-on-open effect.
   const [mode, setMode] = useState<BinderMode>(editMode)
-  const [name, setName] = useState(() => editing?.name ?? '')
+  const [name, setName] = useState(() => editing?.name ?? prefill?.name ?? '')
   const [color, setColor] = useState<string | null>(
     () => editing?.binder_color ?? (editing ? null : 'palm'),
   )
@@ -92,15 +103,21 @@ export function BinderModal({ open, onOpenChange, editing }: Props) {
   const [capacity, setCapacity] = useState(() =>
     editing?.capacity != null ? String(editing.capacity) : '',
   )
-  const [sourceSetId, setSourceSetId] = useState(() => editing?.source_set_id ?? '')
-  const [isMasterSet, setIsMasterSet] = useState(() => Boolean(editing?.is_master_set))
+  const [sourceSetId, setSourceSetId] = useState(
+    () => editing?.source_set_id ?? prefill?.sourceSetId ?? '',
+  )
+  const [isMasterSet, setIsMasterSet] = useState(() =>
+    Boolean(editing?.is_master_set ?? prefill?.isMasterSet),
+  )
   const [detailsOpen, setDetailsOpen] = useState(() =>
     Boolean(
       editing?.binder_format ||
         editing?.capacity ||
         editing?.source_set_id ||
         editing?.binder_type ||
-        editing?.is_master_set,
+        editing?.is_master_set ||
+        prefill?.sourceSetId ||
+        prefill?.isMasterSet,
     ),
   )
   // Smart-binder rule state.
@@ -408,12 +425,11 @@ export function BinderModal({ open, onOpenChange, editing }: Props) {
                           <span className="text-[11px] font-medium text-coconut-500 dark:text-sand-300">
                             Organizes a set (optional)
                           </span>
-                          <input
-                            type="text"
+                          <SetCombobox
                             value={sourceSetId}
-                            onChange={(e) => setSourceSetId(e.target.value)}
-                            placeholder="Set ID, e.g. sv1"
-                            className={inputClass}
+                            onChange={setSourceSetId}
+                            inputClassName={inputClass}
+                            placeholder="Search sets, e.g. Surging Sparks"
                           />
                         </label>
                       )}

--- a/web/src/components/BrowsePanel.test.tsx
+++ b/web/src/components/BrowsePanel.test.tsx
@@ -208,6 +208,48 @@ describe('BrowsePanel — pokedex view (#577)', () => {
     ).toBeInTheDocument()
   })
 
+  it('set view: creates a binder pre-anchored to the set you are walking (#682)', async () => {
+    vi.spyOn(client, 'fetchSetCards').mockResolvedValue([])
+    const create = vi.spyOn(client, 'createCollection').mockResolvedValue({
+      id: 42,
+      name: 'New binder',
+      description: null,
+      created_at: '2026-06-16T00:00:00',
+      items: [],
+      kind: 'binder',
+    } as never)
+
+    render(<Harness />)
+
+    // Drill into the first baked set, then open the binder modal from the
+    // contextual "Create binder" action.
+    const setTile = screen
+      .getAllByRole('button')
+      .find((b) => /\bcards$|count unknown/.test(b.textContent ?? ''))!
+    fireEvent.click(setTile)
+    fireEvent.click(await screen.findByRole('button', { name: /create binder/i }))
+
+    // The modal opens pre-seeded with the set's name, and the set anchor shows
+    // that same name in the combobox (resolved from the ID).
+    const dialog = await screen.findByRole('dialog')
+    const setName = within(dialog).getByPlaceholderText<HTMLInputElement>('Trade binder').value
+    expect(setName.length).toBeGreaterThan(0)
+    expect(within(dialog).getByPlaceholderText(/search sets/i)).toHaveValue(setName)
+
+    fireEvent.click(within(dialog).getByRole('button', { name: /^create$/i }))
+
+    // Created as a physical binder anchored to the walked set's ID.
+    await waitFor(() =>
+      expect(create).toHaveBeenCalledWith(
+        setName,
+        expect.objectContaining({
+          kind: 'binder',
+          source_set_id: expect.stringMatching(/.+/),
+        }),
+      ),
+    )
+  })
+
   it('swaps a broken printing thumbnail for the placeholder', async () => {
     vi.spyOn(client, 'fetchPokedexCards').mockResolvedValue([
       { ...CHARIZARD_PRINTINGS[0], thumb: 'https://img/base1-4.png' },

--- a/web/src/components/BrowsePanel.tsx
+++ b/web/src/components/BrowsePanel.tsx
@@ -6,12 +6,13 @@
  * Pokémon across every set). State + effects live in
  * [useBrowseController](./useBrowseController.ts).
  */
-import { ArrowLeft, ImageOff, Library, Loader2, Search } from 'lucide-react'
+import { ArrowLeft, ImageOff, Library, Loader2, Search, Wallet } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
 import { pokemonSpriteUrl, setLogoUrl } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
 import type { PokedexCard, PokedexEntry, Row, SetCard, SetInfo } from '../types'
+import { BinderModal, type BinderPrefill } from './BinderModal'
 import { browseCardToPayload, browseCardToRow, type BrowseSetContext } from './browseCard'
 import { CardDetailModal } from './CardDetailModal'
 import { useCardOwnership } from './useCardOwnership'
@@ -74,6 +75,10 @@ export function BrowsePanel({ controller }: BrowsePanelProps) {
   const { user } = useAuth()
   const showSavedActions = user !== null
 
+  // A fresh binder pre-anchored to the set you're walking (#682). Non-null
+  // mounts the modal; closing clears it so the next open re-seeds cleanly.
+  const [binderPrefill, setBinderPrefill] = useState<BinderPrefill | null>(null)
+
   const drilledIn = viewMode === 'set' ? !!activeSet : !!activePokemon
   const onBack = () =>
     viewMode === 'set' ? setActiveSet(null) : setActivePokemon(null)
@@ -121,7 +126,21 @@ export function BrowsePanel({ controller }: BrowsePanelProps) {
             </span>
           )}
         </div>
-        <ViewModeToggle value={viewMode} onChange={setViewMode} />
+        <div className="flex flex-none items-center gap-2">
+          {viewMode === 'set' && activeSet && showSavedActions && (
+            <button
+              type="button"
+              onClick={() =>
+                setBinderPrefill({ name: activeSet.name, sourceSetId: activeSet.id })
+              }
+              className="inline-flex items-center gap-1.5 rounded-md border border-sand-300 dark:border-husk-50 bg-sand-200 dark:bg-husk-100 px-2.5 py-1 text-xs text-coconut-600 dark:text-sand-200 hover:bg-sand-50 dark:hover:bg-husk-200"
+            >
+              <Wallet size={14} />
+              Create binder
+            </button>
+          )}
+          <ViewModeToggle value={viewMode} onChange={setViewMode} />
+        </div>
       </header>
 
       <p className="px-5 pt-3 text-sm text-coconut-400 dark:text-sand-300">
@@ -166,6 +185,18 @@ export function BrowsePanel({ controller }: BrowsePanelProps) {
           filter={pokedexFilter}
           onFilter={setPokedexFilter}
           onPick={(p) => setActivePokemon(p)}
+        />
+      )}
+
+      {/* Mounted only while a prefill is set, so each open re-seeds the form
+          from the current set via the modal's lazy initializers (#682). */}
+      {binderPrefill && (
+        <BinderModal
+          open
+          onOpenChange={(o) => {
+            if (!o) setBinderPrefill(null)
+          }}
+          prefill={binderPrefill}
         />
       )}
     </div>

--- a/web/src/components/SetCombobox.test.tsx
+++ b/web/src/components/SetCombobox.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { SetCombobox } from './SetCombobox'
+
+describe('SetCombobox', () => {
+  it('filters the catalog by name and resolves a pick to the set ID', () => {
+    const onChange = vi.fn()
+    render(<SetCombobox value="" onChange={onChange} />)
+
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'jungle' } })
+    const option = screen.getByRole('option', { name: /jungle/i })
+    fireEvent.click(within(option).getByRole('button'))
+
+    expect(onChange).toHaveBeenLastCalledWith('base2')
+    expect(screen.getByRole('combobox')).toHaveValue('Jungle')
+  })
+
+  it('passes a typed value through, resolving to an ID on an exact match', () => {
+    const onChange = vi.fn()
+    render(<SetCombobox value="" onChange={onChange} />)
+
+    const input = screen.getByRole('combobox')
+    // A free-text fragment that matches no set ID/name is passed through raw.
+    fireEvent.change(input, { target: { value: 'sv-unknown' } })
+    expect(onChange).toHaveBeenLastCalledWith('sv-unknown')
+    // An exact ID resolves to that ID (the canonical stored value).
+    fireEvent.change(input, { target: { value: 'base1' } })
+    expect(onChange).toHaveBeenLastCalledWith('base1')
+  })
+
+  it('shows the set name, not the bare ID, for a known starting value', () => {
+    render(<SetCombobox value="base1" onChange={() => {}} />)
+    expect(screen.getByRole('combobox')).toHaveValue('Base')
+  })
+})

--- a/web/src/components/SetCombobox.test.tsx
+++ b/web/src/components/SetCombobox.test.tsx
@@ -28,6 +28,18 @@ describe('SetCombobox', () => {
     expect(onChange).toHaveBeenLastCalledWith('base1')
   })
 
+  it('does not store a partial name fragment as a set ID', () => {
+    const onChange = vi.fn()
+    render(<SetCombobox value="" onChange={onChange} />)
+
+    // "jung" matches Jungle but is no set's exact name/ID — it must not be
+    // committed as the anchor; the value stays empty until a pick.
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'jung' } })
+    expect(onChange).toHaveBeenLastCalledWith('')
+    // The matches still surface so the user can pick the real set.
+    expect(screen.getAllByRole('option').length).toBeGreaterThan(0)
+  })
+
   it('shows the set name, not the bare ID, for a known starting value', () => {
     render(<SetCombobox value="base1" onChange={() => {}} />)
     expect(screen.getByRole('combobox')).toHaveValue('Base')

--- a/web/src/components/SetCombobox.test.tsx
+++ b/web/src/components/SetCombobox.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent, within } from '@testing-library/react'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, within, act } from '@testing-library/react'
 import { SetCombobox } from './SetCombobox'
 
 describe('SetCombobox', () => {
@@ -9,7 +9,10 @@ describe('SetCombobox', () => {
 
     fireEvent.change(screen.getByRole('combobox'), { target: { value: 'jungle' } })
     const option = screen.getByRole('option', { name: /jungle/i })
-    fireEvent.click(within(option).getByRole('button'))
+    const button = within(option).getByRole('button')
+    // mousedown is prevented so input focus survives the click → pick.
+    fireEvent.mouseDown(button)
+    fireEvent.click(button)
 
     expect(onChange).toHaveBeenLastCalledWith('base2')
     expect(screen.getByRole('combobox')).toHaveValue('Jungle')
@@ -26,6 +29,9 @@ describe('SetCombobox', () => {
     // An exact ID resolves to that ID (the canonical stored value).
     fireEvent.change(input, { target: { value: 'base1' } })
     expect(onChange).toHaveBeenLastCalledWith('base1')
+    // Clearing the field clears the anchor.
+    fireEvent.change(input, { target: { value: '' } })
+    expect(onChange).toHaveBeenLastCalledWith('')
   })
 
   it('does not store a partial name fragment as a set ID', () => {
@@ -44,4 +50,83 @@ describe('SetCombobox', () => {
     render(<SetCombobox value="base1" onChange={() => {}} />)
     expect(screen.getByRole('combobox')).toHaveValue('Base')
   })
+
+  it('navigates the list with the arrow keys and picks the active row on Enter', () => {
+    const onChange = vi.fn()
+    render(<SetCombobox value="" onChange={onChange} />)
+    const input = screen.getByRole('combobox')
+
+    fireEvent.change(input, { target: { value: 'base' } })
+    const options = screen.getAllByRole('option')
+    expect(options.length).toBeGreaterThan(1)
+    // First row is active by default; arrow down moves to the second.
+    expect(options[0]).toHaveAttribute('aria-selected', 'true')
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' })
+    expect(screen.getAllByRole('option')[1]).toHaveAttribute('aria-selected', 'true')
+    // Arrow up returns to the first row.
+    fireEvent.keyDown(input, { key: 'ArrowUp' })
+    expect(screen.getAllByRole('option')[0]).toHaveAttribute('aria-selected', 'true')
+
+    fireEvent.keyDown(input, { key: 'Enter' })
+    // Enter commits the active row's set ID and shows its name.
+    expect(onChange).toHaveBeenLastCalledWith('base1')
+    expect(input).toHaveValue('Base')
+  })
+
+  it('hovering a row makes it active', () => {
+    render(<SetCombobox value="" onChange={() => {}} />)
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'base' } })
+
+    const second = screen.getAllByRole('option')[1]
+    fireEvent.mouseEnter(within(second).getByRole('button'))
+    expect(second).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('closes the list on Escape and re-opens on focus', () => {
+    render(<SetCombobox value="" onChange={() => {}} />)
+    const input = screen.getByRole('combobox')
+
+    fireEvent.change(input, { target: { value: 'base' } })
+    expect(screen.queryByRole('listbox')).toBeInTheDocument()
+
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+
+    fireEvent.focus(input)
+    expect(screen.queryByRole('listbox')).toBeInTheDocument()
+  })
+
+  it('closes the list shortly after blur', () => {
+    vi.useFakeTimers()
+    try {
+      render(<SetCombobox value="" onChange={() => {}} />)
+      const input = screen.getByRole('combobox')
+
+      fireEvent.change(input, { target: { value: 'base' } })
+      expect(screen.queryByRole('listbox')).toBeInTheDocument()
+
+      fireEvent.blur(input)
+      act(() => {
+        vi.runAllTimers()
+      })
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('hides a logo that fails to load', () => {
+    render(<SetCombobox value="" onChange={() => {}} />)
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'jungle' } })
+
+    const logo = screen.getByRole('option', { name: /jungle/i }).querySelector('img')
+    expect(logo).not.toBeNull()
+    fireEvent.error(logo!)
+    expect(logo!).toHaveStyle({ display: 'none' })
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
 })

--- a/web/src/components/SetCombobox.tsx
+++ b/web/src/components/SetCombobox.tsx
@@ -1,0 +1,137 @@
+/**
+ * SetCombobox — a searchable set-name picker (#682).
+ *
+ * The binder modal's "Organizes a set" field used to be a raw Set ID box.
+ * This filters the baked set catalog ([BAKED_SETS](../data/sets.ts)) by name
+ * or ID as you type, shows logo + name + ID, and resolves the pick to the
+ * set's ID — which is what the API stores. A typed value that doesn't match a
+ * known set is passed through as-is, so a raw ID still works as a fallback.
+ *
+ * BAKED_SETS is the same zero-round-trip catalog the export picker uses; a set
+ * that landed upstream since the last bake won't autocomplete, but typing its
+ * ID still works.
+ */
+import { useMemo, useState } from 'react'
+import { setLogoUrl } from '../api/client'
+import { BAKED_SETS } from '../data/sets'
+import type { SetInfo } from '../types'
+
+interface Props {
+  /** Current set ID (or a raw typed value). */
+  value: string
+  onChange: (id: string) => void
+  inputClassName?: string
+  placeholder?: string
+  id?: string
+}
+
+const MAX_MATCHES = 8
+
+function setById(id: string): SetInfo | undefined {
+  return BAKED_SETS.find((s) => s.id === id)
+}
+
+export function SetCombobox({ value, onChange, inputClassName, placeholder, id }: Props) {
+  // Show the set name when the value is a known ID; otherwise the raw text.
+  const [query, setQuery] = useState(() => setById(value)?.name ?? value)
+  const [open, setOpen] = useState(false)
+  const [active, setActive] = useState(0)
+
+  const matches = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return [] as SetInfo[]
+    return BAKED_SETS.filter(
+      (s) => s.name.toLowerCase().includes(q) || s.id.toLowerCase().includes(q),
+    ).slice(0, MAX_MATCHES)
+  }, [query])
+
+  // Resolve free text to a known set's ID when it matches a name/ID exactly,
+  // else pass the raw text through so a typed ID still works.
+  function resolve(text: string) {
+    const q = text.trim().toLowerCase()
+    const exact = BAKED_SETS.find((s) => s.name.toLowerCase() === q || s.id.toLowerCase() === q)
+    onChange(exact ? exact.id : text.trim())
+  }
+
+  function pick(s: SetInfo) {
+    setQuery(s.name)
+    onChange(s.id)
+    setOpen(false)
+  }
+
+  const showList = open && matches.length > 0
+
+  return (
+    <div className="relative">
+      <input
+        id={id}
+        type="text"
+        role="combobox"
+        aria-expanded={showList}
+        aria-autocomplete="list"
+        autoComplete="off"
+        value={query}
+        placeholder={placeholder ?? 'Search sets…'}
+        onChange={(e) => {
+          setQuery(e.target.value)
+          resolve(e.target.value)
+          setOpen(true)
+          setActive(0)
+        }}
+        onFocus={() => setOpen(true)}
+        // Delay close so a click on an option lands before blur hides it.
+        onBlur={() => setTimeout(() => setOpen(false), 120)}
+        onKeyDown={(e) => {
+          if (e.key === 'ArrowDown') {
+            e.preventDefault()
+            setOpen(true)
+            setActive((a) => Math.min(a + 1, matches.length - 1))
+          } else if (e.key === 'ArrowUp') {
+            e.preventDefault()
+            setActive((a) => Math.max(a - 1, 0))
+          } else if (e.key === 'Enter' && showList && matches[active]) {
+            e.preventDefault()
+            pick(matches[active])
+          } else if (e.key === 'Escape') {
+            setOpen(false)
+          }
+        }}
+        className={inputClassName}
+      />
+      {showList && (
+        <ul
+          role="listbox"
+          className="absolute z-10 mt-1 max-h-52 w-full overflow-auto rounded-md border border-sand-300 bg-coconut-50 py-1 shadow-lg dark:border-husk-100 dark:bg-husk-100"
+        >
+          {matches.map((s, i) => (
+            <li key={s.id} role="option" aria-selected={i === active}>
+              <button
+                type="button"
+                // Keep input focus so the click resolves before blur closes.
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => pick(s)}
+                onMouseEnter={() => setActive(i)}
+                className={`flex w-full items-center gap-2 px-2 py-1.5 text-left text-xs text-coconut-700 dark:text-sand-50 ${
+                  i === active ? 'bg-sand-200 dark:bg-husk-200' : ''
+                }`}
+              >
+                <img
+                  src={setLogoUrl(s.id)}
+                  alt=""
+                  className="h-4 w-8 shrink-0 object-contain"
+                  onError={(e) => {
+                    e.currentTarget.style.display = 'none'
+                  }}
+                />
+                <span className="truncate">{s.name}</span>
+                <span className="ml-auto shrink-0 text-[10px] text-coconut-400 dark:text-sand-300">
+                  {s.id}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/SetCombobox.tsx
+++ b/web/src/components/SetCombobox.tsx
@@ -45,12 +45,29 @@ export function SetCombobox({ value, onChange, inputClassName, placeholder, id }
     ).slice(0, MAX_MATCHES)
   }, [query])
 
-  // Resolve free text to a known set's ID when it matches a name/ID exactly,
-  // else pass the raw text through so a typed ID still works.
+  // Resolve free text to the stored set ID. An exact name/ID match commits
+  // that set's ID; empty clears the anchor. A partial fragment that still
+  // matches known sets isn't a valid anchor — leave it uncommitted (empty)
+  // so a half-typed name like "Surging" never gets stored as a set ID; the
+  // user resolves it by picking an option or finishing the exact name. Text
+  // that matches no known set passes through as a raw ID (a set that landed
+  // upstream since the last catalog bake still works).
   function resolve(text: string) {
-    const q = text.trim().toLowerCase()
+    const raw = text.trim()
+    const q = raw.toLowerCase()
+    if (!q) {
+      onChange('')
+      return
+    }
     const exact = BAKED_SETS.find((s) => s.name.toLowerCase() === q || s.id.toLowerCase() === q)
-    onChange(exact ? exact.id : text.trim())
+    if (exact) {
+      onChange(exact.id)
+      return
+    }
+    const isFragment = BAKED_SETS.some(
+      (s) => s.name.toLowerCase().includes(q) || s.id.toLowerCase().includes(q),
+    )
+    onChange(isFragment ? '' : raw)
   }
 
   function pick(s: SetInfo) {


### PR DESCRIPTION
Closes #682

## What

Two binder entry-point improvements, following on from #679 / #681.

- **Set-name autocomplete.** The binder modal's "Organizes a set (optional)" field was a raw Set ID text box. It's now a searchable `SetCombobox` over the baked set catalog (`BAKED_SETS`) — match by name or ID, see logo + name + ID as you type, and the pick resolves to the set's ID (the value the API stores). A typed value that matches no known set passes through as-is, so a raw ID still works as a fallback, and editing a set-anchored binder shows the set name instead of the bare ID.
- **Quick binder-create from Browse.** Walking a set in Browse now surfaces a "Create binder" action in the set-detail header (signed-in only) that opens the binder modal pre-anchored to that set — name + `source_set_id` seeded, the details disclosure auto-expanded — so you can spin up a binder for the set you're looking at without retyping anything.

## How it's built

- New `SetCombobox` component: filters `BAKED_SETS` (the same zero-round-trip catalog the export picker uses), keyboard-navigable, resolves free text to a known set's ID on exact match and passes raw text through otherwise.
- `BinderModal` gains a `prefill` prop (`name` / `sourceSetId` / `isMasterSet`) applied to its create-mode lazy initializers only — editing an existing binder is unaffected.
- `BrowsePanel` hosts the prefill state and mounts `BinderModal` only while a prefill is set, so each open re-seeds cleanly from the current set.

## How to verify

- `make check` green; `cd web && npm run build` green.
- In the binder modal's "More details", start typing a set name → matching sets appear with logos; picking one stores its ID. Re-open a set-anchored binder via the edit pencil → the field shows the set name, not the bare ID. A typed raw ID (e.g. `sv1`) still resolves.
- Browse → drill into a set → "Create binder" → the modal opens with the set's name and anchor prefilled; creating it lands a `kind='binder'` organized for that set.
- Covered by tests: `SetCombobox` (filter / resolve / known-value display), `BinderModal` (prefill seeding), and `BrowsePanel` (end-to-end Browse → create-binder flow).