### PR TITLE
feat(web): collection-aware card detail modal — save actions, ownership badges, prominent buy links

### DIFF
--- a/web/src/components/CardDetailModal.test.tsx
+++ b/web/src/components/CardDetailModal.test.tsx
@@ -603,6 +603,27 @@ describe('CardDetailModal — library actions (#699)', () => {
     expect(screen.getByRole('button', { name: /Save to wishlist/i })).toBeInTheDocument()
   })
 
+  it('does not navigate when arrowing through save-action inputs', async () => {
+    const rows = [
+      identifiedRow(),
+      buildRow({ card: { name: 'Blastoise', id: 'b', set: { name: 'Base' } } }),
+    ]
+    const onChange = vi.fn()
+    render(<CardDetailModal rows={rows} index={0} onChangeIndex={onChange} />)
+
+    const trigger = await screen.findByRole('button', { name: /Save to collection/i })
+    trigger.focus()
+    fireEvent.keyDown(trigger, { key: 'Enter', code: 'Enter' })
+    fireEvent.click(
+      (await screen.findByText(/New collection/i)).closest('[role="menuitem"]')!,
+    )
+
+    const input = await screen.findByRole('textbox', { name: /New collection name/i })
+    fireEvent.keyDown(input, { key: 'ArrowRight' })
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
   it('hides the save actions when signed out', async () => {
     vi.spyOn(client, 'fetchMe').mockRejectedValue(new Error('401'))
     render(<CardDetailModal rows={[identifiedRow()]} index={0} onChangeIndex={() => {}} />)

--- a/web/src/components/CardDetailModal.test.tsx
+++ b/web/src/components/CardDetailModal.test.tsx
@@ -1,7 +1,12 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { CardDetailModal } from './CardDetailModal'
 import type { Row } from '../types'
+import * as client from '../api/client'
+import { _resetAuthStoreForTests } from '../hooks/useAuth'
+import { _resetCardOwnershipForTests } from './useCardOwnership'
+import { _resetCollectionsCacheForTests } from './useCollections'
+import { _resetWishlistsCacheForTests } from './useWishlists'
 
 // Fabricate a minimal Row with the slots the modal reads. Tests shallow-merge
 // (via spread) additional fields onto the underlying card so each one only
@@ -557,5 +562,64 @@ describe('CardDetailModal', () => {
       <CardDetailModal rows={[buildRow({ card: null })]} index={0} onChangeIndex={() => {}} />,
     )
     expect(screen.queryByText('Buy')).toBeNull()
+  })
+})
+
+describe('CardDetailModal — library actions (#699)', () => {
+  // A card carrying a set id so the ownership lookup (keyed by set::number)
+  // resolves; the default fixture only has a set name.
+  function identifiedRow() {
+    return buildRow({
+      card: {
+        id: 'base1-4',
+        name: 'Charizard',
+        number: '4',
+        rarity: 'Rare Holo',
+        set: { id: 'base1', name: 'Base Set', series: 'Base' },
+        images: { large: 'https://example.com/charizard-large.png' },
+      },
+    })
+  }
+
+  beforeEach(() => {
+    _resetAuthStoreForTests()
+    _resetCardOwnershipForTests()
+    _resetCollectionsCacheForTests()
+    _resetWishlistsCacheForTests()
+    vi.spyOn(client, 'fetchMe').mockResolvedValue({
+      user: { id: 1, email: 'u@e.com', display_name: 'U' },
+      authEnabled: true,
+    })
+    vi.spyOn(client, 'fetchCollections').mockResolvedValue([])
+    vi.spyOn(client, 'fetchWishlists').mockResolvedValue([])
+    vi.spyOn(client, 'fetchCardOwnership').mockResolvedValue({})
+  })
+
+  it('renders the save-to-collection and save-to-wishlist actions when signed in', async () => {
+    render(<CardDetailModal rows={[identifiedRow()]} index={0} onChangeIndex={() => {}} />)
+    expect(
+      await screen.findByRole('button', { name: /Save to collection/i }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Save to wishlist/i })).toBeInTheDocument()
+  })
+
+  it('hides the save actions when signed out', async () => {
+    vi.spyOn(client, 'fetchMe').mockRejectedValue(new Error('401'))
+    render(<CardDetailModal rows={[identifiedRow()]} index={0} onChangeIndex={() => {}} />)
+    // Let the auth probe settle, then assert the actions never mounted.
+    await waitFor(() => expect(client.fetchMe).toHaveBeenCalled())
+    expect(screen.queryByRole('button', { name: /Save to collection/i })).toBeNull()
+  })
+
+  it('shows owned (with quantity) and chasing badges from the ownership lookup', async () => {
+    vi.spyOn(client, 'fetchCardOwnership').mockResolvedValue({
+      'base1::4': {
+        collections: [{ id: 1, name: 'Show binder', quantity: 2 }],
+        wishlists: [{ id: 1, name: 'Chase list' }],
+      },
+    })
+    render(<CardDetailModal rows={[identifiedRow()]} index={0} onChangeIndex={() => {}} />)
+    expect(await screen.findByText(/owned ×2/i)).toBeInTheDocument()
+    expect(screen.getByText(/chasing/i)).toBeInTheDocument()
   })
 })

