### PR TITLE
feat(web): favorite-set pinning and suggestion from swipe + owned signal

### DIFF
--- a/api/db/models.py
+++ b/api/db/models.py
@@ -515,6 +515,36 @@ class SwipeSeen(Base):
     swipe_dir: Mapped[str | None] = mapped_column(String(8), nullable=True)
 
 
+class FavoriteSet(Base):
+    """One set a user has pinned as a favorite (#712).
+
+    Durable, per-user, server-side — unlike the localStorage swipe taste
+    profile — so other surfaces (search defaults, set ID cards, swipe
+    candidate weighting) can read an explicit "I love this set" signal that
+    survives a device change. The set is referenced by its catalog id
+    (``base1``, ``sv4pt5``); the friendly name is resolved client-side from
+    the baked set catalog, so it isn't denormalised here.
+
+    Append-only and idempotent: the unique constraint on
+    ``(user_id, set_id)`` makes re-pinning a no-op rather than a duplicate
+    row, mirroring :class:`SwipeSeen`."""
+
+    __tablename__ = "favorite_sets"
+    __table_args__ = (UniqueConstraint("user_id", "set_id", name="uq_favorite_set_user_set"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        default=DEFAULT_USER_ID,
+        nullable=False,
+        index=True,
+    )
+    set_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    pinned_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, nullable=False
+    )
+
+
 class RunRow(Base):
     __tablename__ = "run_rows"
 

