### PR TITLE
feat(web): delete a saved search (run)

### DIFF
--- a/api/routes/runs.py
+++ b/api/routes/runs.py
@@ -17,6 +17,8 @@ Endpoints:
 - `PATCH /runs/{id}` — save / rename a run. Sets ``name`` and stores the
   current ResultsTable view state (sort + filters) so a future
   click-to-load can restore the exact view.
+- `DELETE /runs/{id}` — delete a run (and its rows). Owner-only; prunes a
+  saved search the user no longer wants (#698).
 """
 
 from __future__ import annotations
@@ -219,3 +221,18 @@ def save_run(run_id: int, req: SaveRunRequest, db: DbSession, current_user: Curr
         name=run.name,
         view_state=run.view_state,
     ).model_dump()
+
+
+@router.delete("/runs/{run_id}", status_code=204)
+def delete_run(run_id: int, db: DbSession, current_user: CurrentUser) -> None:
+    """Delete a run and its rows. Owner-only — a missing or not-owned id 404s.
+
+    Hard delete, matching the collections / wishlists routes: the run row and
+    its cascaded ``run_rows`` are removed outright (no soft-delete column).
+    Unlike ``GET`` / ``PATCH`` there's no anonymous-unnamed carve-out — you
+    only delete saved searches, which are named and already yours."""
+    run = db.scalar(select(Run).where(Run.id == run_id))
+    if run is None or run.user_id != current_user.id:
+        raise HTTPException(status_code=404, detail=f"run {run_id} not found")
+    db.delete(run)
+    db.commit()

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -317,6 +317,36 @@ class SavedSearchesTests(_IsolatedDbMixin):
             resp = c.patch("/api/v1/runs/99999", json={"name": "ignored"})
             self.assertEqual(resp.status_code, 404)
 
+    def test_delete_removes_a_saved_run_and_its_rows(self) -> None:
+        from api.main import app
+
+        with TestClient(app) as c:
+            run_id = self._seed_run(name="Show prep, June")
+            self.assertEqual(c.get("/api/v1/runs").json()["total"], 1)
+
+            self.assertEqual(c.delete(f"/api/v1/runs/{run_id}").status_code, 204)
+
+            # Gone from the list and individually 404s after delete.
+            self.assertEqual(c.get("/api/v1/runs").json()["total"], 0)
+            self.assertEqual(c.get(f"/api/v1/runs/{run_id}").status_code, 404)
+
+    def test_delete_404s_on_missing_id(self) -> None:
+        from api.main import app
+
+        with TestClient(app) as c:
+            self.assertEqual(c.delete("/api/v1/runs/99999").status_code, 404)
+
+    def test_delete_404s_on_another_users_run(self) -> None:
+        from api.main import app
+
+        with TestClient(app) as c:
+            # A run owned by a different user must not be deletable; it 404s
+            # and survives.
+            other_id = self._seed_run(user_id=999, name="Not yours")
+            self.assertEqual(c.delete(f"/api/v1/runs/{other_id}").status_code, 404)
+            with session_mod.get_session_factory()() as s:
+                self.assertIsNotNone(s.get(Run, other_id))
+
 
 class SavedSearchesAuthGateTests(_IsolatedDbMixin):
     """Hosted-demo auth-on saved searches are scoped to the session user.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -419,6 +419,14 @@ export async function saveRun(
   return (await res.json()) as RunSummary
 }
 
+/** Delete a saved search (run) and its rows (#698). Owner-only server-side. */
+export async function deleteRun(runId: number): Promise<void> {
+  const res = await fetch(`${BASE}/runs/${runId}`, { method: 'DELETE' })
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`delete run ${runId} failed: ${res.status}`)
+  }
+}
+
 // ---------------------------------------------------------------------------
 // cache
 // ---------------------------------------------------------------------------

