### PR TITLE
fix(web): rename the Library panel to "Backpack" to match its icon

### DIFF
--- a/design/DESIGN_SYSTEM.md
+++ b/design/DESIGN_SYSTEM.md
@@ -294,7 +294,7 @@ The library surfaces (saved searches, want-lists, collections, binders) each car
 
 | Meaning | Icon | Where it shows |
 |---|---|---|
-| Library panel (your saved stuff) | `Backpack` | Library panel header + collapsed strip |
+| Backpack panel (your saved stuff) | `Backpack` | Backpack panel header + collapsed strip |
 | Binder | `Library` | Binders tab, binder rows/headers |
 | Smart binder | `Sparkles` | Smart-binder toggle + rows |
 | Collection (save a card you own) | `Book` | Result-row "save to collection", bulk "add as owned" |
@@ -305,7 +305,7 @@ The library surfaces (saved searches, want-lists, collections, binders) each car
 | Delete | `Trash2` | Any destructive row action |
 | Browse a set ("walk a set") | `GalleryHorizontalEnd` | Browse mode tab + panel header |
 
-`Heart` means *favorite*, never *wishlist* — chasing is `Footprints`. `Library` means *binder*, not the Library panel (that's `Backpack`) and not Browse (that's `GalleryHorizontalEnd`). When empty-state or help copy names an icon ("click the book icon…"), keep it in sync with this table.
+`Heart` means *favorite*, never *wishlist* — chasing is `Footprints`. `Library` means *binder*, not the Backpack panel (your saved-stuff hub, which uses `Backpack`) and not Browse (that's `GalleryHorizontalEnd`). When empty-state or help copy names an icon ("click the book icon…"), keep it in sync with this table.
 
 **This design system continues to use Lucide** — load via CDN:
 

--- a/web/src/components/HelpModal.test.tsx
+++ b/web/src/components/HelpModal.test.tsx
@@ -201,7 +201,7 @@ describe('HelpModal', () => {
     // have a matching help section.
     expect(await screen.findByText('Finding cards')).toBeInTheDocument()
     expect(screen.getByText('Results & card details')).toBeInTheDocument()
-    expect(screen.getByText('Library')).toBeInTheDocument()
+    expect(screen.getByText('Backpack')).toBeInTheDocument()
     expect(screen.getByText('Binders')).toBeInTheDocument()
   })
 

--- a/web/src/components/HelpModal.tsx
+++ b/web/src/components/HelpModal.tsx
@@ -329,7 +329,7 @@ export function HelpModal({ onStartTour }: Props) {
               />
             </Section>
 
-            <Section title="Library">
+            <Section title="Backpack">
               <Definitions
                 rows={[
                   ['Searches', 'Lookups you have saved with a name. Click one to reload its cards, sort, and filters.'],

--- a/web/src/components/LibraryPanel.test.tsx
+++ b/web/src/components/LibraryPanel.test.tsx
@@ -83,17 +83,17 @@ describe('LibraryPanel', () => {
       expect(screen.getByText(/No saved searches yet/i)).toBeInTheDocument(),
     )
 
-    const collapseBtn = screen.getByRole('button', { name: /Collapse Library/i })
+    const collapseBtn = screen.getByRole('button', { name: /Collapse Backpack/i })
     expect(collapseBtn).toHaveAttribute('aria-expanded', 'true')
     fireEvent.click(collapseBtn)
 
-    const expandBtn = screen.getByRole('button', { name: /Expand Library/i })
+    const expandBtn = screen.getByRole('button', { name: /Expand Backpack/i })
     expect(expandBtn).toHaveAttribute('aria-expanded', 'false')
   })
 
   it('accordion variant is collapsed by default and tabs are hidden until expanded', async () => {
     render(<LibraryPanel variant="accordion" onRun={vi.fn()} />)
-    const trigger = screen.getByRole('button', { name: /Library/i })
+    const trigger = screen.getByRole('button', { name: /Backpack/i })
     expect(trigger).toHaveAttribute('aria-expanded', 'false')
     expect(screen.queryByRole('tab', { name: /Searches/i })).not.toBeInTheDocument()
 
@@ -168,7 +168,7 @@ describe('LibraryPanel', () => {
       ],
     })
     render(<LibraryPanel variant="accordion" onRun={vi.fn()} />)
-    const trigger = await screen.findByRole('button', { name: /Library/i })
+    const trigger = await screen.findByRole('button', { name: /Backpack/i })
     // Accordion header — no "(2)" badge for the signed-out visitor.
     expect(trigger.textContent ?? '').not.toMatch(/\(2\)/)
   })

--- a/web/src/components/LibraryPanel.tsx
+++ b/web/src/components/LibraryPanel.tsx
@@ -76,13 +76,13 @@ export function LibraryPanel({ variant, onRun }: Props) {
     if (sidebarCollapsed) {
       return (
         <aside
-          aria-label="Library (collapsed)"
+          aria-label="Backpack (collapsed)"
           className="sticky top-20 flex h-fit w-9 flex-col items-center gap-2 rounded-md border border-sand-200 dark:border-husk-100 bg-sand-50 dark:bg-husk-200/40 px-1 py-2"
         >
           <button
             type="button"
             onClick={() => setSidebarCollapsed(false)}
-            aria-label="Expand Library"
+            aria-label="Expand Backpack"
             aria-expanded={false}
             className="flex h-7 w-7 items-center justify-center rounded text-coconut-400 dark:text-sand-300 hover:bg-sand-200 dark:hover:bg-husk-100 hover:text-coconut-600 dark:hover:text-sand-200"
           >
@@ -100,18 +100,18 @@ export function LibraryPanel({ variant, onRun }: Props) {
 
     return (
       <aside
-        aria-label="Library"
+        aria-label="Backpack"
         className="sticky top-20 flex h-fit max-h-[calc(100vh-6rem)] w-72 flex-col gap-2 rounded-md border border-sand-200 dark:border-husk-100 bg-sand-50 dark:bg-husk-200/40 px-3 py-2"
       >
         <header className="flex items-center justify-between">
           <h2 className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-coconut-400 dark:text-sand-300">
             <Backpack size={12} aria-hidden />
-            Library
+            Backpack
           </h2>
           <button
             type="button"
             onClick={() => setSidebarCollapsed(true)}
-            aria-label="Collapse Library"
+            aria-label="Collapse Backpack"
             aria-expanded={true}
             className="rounded p-1 text-coconut-400 dark:text-sand-400 hover:bg-sand-200 dark:hover:bg-husk-100 hover:text-coconut-600 dark:hover:text-sand-200"
           >
@@ -133,7 +133,7 @@ export function LibraryPanel({ variant, onRun }: Props) {
   // Mobile accordion above the editor: collapsed by default so the
   // editor stays the hero on small viewports.
   return (
-    <section aria-label="Library" className="rounded-md border border-sand-200 dark:border-husk-100 bg-sand-50 dark:bg-husk-200/40">
+    <section aria-label="Backpack" className="rounded-md border border-sand-200 dark:border-husk-100 bg-sand-50 dark:bg-husk-200/40">
       <button
         type="button"
         onClick={() => setAccordionOpen((o) => !o)}
@@ -142,7 +142,7 @@ export function LibraryPanel({ variant, onRun }: Props) {
       >
         <span className="flex items-center gap-2">
           <Backpack size={14} aria-hidden />
-          Library
+          Backpack
           {showUserScoped && (
             <span className="text-coconut-400 dark:text-sand-400">({savedSearchCount})</span>
           )}
@@ -201,7 +201,7 @@ function TabStrip({
   return (
     <div
       role="tablist"
-      aria-label="Library sections"
+      aria-label="Backpack sections"
       className="grid grid-cols-2 gap-1 rounded border border-sand-200 dark:border-husk-100 bg-sand-100 dark:bg-husk-200 p-0.5"
     >
       {tabs.map((t, i) => {


### PR DESCRIPTION
Follow-up to the library symbol system (#619): the saved-stuff panel took the `Backpack` icon there but kept the "Library" label, so the name and glyph disagreed. This renames the user-facing label to "Backpack".

## What

- `LibraryPanel` — the header text, collapsed-strip / accordion labels, and every aria-label ("Backpack", "Backpack (collapsed)", "Expand/Collapse Backpack", "Backpack sections").
- `HelpModal` — the help section title.
- `design/DESIGN_SYSTEM.md` — the symbol table now reads "Backpack panel".

Code identifiers (`LibraryPanel`, `LibraryTab`, the file names) stay as-is — this is a copy change, not a refactor, so there's no churn in imports/tests beyond the asserted strings.

## Why

The icon and the name should say the same thing. `Backpack` is the saved-stuff hub (Searches / Recent / Binders); `Library` the glyph now means *binder* (per the symbol system), so leaving the panel labelled "Library" was the one place the two still clashed.

## How to verify

`npm run build` + `eslint` clean; `LibraryPanel` + `HelpModal` suites green (25 tests). Ran the SPA: the panel header now reads "Backpack" with the backpack glyph.

## Screenshot

<!-- panel header reading "Backpack" — drag the image here -->