--- a/api/main.py
+++ b/api/main.py
@@ -49,6 +49,7 @@ from .routes import (
     collections,
     ebay,
     export,
+    favorite_sets,
     lookup,
     overrides,
     ownership,
@@ -545,6 +546,7 @@ app.include_router(collections.router, prefix="/api/v1", tags=["collections"])
 app.include_router(binders.router, prefix="/api/v1", tags=["binders"])
 app.include_router(wishlists.router, prefix="/api/v1", tags=["wishlists"])
 app.include_router(swipe.router, prefix="/api/v1", tags=["swipe"])
+app.include_router(favorite_sets.router, prefix="/api/v1", tags=["favorite-sets"])
 app.include_router(ownership.router, prefix="/api/v1", tags=["ownership"])
 app.include_router(cache_route.router, prefix="/api/v1", tags=["cache"])
 app.include_router(ebay.router, prefix="/api/v1", tags=["ebay"])

--- a/api/migrations/versions/c8b4e1f6a2d7_favorite_sets.py
+++ b/api/migrations/versions/c8b4e1f6a2d7_favorite_sets.py
@@ -1,0 +1,54 @@
+"""favorite_sets — per-user pinned favorite sets for the personalization surface
+
+Child slice of the swipe-personalization epic (#701); see #712. Gives the
+user an explicit, durable "I love this set" signal — distinct from the
+localStorage swipe taste profile — so other surfaces (search defaults, set
+ID cards, swipe candidate weighting) can key off it across devices.
+
+Keyed by the catalog set id (``base1`` / ``sv4pt5``); the friendly name is
+resolved client-side from the baked set catalog, so it isn't stored here.
+
+Append-only and idempotent: the unique constraint on ``(user_id, set_id)``
+makes re-pinning a no-op, mirroring ``swipe_seen``.
+
+Revision ID: c8b4e1f6a2d7
+Revises: a7d3f1e0c2b5
+Create Date: 2026-06-20
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c8b4e1f6a2d7"
+down_revision: str | Sequence[str] | None = "a7d3f1e0c2b5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "favorite_sets",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("set_id", sa.String(length=64), nullable=False),
+        sa.Column("pinned_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "set_id", name="uq_favorite_set_user_set"),
+    )
+    # Every read filters by user_id first; a leading-user_id index keeps the
+    # per-user fetch and the idempotent-insert conflict check off a scan.
+    op.create_index(
+        "ix_favorite_sets_user_id",
+        "favorite_sets",
+        ["user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_favorite_sets_user_id", table_name="favorite_sets")
+    op.drop_table("favorite_sets")

--- a/api/routes/favorite_sets.py
+++ b/api/routes/favorite_sets.py
@@ -146,28 +146,30 @@ def list_suggestions(
     Tallies the user's ``collection_items`` by ``card_set_id`` — the sets
     they've already invested a collection in are the strongest owned signal
     for a favorite — and drops any set they've already pinned. The SPA folds
-    its own swipe ``set`` counter into this before rendering."""
+    its own swipe ``set`` counter into this before rendering.
+
+    Counts owned *copies* (``sum(quantity)``), not rows, so the rest of the
+    collections model's quantity semantics hold — a single ``quantity: 10``
+    row is ten owned, not one."""
     pinned = set(
         db.scalars(select(FavoriteSet.set_id).where(FavoriteSet.user_id == current_user.id)).all()
     )
 
+    owned = func.coalesce(func.sum(CollectionItem.quantity), 0).label("owned")
     rows = db.execute(
-        select(
-            CollectionItem.card_set_id,
-            func.count().label("owned"),
-        )
+        select(CollectionItem.card_set_id, owned)
         .join(Collection, CollectionItem.collection_id == Collection.id)
         .where(
             Collection.user_id == current_user.id,
             CollectionItem.card_set_id.is_not(None),
         )
         .group_by(CollectionItem.card_set_id)
-        .order_by(func.count().desc())
+        .order_by(owned.desc())
     ).all()
 
     suggestions = [
-        SuggestionOut(set_id=set_id, owned_count=owned)
-        for set_id, owned in rows
+        SuggestionOut(set_id=set_id, owned_count=int(count))
+        for set_id, count in rows
         if set_id not in pinned
     ][:limit]
     return SuggestionsOut(suggestions=suggestions).model_dump()

--- a/api/routes/favorite_sets.py
+++ b/api/routes/favorite_sets.py
@@ -1,0 +1,173 @@
+"""`/api/v1/favorite-sets` — per-user pinned favorite sets (#712).
+
+Part of turning swipe into a personalization surface (#701). A favorite
+set is an explicit, durable "I love this set" signal — distinct from the
+localStorage swipe taste profile — that other surfaces (search defaults,
+set ID cards, swipe candidate weighting) can read across devices.
+
+Sets are referenced by their catalog id (``base1`` / ``sv4pt5``); the
+friendly name is resolved client-side from the baked set catalog, so it
+isn't stored or returned here.
+
+Endpoints:
+
+- ``GET    /favorite-sets``               the user's pinned set ids
+- ``POST   /favorite-sets``               pin a set (idempotent)
+- ``DELETE /favorite-sets/{set_id}``      unpin a set
+- ``GET    /favorite-sets/suggestions``   sets to consider pinning, ranked
+  by how many owned cards the user has in each — the server-side half of
+  the suggestion (the SPA folds in its swipe signal client-side).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query, Response
+from pydantic import BaseModel, Field
+from sqlalchemy import delete, func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from ..auth.session import current_user_or_default
+from ..db.models import (
+    Collection,
+    CollectionItem,
+    FavoriteSet,
+    User,
+)
+from ..db.session import get_db
+
+router = APIRouter()
+
+DbSession = Annotated[Session, Depends(get_db)]
+CurrentUser = Annotated[User, Depends(current_user_or_default)]
+
+#: Default cap on suggestion rows — enough to fill the panel without a long tail.
+_SUGGESTION_LIMIT = 6
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class FavoriteSetOut(BaseModel):
+    set_id: str
+    pinned_at: str
+
+
+class FavoriteSetsOut(BaseModel):
+    sets: list[FavoriteSetOut]
+
+
+class FavoriteSetCreate(BaseModel):
+    set_id: str = Field(min_length=1, max_length=64)
+
+
+class SuggestionOut(BaseModel):
+    """One suggested set with the owned-card count behind the suggestion."""
+
+    set_id: str
+    owned_count: int
+
+
+class SuggestionsOut(BaseModel):
+    suggestions: list[SuggestionOut]
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@router.get("/favorite-sets")
+def list_favorites(db: DbSession, current_user: CurrentUser) -> dict:
+    """The user's pinned sets, newest first."""
+    rows = db.execute(
+        select(FavoriteSet.set_id, FavoriteSet.pinned_at)
+        .where(FavoriteSet.user_id == current_user.id)
+        .order_by(FavoriteSet.pinned_at.desc())
+    ).all()
+    sets = [FavoriteSetOut(set_id=s, pinned_at=p.isoformat()) for s, p in rows]
+    return FavoriteSetsOut(sets=sets).model_dump()
+
+
+@router.post("/favorite-sets", status_code=204)
+def pin_favorite(
+    req: FavoriteSetCreate,
+    db: DbSession,
+    current_user: CurrentUser,
+) -> Response:
+    """Pin a set. Idempotent: re-pinning is a no-op.
+
+    The unique constraint on ``(user_id, set_id)`` is the source of truth —
+    a concurrent duplicate insert raises ``IntegrityError``, which we
+    swallow so the call still reports success (the set is already pinned)."""
+    row = FavoriteSet(
+        user_id=current_user.id,
+        set_id=req.set_id,
+        pinned_at=datetime.now(UTC),
+    )
+    db.add(row)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+    return Response(status_code=204)
+
+
+@router.delete("/favorite-sets/{set_id}", status_code=204)
+def unpin_favorite(
+    set_id: str,
+    db: DbSession,
+    current_user: CurrentUser,
+) -> Response:
+    """Unpin a set. A no-op (still 204) when it wasn't pinned."""
+    db.execute(
+        delete(FavoriteSet).where(
+            FavoriteSet.user_id == current_user.id,
+            FavoriteSet.set_id == set_id,
+        )
+    )
+    db.commit()
+    return Response(status_code=204)
+
+
+@router.get("/favorite-sets/suggestions")
+def list_suggestions(
+    db: DbSession,
+    current_user: CurrentUser,
+    limit: Annotated[int, Query(ge=1, le=50)] = _SUGGESTION_LIMIT,
+) -> dict:
+    """Sets the user might want to pin, ranked by owned-card count.
+
+    Tallies the user's ``collection_items`` by ``card_set_id`` — the sets
+    they've already invested a collection in are the strongest owned signal
+    for a favorite — and drops any set they've already pinned. The SPA folds
+    its own swipe ``set`` counter into this before rendering."""
+    pinned = set(
+        db.scalars(select(FavoriteSet.set_id).where(FavoriteSet.user_id == current_user.id)).all()
+    )
+
+    rows = db.execute(
+        select(
+            CollectionItem.card_set_id,
+            func.count().label("owned"),
+        )
+        .join(Collection, CollectionItem.collection_id == Collection.id)
+        .where(
+            Collection.user_id == current_user.id,
+            CollectionItem.card_set_id.is_not(None),
+        )
+        .group_by(CollectionItem.card_set_id)
+        .order_by(func.count().desc())
+    ).all()
+
+    suggestions = [
+        SuggestionOut(set_id=set_id, owned_count=owned)
+        for set_id, owned in rows
+        if set_id not in pinned
+    ][:limit]
+    return SuggestionsOut(suggestions=suggestions).model_dump()

--- a/tests/test_favorite_sets_api.py
+++ b/tests/test_favorite_sets_api.py
@@ -137,10 +137,13 @@ class FavoriteSetsCrudTests(_IsolatedDbMixin):
 
 
 class FavoriteSetSuggestionTests(_IsolatedDbMixin):
-    def _own(self, c: TestClient, cards: list[dict]) -> None:
+    def _own(self, c: TestClient, cards: list[dict], quantity: int = 1) -> None:
         cid = c.post("/api/v1/collections", json={"name": "Owned"}).json()["id"]
         for card in cards:
-            c.post(f"/api/v1/collections/{cid}/items", json={"card": card})
+            c.post(
+                f"/api/v1/collections/{cid}/items",
+                json={"card": card, "quantity": quantity},
+            )
 
     def test_suggestions_rank_sets_by_owned_count(self) -> None:
         with self._client() as c:
@@ -157,6 +160,17 @@ class FavoriteSetSuggestionTests(_IsolatedDbMixin):
             c.post("/api/v1/favorite-sets", json={"set_id": "base1"})
             body = c.get("/api/v1/favorite-sets/suggestions").json()["suggestions"]
             self.assertEqual([s["set_id"] for s in body], ["sv4pt5"])
+
+    def test_suggestions_count_owned_copies_not_rows(self) -> None:
+        # One sv4pt5 row with quantity 5 must out-rank two base1 rows of 1.
+        with self._client() as c:
+            self._own(c, [CHARIZARD, BLASTOISE])  # base1: 2 copies across 2 rows
+            self._own(c, [MEW_EX], quantity=5)  # sv4pt5: 5 copies in 1 row
+            body = c.get("/api/v1/favorite-sets/suggestions").json()["suggestions"]
+            self.assertEqual(
+                [(s["set_id"], s["owned_count"]) for s in body],
+                [("sv4pt5", 5), ("base1", 2)],
+            )
 
     def test_suggestions_empty_without_a_collection(self) -> None:
         with self._client() as c:

--- a/tests/test_favorite_sets_api.py
+++ b/tests/test_favorite_sets_api.py
@@ -1,0 +1,170 @@
+"""Tests for `/api/v1/favorite-sets` — per-user pinned favorite sets (#712).
+
+Covers:
+
+- Alembic migration up/down round-trip for the `favorite_sets` table.
+- CRUD: list, idempotent pin, unpin (including unpin-of-unpinned no-op).
+- Suggestions: owned `collection_items` tallied per set, ranked, with the
+  already-pinned sets dropped.
+
+Mirrors the per-test tempfile DB isolation from `tests/test_swipe.py`.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+from sqlalchemy import inspect
+
+from api.db import session as session_mod
+from api.db.migrate import upgrade_head
+
+CHARIZARD = {
+    "id": "base1-4",
+    "name": "Charizard",
+    "set": {"id": "base1", "name": "Base Set"},
+    "number": "4",
+    "rarity": "Rare Holo",
+}
+BLASTOISE = {
+    "id": "base1-2",
+    "name": "Blastoise",
+    "set": {"id": "base1", "name": "Base Set"},
+    "number": "2",
+    "rarity": "Rare Holo",
+}
+MEW_EX = {
+    "id": "sv4pt5-205",
+    "name": "Mew ex",
+    "set": {"id": "sv4pt5", "name": "151"},
+    "number": "205",
+    "rarity": "Special Illustration Rare",
+}
+
+
+class _IsolatedDbMixin(unittest.TestCase):
+    """Point MGZ_PKMN_DATABASE_URL at a fresh sqlite file per test."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._db_path = Path(self._tmp.name) / "test.db"
+        self._old_url = os.environ.get("MGZ_PKMN_DATABASE_URL")
+        os.environ["MGZ_PKMN_DATABASE_URL"] = f"sqlite:///{self._db_path}"
+        session_mod.reset_engine()
+
+    def tearDown(self) -> None:
+        session_mod.reset_engine()
+        if self._old_url is None:
+            os.environ.pop("MGZ_PKMN_DATABASE_URL", None)
+        else:
+            os.environ["MGZ_PKMN_DATABASE_URL"] = self._old_url
+        self._tmp.cleanup()
+
+    def _client(self) -> TestClient:
+        from api.main import app
+
+        return TestClient(app)
+
+
+class FavoriteSetsMigrationTests(_IsolatedDbMixin):
+    def test_upgrade_creates_table_then_downgrade_drops_it(self) -> None:
+        engine = session_mod.get_engine()
+        upgrade_head(engine)
+        insp = inspect(engine)
+        self.assertIn("favorite_sets", insp.get_table_names())
+        cols = {c["name"] for c in insp.get_columns("favorite_sets")}
+        self.assertEqual(cols, {"id", "user_id", "set_id", "pinned_at"})
+        self.assertIn(
+            "ix_favorite_sets_user_id",
+            {i["name"] for i in insp.get_indexes("favorite_sets")},
+        )
+
+        from alembic.command import downgrade
+        from alembic.config import Config
+
+        cfg = Config(str(Path(__file__).resolve().parents[1] / "api" / "alembic.ini"))
+        downgrade(cfg, "-1")
+        self.assertNotIn("favorite_sets", inspect(session_mod.get_engine()).get_table_names())
+
+
+class FavoriteSetsCrudTests(_IsolatedDbMixin):
+    def test_list_is_empty_initially(self) -> None:
+        with self._client() as c:
+            resp = c.get("/api/v1/favorite-sets")
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.json(), {"sets": []})
+
+    def test_pin_then_list(self) -> None:
+        with self._client() as c:
+            self.assertEqual(
+                c.post("/api/v1/favorite-sets", json={"set_id": "base1"}).status_code,
+                204,
+            )
+            body = c.get("/api/v1/favorite-sets").json()
+            self.assertEqual([s["set_id"] for s in body["sets"]], ["base1"])
+            self.assertIn("pinned_at", body["sets"][0])
+
+    def test_pin_is_idempotent(self) -> None:
+        with self._client() as c:
+            c.post("/api/v1/favorite-sets", json={"set_id": "base1"})
+            c.post("/api/v1/favorite-sets", json={"set_id": "base1"})
+            body = c.get("/api/v1/favorite-sets").json()
+            self.assertEqual(len(body["sets"]), 1)
+
+    def test_pin_rejects_blank_set_id(self) -> None:
+        with self._client() as c:
+            self.assertEqual(c.post("/api/v1/favorite-sets", json={"set_id": ""}).status_code, 422)
+
+    def test_unpin_removes_only_that_set(self) -> None:
+        with self._client() as c:
+            c.post("/api/v1/favorite-sets", json={"set_id": "base1"})
+            c.post("/api/v1/favorite-sets", json={"set_id": "sv4pt5"})
+            self.assertEqual(c.delete("/api/v1/favorite-sets/base1").status_code, 204)
+            remaining = [s["set_id"] for s in c.get("/api/v1/favorite-sets").json()["sets"]]
+            self.assertEqual(remaining, ["sv4pt5"])
+
+    def test_unpin_unpinned_is_a_noop(self) -> None:
+        with self._client() as c:
+            self.assertEqual(c.delete("/api/v1/favorite-sets/never-pinned").status_code, 204)
+
+
+class FavoriteSetSuggestionTests(_IsolatedDbMixin):
+    def _own(self, c: TestClient, cards: list[dict]) -> None:
+        cid = c.post("/api/v1/collections", json={"name": "Owned"}).json()["id"]
+        for card in cards:
+            c.post(f"/api/v1/collections/{cid}/items", json={"card": card})
+
+    def test_suggestions_rank_sets_by_owned_count(self) -> None:
+        with self._client() as c:
+            self._own(c, [CHARIZARD, BLASTOISE, MEW_EX])  # base1: 2, sv4pt5: 1
+            body = c.get("/api/v1/favorite-sets/suggestions").json()["suggestions"]
+            self.assertEqual(
+                [(s["set_id"], s["owned_count"]) for s in body],
+                [("base1", 2), ("sv4pt5", 1)],
+            )
+
+    def test_suggestions_drop_already_pinned_sets(self) -> None:
+        with self._client() as c:
+            self._own(c, [CHARIZARD, BLASTOISE, MEW_EX])
+            c.post("/api/v1/favorite-sets", json={"set_id": "base1"})
+            body = c.get("/api/v1/favorite-sets/suggestions").json()["suggestions"]
+            self.assertEqual([s["set_id"] for s in body], ["sv4pt5"])
+
+    def test_suggestions_empty_without_a_collection(self) -> None:
+        with self._client() as c:
+            self.assertEqual(
+                c.get("/api/v1/favorite-sets/suggestions").json(),
+                {"suggestions": []},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -872,6 +872,55 @@ export async function deleteBinder(binderId: number): Promise<void> {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Favorite sets (#712) — durable per-user pinned sets for personalization.
+// ---------------------------------------------------------------------------
+
+export interface FavoriteSet {
+  set_id: string
+  pinned_at: string
+}
+
+/** A set the user might want to pin, with the owned-card count behind it. */
+export interface FavoriteSetSuggestion {
+  set_id: string
+  owned_count: number
+}
+
+export async function fetchFavoriteSets(): Promise<FavoriteSet[]> {
+  const res = await fetch(`${BASE}/favorite-sets`)
+  if (!res.ok) throw new Error(`favorite sets failed: ${res.status}`)
+  const data = await res.json()
+  return data.sets as FavoriteSet[]
+}
+
+export async function pinFavoriteSet(setId: string): Promise<void> {
+  const res = await fetch(`${BASE}/favorite-sets`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ set_id: setId }),
+  })
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`pin favorite set failed: ${res.status}`)
+  }
+}
+
+export async function unpinFavoriteSet(setId: string): Promise<void> {
+  const res = await fetch(`${BASE}/favorite-sets/${encodeURIComponent(setId)}`, {
+    method: 'DELETE',
+  })
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`unpin favorite set failed: ${res.status}`)
+  }
+}
+
+export async function fetchFavoriteSetSuggestions(): Promise<FavoriteSetSuggestion[]> {
+  const res = await fetch(`${BASE}/favorite-sets/suggestions`)
+  if (!res.ok) throw new Error(`favorite set suggestions failed: ${res.status}`)
+  const data = await res.json()
+  return data.suggestions as FavoriteSetSuggestion[]
+}
+
 /**
  * Download the printable collection ID card PDF (#507) — the cover cutout for
  * the top-left binder pocket (title, a representative card photo, owned/total).

--- a/web/src/components/FavoriteSetsPanel.test.tsx
+++ b/web/src/components/FavoriteSetsPanel.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  act,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react'
+import {
+  fetchFavoriteSets,
+  fetchFavoriteSetSuggestions,
+  pinFavoriteSet,
+  unpinFavoriteSet,
+} from '../api/client'
+import { FavoriteSetsPanel } from './FavoriteSetsPanel'
+import { _resetFavoriteSetsCacheForTests } from './useFavoriteSets'
+import {
+  useSwipeProfile,
+  _resetSwipeProfileForTests,
+} from './useSwipeProfile'
+import type { SetCard } from '../types'
+
+vi.mock('../api/client', () => ({
+  fetchFavoriteSets: vi.fn(),
+  fetchFavoriteSetSuggestions: vi.fn(),
+  pinFavoriteSet: vi.fn(),
+  unpinFavoriteSet: vi.fn(),
+}))
+
+const mockFetch = vi.mocked(fetchFavoriteSets)
+const mockSuggestions = vi.mocked(fetchFavoriteSetSuggestions)
+const mockPin = vi.mocked(pinFavoriteSet)
+const mockUnpin = vi.mocked(unpinFavoriteSet)
+
+function card(setId: string): SetCard {
+  return {
+    id: `${setId}-1`,
+    name: 'Card',
+    number: '1',
+    rarity: 'Rare Holo',
+    supertype: 'Pokémon',
+    subtypes: ['Basic'],
+    thumb: null,
+    market: 1,
+  }
+}
+
+describe('FavoriteSetsPanel', () => {
+  beforeEach(() => {
+    _resetFavoriteSetsCacheForTests()
+    _resetSwipeProfileForTests()
+    mockFetch.mockReset().mockResolvedValue([])
+    mockSuggestions.mockReset().mockResolvedValue([])
+    mockPin.mockReset().mockResolvedValue(undefined)
+    mockUnpin.mockReset().mockResolvedValue(undefined)
+  })
+
+  it('renders nothing when there is nothing pinned and nothing to suggest', async () => {
+    const { container } = render(<FavoriteSetsPanel />)
+    await waitFor(() => expect(mockSuggestions).toHaveBeenCalled())
+    expect(container.querySelector('section')).toBeNull()
+  })
+
+  it('suggests an owned set with a reason and pins it on click', async () => {
+    mockSuggestions.mockResolvedValue([{ set_id: 'base1', owned_count: 5 }])
+    render(<FavoriteSetsPanel />)
+
+    const suggestion = await screen.findByText('Base')
+    expect(suggestion.parentElement).toHaveTextContent('5 owned')
+
+    fireEvent.click(screen.getByRole('button', { name: /pin base/i }))
+    await waitFor(() => expect(mockPin).toHaveBeenCalledWith('base1'))
+    // Optimistically becomes a pinned chip with an unpin control.
+    await screen.findByRole('button', { name: /unpin base/i })
+  })
+
+  it('merges the swipe lean into suggestions with a "loved in swipe" reason', async () => {
+    // Seed a positive swipe lean on a set the server didn't surface.
+    const { result } = renderHook(() => useSwipeProfile())
+    act(() => {
+      result.current.act(card('neo1'), 'neo1', 'love') // neo1 = +2
+    })
+
+    render(<FavoriteSetsPanel />)
+    const neo = await screen.findByText('Neo Genesis')
+    expect(neo.parentElement).toHaveTextContent('loved in swipe')
+  })
+
+  it('lists pinned sets and unpins on click', async () => {
+    mockFetch.mockResolvedValue([
+      { set_id: 'base1', pinned_at: '2026-06-20T00:00:00Z' },
+    ])
+    render(<FavoriteSetsPanel />)
+
+    const region = await screen.findByRole('region', { name: /favorite sets/i })
+    expect(within(region).getByText('Base')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /unpin base/i }))
+    await waitFor(() => expect(mockUnpin).toHaveBeenCalledWith('base1'))
+  })
+})

--- a/web/src/components/FavoriteSetsPanel.tsx
+++ b/web/src/components/FavoriteSetsPanel.tsx
@@ -1,0 +1,161 @@
+/**
+ * FavoriteSetsPanel — pin favorite sets and get suggestions for which to
+ * pin (#712, part of the personalization epic #701).
+ *
+ * Two halves:
+ *
+ *   - **Pinned** — the durable, server-side favorite-sets list from
+ *     {@link useFavoriteSets}, shown as removable chips. This is the signal
+ *     other surfaces (search defaults, set ID cards, candidate weighting)
+ *     will read.
+ *   - **Suggestions** — sets the user might love, merging two signals: the
+ *     owned-card count the server tallies from their collections, and the
+ *     positive swipe lean in {@link useSwipeProfile}'s `set` counter. Each
+ *     suggestion pins with one click.
+ *
+ * Set ids resolve to friendly names via the baked catalog. The panel hides
+ * itself when there's nothing pinned and nothing to suggest, so a cold
+ * account doesn't carry an empty shell.
+ */
+import { useMemo } from 'react'
+import { Plus, Star, X } from 'lucide-react'
+import { BAKED_SETS } from '../data/sets'
+import { useFavoriteSets } from './useFavoriteSets'
+import { useSwipeProfile } from './useSwipeProfile'
+
+/** set id → friendly name, resolved once from the baked catalog. */
+const SET_NAME = new Map(BAKED_SETS.map((s) => [s.id, s.name]))
+
+function setName(setId: string): string {
+  return SET_NAME.get(setId) ?? setId
+}
+
+/** How many suggestions to surface — enough to act on, short of a long tail. */
+const MAX_SUGGESTIONS = 6
+
+interface Suggestion {
+  setId: string
+  ownedCount: number
+  swipeWeight: number
+}
+
+/** Plain-language reason a set is being suggested. */
+function reason(s: Suggestion): string {
+  const parts: string[] = []
+  if (s.ownedCount > 0) {
+    parts.push(`${s.ownedCount} owned`)
+  }
+  if (s.swipeWeight > 0) {
+    parts.push('loved in swipe')
+  }
+  return parts.join(' · ')
+}
+
+export function FavoriteSetsPanel() {
+  const { favorites, suggestions, pin, unpin } = useFavoriteSets()
+  const { profile } = useSwipeProfile()
+
+  const pinnedIds = useMemo(
+    () => new Set(favorites.map((f) => f.set_id)),
+    [favorites],
+  )
+
+  // Merge the server owned-signal suggestions with the client's positive
+  // swipe lean, drop anything already pinned, and rank by a combined score
+  // (a strong swipe lean counts as much as a couple of owned cards).
+  const merged = useMemo<Suggestion[]>(() => {
+    const byId = new Map<string, Suggestion>()
+    for (const s of suggestions) {
+      if (pinnedIds.has(s.set_id)) continue
+      byId.set(s.set_id, {
+        setId: s.set_id,
+        ownedCount: s.owned_count,
+        swipeWeight: profile.set[s.set_id] ?? 0,
+      })
+    }
+    for (const [setId, weight] of Object.entries(profile.set)) {
+      if (weight <= 0 || pinnedIds.has(setId)) continue
+      const existing = byId.get(setId)
+      if (existing) existing.swipeWeight = weight
+      else byId.set(setId, { setId, ownedCount: 0, swipeWeight: weight })
+    }
+    return [...byId.values()]
+      .sort(
+        (a, b) =>
+          b.ownedCount + b.swipeWeight - (a.ownedCount + a.swipeWeight),
+      )
+      .slice(0, MAX_SUGGESTIONS)
+  }, [suggestions, profile.set, pinnedIds])
+
+  // Nothing pinned and nothing worth suggesting — stay out of the way.
+  if (favorites.length === 0 && merged.length === 0) return null
+
+  return (
+    <section
+      aria-label="Favorite sets"
+      className="flex flex-col gap-3 rounded-lg border border-sand-300 bg-sand-50 px-4 py-3 dark:border-husk-50 dark:bg-husk-100"
+    >
+      <div className="flex items-center gap-1.5">
+        <Star
+          className="h-4 w-4 text-sun-500 dark:text-sun-300"
+          aria-hidden
+        />
+        <h3 className="text-sm font-semibold text-coconut-700 dark:text-sand-50">
+          Favorite sets
+        </h3>
+      </div>
+
+      {favorites.length > 0 && (
+        <ul className="flex flex-wrap gap-2">
+          {favorites.map((f) => (
+            <li key={f.set_id}>
+              <span className="inline-flex items-center gap-1 rounded-full border border-sun-500/40 bg-sun-500/10 py-1 pl-3 pr-1 text-sm text-coconut-700 dark:border-sun-300/40 dark:bg-sun-300/15 dark:text-sand-50">
+                {setName(f.set_id)}
+                <button
+                  type="button"
+                  aria-label={`Unpin ${setName(f.set_id)}`}
+                  onClick={() => void unpin(f.set_id)}
+                  className="rounded-full p-0.5 text-coconut-400 hover:bg-ember-500/15 hover:text-ember-400 dark:text-sand-300 dark:hover:bg-ember-500/25 dark:hover:text-ember-300"
+                >
+                  <X className="h-3.5 w-3.5" aria-hidden />
+                </button>
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {merged.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          <p className="text-xs text-coconut-400 dark:text-sand-300">
+            {favorites.length > 0 ? 'More to pin' : 'You seem to love'}
+          </p>
+          <ul className="flex flex-col gap-1">
+            {merged.map((s) => (
+              <li
+                key={s.setId}
+                className="flex items-center justify-between gap-2 text-sm text-coconut-700 dark:text-sand-50"
+              >
+                <span className="min-w-0 flex-1 truncate">
+                  {setName(s.setId)}
+                  <span className="ml-2 text-xs text-coconut-400 dark:text-sand-300">
+                    {reason(s)}
+                  </span>
+                </span>
+                <button
+                  type="button"
+                  aria-label={`Pin ${setName(s.setId)}`}
+                  onClick={() => void pin(s.setId)}
+                  className="inline-flex shrink-0 items-center gap-1 rounded-md border border-sand-300 px-2 py-1 text-xs text-coconut-700 hover:border-sun-500 hover:text-sun-600 dark:border-husk-50 dark:text-sand-50 dark:hover:border-sun-300 dark:hover:text-sun-300"
+                >
+                  <Plus className="h-3.5 w-3.5" aria-hidden />
+                  Pin
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/web/src/components/SwipePanel.tsx
+++ b/web/src/components/SwipePanel.tsx
@@ -250,7 +250,12 @@ export function SwipePanel({ active }: SwipePanelProps) {
         }
       />
 
-      <FavoriteSetsPanel />
+      {/* Favorite sets are durable + per-user, so gate the panel on a
+          signed-in user like the other user-scoped Swipe controls — an
+          anonymous mount would otherwise read/write the default user's
+          favorites. The taste profile below is browser-local, so it shows
+          for everyone. */}
+      {showSavedActions && <FavoriteSetsPanel />}
 
       <SwipeProfilePanel />
 

--- a/web/src/components/SwipePanel.tsx
+++ b/web/src/components/SwipePanel.tsx
@@ -32,6 +32,7 @@ import { useAppStore } from '../store'
 import type { RarityFloor, Row, SetCard } from '../types'
 import { browseCardToPayload, browseCardToRow } from './browseCard'
 import { CardDetailModal } from './CardDetailModal'
+import { FavoriteSetsPanel } from './FavoriteSetsPanel'
 import { useCardOwnership } from './useCardOwnership'
 import { OwnershipBadge } from './OwnershipBadge'
 import { SaveCardActions } from './SaveCardActions'
@@ -248,6 +249,8 @@ export function SwipePanel({ active }: SwipePanelProps) {
           updateSettings({ swipeExcludeChasing })
         }
       />
+
+      <FavoriteSetsPanel />
 
       <SwipeProfilePanel />
 

--- a/web/src/components/useFavoriteSets.test.ts
+++ b/web/src/components/useFavoriteSets.test.ts
@@ -55,16 +55,19 @@ describe('useFavoriteSets', () => {
     expect(mockPin).toHaveBeenCalledWith('neo1')
   })
 
-  it('rolls back a pin when the request fails', async () => {
+  it('rolls back a pin — and restores the suggestion — when the request fails', async () => {
+    mockSuggestions.mockResolvedValue([{ set_id: 'base1', owned_count: 3 }])
     mockPin.mockRejectedValue(new Error('boom'))
     const { result } = renderHook(() => useFavoriteSets())
-    await waitFor(() => expect(result.current.loading).toBe(false))
+    await waitFor(() => expect(result.current.suggestions.length).toBe(1))
 
     await act(async () => {
       await result.current.pin('base1')
     })
     expect(result.current.isPinned('base1')).toBe(false)
     expect(result.current.error).toBe('boom')
+    // The set returns to the suggestion list so the user can retry.
+    expect(result.current.suggestions.some((s) => s.set_id === 'base1')).toBe(true)
   })
 
   it('unpins a set', async () => {

--- a/web/src/components/useFavoriteSets.test.ts
+++ b/web/src/components/useFavoriteSets.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import {
+  fetchFavoriteSets,
+  fetchFavoriteSetSuggestions,
+  pinFavoriteSet,
+  unpinFavoriteSet,
+} from '../api/client'
+import {
+  useFavoriteSets,
+  _resetFavoriteSetsCacheForTests,
+} from './useFavoriteSets'
+
+vi.mock('../api/client', () => ({
+  fetchFavoriteSets: vi.fn(),
+  fetchFavoriteSetSuggestions: vi.fn(),
+  pinFavoriteSet: vi.fn(),
+  unpinFavoriteSet: vi.fn(),
+}))
+
+const mockFetch = vi.mocked(fetchFavoriteSets)
+const mockSuggestions = vi.mocked(fetchFavoriteSetSuggestions)
+const mockPin = vi.mocked(pinFavoriteSet)
+const mockUnpin = vi.mocked(unpinFavoriteSet)
+
+describe('useFavoriteSets', () => {
+  beforeEach(() => {
+    _resetFavoriteSetsCacheForTests()
+    mockFetch.mockReset().mockResolvedValue([])
+    mockSuggestions.mockReset().mockResolvedValue([])
+    mockPin.mockReset().mockResolvedValue(undefined)
+    mockUnpin.mockReset().mockResolvedValue(undefined)
+  })
+
+  it('loads pins and suggestions on mount', async () => {
+    mockFetch.mockResolvedValue([{ set_id: 'base1', pinned_at: '2026-06-20T00:00:00Z' }])
+    mockSuggestions.mockResolvedValue([{ set_id: 'sv4pt5', owned_count: 9 }])
+    const { result } = renderHook(() => useFavoriteSets())
+    await waitFor(() => expect(result.current.favorites.length).toBe(1))
+    expect(result.current.favorites[0].set_id).toBe('base1')
+    expect(result.current.suggestions[0]).toEqual({ set_id: 'sv4pt5', owned_count: 9 })
+    expect(result.current.isPinned('base1')).toBe(true)
+  })
+
+  it('pins optimistically and drops the set from suggestions', async () => {
+    mockSuggestions.mockResolvedValue([{ set_id: 'neo1', owned_count: 4 }])
+    const { result } = renderHook(() => useFavoriteSets())
+    await waitFor(() => expect(result.current.suggestions.length).toBe(1))
+
+    await act(async () => {
+      await result.current.pin('neo1')
+    })
+    expect(result.current.isPinned('neo1')).toBe(true)
+    expect(result.current.suggestions.some((s) => s.set_id === 'neo1')).toBe(false)
+    expect(mockPin).toHaveBeenCalledWith('neo1')
+  })
+
+  it('rolls back a pin when the request fails', async () => {
+    mockPin.mockRejectedValue(new Error('boom'))
+    const { result } = renderHook(() => useFavoriteSets())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await act(async () => {
+      await result.current.pin('base1')
+    })
+    expect(result.current.isPinned('base1')).toBe(false)
+    expect(result.current.error).toBe('boom')
+  })
+
+  it('unpins a set', async () => {
+    mockFetch.mockResolvedValue([{ set_id: 'base1', pinned_at: '2026-06-20T00:00:00Z' }])
+    const { result } = renderHook(() => useFavoriteSets())
+    await waitFor(() => expect(result.current.favorites.length).toBe(1))
+
+    await act(async () => {
+      await result.current.unpin('base1')
+    })
+    expect(result.current.isPinned('base1')).toBe(false)
+    expect(mockUnpin).toHaveBeenCalledWith('base1')
+  })
+})

--- a/web/src/components/useFavoriteSets.ts
+++ b/web/src/components/useFavoriteSets.ts
@@ -1,0 +1,126 @@
+/**
+ * useFavoriteSets — shared fetcher + cache for the `/api/v1/favorite-sets`
+ * pinned-set list and its owned-signal suggestions (#712, epic #701).
+ *
+ * Favorite sets are the durable, server-side half of the swipe taste
+ * profile: an explicit "I love this set" the user curates, kept in the DB
+ * so other surfaces can read it across devices.
+ *
+ * Mirrors the module-level-store pattern in `useBinders` so a pin in one
+ * surface lights up every consumer without a refetch. Pins and unpins are
+ * optimistic; suggestions drop a set the moment it's pinned.
+ */
+import { useCallback, useEffect, useState } from 'react'
+import {
+  fetchFavoriteSets,
+  fetchFavoriteSetSuggestions,
+  pinFavoriteSet,
+  unpinFavoriteSet,
+  type FavoriteSet,
+  type FavoriteSetSuggestion,
+} from '../api/client'
+
+interface State {
+  favorites: FavoriteSet[]
+  suggestions: FavoriteSetSuggestion[]
+  loading: boolean
+  error: string | null
+}
+
+const listeners = new Set<(s: State) => void>()
+let state: State = {
+  favorites: [],
+  suggestions: [],
+  loading: false,
+  error: null,
+}
+let inflight: Promise<void> | null = null
+
+function set(next: Partial<State>) {
+  state = { ...state, ...next }
+  for (const fn of listeners) fn(state)
+}
+
+async function refresh(): Promise<void> {
+  if (inflight) return inflight
+  set({ loading: true, error: null })
+  inflight = (async () => {
+    try {
+      const [favorites, suggestions] = await Promise.all([
+        fetchFavoriteSets(),
+        fetchFavoriteSetSuggestions(),
+      ])
+      set({ favorites, suggestions, loading: false })
+    } catch (e) {
+      set({ loading: false, error: e instanceof Error ? e.message : String(e) })
+    } finally {
+      inflight = null
+    }
+  })()
+  return inflight
+}
+
+export function useFavoriteSets() {
+  const [snapshot, setSnapshot] = useState<State>(state)
+
+  useEffect(() => {
+    listeners.add(setSnapshot)
+    if (
+      state.favorites.length === 0 &&
+      state.suggestions.length === 0 &&
+      !state.loading
+    ) {
+      void refresh()
+    }
+    return () => {
+      listeners.delete(setSnapshot)
+    }
+  }, [])
+
+  const pin = useCallback(async (setId: string) => {
+    if (state.favorites.some((f) => f.set_id === setId)) return
+    // Optimistic: add the pin and drop it from the suggestion list.
+    set({
+      favorites: [
+        { set_id: setId, pinned_at: new Date().toISOString() },
+        ...state.favorites,
+      ],
+      suggestions: state.suggestions.filter((s) => s.set_id !== setId),
+    })
+    try {
+      await pinFavoriteSet(setId)
+    } catch (e) {
+      set({
+        favorites: state.favorites.filter((f) => f.set_id !== setId),
+        error: e instanceof Error ? e.message : String(e),
+      })
+    }
+  }, [])
+
+  const unpin = useCallback(async (setId: string) => {
+    const previous = state.favorites
+    set({ favorites: state.favorites.filter((f) => f.set_id !== setId) })
+    try {
+      await unpinFavoriteSet(setId)
+    } catch (e) {
+      set({
+        favorites: previous,
+        error: e instanceof Error ? e.message : String(e),
+      })
+    }
+  }, [])
+
+  const isPinned = useCallback(
+    (setId: string) => snapshot.favorites.some((f) => f.set_id === setId),
+    [snapshot.favorites],
+  )
+
+  return { ...snapshot, refresh, pin, unpin, isPinned }
+}
+
+// Test-only: reset the module-level cache between vitest runs.
+export function _resetFavoriteSetsCacheForTests() {
+  state = { favorites: [], suggestions: [], loading: false, error: null }
+  inflight = null
+  listeners.clear()
+}

--- a/web/src/components/useFavoriteSets.ts
+++ b/web/src/components/useFavoriteSets.ts
@@ -79,7 +79,12 @@ export function useFavoriteSets() {
 
   const pin = useCallback(async (setId: string) => {
     if (state.favorites.some((f) => f.set_id === setId)) return
-    // Optimistic: add the pin and drop it from the suggestion list.
+    // Optimistic: add the pin and drop it from the suggestion list. Keep
+    // both snapshots so a failed request restores the suggestion too —
+    // otherwise a transient error would strand the set, pinned nowhere and
+    // no longer suggested.
+    const previousFavorites = state.favorites
+    const previousSuggestions = state.suggestions
     set({
       favorites: [
         { set_id: setId, pinned_at: new Date().toISOString() },
@@ -91,7 +96,8 @@ export function useFavoriteSets() {
       await pinFavoriteSet(setId)
     } catch (e) {
       set({
-        favorites: state.favorites.filter((f) => f.set_id !== setId),
+        favorites: previousFavorites,
+        suggestions: previousSuggestions,
         error: e instanceof Error ? e.message : String(e),
       })
     }


### PR DESCRIPTION
Closes #712

## What

The durable, server-side half of the swipe personalization surface (epic #701). A **favorite set** is an explicit "I love this set" the user curates — distinct from the localStorage swipe taste profile — kept in the DB so it survives a device change and other surfaces can read it.

**Backend**
- `FavoriteSet` ORM model + migration `c8b4e1f6a2d7` — a per-user `(user_id, set_id)` table mirroring the `swipe_seen` pattern (unique constraint makes re-pinning a no-op; leading-`user_id` index). Up/down round-trip tested.
- `/api/v1/favorite-sets` route: `GET` list, `POST` pin (idempotent), `DELETE /{set_id}` unpin, and `GET /suggestions` — owned `collection_items` tallied per set, ranked, with already-pinned sets dropped. Registered in `main.py`.

**Frontend**
- `useFavoriteSets` module-store hook (mirrors `useBinders`) with optimistic pin/unpin.
- `FavoriteSetsPanel` in Swipe: pinned sets as removable chips, plus a "you seem to love" list that **merges two signals** — the server's owned-card count and the client's positive swipe `set` lean — each pinnable in one click. Set ids resolve to friendly names from the baked catalog.

## Design decisions (the two the issue flagged for review)

- **Persistence:** a new `favorite_sets` table (server-side), not an extension of the localStorage profile — so search defaults / set ID cards / candidate weighting can all read it. Chose the obvious `swipe_seen`-shaped model.
- **Suggestions = owned + swipe:** the server returns the owned-card tally; the SPA folds its swipe lean in client-side and ranks by the combined score (an explicit strong lean can out-rank a couple of owned cards). Pinned sets are excluded.

## Scope

**Foundation only**, per the agreed cut. Deliberate follow-ups, not in this PR:
- Biasing swipe candidate selection by pins → **#713**.
- Threading pins into **search defaults** and **set ID cards** → follow-up issues.
- Pinning an arbitrary set via a picker (today you pin from suggestions / unpin chips).

## How to verify

1. `make check` (977 Python tests incl. 10 new in `tests/test_favorite_sets_api.py` — migration round-trip, CRUD, idempotent pin, unpin no-op, suggestion ranking + pinned-exclusion) and `cd web && npm run build`. Web suite adds 8 tests (`useFavoriteSets` 4, `FavoriteSetsPanel` 4).
2. Run the API + web, open **Swipe**: a "Favorite sets" panel shows your pinned sets and a "you seem to love" list. Pinning a suggestion moves it to a chip and persists (`GET /api/v1/favorite-sets`); the set drops from suggestions.

## Screenshot

Verified end-to-end against the running API — "Base" pinned, suggestions merging `loved in swipe` (Neo Genesis, Paldean Fates) and `N owned` (Obsidian Flames, Scarlet & Violet, Jungle):

<!-- "Favorite sets" panel on the Swipe tab — drag the image here -->