### PR TITLE
feat(web): cover-color picker on the Add binder form

### DIFF
--- a/web/src/components/BinderColorPicker.tsx
+++ b/web/src/components/BinderColorPicker.tsx
@@ -1,0 +1,74 @@
+/**
+ * BinderColorPicker — the cover-color swatch row shared by the binder
+ * create/edit surfaces: preset color tokens (#681) plus a native custom-hex
+ * picker styled as a swatch. Clicking the active preset clears it (back to
+ * no color). Extracted from BinderModal so the "Add binder" inventory form
+ * and the smart-binder modal share one control.
+ */
+import {
+  BINDER_COLOR_OPTIONS,
+  SWATCH_BG,
+} from './binderIdentity'
+
+//: Seed value for the native color picker before a hex is chosen — a neutral
+//: gray, not a brand color, so it stays clear of the no-hex theme rule.
+const CUSTOM_COLOR_SEED = '#8a8a8a'
+
+interface Props {
+  /** Current color: a preset token stem, a ``#rrggbb`` hex, or null. */
+  value: string | null
+  onChange: (color: string | null) => void
+  /** Optional label above the swatches. Hidden when omitted. */
+  label?: string
+}
+
+export function BinderColorPicker({ value, onChange, label }: Props) {
+  const customActive = Boolean(value?.startsWith('#'))
+  return (
+    <div className="space-y-1.5">
+      {label && (
+        <span className="text-[11px] font-medium uppercase tracking-wide text-coconut-400 dark:text-sand-300">
+          {label}
+        </span>
+      )}
+      <div className="flex flex-wrap items-center gap-2">
+        {BINDER_COLOR_OPTIONS.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            aria-label={opt.label}
+            aria-pressed={value === opt.value}
+            title={opt.label}
+            onClick={() => onChange(value === opt.value ? null : opt.value)}
+            className={`h-7 w-7 rounded-full ${SWATCH_BG[opt.value]} ring-offset-1 ring-offset-sand-50 transition dark:ring-offset-husk-200 ${
+              value === opt.value
+                ? 'ring-2 ring-coconut-600 dark:ring-sand-50'
+                : 'ring-1 ring-sand-300 dark:ring-husk-100'
+            }`}
+          />
+        ))}
+        {/* Custom hex — a native color input styled as a swatch. */}
+        <label
+          title="Custom color"
+          className={`relative h-7 w-7 cursor-pointer overflow-hidden rounded-full ring-offset-1 ring-offset-sand-50 transition dark:ring-offset-husk-200 ${
+            customActive
+              ? 'ring-2 ring-coconut-600 dark:ring-sand-50'
+              : 'ring-1 ring-sand-300 dark:ring-husk-100'
+          }`}
+          style={customActive && value ? { backgroundColor: value } : undefined}
+        >
+          {!customActive && (
+            <span className="absolute inset-0 bg-[conic-gradient(red,orange,yellow,lime,aqua,blue,magenta,red)] opacity-70" />
+          )}
+          <input
+            type="color"
+            aria-label="Custom cover color"
+            value={customActive && value ? value : CUSTOM_COLOR_SEED}
+            onChange={(e) => onChange(e.target.value)}
+            className="absolute inset-0 cursor-pointer opacity-0"
+          />
+        </label>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/BinderInventory.test.tsx
+++ b/web/src/components/BinderInventory.test.tsx
@@ -137,6 +137,27 @@ describe('BinderInventory', () => {
     expect(await screen.findByText('Jungle')).toBeInTheDocument()
   })
 