--- a/web/src/components/CardDetailModal.tsx
+++ b/web/src/components/CardDetailModal.tsx
@@ -17,13 +17,18 @@
  */
 import * as Dialog from '@radix-ui/react-dialog'
 import { ChevronLeft, ChevronRight, ExternalLink, X } from 'lucide-react'
-import { useEffect } from 'react'
-import type { CardData, EbaySoldComp, Pricing, Row } from '../types'
+import { useEffect, useMemo } from 'react'
+import type { CardOwnership } from '../api/client'
+import { useAuth } from '../hooks/useAuth'
+import type { CardData, CardSet, EbaySoldComp, Pricing, Row } from '../types'
 import { ebayAffiliateUrl, tcgplayerAffiliateUrl } from '../utils/affiliateLinks'
 import { formatComp, formatMoney } from '../utils/format'
 import { AffiliateLinks } from './AffiliateLinks'
 import { EbaySparkline } from './EbaySparkline'
 import { hasEbayData, soldPriceSeries } from './ebayComps'
+import { OwnershipBadge } from './OwnershipBadge'
+import { SaveCardActions } from './SaveCardActions'
+import { useCardOwnership } from './useCardOwnership'
 
 interface Props {
   /** The already filtered + sorted row set the parent table is showing. */
@@ -37,6 +42,33 @@ interface Props {
 export function CardDetailModal({ rows, index, onChangeIndex }: Props) {
   const isOpen = index !== null && index >= 0 && index < rows.length
   const row = isOpen ? rows[index] : null
+
+  // Collection-aware actions + owned/chasing badges, gated on a signed-in
+  // user (matching the result-row save column). Warm the ownership cache for
+  // the whole row set the modal can page through, so ←/→ navigation is
+  // instant; the lookup is keyed by (set id, number) like every other surface.
+  const { user } = useAuth()
+  const showActions = user !== null
+  const ownershipIds = useMemo(
+    () =>
+      showActions
+        ? rows
+            .map((r) => ({
+              setId: (r.card?.set as CardSet | undefined)?.id ?? '',
+              number: (r.card?.number as string | undefined) ?? '',
+            }))
+            .filter((idt) => idt.setId && idt.number)
+        : [],
+    [rows, showActions],
+  )
+  const { lookup: lookupOwnership } = useCardOwnership(ownershipIds)
+
+  const currentSetId = (row?.card?.set as CardSet | undefined)?.id
+  const currentNumber = row?.card?.number as string | undefined
+  const ownership: CardOwnership | null | undefined =
+    showActions && currentSetId && currentNumber
+      ? lookupOwnership(currentSetId, currentNumber)
+      : null
 
   // Reset to null when the parent's row set shifts so the modal no longer
   // points at a valid entry — e.g. a filter is applied while the modal is
@@ -85,6 +117,8 @@ export function CardDetailModal({ rows, index, onChangeIndex }: Props) {
               row={row}
               index={index!}
               total={rows.length}
+              showActions={showActions}
+              ownership={ownership}
               onPrev={
                 index! > 0 ? () => onChangeIndex(index! - 1) : undefined
               }
@@ -109,12 +143,16 @@ function CardDetailBody({
   row,
   index,
   total,
+  showActions,
+  ownership,
   onPrev,
   onNext,
 }: {
   row: Row
   index: number
   total: number
+  showActions: boolean
+  ownership: CardOwnership | null | undefined
   onPrev?: () => void
   onNext?: () => void
 }) {
@@ -190,6 +228,19 @@ function CardDetailBody({
 
           {/* Identity + pricing two-column */}
           <div className="space-y-5">
+            {/* Library actions — owned/chasing at a glance + save buttons.
+                Signed-in + matched cards only; both pieces self-hide when
+                there's nothing to show. */}
+            {showActions && card && (
+              <div className="flex items-center gap-3">
+                <OwnershipBadge ownership={ownership} />
+                <SaveCardActions
+                  card={card as unknown as Record<string, unknown>}
+                  show={showActions}
+                  className="ml-auto"
+                />
+              </div>
+            )}
             <div className="grid gap-4 sm:grid-cols-2">
               <DefinitionList
                 rows={[
@@ -244,10 +295,11 @@ function CardDetailBody({
                     View on {source.label} <ExternalLink size={11} />
                   </a>
                 )}
+                {/* eBay / TCGplayer buy links sit directly under the price —
+                    the "go buy this" path next to what it costs (#699). */}
+                <BuyBlock card={card} />
               </div>
             </div>
-
-            <BuyBlock card={card} />
 
             <EbayCompsBlock pricing={pricing} />
 
@@ -272,7 +324,7 @@ function BuyBlock({ card }: { card: CardData | null }) {
   if (!ebayAffiliateUrl(card) && !tcgplayerAffiliateUrl(card)) return null
 
   return (
-    <div>
+    <div className="mt-3 border-t border-sand-200 dark:border-husk-100 pt-3">
       <h3 className="text-xs font-semibold uppercase tracking-wider text-coconut-400 dark:text-sand-300 mb-2">
         Buy
       </h3>

--- a/web/src/components/CardDetailModal.tsx
+++ b/web/src/components/CardDetailModal.tsx
@@ -39,6 +39,13 @@ interface Props {
   onChangeIndex: (next: number | null) => void
 }
 
+function shouldIgnoreModalArrowKey(e: KeyboardEvent) {
+  const target = e.target
+  if (!(target instanceof Element)) return false
+  if (target instanceof HTMLElement && target.isContentEditable) return true
+  return target.closest('input, textarea, select, [contenteditable="true"], [role="menu"]') !== null
+}
+
 export function CardDetailModal({ rows, index, onChangeIndex }: Props) {
   const isOpen = index !== null && index >= 0 && index < rows.length
   const row = isOpen ? rows[index] : null
@@ -88,6 +95,7 @@ export function CardDetailModal({ rows, index, onChangeIndex }: Props) {
   useEffect(() => {
     if (!isOpen) return
     function handleKey(e: KeyboardEvent) {
+      if (shouldIgnoreModalArrowKey(e)) return
       if (e.key === 'ArrowLeft' && index! > 0) {
         e.preventDefault()
         onChangeIndex(index! - 1)


### PR DESCRIPTION
Closes #699

## What

Makes `CardDetailModal` collection-aware — the one save surface it wasn't. When signed in, a library action bar at the top of the detail column shows:

1. **Save actions** — `AddToCollectionButton` + `AddToWishlistButton` (via the shared `SaveCardActions`), so you can save the card you're inspecting without closing the modal.
2. **Owned / chasing badges** — `OwnershipBadge` keyed off the cross-collection `useCardOwnership` lookup, with **"owned ×N"** for multiples. Same pieces the search / browse / swipe cards already use, so a card saved from the modal lights up everywhere.
3. **Prominent buy links** — the eBay / TCGplayer affiliate links move out of their own block below the fold and **into the pricing column, directly under the comps** — the "go buy this" path next to what it costs.

Ownership is warmed for the whole row set the modal pages through, so ←/→ navigation stays instant. Everything self-hides when signed out or for a card without an identity, so the anonymous modal is unchanged.

## Why

The modal let you study a card in detail but not act on it, and gave no at-a-glance "do I already own this?". This closes that gap and lifts the affiliate links — the revenue surface — to where the eye lands.

## How to verify

`npm run build` + `eslint` clean; the `CardDetailModal` suite is green (30 tests, incl. 3 new: save actions render when signed in / hide when signed out, and owned-×2 + chasing badges from the ownership lookup); full web suite 460 green. In the app, open the detail modal signed in for a card you own (qty 2) and one you're chasing: the badges read "owned ×2" / "chasing", both save buttons work and reflect state, and the eBay/TCGplayer links sit under the price.

## Screenshot

<!-- signed-in detail modal: owned ×2 / chasing badges + save buttons + Buy links under pricing — drag the image here (auth-gated, captured locally) -->