--- a/web/src/components/LibrarySearchesTab.test.tsx
+++ b/web/src/components/LibrarySearchesTab.test.tsx
@@ -225,4 +225,67 @@ describe('LibrarySearchesTab', () => {
     render(<LibrarySearchesTab />)
     expect(await screen.findByRole('alert')).toHaveTextContent('boom')
   })
+
+  it('deletes a saved search after a two-step confirm and optimistically removes it', async () => {
+    vi.spyOn(client, 'listRuns').mockResolvedValue({
+      items: [makeRun(1, { name: 'Keep me' }), makeRun(2, { name: 'Trash me' })],
+      total: 2,
+    })
+    const deleteSpy = vi.spyOn(client, 'deleteRun').mockResolvedValue(undefined)
+    render(<LibrarySearchesTab />)
+    await waitFor(() => expect(useAppStore.getState().runs).toHaveLength(2))
+
+    // First click reveals confirm rather than deleting.
+    fireEvent.click(screen.getByRole('button', { name: /Delete saved search Trash me/i }))
+    expect(deleteSpy).not.toHaveBeenCalled()
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /Confirm delete saved search Trash me/i }),
+    )
+    await waitFor(() => expect(deleteSpy).toHaveBeenCalledWith(2))
+    await waitFor(() => expect(useAppStore.getState().runs.map((r) => r.id)).toEqual([1]))
+    expect(screen.queryByText('Trash me')).not.toBeInTheDocument()
+  })
+
+  it('cancelling the confirm leaves the saved search in place', async () => {
+    vi.spyOn(client, 'listRuns').mockResolvedValue({ items: [makeRun(1, { name: 'Keep me' })], total: 1 })
+    const deleteSpy = vi.spyOn(client, 'deleteRun').mockResolvedValue(undefined)
+    render(<LibrarySearchesTab />)
+    await waitFor(() => expect(useAppStore.getState().runs).toHaveLength(1))
+
+    fireEvent.click(screen.getByRole('button', { name: /Delete saved search Keep me/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Cancel delete/i }))
+
+    expect(deleteSpy).not.toHaveBeenCalled()
+    expect(screen.getByText('Keep me')).toBeInTheDocument()
+  })
+
+  it('restores the row and surfaces an error when delete fails', async () => {
+    vi.spyOn(client, 'listRuns').mockResolvedValue({ items: [makeRun(3, { name: 'Oops' })], total: 1 })
+    vi.spyOn(client, 'deleteRun').mockRejectedValue(new Error('nope'))
+    render(<LibrarySearchesTab />)
+    await waitFor(() => expect(useAppStore.getState().runs).toHaveLength(1))
+
+    fireEvent.click(screen.getByRole('button', { name: /Delete saved search Oops/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Confirm delete saved search Oops/i }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('nope')
+    // Rolled back — the run is still listed.
+    await waitFor(() => expect(useAppStore.getState().runs.map((r) => r.id)).toEqual([3]))
+  })
+
+  it('clears currentRunId when the deleted run was loaded', async () => {
+    vi.spyOn(client, 'listRuns').mockResolvedValue({ items: [makeRun(5, { name: 'Active' })], total: 1 })
+    vi.spyOn(client, 'deleteRun').mockResolvedValue(undefined)
+    render(<LibrarySearchesTab />)
+    await waitFor(() => expect(useAppStore.getState().runs).toHaveLength(1))
+    act(() => {
+      useAppStore.setState({ currentRunId: 5 })
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /Delete saved search Active/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Confirm delete saved search Active/i }))
+
+    await waitFor(() => expect(useAppStore.getState().currentRunId).toBeNull())
+  })
 })

--- a/web/src/components/LibrarySearchesTab.tsx
+++ b/web/src/components/LibrarySearchesTab.tsx
@@ -9,7 +9,8 @@
  * recent *inputs* stored client-side for one-tap re-runs.
  */
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { getRun, listRuns } from '../api/client'
+import { Check, Trash2, X } from 'lucide-react'
+import { deleteRun, getRun, listRuns } from '../api/client'
 import { useAuth } from '../hooks/useAuth'
 import { EMPTY_VIEW_STATE, useAppStore } from '../store'
 import { formatMoney, formatRelativeTime } from '../utils/format'