+  it('creates a binder with the chosen cover color', async () => {
+    mockFetch.mockResolvedValue([])
+    mockCreate.mockResolvedValue(
+      binder({ id: 5, name: 'Sun binder', capacity: null, binder_format: null, binder_color: 'sun' }) as never,
+    )
+    render(<BinderInventory />)
+    await screen.findByText(/Add an empty binder/i)
+
+    fireEvent.click(screen.getByRole('button', { name: /Add binder/i }))
+    fireEvent.change(screen.getByLabelText(/Binder name/i), { target: { value: 'Sun binder' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Sun' }))
+    fireEvent.click(screen.getByRole('button', { name: /^Add$/i }))
+
+    await waitFor(() =>
+      expect(mockCreate).toHaveBeenCalledWith(
+        'Sun binder',
+        expect.objectContaining({ binder_color: 'sun' }),
+      ),
+    )
+  })
+
   it('deletes a binder after confirmation', async () => {
     mockFetch.mockResolvedValue([binder({ id: 9, name: 'Old binder' })] as never)
     mockDelete.mockResolvedValue(undefined)

--- a/web/src/components/BinderInventory.tsx
+++ b/web/src/components/BinderInventory.tsx
@@ -14,6 +14,7 @@ import { Check, FolderPlus, Library, Loader2, Plus, Trash2, X } from 'lucide-rea
 import { useMemo, useState } from 'react'
 import type { BinderFormat, BinderSummary, CollectionSummary } from '../api/client'
 import { BINDER_FORMAT_OPTIONS, coverSwatch } from './binderIdentity'
+import { BinderColorPicker } from './BinderColorPicker'
 import { NameCreateDialog } from './NameCreateDialog'
 import { useBinders } from './useBinders'
 import { useCollections } from './useCollections'
@@ -26,6 +27,7 @@ export function BinderInventory() {
   const [name, setName] = useState('')
   const [format, setFormat] = useState<BinderFormat | ''>('')
   const [capacity, setCapacity] = useState('')
+  const [color, setColor] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [confirmingId, setConfirmingId] = useState<number | null>(null)
@@ -49,6 +51,7 @@ export function BinderInventory() {
     setName('')
     setFormat('')
     setCapacity('')
+    setColor(null)
     setSubmitError(null)
   }
 
@@ -61,6 +64,7 @@ export function BinderInventory() {
       const cap = capacity.trim() ? Number(capacity) : null
       await create(trimmed, {
         binder_format: format || null,
+        binder_color: color,
         capacity: cap && cap > 0 ? cap : null,
       })
       resetForm()
@@ -120,6 +124,7 @@ export function BinderInventory() {
             aria-label="Binder name"
             className="w-full rounded border border-sand-300 bg-sand-50 px-2 py-1 text-xs text-coconut-700 placeholder:text-coconut-300 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:border-coconut-500 dark:bg-husk-100 dark:text-sand-50 dark:placeholder:text-sand-500 dark:focus:ring-sun-300"
           />
+          <BinderColorPicker value={color} onChange={setColor} label="Cover color" />
           <div className="flex items-center gap-1">
             <select
               value={format}

--- a/web/src/components/BinderModal.tsx
+++ b/web/src/components/BinderModal.tsx
@@ -27,12 +27,8 @@ import type {
   CollectionSummary,
   DynamicScope,
 } from '../api/client'
-import {
-  BINDER_COLOR_OPTIONS,
-  BINDER_FORMAT_OPTIONS,
-  BINDER_TYPE_OPTIONS,
-  SWATCH_BG,
-} from './binderIdentity'
+import { BINDER_FORMAT_OPTIONS, BINDER_TYPE_OPTIONS } from './binderIdentity'
+import { BinderColorPicker } from './BinderColorPicker'
 import { SetCombobox } from './SetCombobox'
 import { useCollections } from './useCollections'
 
@@ -65,10 +61,6 @@ type BinderMode = 'binder' | 'smart'
 
 //: Cardrake's master-set guide — credited source for the explainer (#681).
 const CARDRAKE_MASTER_SET_URL = 'https://www.cardrake.com/guides/master-set'
-
-//: Seed value for the native color picker before a hex is chosen — a neutral
-//: gray, not a brand color, so it stays clear of the no-hex theme rule.
-const CUSTOM_COLOR_SEED = '#8a8a8a'
 
 function buildRule(field: RuleField, value: string): CollectionRule {
   const v = value.trim()
@@ -198,7 +190,6 @@ export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }:
 
   const inputClass =
     'w-full rounded border border-sand-300 bg-coconut-50 px-2.5 py-1.5 text-sm text-coconut-700 placeholder:text-coconut-400 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:border-husk-100 dark:bg-husk-100 dark:text-sand-50 dark:focus:ring-sun-300'
-  const customActive = Boolean(color?.startsWith('#'))
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
@@ -261,49 +252,7 @@ export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }:
             </label>
 
             {/* Cover color — shared identity, presets + a custom hex picker. */}
-            <div className="space-y-1.5">
-              <span className="text-[11px] font-medium uppercase tracking-wide text-coconut-400 dark:text-sand-300">
-                Cover color
-              </span>
-              <div className="flex flex-wrap items-center gap-2">
-                {BINDER_COLOR_OPTIONS.map((opt) => (
-                  <button
-                    key={opt.value}
-                    type="button"
-                    aria-label={opt.label}
-                    aria-pressed={color === opt.value}
-                    title={opt.label}
-                    onClick={() => setColor(color === opt.value ? null : opt.value)}
-                    className={`h-7 w-7 rounded-full ${SWATCH_BG[opt.value]} ring-offset-1 ring-offset-sand-50 transition dark:ring-offset-husk-200 ${
-                      color === opt.value
-                        ? 'ring-2 ring-coconut-600 dark:ring-sand-50'
-                        : 'ring-1 ring-sand-300 dark:ring-husk-100'
-                    }`}
-                  />
-                ))}
-                {/* Custom hex — a native color input styled as a swatch. */}
-                <label
-                  title="Custom color"
-                  className={`relative h-7 w-7 cursor-pointer overflow-hidden rounded-full ring-offset-1 ring-offset-sand-50 transition dark:ring-offset-husk-200 ${
-                    customActive
-                      ? 'ring-2 ring-coconut-600 dark:ring-sand-50'
-                      : 'ring-1 ring-sand-300 dark:ring-husk-100'
-                  }`}
-                  style={customActive && color ? { backgroundColor: color } : undefined}
-                >
-                  {!customActive && (
-                    <span className="absolute inset-0 bg-[conic-gradient(red,orange,yellow,lime,aqua,blue,magenta,red)] opacity-70" />
-                  )}
-                  <input
-                    type="color"
-                    aria-label="Custom cover color"
-                    value={customActive && color ? color : CUSTOM_COLOR_SEED}
-                    onChange={(e) => setColor(e.target.value)}
-                    className="absolute inset-0 cursor-pointer opacity-0"
-                  />
-                </label>
-              </div>
-            </div>
+            <BinderColorPicker value={color} onChange={setColor} label="Cover color" />
 
             {editingRule && (
               <div className="space-y-3">


### PR DESCRIPTION
Closes #720

## What

Adds the cover-color picker to the **"Add binder"** inventory form, so a physical binder gets its cover color at create time instead of landing colorless and needing an edit. Extracts the swatch row (preset tokens + custom hex, #681) out of `BinderModal` into a shared **`BinderColorPicker`** used by both surfaces — no duplicated JSX.

- New `BinderColorPicker` component (presets + native custom-hex swatch; clicking the active preset clears it).
- `BinderModal` now renders it instead of the inline block.
- `BinderInventory`'s Add-binder form gains a "Cover color" row and sends `binder_color` on create.

## How to verify

1. `cd web && npm run build` + full vitest (495) green. `BinderInventory` adds a test that a chosen color is sent on create; `BinderModal`'s existing color tests pass against the shared component.
2. Binders tab → **Add binder**: a "Cover color" swatch row sits under the name. Pick a color, add the binder — it lands with that cover swatch, no extra edit. Verified end-to-end (all 7 presets render with selection state).

## Screenshot

<!-- Add binder form with the cover-color row — drag the image here -->