### PR TITLE
feat(web): editable swipe taste-profile view — sets, types, eras, rarity

### DIFF
--- a/web/src/components/SwipePanel.tsx
+++ b/web/src/components/SwipePanel.tsx
@@ -40,6 +40,7 @@ import {
   type SavedCard,
   type SwipeAction,
 } from './useSwipeProfile'
+import { SwipeProfilePanel } from './SwipeProfilePanel'
 import { STACK_SIZE, useSwipeCandidates } from './useSwipeCandidates'
 import { useSwipeExclusions } from './useSwipeExclusions'
 import { useWishlists } from './useWishlists'
@@ -247,6 +248,8 @@ export function SwipePanel({ active }: SwipePanelProps) {
           updateSettings({ swipeExcludeChasing })
         }
       />
+
+      <SwipeProfilePanel />
 
       {profile.saved.length >= PREP_LIST_NUDGE_THRESHOLD && (
         <BuildPrepList saved={profile.saved} onCleared={clearSaved} />

--- a/web/src/components/SwipeProfilePanel.test.tsx
+++ b/web/src/components/SwipeProfilePanel.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { act, fireEvent, render, renderHook, screen, within } from '@testing-library/react'
+import { SwipeProfilePanel } from './SwipeProfilePanel'
+import {
+  useSwipeProfile,
+  _resetSwipeProfileForTests,
+} from './useSwipeProfile'
+import type { SetCard } from '../types'
+
+function card(overrides: Partial<SetCard> = {}): SetCard {
+  return {
+    id: 'neo1-1',
+    name: 'Lugia',
+    number: '1',
+    rarity: 'Rare Holo',
+    supertype: 'Pokémon',
+    subtypes: ['Basic'],
+    thumb: null,
+    market: 12,
+    ...overrides,
+  }
+}
+
+/** Seed the shared profile store, then render the panel against it. */
+function seed(fn: (p: ReturnType<typeof useSwipeProfile>) => void) {
+  const { result } = renderHook(() => useSwipeProfile())
+  act(() => fn(result.current))
+  return result
+}
+
+function expand() {
+  fireEvent.click(screen.getByRole('button', { name: /your taste/i }))
+}
+
+describe('SwipeProfilePanel', () => {
+  beforeEach(() => {
+    _resetSwipeProfileForTests()
+  })
+
+  it('shows an empty-state hint when no signal has accrued', () => {
+    render(<SwipeProfilePanel />)
+    expect(screen.getByText(/nothing yet/i)).toBeInTheDocument()
+    expand()
+    expect(
+      screen.getByText(/swipe a few cards and your taste/i),
+    ).toBeInTheDocument()
+  })
+
+  it('groups the profile by set, type, era, and rarity with friendly labels', () => {
+    seed((p) => p.act(card({ subtypes: ['V'] }), 'neo1', 'love'))
+    render(<SwipeProfilePanel />)
+    expand()
+
+    // Set label resolves to the friendly catalog name, not the raw id.
+    expect(within(screen.getByLabelText('Sets')).getByText('Neo Genesis')).toBeInTheDocument()
+    // Era rolls the set up by its series.
+    expect(within(screen.getByLabelText('Eras')).getByText('Neo')).toBeInTheDocument()
+    // Types strip the super:/sub: prefix.
+    const types = within(screen.getByLabelText('Types'))
+    expect(types.getByText('Pokémon')).toBeInTheDocument()
+    expect(types.getByText('V')).toBeInTheDocument()
+    // Rarity passes through verbatim.
+    expect(within(screen.getByLabelText('Rarity')).getByText('Rare Holo')).toBeInTheDocument()
+    // A love is +2.
+    expect(screen.getAllByText('+2').length).toBeGreaterThan(0)
+  })
+
+  it('nudges a weight up via the +1 control', () => {
+    const result = seed((p) => p.act(card(), 'neo1', 'save')) // neo1 = +1
+    render(<SwipeProfilePanel />)
+    expand()
+    fireEvent.click(screen.getByRole('button', { name: /more like neo genesis/i }))
+    expect(result.current.profile.set['neo1']).toBe(2)
+  })
+
+  it('clears a single entry via the forget control', () => {
+    const result = seed((p) => p.act(card(), 'neo1', 'love')) // neo1 = +2
+    render(<SwipeProfilePanel />)
+    expand()
+    fireEvent.click(screen.getByRole('button', { name: /forget neo genesis/i }))
+    expect('neo1' in result.current.profile.set).toBe(false)
+    // The rarity signal it came in with is untouched.
+    expect(result.current.profile.rarity['Rare Holo']).toBe(2)
+  })
+})

--- a/web/src/components/SwipeProfilePanel.tsx
+++ b/web/src/components/SwipeProfilePanel.tsx
@@ -1,0 +1,261 @@
+/**
+ * SwipeProfilePanel — the visible, editable taste profile for Swipe mode
+ * (#711, part of the personalization epic #701).
+ *
+ * Surfaces the counters {@link useSwipeProfile} accretes from every pass /
+ * save / love, grouped four ways:
+ *
+ *   - **Sets** — the per-set lean (`profile.set`), labelled with the
+ *     friendly set name from the baked catalog.
+ *   - **Types** — supertype + subtype tags (`profile.tag`).
+ *   - **Rarity** — the per-rarity lean (`profile.rarity`).
+ *   - **Eras** — a read-only rollup of the set lean grouped by the set's
+ *     `series` (the canonical TCG era). Derived, so it isn't edited
+ *     directly — adjust the underlying sets and the era moves with them.
+ *
+ * The first three are stored counters, so each entry gets inline controls
+ * to nudge (−/+) or clear (×) its weight. Persistence stays local for now
+ * (the hook is localStorage-backed); server durability arrives with the
+ * favorite-set work (#712).
+ */
+import { useMemo, useState } from 'react'
+import { ChevronDown, Minus, Plus, X } from 'lucide-react'
+import { BAKED_SETS } from '../data/sets'
+import {
+  useSwipeProfile,
+  type ProfileBucket,
+  type SwipeProfile,
+} from './useSwipeProfile'
+
+/** set id → friendly name + series, resolved once from the baked catalog. */
+const SET_META = new Map(
+  BAKED_SETS.map((s) => [s.id, { name: s.name, series: s.series }]),
+)
+
+/** One displayable profile entry: a stored key, its weight, and its label. */
+interface Entry {
+  key: string
+  weight: number
+  label: string
+}
+
+/** Most-loved first; passes sink to the bottom. */
+function byWeightDesc(a: Entry, b: Entry): number {
+  return b.weight - a.weight
+}
+
+function toEntries(
+  counter: Record<string, number>,
+  label: (key: string) => string,
+): Entry[] {
+  return Object.entries(counter)
+    .map(([key, weight]) => ({ key, weight, label: label(key) }))
+    .sort(byWeightDesc)
+}
+
+/** Strip the `super:` / `sub:` prefix off a tag key for display. */
+function tagLabel(key: string): string {
+  return key.replace(/^(super|sub):/, '')
+}
+
+/** Roll the per-set lean up into eras via each set's `series`. */
+function eraEntries(setCounter: Record<string, number>): Entry[] {
+  const byEra: Record<string, number> = {}
+  for (const [setId, weight] of Object.entries(setCounter)) {
+    const era = SET_META.get(setId)?.series
+    if (!era) continue // can't place an unknown set into an era
+    byEra[era] = (byEra[era] ?? 0) + weight
+  }
+  return toEntries(byEra, (era) => era)
+}
+
+function isEmpty(profile: SwipeProfile): boolean {
+  return (
+    Object.keys(profile.rarity).length === 0 &&
+    Object.keys(profile.set).length === 0 &&
+    Object.keys(profile.tag).length === 0
+  )
+}
+
+export function SwipeProfilePanel() {
+  const { profile, adjustWeight, clearWeight } = useSwipeProfile()
+  const [open, setOpen] = useState(false)
+
+  const sets = useMemo(
+    () =>
+      toEntries(profile.set, (id) => SET_META.get(id)?.name ?? id),
+    [profile.set],
+  )
+  const types = useMemo(() => toEntries(profile.tag, tagLabel), [profile.tag])
+  const rarity = useMemo(
+    () => toEntries(profile.rarity, (r) => r),
+    [profile.rarity],
+  )
+  const eras = useMemo(() => eraEntries(profile.set), [profile.set])
+
+  const signalCount = sets.length + types.length + rarity.length
+  const empty = isEmpty(profile)
+
+  return (
+    <div className="rounded-lg border border-sand-300 bg-sand-50 dark:border-husk-50 dark:bg-husk-100">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="flex w-full items-center justify-between gap-2 px-4 py-2.5 text-left"
+      >
+        <span className="flex items-baseline gap-2">
+          <span className="text-sm font-semibold text-coconut-700 dark:text-sand-50">
+            Your taste
+          </span>
+          <span className="text-xs text-coconut-400 dark:text-sand-300">
+            {empty
+              ? 'nothing yet'
+              : `${signalCount} ${signalCount === 1 ? 'signal' : 'signals'}`}
+          </span>
+        </span>
+        <ChevronDown
+          className={`h-4 w-4 shrink-0 text-coconut-400 transition-transform dark:text-sand-300 ${
+            open ? 'rotate-180' : ''
+          }`}
+          aria-hidden
+        />
+      </button>
+
+      {open && (
+        <div className="flex flex-col gap-4 border-t border-sand-300 px-4 py-3 dark:border-husk-50">
+          {empty ? (
+            <p className="text-xs text-coconut-400 dark:text-sand-300">
+              Swipe a few cards and your taste starts showing up here — the sets,
+              types, eras, and rarities you lean toward.
+            </p>
+          ) : (
+            <>
+              <ProfileGroup
+                title="Sets"
+                bucket="set"
+                entries={sets}
+                onAdjust={adjustWeight}
+                onClear={clearWeight}
+              />
+              <ProfileGroup
+                title="Types"
+                bucket="tag"
+                entries={types}
+                onAdjust={adjustWeight}
+                onClear={clearWeight}
+              />
+              <EraSummary entries={eras} />
+              <ProfileGroup
+                title="Rarity"
+                bucket="rarity"
+                entries={rarity}
+                onAdjust={adjustWeight}
+                onClear={clearWeight}
+              />
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ProfileGroup({
+  title,
+  bucket,
+  entries,
+  onAdjust,
+  onClear,
+}: {
+  title: string
+  bucket: ProfileBucket
+  entries: Entry[]
+  onAdjust: (bucket: ProfileBucket, key: string, delta: number) => void
+  onClear: (bucket: ProfileBucket, key: string) => void
+}) {
+  if (entries.length === 0) return null
+  return (
+    <section aria-label={title} className="flex flex-col gap-1.5">
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-coconut-300 dark:text-sand-400">
+        {title}
+      </h3>
+      <ul className="flex flex-col gap-1">
+        {entries.map((e) => (
+          <li
+            key={e.key}
+            className="flex items-center justify-between gap-2 text-sm text-coconut-700 dark:text-sand-50"
+          >
+            <span className="min-w-0 flex-1 truncate">{e.label}</span>
+            <span className="flex shrink-0 items-center gap-1">
+              <WeightPill weight={e.weight} />
+              <button
+                type="button"
+                aria-label={`Less like ${e.label}`}
+                onClick={() => onAdjust(bucket, e.key, -1)}
+                className="rounded p-0.5 text-coconut-400 hover:bg-sand-200 hover:text-coconut-700 dark:text-sand-300 dark:hover:bg-husk-200 dark:hover:text-sand-50"
+              >
+                <Minus className="h-3.5 w-3.5" aria-hidden />
+              </button>
+              <button
+                type="button"
+                aria-label={`More like ${e.label}`}
+                onClick={() => onAdjust(bucket, e.key, 1)}
+                className="rounded p-0.5 text-coconut-400 hover:bg-sand-200 hover:text-coconut-700 dark:text-sand-300 dark:hover:bg-husk-200 dark:hover:text-sand-50"
+              >
+                <Plus className="h-3.5 w-3.5" aria-hidden />
+              </button>
+              <button
+                type="button"
+                aria-label={`Forget ${e.label}`}
+                onClick={() => onClear(bucket, e.key)}
+                className="rounded p-0.5 text-coconut-400 hover:bg-ember-500/10 hover:text-ember-400 dark:text-sand-300 dark:hover:bg-ember-500/20 dark:hover:text-ember-300"
+              >
+                <X className="h-3.5 w-3.5" aria-hidden />
+              </button>
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+/** Read-only era rollup — eras are derived from sets, not edited directly. */
+function EraSummary({ entries }: { entries: Entry[] }) {
+  if (entries.length === 0) return null
+  return (
+    <section aria-label="Eras" className="flex flex-col gap-1.5">
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-coconut-300 dark:text-sand-400">
+        Eras
+      </h3>
+      <ul className="flex flex-col gap-1">
+        {entries.map((e) => (
+          <li
+            key={e.key}
+            className="flex items-center justify-between gap-2 text-sm text-coconut-700 dark:text-sand-50"
+          >
+            <span className="min-w-0 flex-1 truncate">{e.label}</span>
+            <WeightPill weight={e.weight} />
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+/** Signed-weight chip: warm palm for a lean toward, muted for against. */
+function WeightPill({ weight }: { weight: number }) {
+  const positive = weight > 0
+  return (
+    <span
+      className={`rounded px-1.5 py-0.5 text-xs font-medium tabular-nums ${
+        positive
+          ? 'bg-palm-500/15 text-palm-600 dark:bg-palm-500/25 dark:text-palm-300'
+          : 'bg-coconut-700/10 text-coconut-400 dark:bg-husk-200 dark:text-sand-300'
+      }`}
+    >
+      {positive ? `+${weight}` : weight}
+    </span>
+  )
+}

--- a/web/src/components/useSwipeProfile.test.ts
+++ b/web/src/components/useSwipeProfile.test.ts
@@ -84,6 +84,35 @@ describe('useSwipeProfile', () => {
     expect(result.current.profile.set['sv1']).toBe(1)
   })
 
+  it('adjustWeight nudges an entry and drops it when it lands on 0', () => {
+    const { result } = renderHook(() => useSwipeProfile())
+    act(() => {
+      result.current.act(card(), 'sv1', 'save') // set sv1 = +1
+    })
+    act(() => {
+      result.current.adjustWeight('set', 'sv1', 1) // +1 → +2
+    })
+    expect(result.current.profile.set['sv1']).toBe(2)
+    act(() => {
+      result.current.adjustWeight('set', 'sv1', -2) // +2 → 0 → dropped
+    })
+    expect('sv1' in result.current.profile.set).toBe(false)
+  })
+
+  it('clearWeight removes a single entry without touching others', () => {
+    const { result } = renderHook(() => useSwipeProfile())
+    act(() => {
+      result.current.act(card({ rarity: 'Rare Holo' }), 'sv1', 'love')
+    })
+    expect(result.current.profile.rarity['Rare Holo']).toBe(2)
+    expect(result.current.profile.set['sv1']).toBe(2)
+    act(() => {
+      result.current.clearWeight('rarity', 'Rare Holo')
+    })
+    expect('Rare Holo' in result.current.profile.rarity).toBe(false)
+    expect(result.current.profile.set['sv1']).toBe(2) // untouched
+  })
+
   it('reset clears everything', () => {
     const { result } = renderHook(() => useSwipeProfile())
     act(() => {

--- a/web/src/components/useSwipeProfile.ts
+++ b/web/src/components/useSwipeProfile.ts
@@ -52,6 +52,9 @@ export interface SavedCard {
 
 export type SwipeAction = 'pass' | 'save' | 'love'
 
+/** The three editable counters that make up the visible taste profile. */
+export type ProfileBucket = 'rarity' | 'set' | 'tag'
+
 const EMPTY_PROFILE: SwipeProfile = {
   rarity: {},
   set: {},
@@ -103,6 +106,23 @@ function bump(
 ): Record<string, number> {
   if (!key) return counter
   return { ...counter, [key]: (counter[key] ?? 0) + weight }
+}
+
+/**
+ * Set one bucket entry to an explicit weight (manual edit, not a swipe).
+ * A weight of 0 drops the key entirely so a neutralised attribute leaves
+ * no trace in the profile or in `scoreCard`.
+ */
+function setWeight(
+  profile: SwipeProfile,
+  bucket: ProfileBucket,
+  key: string,
+  weight: number,
+): SwipeProfile {
+  const next = { ...profile[bucket] }
+  if (weight === 0) delete next[key]
+  else next[key] = weight
+  return { ...profile, [bucket]: next }
 }
 
 function bumpTags(
@@ -176,6 +196,20 @@ export function useSwipeProfile() {
     publish({ ...EMPTY_PROFILE })
   }, [])
 
+  // Manual edits to the visible profile (#711). `adjustWeight` nudges one
+  // entry by a delta; `clearWeight` neutralises it. Both drop the key when
+  // the weight lands on 0 so the profile only carries live signal.
+  const adjustWeight = useCallback(
+    (bucket: ProfileBucket, key: string, delta: number) => {
+      publish(setWeight(state, bucket, key, (state[bucket][key] ?? 0) + delta))
+    },
+    [],
+  )
+
+  const clearWeight = useCallback((bucket: ProfileBucket, key: string) => {
+    publish(setWeight(state, bucket, key, 0))
+  }, [])
+
   /** Score a candidate by current profile weights. Higher = better match. */
   const scoreCard = useCallback((card: SetCard, setId: string): number => {
     let score = 0
@@ -198,6 +232,8 @@ export function useSwipeProfile() {
     clearSaved,
     reset,
     scoreCard,
+    adjustWeight,
+    clearWeight,
   }
 }
 


### PR DESCRIPTION
Closes #711

## What

Makes the swipe taste profile **visible and editable**. `useSwipeProfile` already accretes signed counters (`rarity` / `set` / `tag`) from every pass / save / love, but the profile was invisible — it only fed `scoreCard` and the saved-card list. This adds a collapsible **"Your taste"** panel to the Swipe tab, grouped four ways:

- **Sets** — the per-set lean, labelled with the friendly set name from the baked catalog (`Neo Genesis`, not `neo1`).
- **Types** — supertype + subtype tags, with the `super:` / `sub:` prefix stripped.
- **Eras** — a **read-only** rollup of the set lean grouped by each set's `series` (the canonical TCG era — Neo, Scarlet & Violet, …). It's derived, so it isn't edited directly; adjust the underlying sets and the era moves with it.
- **Rarity** — the per-rarity lean, verbatim.

Each of the three stored counters gets inline controls to **nudge (−/+)** or **clear (×)** a single weight. Clearing a weight to 0 drops the key entirely, so the profile (and `scoreCard`) only carries live signal.

## Implementation

- `useSwipeProfile`: new `adjustWeight(bucket, key, delta)` and `clearWeight(bucket, key)` mutators on the existing module store, plus a `ProfileBucket` type.
- New `SwipeProfilePanel` component, rendered under the header in `SwipePanel`.
- Eras resolve via a set-id → `series` map built once from `BAKED_SETS` — this answers the issue's open question (era banding) using data the SPA already ships, no new lookup.

## Scope

Persistence stays **local** (the hook is localStorage-backed) — server durability arrives with the favorite-set work (#712), which also wants it for biasing other surfaces. Candidate weighting (#713) is unaffected; it already consumes the same counters via `scoreCard`.

## How to verify

1. Web: `cd web && npm run build` (typecheck + build) and `npm run test` — 12 covering tests (`useSwipeProfile` adjust/clear + drop-on-zero; `SwipeProfilePanel` grouping, friendly labels, era rollup, nudge, clear).
2. In the app, open the **Swipe** tab and swipe a few cards (or seed `localStorage['mgz-pkmn:swipe-profile:v1']`). Expand **"Your taste"**: sets show friendly names, eras roll up by series and are read-only, and −/+/× edit the sets/types/rarity weights live.

## Screenshot

<!-- "Your taste" panel expanded on the Swipe tab — drag the image here -->