@@ -55,6 +56,7 @@ export function LibrarySearchesTab() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [loadingRunId, setLoadingRunId] = useState<number | null>(null)
+  const [deletingRunId, setDeletingRunId] = useState<number | null>(null)
   // Synchronous guard against rapid-fire concurrent loads — see
   // SavedSearchesSidebar history; a ref updates synchronously where a
   // useState value would be stale across consecutive native click events
@@ -138,6 +140,30 @@ export function LibrarySearchesTab() {
     ],
   )
 
+  // Optimistic delete: drop the row immediately, restore it (and surface the
+  // error) if the request fails. Mirrors the collection / wishlist list
+  // mutation pattern. `setRuns` is a wholesale replace, so we snapshot and
+  // restore the full list.
+  const handleDelete = useCallback(
+    async (run: RunSummary) => {
+      if (deletingRunId !== null) return
+      const previous = runs
+      setDeletingRunId(run.id)
+      setError(null)
+      setRuns(runs.filter((r) => r.id !== run.id))
+      if (run.id === currentRunId) setCurrentRunId(null)
+      try {
+        await deleteRun(run.id)
+      } catch (err) {
+        setRuns(previous)
+        setError(err instanceof Error ? err.message : `Failed to delete run ${run.id}`)
+      } finally {
+        setDeletingRunId(null)
+      }
+    },
+    [deletingRunId, runs, currentRunId, setRuns, setCurrentRunId],
+  )
+
   if (auth.loading) {
     return <p className="text-xs text-coconut-400 dark:text-sand-400">Loading...</p>
   }
@@ -177,7 +203,9 @@ export function LibrarySearchesTab() {
               run={run}
               isCurrent={run.id === currentRunId}
               disabled={isRunning || loadingRunId !== null}
+              deleting={deletingRunId === run.id}
               onLoad={() => handleLoad(run)}
+              onDelete={() => handleDelete(run)}
             />
           ))}
         </ul>
