### PR TITLE
feat(web): route TCGPlayer buy links through the approved affiliate redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ Prefer not to install anything? The same UI is hosted at
 
 Every matched result — both in the results table and the card detail
 view — carries a "Buy" affordance that links out to eBay and TCGPlayer
-searches for that exact printing, opening in a new tab. The links are
-affiliate-tagged where a code is configured (eBay today; TCGPlayer once
-its affiliate application lands) and fall back to plain searches
-otherwise, so they always work.
+searches for that exact printing, opening in a new tab. Both are
+affiliate-tagged (eBay via its Partner Network, TCGPlayer via an Impact
+tracking redirect) and fall back to plain searches when no code is
+configured, so they always work.
 
 The hosted demo can sign users in with GitHub, Google, Discord, or an
 email magic link when auth is enabled. See

--- a/web/src/components/CardDetailModal.test.tsx
+++ b/web/src/components/CardDetailModal.test.tsx
@@ -547,7 +547,8 @@ describe('CardDetailModal', () => {
     expect(ebay).toHaveAttribute('href', expect.stringContaining('Charizard'))
     expect(ebay).toHaveAttribute('rel', 'sponsored noopener')
     expect(ebay).toHaveAttribute('target', '_blank')
-    expect(tcg).toHaveAttribute('href', expect.stringContaining('tcgplayer.com/search'))
+    // Routed through the TCGPlayer Impact tracking redirect (#696).
+    expect(tcg).toHaveAttribute('href', expect.stringContaining('partner.tcgplayer.com/c/'))
     expect(tcg).toHaveAttribute('rel', 'sponsored noopener')
   })
 

--- a/web/src/components/ResultsTable.test.tsx
+++ b/web/src/components/ResultsTable.test.tsx
@@ -198,7 +198,8 @@ describe('ResultsTable', () => {
     const tcg = screen.getByTitle('Find on TCGPlayer')
     expect(ebay).toHaveAttribute('href', expect.stringContaining('ebay.com/sch'))
     expect(ebay).toHaveAttribute('rel', 'sponsored noopener')
-    expect(tcg).toHaveAttribute('href', expect.stringContaining('tcgplayer.com/search'))
+    // Routed through the TCGPlayer Impact tracking redirect (#696).
+    expect(tcg).toHaveAttribute('href', expect.stringContaining('partner.tcgplayer.com/c/'))
     expect(tcg).toHaveAttribute('rel', 'sponsored noopener')
     useAppStore.setState({ rows: [] })
   })

