### PR TITLE
feat(web): weight swipe candidates by the learned taste profile

### DIFF
--- a/web/src/components/SwipePanel.tsx
+++ b/web/src/components/SwipePanel.tsx
@@ -33,6 +33,7 @@ import type { RarityFloor, Row, SetCard } from '../types'
 import { browseCardToPayload, browseCardToRow } from './browseCard'
 import { CardDetailModal } from './CardDetailModal'
 import { FavoriteSetsPanel } from './FavoriteSetsPanel'
+import { useFavoriteSets } from './useFavoriteSets'
 import { useCardOwnership } from './useCardOwnership'
 import { OwnershipBadge } from './OwnershipBadge'
 import { SaveCardActions } from './SaveCardActions'
@@ -57,6 +58,10 @@ const CLICK_SLOP = 6
  *  appears — casual swipers aren't pestered before they have a haul worth
  *  turning into a wishlist. */
 const PREP_LIST_NUDGE_THRESHOLD = 3
+/** Profile-score bonus a pinned favorite set adds to its walk weight (#713).
+ *  Sized so an explicit pin outweighs an accreted lean and lands a set near
+ *  the multiplier cap, without zeroing out the rest of the catalog. */
+const FAVORITE_SET_BONUS = 12
 
 interface Drag {
   startX: number
@@ -72,8 +77,25 @@ interface SwipePanelProps {
 }
 
 export function SwipePanel({ active }: SwipePanelProps) {
-  const { profile, seenSet, act, clearSaved, reset } = useSwipeProfile()
+  const { profile, seenSet, act, clearSaved, reset, scoreCard } =
+    useSwipeProfile()
   const { settings, updateSettings } = useAppStore()
+  const { user } = useAuth()
+  const showSavedActions = user !== null
+  // Favorite sets feed the candidate weighting; gate the fetch on a signed-in
+  // user (they're per-user) so a signed-out deck isn't biased by — and doesn't
+  // hit the endpoint as — the default user.
+  const { isPinned } = useFavoriteSets({ enabled: showSavedActions })
+
+  // Profile-weighted candidate selection (#713). `setScore` biases which set
+  // is walked next — the learned per-set lean plus a strong bonus for pinned
+  // favorites; `cardScore` biases the card within it via the full taste
+  // profile. Both fall back to a flat 0 (the unbiased walk) before any signal.
+  const setScore = useCallback(
+    (setId: string) =>
+      (profile.set[setId] ?? 0) + (isPinned(setId) ? FAVORITE_SET_BONUS : 0),
+    [profile.set, isPinned],
+  )
   const { excludedKeys, recordSeen, resetDeck } = useSwipeExclusions({
     excludeOwned: settings.swipeExcludeOwned,
     excludeChasing: settings.swipeExcludeChasing,
@@ -84,9 +106,9 @@ export function SwipePanel({ active }: SwipePanelProps) {
       seenSet,
       excludedKeys,
       rarityFloor: settings.swipeRarityFloor,
+      setScore,
+      cardScore: scoreCard,
     })
-  const { user } = useAuth()
-  const showSavedActions = user !== null
 
   // Cross-collection ownership badge (#576). Prefetch the current card plus
   // the peeks beneath it so the badge is ready as each rises to the top.

--- a/web/src/components/useFavoriteSets.ts
+++ b/web/src/components/useFavoriteSets.ts
@@ -60,12 +60,19 @@ async function refresh(): Promise<void> {
   return inflight
 }
 
-export function useFavoriteSets() {
+/**
+ * @param enabled When false, skip the auto-fetch on mount — favorite sets
+ *   are per-user, so a signed-out consumer (e.g. the candidate-weighting in
+ *   `SwipePanel`) reads an empty list instead of hitting the endpoint as the
+ *   default user. Defaults to true.
+ */
+export function useFavoriteSets({ enabled = true }: { enabled?: boolean } = {}) {
   const [snapshot, setSnapshot] = useState<State>(state)
 
   useEffect(() => {
     listeners.add(setSnapshot)
     if (
+      enabled &&
       state.favorites.length === 0 &&
       state.suggestions.length === 0 &&
       !state.loading
@@ -75,7 +82,7 @@ export function useFavoriteSets() {
     return () => {
       listeners.delete(setSnapshot)
     }
-  }, [])
+  }, [enabled])
 
   const pin = useCallback(async (setId: string) => {
     if (state.favorites.some((f) => f.set_id === setId)) return

--- a/web/src/components/useSwipeCandidates.test.ts
+++ b/web/src/components/useSwipeCandidates.test.ts
@@ -5,6 +5,8 @@ import {
   DEFAULT_WEIGHT,
   rarityWeight,
   weightedSample,
+  weightedShuffle,
+  profileMultiplier,
   rarityTier,
   chaseTierForSet,
   isEligible,
@@ -77,6 +79,44 @@ describe('weightedSample', () => {
     // picks index 0, rng→1 picks the last index.
     expect(weightedSample([0, 0, 0], () => 0)).toBe(0)
     expect(weightedSample([0, 0, 0], () => 0.99)).toBe(2)
+  })
+})
+
+describe('profileMultiplier (#713)', () => {
+  it('is neutral (1×) at score 0', () => {
+    expect(profileMultiplier(0)).toBe(1)
+  })
+
+  it('grows with a positive lean but is capped', () => {
+    expect(profileMultiplier(2)).toBeCloseTo(1.3)
+    expect(profileMultiplier(1000)).toBe(4) // PROFILE_MULT_MAX
+  })
+
+  it('shrinks with a negative lean but never reaches zero', () => {
+    expect(profileMultiplier(-2)).toBeCloseTo(0.7)
+    expect(profileMultiplier(-1000)).toBe(0.25) // PROFILE_MULT_MIN floor
+  })
+})
+
+describe('weightedShuffle (#713)', () => {
+  it('keeps every item — output is a permutation of the input', () => {
+    const items = ['a', 'b', 'c', 'd']
+    const out = weightedShuffle(items, [1, 5, 2, 9], Math.random)
+    expect(out.length).toBe(items.length)
+    expect(new Set(out)).toEqual(new Set(items))
+  })
+
+  it('degrades to input order under rng=0 with equal weights', () => {
+    expect(weightedShuffle(['a', 'b', 'c'], [1, 1, 1], () => 0)).toEqual([
+      'a',
+      'b',
+      'c',
+    ])
+  })
+
+  it('floats a heavily-weighted item toward the front', () => {
+    // rng=0.5 over weights [1, 100] lands in the high-weight bucket first.
+    expect(weightedShuffle(['a', 'b'], [1, 100], () => 0.5)).toEqual(['b', 'a'])
   })
 })
 
@@ -246,6 +286,80 @@ describe('useSwipeCandidates — prefetched stack', () => {
     act(() => result.current.advance())
     await waitFor(() => expect(result.current.exhausted).toBe(true))
     expect(result.current.current).toBeNull()
+  })
+})
+
+describe('useSwipeCandidates — profile weighting (#713)', () => {
+  const TWO_SETS = [
+    { id: 'sv1', name: 'Set One', series: 'SV', total: 1, releaseDate: '2023/03/31' },
+    { id: 'sv2', name: 'Set Two', series: 'SV', total: 1, releaseDate: '2023/06/30' },
+  ]
+
+  beforeEach(() => {
+    mockFetchSets.mockReset()
+    mockFetchSetCards.mockReset()
+    mockFetchSets.mockResolvedValue(TWO_SETS)
+    mockFetchSetCards.mockImplementation(async (setId: string) =>
+      setId === 'sv1' ? [card('a1', 'Rare Holo')] : [card('b1', 'Rare Holo')],
+    )
+  })
+
+  it('walks a leaned-toward set first via setScore', async () => {
+    // sv2 is strongly favoured; under rng=0.5 the weighted shuffle puts it
+    // ahead of sv1, so its card tops the stack.
+    const seenSet = new Set<string>()
+    const { result } = renderHook(() =>
+      useSwipeCandidates({
+        active: true,
+        seenSet,
+        rng: () => 0.5,
+        setScore: (id) => (id === 'sv2' ? 1000 : 0),
+      }),
+    )
+    await waitFor(() => expect(result.current.current).not.toBeNull())
+    expect(result.current.current!.setId).toBe('sv2')
+    expect(result.current.current!.card.id).toBe('b1')
+  })
+
+  it('favours a leaned-toward card within a set via cardScore', async () => {
+    // One set, two equal-rarity cards; cardScore lifts 'y' so it's sampled
+    // ahead of 'x' despite identical rarity weights.
+    mockFetchSets.mockResolvedValue([TWO_SETS[0]])
+    mockFetchSetCards.mockResolvedValue([
+      card('x', 'Rare Holo'),
+      card('y', 'Rare Holo'),
+    ])
+    const seenSet = new Set<string>()
+    const { result } = renderHook(() =>
+      useSwipeCandidates({
+        active: true,
+        seenSet,
+        rng: () => 0.5,
+        cardScore: (c) => (c.id === 'y' ? 1000 : 0),
+      }),
+    )
+    await waitFor(() => expect(result.current.current).not.toBeNull())
+    expect(result.current.current!.card.id).toBe('y')
+  })
+
+  it('still reaches a downweighted set (exploration preserved)', async () => {
+    // sv1 is heavily downweighted but not excluded; walking the deck still
+    // surfaces its card alongside sv2's.
+    const seenSet = new Set<string>()
+    const { result } = renderHook(() =>
+      useSwipeCandidates({
+        active: true,
+        seenSet,
+        rng: () => 0.5,
+        setScore: (id) => (id === 'sv1' ? -1000 : 0),
+      }),
+    )
+    await waitFor(() => expect(result.current.upcoming.length).toBe(1))
+    const setIds = [
+      result.current.current!.setId,
+      ...result.current.upcoming.map((c) => c.setId),
+    ]
+    expect(new Set(setIds)).toEqual(new Set(['sv1', 'sv2']))
   })
 })
 

--- a/web/src/components/useSwipeCandidates.ts
+++ b/web/src/components/useSwipeCandidates.ts
@@ -21,11 +21,15 @@
  * background; because the next card is already fetched there's no loader
  * flash between swipes.
  *
- * The taste profile (rarity / set / supertype counters) tracked by
- * `useSwipeProfile` is intentionally *not* fed back into selection
- * here — it's saved for the prep-list output. The user wanted simple
- * rarity-weighted random across the whole catalog, not a recency-
- * or profile-shaped walk.
+ * Profile weighting ([#713](https://github.com/mgzwarrior/mgz-pkmn/issues/713)):
+ * the learned taste profile now *softly* biases the walk via two optional,
+ * injected scorers — `setScore(setId)` shapes which set is walked next, and
+ * `cardScore(card, setId)` shapes which card within it. Each score is mapped
+ * to a bounded multiplier ({@link profileMultiplier}) so a lean nudges the
+ * odds without ever zeroing a set out — exploration is preserved and a
+ * disliked set still surfaces occasionally. With no scorers passed (the
+ * default) the walk is the original uniform-set / rarity-weighted-card
+ * sample, so the hook stays usable without a profile.
  *
  * The hook returns `{ current, upcoming, advance, loading, exhausted,
  * error }`. The consumer calls `advance()` after each swipe; profile
@@ -85,6 +89,17 @@ interface UseSwipeCandidatesOpts {
    * (defaults to `Math.random`); tests inject a deterministic source.
    */
   rng?: () => number
+  /**
+   * Profile lean for a whole set — biases which set is walked next (#713).
+   * Higher favours the set; negative downweights it. Pinned favorite sets
+   * and the swipe `set` counter feed this. Defaults to a flat `0` (no bias).
+   */
+  setScore?: (setId: string) => number
+  /**
+   * Profile lean for a single card within its set — biases which card is
+   * sampled (#713). Fed by `useSwipeProfile.scoreCard`. Defaults to `0`.
+   */
+  cardScore?: (card: SetCard, setId: string) => number
 }
 
 /**
@@ -221,12 +236,43 @@ function isEligible(
   return rarityTier(rarity) >= setMaxTier
 }
 
-/** In-place-free Fisher–Yates shuffle driven by the injected rng. */
-function shuffled<T>(items: T[], rng: () => number): T[] {
-  const out = items.slice()
-  for (let i = out.length - 1; i > 0; i--) {
-    const j = Math.floor(rng() * (i + 1))
-    ;[out[i], out[j]] = [out[j], out[i]]
+/**
+ * Map a profile score (any sign) to a bounded sampling multiplier (#713).
+ * A score of 0 is neutral (1×); positive leans favour, negative downweight.
+ * Clamped to `[PROFILE_MULT_MIN, PROFILE_MULT_MAX]` so a strong lean only
+ * ever *nudges* the odds — the floor keeps a disliked set/card reachable
+ * (exploration), the ceiling stops a loved one from collapsing the feed.
+ */
+const PROFILE_SENSITIVITY = 0.15
+const PROFILE_MULT_MIN = 0.25
+const PROFILE_MULT_MAX = 4
+
+function profileMultiplier(score: number): number {
+  return Math.min(
+    PROFILE_MULT_MAX,
+    Math.max(PROFILE_MULT_MIN, 1 + score * PROFILE_SENSITIVITY),
+  )
+}
+
+/**
+ * Weighted shuffle — a random permutation where higher-weight items tend
+ * to come first (weighted sampling without replacement). With equal
+ * weights it degrades to a uniform shuffle. Non-positive weights still
+ * participate (they just sort toward the back), so no item is dropped.
+ */
+function weightedShuffle<T>(
+  items: T[],
+  weights: number[],
+  rng: () => number,
+): T[] {
+  const remainingItems = items.slice()
+  const remainingWeights = weights.slice()
+  const out: T[] = []
+  while (remainingItems.length > 0) {
+    const k = weightedSample(remainingWeights, rng)
+    out.push(remainingItems[k])
+    remainingItems.splice(k, 1)
+    remainingWeights.splice(k, 1)
   }
   return out
 }
@@ -247,6 +293,10 @@ function weightedSample(weights: number[], rng: () => number): number {
 }
 
 const EMPTY_KEYS: Set<string> = new Set()
+/** Default scorers — a flat 0 lean, i.e. the original unbiased walk. The
+ *  args are unused, so they're elided (still assignable to the scorer types). */
+const ZERO_SCORE = (): number => 0
+const ZERO_CARD_SCORE = (): number => 0
 
 export function useSwipeCandidates(opts: UseSwipeCandidatesOpts) {
   const {
@@ -255,6 +305,8 @@ export function useSwipeCandidates(opts: UseSwipeCandidatesOpts) {
     excludedKeys = EMPTY_KEYS,
     rarityFloor = 'chase',
     rng = Math.random,
+    setScore = ZERO_SCORE,
+    cardScore = ZERO_CARD_SCORE,
   } = opts
   // Read the live exclusion set at sample time (like `rngRef`) so an
   // incremental `recordSeen` is honored on the next pick without churning
@@ -271,6 +323,15 @@ export function useSwipeCandidates(opts: UseSwipeCandidatesOpts) {
   const rngRef = useRef(rng)
   useEffect(() => {
     rngRef.current = rng
+  })
+  // Profile scorers (#713) behind refs for the same reason — the consumer
+  // passes fresh closures each render as the profile updates, but we read
+  // them at sample time so `sampleOne` / `fill` identities stay stable.
+  const setScoreRef = useRef(setScore)
+  const cardScoreRef = useRef(cardScore)
+  useEffect(() => {
+    setScoreRef.current = setScore
+    cardScoreRef.current = cardScore
   })
 
   const [state, setState] = useState<State>({
@@ -332,8 +393,15 @@ export function useSwipeCandidates(opts: UseSwipeCandidatesOpts) {
     async (exclude: Set<string>, floor: RarityFloor): Promise<SampleResult> => {
       if (allSets.length === 0) return { kind: 'exhausted' }
 
-      const available = shuffled(
-        allSets.filter((s) => !exhaustedSetsRef.current.has(s.id)),
+      // Walk the un-retired sets in a *profile-weighted* random order so a
+      // leaned-toward (or pinned) set tends to be tried first, while every
+      // set stays reachable. Equal scores ⇒ a plain uniform shuffle.
+      const candidates = allSets.filter(
+        (s) => !exhaustedSetsRef.current.has(s.id),
+      )
+      const available = weightedShuffle(
+        candidates,
+        candidates.map((s) => profileMultiplier(setScoreRef.current(s.id))),
         rngRef.current,
       )
 
@@ -374,7 +442,14 @@ export function useSwipeCandidates(opts: UseSwipeCandidatesOpts) {
         // exclusion off — or a lower floor — brings the set back).
         if (eligible.length === 0) continue
 
-        const weights = eligible.map((c) => rarityWeight(c.rarity))
+        // Rarity weight (the chase-card bias) scaled by the card's profile
+        // lean (#713) — favours the rarities / types the user leans toward
+        // without overriding the rarity floor or the chase-reel feel.
+        const weights = eligible.map(
+          (c) =>
+            rarityWeight(c.rarity) *
+            profileMultiplier(cardScoreRef.current(c, set.id)),
+        )
         const idx = weightedSample(weights, rngRef.current)
         return {
           kind: 'card',
@@ -516,6 +591,8 @@ export {
   DEFAULT_WEIGHT,
   rarityWeight,
   weightedSample,
+  weightedShuffle,
+  profileMultiplier,
   rarityTier,
   chaseTierForSet,
   isEligible,


### PR DESCRIPTION
Closes #713

## What

Feeds the taste profile back into candidate selection so the swipe deck **favours the sets, types, and rarities a user leans toward** instead of sampling uniformly — the "smarter candidate selection" piece of the personalization epic (#701).

[`useSwipeCandidates`](web/src/components/useSwipeCandidates.ts) gains two optional, injected scorers (same pattern as the existing `rng`):

- **`setScore(setId)`** biases *which set is walked next* via a **profile-weighted shuffle** over the catalog (replacing the uniform shuffle). Fed by the per-set lean plus a strong bonus for pinned favorite sets (#712).
- **`cardScore(card, setId)`** biases *which card within a set* by scaling the existing rarity weight. Fed by `useSwipeProfile.scoreCard`.

Both scores pass through a **bounded multiplier** (`profileMultiplier`, clamped to `[0.25×, 4×]`) so a lean only nudges the odds: a disliked set still surfaces (exploration preserved) and a loved one never collapses the feed to a single set. The rarity floor and `swipe_seen` exclusion are untouched.

## Backward compatible

With no scorers passed, `setScore`/`cardScore` default to a flat `0` → multiplier `1` → the original uniform-set / rarity-weighted-card walk. Every existing `useSwipeCandidates` test passes unchanged.

## Notes

- Favorite-set reads are gated on a signed-in user (added an `enabled` flag to `useFavoriteSets`), so a signed-out deck isn't biased by — and doesn't fetch — the default user's pins, consistent with #716.
- Pinned sets get a fixed `FAVORITE_SET_BONUS` that lands them near the multiplier cap, so an explicit pin outweighs an accreted lean.

## How to verify

1. `cd web && npm run build` + full vitest (484) green. `useSwipeCandidates` adds 9 tests: `profileMultiplier` bounds, `weightedShuffle` (permutation / order / weight bias), and three integration tests — a leaned set walked first, a leaned card sampled first, and a downweighted set still reachable.
2. In the app, swipe a set repeatedly (or pin a favorite): the deck starts surfacing that set / its rarities more often, while other sets still appear.