@@ -190,13 +218,21 @@ function SavedSearchRow({
   run,
   isCurrent,
   disabled,
+  deleting,
   onLoad,
+  onDelete,
 }: {
   run: RunSummary
   isCurrent: boolean
   disabled: boolean
+  deleting: boolean
   onLoad: () => void
+  onDelete: () => void
 }) {
+  // Two-step inline confirm — a saved search can be real iterative work, so
+  // the trash icon flips to confirm/cancel rather than deleting on first
+  // click. Mirrors the BinderInventory delete affordance.
+  const [confirming, setConfirming] = useState(false)
   const total = summaryTotal(run)
   const createdAt = Date.parse(run.created_at)
   const tagEntries = Object.entries(run.summary.tag_counts ?? {})
@@ -214,24 +250,60 @@ function SavedSearchRow({
           : 'border-transparent hover:border-sand-300 dark:hover:border-husk-50 hover:bg-sand-200 dark:hover:bg-husk-100/60'
       }`}
     >
-      <button
-        type="button"
-        onClick={onLoad}
-        disabled={disabled}
-        aria-label={`Load saved search ${label}: ${summaryLabel}`}
-        aria-current={isCurrent ? 'true' : undefined}
-        className="flex w-full flex-col items-start gap-0.5 text-left text-xs disabled:cursor-not-allowed disabled:opacity-50"
-      >
-        <span className="w-full truncate font-medium text-coconut-700 dark:text-sand-100">
-          {label}
-        </span>
-        <span className="flex w-full items-baseline justify-between gap-2 font-mono text-[11px]">
-          <span className="tabular-nums text-coconut-400 dark:text-sand-300">
-            {formatRelativeTime(createdAt)}
+      <div className="flex items-start gap-1">
+        <button
+          type="button"
+          onClick={onLoad}
+          disabled={disabled}
+          aria-label={`Load saved search ${label}: ${summaryLabel}`}
+          aria-current={isCurrent ? 'true' : undefined}
+          className="flex min-w-0 flex-1 flex-col items-start gap-0.5 text-left text-xs disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <span className="w-full truncate font-medium text-coconut-700 dark:text-sand-100">
+            {label}
           </span>
-          <span className="truncate text-coconut-500 dark:text-sand-300">{summaryLabel}</span>
-        </span>
-      </button>
+          <span className="flex w-full items-baseline justify-between gap-2 font-mono text-[11px]">
+            <span className="tabular-nums text-coconut-400 dark:text-sand-300">
+              {formatRelativeTime(createdAt)}
+            </span>
+            <span className="truncate text-coconut-500 dark:text-sand-300">{summaryLabel}</span>
+          </span>
+        </button>
+        {confirming ? (
+          <span className="flex shrink-0 items-center gap-0.5">
+            <button
+              type="button"
+              onClick={() => {
+                setConfirming(false)
+                onDelete()
+              }}
+              disabled={deleting}
+              aria-label={`Confirm delete saved search ${label}`}
+              className="rounded p-1 text-sun-600 hover:bg-sun-50 disabled:opacity-50 dark:text-sun-300 dark:hover:bg-husk-100"
+            >
+              <Check size={13} />
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirming(false)}
+              aria-label="Cancel delete"
+              className="rounded p-1 text-coconut-400 hover:bg-sand-200 dark:text-sand-300 dark:hover:bg-husk-100"
+            >
+              <X size={13} />
+            </button>
+          </span>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setConfirming(true)}
+            disabled={deleting}
+            aria-label={`Delete saved search ${label}`}
+            className="shrink-0 rounded p-1 text-coconut-400 hover:text-sun-600 disabled:opacity-50 dark:text-sand-300 dark:hover:text-sun-300"
+          >
+            <Trash2 size={13} />
+          </button>
+        )}
+      </div>
       {tagEntries.length > 0 && (
         <div className="flex flex-wrap gap-1">
           {tagEntries.map(([tag, count]) => (


### PR DESCRIPTION
Closes #698

## What

Adds the missing **delete** verb to the saved-search (runs) surface — the list could be created, listed, viewed, and renamed, but only ever grew.

**API**
- `DELETE /api/v1/runs/{run_id}` in [`api/routes/runs.py`](api/routes/runs.py): a **hard delete** (cascades `run_rows`), **owner-only** with a `404` for a missing or not-owned id. Matches the collections / wishlists delete routes (no soft-delete column); no anonymous-unnamed carve-out since you only delete saved searches, which are named and already yours.

**Web**
- `deleteRun` client function.
- A trash affordance on each row in [`LibrarySearchesTab`](web/src/components/LibrarySearchesTab.tsx) with a **two-step inline confirm** (a saved search can represent real iterative work), mirroring the `BinderInventory` delete. The row is removed **optimistically** and **rolled back** with a surfaced error on failure; deleting the currently-loaded run clears the selection.

## How to verify

1. `make check` (981 Python tests incl. 3 new: delete removes a run + its rows and 404s after; delete 404s on a missing id; delete 404s on — and preserves — another user's run) and `cd web && npm run build`. Web suite adds 5 `LibrarySearchesTab` tests (two-step confirm, optimistic remove, cancel, rollback-on-error, clears `currentRunId`).
2. In the app: save a search, open the **Searches** tab, click the trash → confirm. The row disappears and `GET /api/v1/runs` no longer returns it; a reload confirms it's gone.

## Screenshots

Searches tab with the trash affordance, and the two-step confirm (✓ / ✕) on a row — verified end-to-end against the running API (the deleted run is gone from both the UI and `GET /runs`).

<!-- drag the two screenshots here -->