--- a/web/src/utils/affiliateLinks.test.ts
+++ b/web/src/utils/affiliateLinks.test.ts
@@ -13,9 +13,9 @@ function card(over: Partial<CardData> = {}): CardData {
 
 const WITH_CODES: AffiliateConfig = {
   ebayCampaignId: '5339000000',
-  tcgplayerAffiliateId: 'mgzpkmn',
+  tcgplayerPartnerLink: 'https://partner.tcgplayer.com/c/123/456/789',
 }
-const NO_CODES: AffiliateConfig = { ebayCampaignId: '', tcgplayerAffiliateId: '' }
+const NO_CODES: AffiliateConfig = { ebayCampaignId: '', tcgplayerPartnerLink: '' }
 
 describe('cardSearchQuery', () => {
   it('joins name + set + number', () => {
@@ -60,17 +60,22 @@ describe('tcgplayerAffiliateUrl', () => {
     expect(tcgplayerAffiliateUrl(null, NO_CODES)).toBeNull()
   })
 
-  it('builds a plain search URL when no affiliate id is set', () => {
+  it('builds a plain search URL when no partner link is set', () => {
     const url = tcgplayerAffiliateUrl(card(), NO_CODES)!
     expect(url).toContain('https://www.tcgplayer.com/search/pokemon/product')
     expect(url).toContain('q=Charizard+Base+Set+4')
     expect(url).toContain('productLineName=pokemon')
-    expect(url).not.toContain('partner')
+    expect(url).not.toContain('partner.tcgplayer.com')
   })
 
-  it('tags the URL with the partner id when set', () => {
-    const url = tcgplayerAffiliateUrl(card(), WITH_CODES)!
-    expect(url).toContain('partner=mgzpkmn')
-    expect(url).toContain('utm_campaign=affiliate')
+  it('wraps the search in the Impact tracking redirect when a partner link is set', () => {
+    const url = new URL(tcgplayerAffiliateUrl(card(), WITH_CODES)!)
+    // The outbound link points at the partner redirect, not tcgplayer.com.
+    expect(url.origin + url.pathname).toBe('https://partner.tcgplayer.com/c/123/456/789')
+    // The destination search rides as a percent-encoded `u` param and round-trips.
+    const dest = new URL(url.searchParams.get('u')!)
+    expect(dest.origin + dest.pathname).toBe('https://www.tcgplayer.com/search/pokemon/product')
+    expect(dest.searchParams.get('q')).toBe('Charizard Base Set 4')
+    expect(dest.searchParams.get('productLineName')).toBe('pokemon')
   })
 })

--- a/web/src/utils/affiliateLinks.ts
+++ b/web/src/utils/affiliateLinks.ts
@@ -4,8 +4,9 @@
  * Both links are keyword searches built from the card's name + set + number —
  * we don't carry a stable per-card product id for either marketplace, so a
  * search to the exact printing is the closest we get without a resolution
- * layer. When an affiliate code is configured the tracking params are
- * attached; when it's blank the link still works, it just points at a plain
+ * layer. eBay attaches EPN tracking params; TCGPlayer wraps the search in its
+ * Impact tracking redirect. When the code is configured the link carries
+ * credit; when it's blank the link still works, it just points at a plain
  * (uncredited) search. Drop real codes into `AFFILIATE` to start earning.
  */
 import type { CardData } from '../types'
@@ -13,8 +14,12 @@ import type { CardData } from '../types'
 export interface AffiliateConfig {
   /** eBay Partner Network campaign id — the `campid` rover param. */
   ebayCampaignId: string
-  /** TCGPlayer affiliate / Impact partner id. */
-  tcgplayerAffiliateId: string
+  /**
+   * TCGPlayer Impact tracking link base — `partner.tcgplayer.com/c/.../.../...`.
+   * Deep links append the destination as a percent-encoded `u` param. Blank
+   * falls back to a plain (uncredited) search.
+   */
+  tcgplayerPartnerLink: string
 }
 
 /**
@@ -24,9 +29,7 @@ export interface AffiliateConfig {
  */
 export const AFFILIATE: AffiliateConfig = {
   ebayCampaignId: '5339156329',
-  // Empty until the TCGPlayer (Impact) affiliate application is accepted —
-  // links stay plain searches until then.
-  tcgplayerAffiliateId: '',
+  tcgplayerPartnerLink: 'https://partner.tcgplayer.com/c/7402525/1780961/21018',
 }
 
 // eBay Partner Network rover constants for the US marketplace. Stable across
@@ -67,10 +70,13 @@ export function ebayAffiliateUrl(
 }
 
 /**
- * TCGPlayer search URL for a card, tagged with the affiliate partner id when
- * one is configured. The `partner` + utm shape matches TCGPlayer's affiliate
- * program; adjust here if your Impact link uses a different format. Returns
- * null when the card has no name to search on.
+ * TCGPlayer search URL for a card. When a partner link is configured the
+ * search is wrapped in TCGPlayer's Impact tracking redirect — the destination
+ * rides as a percent-encoded `u` param on `partner.tcgplayer.com/c/...`, which
+ * is how Impact deep links carry credit (see
+ * https://help.impact.com/partner — "Param Parameters Explained"). With no
+ * partner link it returns the plain (uncredited) search. Returns null when the
+ * card has no name to search on.
  */
 export function tcgplayerAffiliateUrl(
   card: CardData | null,
@@ -78,14 +84,11 @@ export function tcgplayerAffiliateUrl(
 ): string | null {
   const query = cardSearchQuery(card)
   if (!query) return null
-  const url = new URL('https://www.tcgplayer.com/search/pokemon/product')
-  url.searchParams.set('q', query)
-  url.searchParams.set('productLineName', 'pokemon')
-  if (config.tcgplayerAffiliateId) {
-    url.searchParams.set('partner', config.tcgplayerAffiliateId)
-    url.searchParams.set('utm_campaign', 'affiliate')
-    url.searchParams.set('utm_medium', config.tcgplayerAffiliateId)
-    url.searchParams.set('utm_source', config.tcgplayerAffiliateId)
-  }
-  return url.toString()
+  const search = new URL('https://www.tcgplayer.com/search/pokemon/product')
+  search.searchParams.set('q', query)
+  search.searchParams.set('productLineName', 'pokemon')
+  if (!config.tcgplayerPartnerLink) return search.toString()
+  const tracked = new URL(config.tcgplayerPartnerLink)
+  tracked.searchParams.set('u', search.toString())
+  return tracked.toString()
 }

--- a/web/src/utils/affiliateLinks.ts
+++ b/web/src/utils/affiliateLinks.ts
@@ -24,8 +24,9 @@ export interface AffiliateConfig {
 
 /**
  * Affiliate codes. These are public values (they ride in every outbound URL),
- * so they live in source rather than a secret store. Both default empty so the
- * links degrade to plain searches until the real codes are filled in.
+ * so they live in source rather than a secret store. Both are live; blank
+ * either one and that marketplace's links degrade to plain (uncredited)
+ * searches.
  */
 export const AFFILIATE: AffiliateConfig = {
   ebayCampaignId: '5339156329',


### PR DESCRIPTION
Closes #696

## What

The TCGPlayer affiliate application was accepted and we now have an Impact tracking link, so outbound TCGPlayer buy links (from #657) carry credit instead of degrading to plain searches.

The original builder was written against a guessed `?partner=<id>` query-param shape. The real link is an Impact **deep-link redirect** — `https://partner.tcgplayer.com/c/<mediaPartnerId>/<campaignId>/<adId>` — which deep-links by wrapping the destination in a percent-encoded `u` param ([Impact: "Param Parameters Explained"](https://help.impact.com/partner/what-would-you-like-to-learn-about/platform-features/tracking/tracking-links/link-parameters/param-parameters-explained)). So the destination search URL gets wrapped in the tracking redirect rather than tagged with query params.

## How it's built

- Replaced the `tcgplayerAffiliateId` config field with `tcgplayerPartnerLink` (the Impact tracking-link base), populated with the approved link.
- Rebuilt `tcgplayerAffiliateUrl` to build the existing `tcgplayer.com/search/pokemon/product?q=…` destination, then wrap it as `?u=<percent-encoded destination>` on the partner redirect. `URL.searchParams.set` handles the encoding.
- Graceful degradation unchanged: a blank partner link returns the plain, uncredited search.
- The eBay builder and the `AffiliateLinks` component are untouched — the component is URL-agnostic.

## How to verify

- `cd web && npm run build` green; full web suite green (452 tests). `affiliateLinks.test.ts` asserts the redirect shape (partner host + round-tripped `u` destination); `CardDetailModal` / `ResultsTable` Buy-link tests assert the `partner.tcgplayer.com/c/` href.
- A Charizard (Base Set #4) row now produces:

  `https://partner.tcgplayer.com/c/7402525/1780961/21018?u=https%3A%2F%2Fwww.tcgplayer.com%2Fsearch%2Fpokemon%2Fproduct%3Fq%3DCharizard%2BBase%2BSet%2B4%26productLineName%3Dpokemon`

  — the partner redirect lands on the percent-encoded TCGPlayer search for the exact printing.