### PR TITLE
Refine create flow: drop binder-modal cover color, file new collections into binders

### DIFF
--- a/web/src/components/BinderModal.test.tsx
+++ b/web/src/components/BinderModal.test.tsx
@@ -27,7 +27,7 @@ describe('BinderModal', () => {
     mockFetch.mockResolvedValue([])
   })
 
-  it('creates a binder with cover color, format, and capacity', async () => {
+  it('creates a binder with format and capacity (no cover color — that lives on the binder unit)', async () => {
     mockCreate.mockResolvedValue({
       id: 5,
       name: 'Trade binder',
@@ -35,7 +35,6 @@ describe('BinderModal', () => {
       created_at: '2026-06-15T00:00:00',
       items: [],
       kind: 'binder',
-      binder_color: 'sky',
       binder_format: '9-pocket',
       binder_type: 'toploader',
       capacity: 360,
@@ -45,8 +44,8 @@ describe('BinderModal', () => {
     fireEvent.change(screen.getByPlaceholderText('Trade binder'), {
       target: { value: 'Trade binder' },
     })
-    // Default cover color is palm; switch to sky.
-    fireEvent.click(screen.getByRole('button', { name: 'Sky' }))
+    // The cover-color picker no longer lives here (#723).
+    expect(screen.queryByRole('button', { name: 'Sky' })).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /more details/i }))
     fireEvent.change(screen.getByPlaceholderText('360'), { target: { value: '360' } })
     fireEvent.change(screen.getByRole('combobox', { name: /storage type/i }), {
@@ -61,16 +60,18 @@ describe('BinderModal', () => {
       expect(mockCreate).toHaveBeenCalledWith('Trade binder', {
         kind: 'binder',
         binder_format: '9-pocket',
-        binder_color: 'sky',
         binder_type: 'toploader',
         capacity: 360,
         source_set_id: null,
         is_master_set: false,
       }),
     )
+    // Cover color isn't part of the create payload anymore.
+    const [, opts] = mockCreate.mock.calls[0]
+    expect(opts).not.toHaveProperty('binder_color')
   })
 
-  it('creates a smart binder carrying shared identity but no physical fields', async () => {
+  it('creates a smart binder carrying shared identity but no physical fields or color', async () => {
     mockCreate.mockResolvedValue({
       id: 6,
       name: 'All Eevees',
@@ -79,7 +80,6 @@ describe('BinderModal', () => {
       items: [],
       kind: 'dynamic',
       rule: { name: 'Eevee' },
-      binder_color: 'ember',
     })
     render(<BinderModal open onOpenChange={() => {}} />)
 
@@ -88,15 +88,15 @@ describe('BinderModal', () => {
       target: { value: 'All Eevees' },
     })
     fireEvent.change(screen.getByPlaceholderText('Eevee'), { target: { value: 'Eevee' } })
-    fireEvent.click(screen.getByRole('button', { name: 'Ember' }))
     fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
 
     await waitFor(() => expect(mockCreate).toHaveBeenCalled())
     const [, opts] = mockCreate.mock.calls[0]
-    expect(opts).toMatchObject({ kind: 'dynamic', binder_color: 'ember', dynamic_scope: 'owned' })
-    // A smart binder has no fixed slots — physical fields aren't sent.
+    expect(opts).toMatchObject({ kind: 'dynamic', dynamic_scope: 'owned' })
+    // A smart binder has no fixed slots and no cover color.
     expect(opts).not.toHaveProperty('binder_format')
     expect(opts).not.toHaveProperty('capacity')
+    expect(opts).not.toHaveProperty('binder_color')
   })
 
   it('lets you save identity edits to an existing smart binder without a rule', async () => {
@@ -110,23 +110,24 @@ describe('BinderModal', () => {
       source_set_id: null,
       rule: { name: 'eevee' },
       dynamic_scope: 'owned',
-      binder_color: 'palm',
     }
-    mockUpdate.mockResolvedValue({ ...smart, items: [], binder_color: 'sky' } as never)
+    mockUpdate.mockResolvedValue({ ...smart, items: [] } as never)
     render(<BinderModal open onOpenChange={() => {}} editing={smart} />)
 
     // Save is enabled immediately — no throwaway rule value required.
     const save = screen.getByRole('button', { name: /^save$/i })
     expect(save).not.toBeDisabled()
-    fireEvent.click(screen.getByRole('button', { name: 'Sky' }))
     fireEvent.click(save)
 
     await waitFor(() =>
       expect(mockUpdate).toHaveBeenCalledWith(
         8,
-        expect.objectContaining({ name: 'All Eevees', binder_color: 'sky' }),
+        expect.objectContaining({ name: 'All Eevees' }),
       ),
     )
+    // The edit no longer touches cover color.
+    const [, patch] = mockUpdate.mock.calls[0]
+    expect(patch).not.toHaveProperty('binder_color')
   })
 
   it('prefills and PATCHes an existing binder', async () => {
@@ -139,7 +140,6 @@ describe('BinderModal', () => {
       kind: 'binder',
       source_set_id: null,
       rule: null,
-      binder_color: 'palm',
       binder_format: '9-pocket',
       capacity: 180,
       is_master_set: false,
@@ -147,19 +147,20 @@ describe('BinderModal', () => {
     mockUpdate.mockResolvedValue({
       ...binder,
       items: [],
-      binder_color: 'ember',
     } as never)
     render(<BinderModal open onOpenChange={() => {}} editing={binder} />)
 
     // Name is prefilled from the binder being edited.
     expect(screen.getByDisplayValue('Show binder')).toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Ember' }))
+    fireEvent.change(screen.getByDisplayValue('Show binder'), {
+      target: { value: 'Show binder 2' },
+    })
     fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
     await waitFor(() =>
       expect(mockUpdate).toHaveBeenCalledWith(
         7,
-        expect.objectContaining({ name: 'Show binder', binder_color: 'ember' }),
+        expect.objectContaining({ name: 'Show binder 2' }),
       ),
     )
   })

--- a/web/src/components/BinderModal.tsx
+++ b/web/src/components/BinderModal.tsx
@@ -4,11 +4,12 @@
  * Everything in the Binders tab is a binder: a **physical binder** (a bucket
  * of cards with a cover, storage style, pocket format, and capacity) or a
  * **smart binder** (a saved rule whose membership is your matching cards).
- * The two share cover/storage-type/master-set identity; pocket format and
- * capacity are physical-only, since a rule-based set has no fixed slots.
+ * The two share storage-type/master-set identity; pocket format and capacity
+ * are physical-only, since a rule-based set has no fixed slots. Cover color
+ * lives on the binder inventory unit (#702), not here (#723).
  *
- * - **Novice path:** name it, pick a cover color, done. The rest is tucked
- *   behind a "More details" disclosure so the simple case stays one decision.
+ * - **Novice path:** name it, done. The rest is tucked behind a "More
+ *   details" disclosure so the simple case stays one decision.
  * - **Vendor path:** open the details to set storage type, pocket format,
  *   capacity, the set it organizes, and a master-set target.
  *
@@ -28,7 +29,6 @@ import type {
   DynamicScope,
 } from '../api/client'
 import { BINDER_FORMAT_OPTIONS, BINDER_TYPE_OPTIONS } from './binderIdentity'
-import { BinderColorPicker } from './BinderColorPicker'
 import { SetCombobox } from './SetCombobox'
 import { useCollections } from './useCollections'
 
@@ -97,9 +97,6 @@ export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }:
     isEdit ? editMode : smartOnly ? 'smart' : 'binder',
   )
   const [name, setName] = useState(() => editing?.name ?? prefill?.name ?? '')
-  const [color, setColor] = useState<string | null>(
-    () => editing?.binder_color ?? (editing ? null : 'palm'),
-  )
   const [binderType, setBinderType] = useState<BinderType | ''>(() => editing?.binder_type ?? '')
   const [format, setFormat] = useState<BinderFormat | ''>(() => editing?.binder_format ?? '')
   const [capacity, setCapacity] = useState(() =>
@@ -144,8 +141,9 @@ export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }:
     setError(null)
     const cap = capacity.trim() ? Number(capacity.trim()) : null
     // Shared identity rides both kinds; physical fields ride binders only.
+    // Cover color is owned by the binder inventory unit (#702), not a
+    // collection/rule, so it isn't set here anymore (#723).
     const shared = {
-      binder_color: color,
       binder_type: binderType || null,
     }
     try {
@@ -210,8 +208,8 @@ export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }:
             </Dialog.Close>
           </header>
           <Dialog.Description className="sr-only">
-            Name your binder, pick a cover color, and optionally set its storage
-            type, pocket format, capacity, and the set it organizes.
+            Name your binder and optionally set its storage type, pocket format,
+            capacity, and the set it organizes.
           </Dialog.Description>
 
           <form onSubmit={handleSubmit} className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
@@ -250,9 +248,6 @@ export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }:
                 className={inputClass}
               />
             </label>
-
-            {/* Cover color — shared identity, presets + a custom hex picker. */}
-            <BinderColorPicker value={color} onChange={setColor} label="Cover color" />
 
             {editingRule && (
               <div className="space-y-3">

--- a/web/src/components/CollectionCreateDialog.test.tsx
+++ b/web/src/components/CollectionCreateDialog.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { CollectionCreateDialog } from './CollectionCreateDialog'
+import { _resetCollectionsCacheForTests } from './useCollections'
+import { _resetBindersCacheForTests } from './useBinders'
+import {
+  fetchCollections,
+  createCollection,
+  fetchBinders,
+  createBinder,
+} from '../api/client'
+
+vi.mock('../api/client', () => ({
+  fetchCollections: vi.fn(),
+  createCollection: vi.fn(),
+  fetchBinders: vi.fn(),
+  createBinder: vi.fn(),
+}))
+
+const mockCollections = vi.mocked(fetchCollections)
+const mockCreate = vi.mocked(createCollection)
+const mockBinders = vi.mocked(fetchBinders)
+const mockCreateBinder = vi.mocked(createBinder)
+
+beforeEach(() => {
+  _resetCollectionsCacheForTests()
+  _resetBindersCacheForTests()
+  mockCollections.mockReset().mockResolvedValue([])
+  mockBinders.mockReset().mockResolvedValue([])
+  mockCreate.mockReset().mockResolvedValue({
+    id: 1,
+    name: 'X',
+    description: null,
+    created_at: '2026-06-21T00:00:00',
+    items: [],
+    kind: 'manual',
+  })
+  mockCreateBinder.mockReset()
+})
+
+describe('CollectionCreateDialog', () => {
+  it('creates a loose collection when no binder is chosen', async () => {
+    render(<CollectionCreateDialog open onOpenChange={() => {}} />)
+    fireEvent.change(screen.getByPlaceholderText('Base Set holos'), {
+      target: { value: 'Trade pile' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+    await waitFor(() => expect(mockCreate).toHaveBeenCalledWith('Trade pile', undefined))
+    expect(mockCreateBinder).not.toHaveBeenCalled()
+  })
+
+  it('files into a chosen binder and shows its free slots', async () => {
+    mockBinders.mockResolvedValue([
+      {
+        id: 3,
+        name: 'Show binder',
+        created_at: '2026-06-01T00:00:00',
+        binder_format: '9-pocket',
+        binder_color: 'sky',
+        binder_type: null,
+        capacity: 360,
+        collection_count: 1,
+        is_empty: false,
+      },
+    ])
+    // One collection already filed into binder 3 occupying 90 slots → 270 free.
+    mockCollections.mockResolvedValue([
+      {
+        id: 9,
+        name: 'Existing',
+        description: null,
+        created_at: '2026-06-02T00:00:00',
+        item_count: 90,
+        kind: 'manual',
+        binder_id: 3,
+      },
+    ])
+
+    render(<CollectionCreateDialog open onOpenChange={() => {}} />)
+    await waitFor(() => expect(screen.getByText('Show binder')).toBeInTheDocument())
+    expect(screen.getByText('270 of 360 slots free')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByPlaceholderText('Base Set holos'), {
+      target: { value: 'Base holos' },
+    })
+    fireEvent.click(screen.getByRole('radio', { name: /show binder/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() => expect(mockCreate).toHaveBeenCalledWith('Base holos', { binder_id: 3 }))
+  })
+
+  it('creates a binder inline when none exist, then files the collection into it', async () => {
+    mockCreateBinder.mockResolvedValue({
+      id: 12,
+      name: 'Slot 1',
+      created_at: '2026-06-21T00:00:00',
+      binder_format: null,
+      binder_color: 'palm',
+      binder_type: null,
+      capacity: 360,
+      collection_count: 0,
+      is_empty: true,
+    } as never)
+
+    render(<CollectionCreateDialog open onOpenChange={() => {}} />)
+    // No binders → the inline binder form is shown.
+    fireEvent.change(screen.getByPlaceholderText('Base Set holos'), {
+      target: { value: 'Base holos' },
+    })
+    fireEvent.change(screen.getByLabelText('New binder name'), {
+      target: { value: 'Slot 1' },
+    })
+    fireEvent.change(screen.getByLabelText('New binder capacity (slots)'), {
+      target: { value: '360' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() =>
+      expect(mockCreateBinder).toHaveBeenCalledWith('Slot 1', {
+        binder_color: null,
+        capacity: 360,
+      }),
+    )
+    await waitFor(() => expect(mockCreate).toHaveBeenCalledWith('Base holos', { binder_id: 12 }))
+  })
+})

--- a/web/src/components/CollectionCreateDialog.test.tsx
+++ b/web/src/components/CollectionCreateDialog.test.tsx
@@ -41,6 +41,8 @@ beforeEach(() => {
 describe('CollectionCreateDialog', () => {
   it('creates a loose collection when no binder is chosen', async () => {
     render(<CollectionCreateDialog open onOpenChange={() => {}} />)
+    // Wait for the binder fetch to settle before deciding "no binders" (#724).
+    await waitFor(() => expect(screen.getByLabelText('New binder name')).toBeInTheDocument())
     fireEvent.change(screen.getByPlaceholderText('Base Set holos'), {
       target: { value: 'Trade pile' },
     })
@@ -103,7 +105,8 @@ describe('CollectionCreateDialog', () => {
     } as never)
 
     render(<CollectionCreateDialog open onOpenChange={() => {}} />)
-    // No binders → the inline binder form is shown.
+    // No binders → the inline binder form is shown once the fetch settles.
+    await waitFor(() => expect(screen.getByLabelText('New binder name')).toBeInTheDocument())
     fireEvent.change(screen.getByPlaceholderText('Base Set holos'), {
       target: { value: 'Base holos' },
     })

--- a/web/src/components/CollectionCreateDialog.tsx
+++ b/web/src/components/CollectionCreateDialog.tsx
@@ -51,7 +51,12 @@ function freeSlots(binder: BinderSummary, usedByBinder: Map<number, number>): nu
 
 function CreateForm({ onClose }: { onClose: () => void }) {
   const { collections, create: createCollection } = useCollections()
-  const { binders, create: createBinder, refresh: refreshBinders } = useBinders()
+  const {
+    binders,
+    loading: bindersLoading,
+    create: createBinder,
+    refresh: refreshBinders,
+  } = useBinders()
 
   const [name, setName] = useState('')
   // Existing-binder target: a binder id, or null for "don't file".
@@ -64,6 +69,12 @@ function CreateForm({ onClose }: { onClose: () => void }) {
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  // Until the binder list resolves, neither branch is safe to show: an empty
+  // `binders` during the in-flight fetch would falsely read as "no binders
+  // yet" and offer the inline-create / loose-collection path even though
+  // existing binders are about to appear (#724 review). Gate on the settled
+  // state instead.
+  const bindersSettled = !bindersLoading
   const hasBinders = binders.length > 0
 
   // Cards already filed into each binder — the sum of its collections' pocket
@@ -77,7 +88,7 @@ function CreateForm({ onClose }: { onClose: () => void }) {
     return map
   }, [collections])
 
-  const canSubmit = name.trim().length > 0 && !submitting
+  const canSubmit = name.trim().length > 0 && !submitting && bindersSettled
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -144,7 +155,12 @@ function CreateForm({ onClose }: { onClose: () => void }) {
           />
         </label>
 
-        {hasBinders ? (
+        {!bindersSettled ? (
+          <div className="flex items-center gap-2 text-[11px] text-coconut-400 dark:text-sand-300">
+            <Loader2 size={12} className="animate-spin" />
+            Loading your binders…
+          </div>
+        ) : hasBinders ? (
           <fieldset className="space-y-1.5">
             <legend className="mb-1 text-[11px] font-medium uppercase tracking-wide text-coconut-400 dark:text-sand-300">
               File into a binder (optional)

--- a/web/src/components/CollectionCreateDialog.tsx
+++ b/web/src/components/CollectionCreateDialog.tsx
@@ -1,0 +1,287 @@
+/**
+ * CollectionCreateDialog — the New ▾ → Collection create flow (#723).
+ *
+ * A plain collection lives inside a physical binder (the inventory unit from
+ * #702), so this dialog connects the two at create time:
+ *
+ * - **Binders exist:** pick one to file the new collection into, each shown
+ *   with its available slots (capacity minus what's already filed; an empty
+ *   binder shows its full capacity). Filing stays optional — "Don't file"
+ *   leaves the collection loose.
+ * - **No binders yet:** create one inline (name + optional cover color and
+ *   capacity) and the collection drops straight into it.
+ *
+ * Both paths go through [useCollections](./useCollections.ts) /
+ * [useBinders](./useBinders.ts) so every surface re-renders without a refetch.
+ */
+import * as Dialog from '@radix-ui/react-dialog'
+import { Library, Loader2, X } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import type { BinderSummary } from '../api/client'
+import { BinderColorPicker } from './BinderColorPicker'
+import { coverSwatch } from './binderIdentity'
+import { useBinders } from './useBinders'
+import { useCollections } from './useCollections'
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+export function CollectionCreateDialog({ open, onOpenChange }: Props) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-coconut-700/50 backdrop-blur-sm dark:bg-husk-500/70" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 flex max-h-[88vh] w-[min(420px,92vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-sand-300 bg-sand-50 shadow-2xl dark:border-husk-50 dark:bg-husk-200">
+        {/* Form state only mounts while open, so each open starts fresh. */}
+        {open && <CreateForm onClose={() => onOpenChange(false)} />}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+/** Slots still free in a binder: capacity minus the cards already filed into
+ *  it. Returns null when the binder has no capacity pinned (no slot limit). */
+function freeSlots(binder: BinderSummary, usedByBinder: Map<number, number>): number | null {
+  if (binder.capacity == null) return null
+  return Math.max(0, binder.capacity - (usedByBinder.get(binder.id) ?? 0))
+}
+
+function CreateForm({ onClose }: { onClose: () => void }) {
+  const { collections, create: createCollection } = useCollections()
+  const { binders, create: createBinder, refresh: refreshBinders } = useBinders()
+
+  const [name, setName] = useState('')
+  // Existing-binder target: a binder id, or null for "don't file".
+  const [binderId, setBinderId] = useState<number | null>(null)
+  // Inline-binder fields (only used when no binders exist yet).
+  const [newBinderName, setNewBinderName] = useState('')
+  const [newBinderColor, setNewBinderColor] = useState<string | null>(null)
+  const [newBinderCapacity, setNewBinderCapacity] = useState('')
+
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const hasBinders = binders.length > 0
+
+  // Cards already filed into each binder — the sum of its collections' pocket
+  // counts (vendor multiples via total_quantity, falling back to row count).
+  const usedByBinder = useMemo(() => {
+    const map = new Map<number, number>()
+    for (const c of collections) {
+      if (c.binder_id == null) continue
+      map.set(c.binder_id, (map.get(c.binder_id) ?? 0) + (c.total_quantity ?? c.item_count))
+    }
+    return map
+  }, [collections])
+
+  const canSubmit = name.trim().length > 0 && !submitting
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!canSubmit) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      // No binders yet + the user named one inline → make the binder first,
+      // then drop the collection straight into it.
+      let target = binderId
+      const inlineName = newBinderName.trim()
+      if (!hasBinders && inlineName) {
+        const cap = newBinderCapacity.trim() ? Number(newBinderCapacity.trim()) : null
+        const binder = await createBinder(inlineName, {
+          binder_color: newBinderColor,
+          capacity: cap && cap > 0 ? cap : null,
+        })
+        target = binder.id
+      }
+      await createCollection(name.trim(), target != null ? { binder_id: target } : undefined)
+      if (target != null) await refreshBinders()
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const inputClass =
+    'w-full rounded border border-sand-300 bg-coconut-50 px-2.5 py-1.5 text-sm text-coconut-700 placeholder:text-coconut-400 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:border-husk-100 dark:bg-husk-100 dark:text-sand-50 dark:focus:ring-sun-300'
+
+  return (
+    <>
+      <header className="flex items-center justify-between gap-3 border-b border-sand-200 px-5 py-4 dark:border-husk-100">
+        <Dialog.Title className="text-lg font-semibold text-coconut-700 dark:text-sand-50">
+          New collection
+        </Dialog.Title>
+        <Dialog.Close asChild>
+          <button
+            aria-label="Close"
+            className="rounded p-1 text-coconut-500 hover:bg-sand-200 dark:text-sand-300 dark:hover:bg-husk-100"
+          >
+            <X size={18} />
+          </button>
+        </Dialog.Close>
+      </header>
+      <Dialog.Description className="sr-only">
+        Name the collection and optionally file it into one of your binders.
+      </Dialog.Description>
+
+      <form onSubmit={handleSubmit} className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
+        <label className="block space-y-1">
+          <span className="text-[11px] font-medium uppercase tracking-wide text-coconut-400 dark:text-sand-300">
+            Name
+          </span>
+          <input
+            autoFocus
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Base Set holos"
+            className={inputClass}
+          />
+        </label>
+
+        {hasBinders ? (
+          <fieldset className="space-y-1.5">
+            <legend className="mb-1 text-[11px] font-medium uppercase tracking-wide text-coconut-400 dark:text-sand-300">
+              File into a binder (optional)
+            </legend>
+            <BinderRadio
+              checked={binderId === null}
+              onSelect={() => setBinderId(null)}
+              label="Don't file"
+              hint="Leave the collection loose."
+            />
+            {binders.map((b) => {
+              const free = freeSlots(b, usedByBinder)
+              const swatch = coverSwatch(b.binder_color)
+              return (
+                <BinderRadio
+                  key={b.id}
+                  checked={binderId === b.id}
+                  onSelect={() => setBinderId(b.id)}
+                  label={b.name}
+                  hint={slotHint(free, b.capacity)}
+                  swatch={swatch}
+                />
+              )
+            })}
+          </fieldset>
+        ) : (
+          <div className="space-y-2 rounded-md border border-sand-200 bg-coconut-50 p-3 dark:border-husk-100 dark:bg-husk-100">
+            <div className="flex items-center gap-1.5 text-[11px] font-medium text-coconut-500 dark:text-sand-200">
+              <Library size={12} aria-hidden />
+              No binders yet — create one to file this into (optional)
+            </div>
+            <input
+              type="text"
+              value={newBinderName}
+              onChange={(e) => setNewBinderName(e.target.value)}
+              placeholder="Binder name, e.g. Slot 1"
+              aria-label="New binder name"
+              className={inputClass}
+            />
+            <BinderColorPicker value={newBinderColor} onChange={setNewBinderColor} label="Cover color" />
+            <label className="block space-y-1">
+              <span className="text-[11px] font-medium text-coconut-500 dark:text-sand-300">
+                Capacity (slots)
+              </span>
+              <input
+                type="number"
+                min={1}
+                value={newBinderCapacity}
+                onChange={(e) => setNewBinderCapacity(e.target.value)}
+                placeholder="360"
+                aria-label="New binder capacity (slots)"
+                className={inputClass}
+              />
+            </label>
+          </div>
+        )}
+
+        {error && (
+          <div role="alert" className="text-[11px] text-sun-600 dark:text-sun-300">
+            {error}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2 border-t border-sand-200 pt-3 dark:border-husk-100">
+          <Dialog.Close asChild>
+            <button
+              type="button"
+              className="rounded px-3 py-1.5 text-xs font-medium text-coconut-500 hover:bg-sand-200 dark:text-sand-300 dark:hover:bg-husk-100"
+            >
+              Cancel
+            </button>
+          </Dialog.Close>
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className="inline-flex items-center gap-1.5 rounded bg-palm-500 px-3.5 py-1.5 text-xs font-medium text-coconut-50 hover:bg-palm-600 disabled:opacity-50 dark:text-husk-300"
+          >
+            {submitting && <Loader2 size={12} className="animate-spin" />}
+            Create
+          </button>
+        </div>
+      </form>
+    </>
+  )
+}
+
+/** The free/capacity hint under a binder option. Empty binders read "Empty",
+ *  capacity-less binders read "No slot limit". */
+function slotHint(free: number | null, capacity: number | null | undefined): string {
+  if (capacity == null) return 'No slot limit'
+  if (free === capacity) return `Empty · ${capacity} slots`
+  return `${free} of ${capacity} slots free`
+}
+
+function BinderRadio({
+  checked,
+  onSelect,
+  label,
+  hint,
+  swatch,
+}: {
+  checked: boolean
+  onSelect: () => void
+  label: string
+  hint: string
+  swatch?: { className: string; style?: { backgroundColor: string } }
+}) {
+  return (
+    <label
+      className={`flex cursor-pointer items-center gap-2 rounded border px-2.5 py-1.5 text-left transition ${
+        checked
+          ? 'border-palm-400 bg-palm-50 dark:border-palm-300 dark:bg-husk-100'
+          : 'border-sand-300 bg-coconut-50 hover:border-sand-400 dark:border-husk-100 dark:bg-husk-100'
+      }`}
+    >
+      <input
+        type="radio"
+        name="collection-binder"
+        checked={checked}
+        onChange={onSelect}
+        className="sr-only"
+      />
+      {swatch ? (
+        <span
+          className={`h-5 w-4 shrink-0 rounded-sm ${swatch.className}`}
+          style={swatch.style}
+          aria-hidden
+        />
+      ) : (
+        <span className="h-5 w-4 shrink-0" aria-hidden />
+      )}
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-xs font-medium text-coconut-700 dark:text-sand-50">
+          {label}
+        </span>
+        <span className="block text-[10px] text-coconut-400 dark:text-sand-300">{hint}</span>
+      </span>
+    </label>
+  )
+}

--- a/web/src/components/LibraryBindersTab.test.tsx
+++ b/web/src/components/LibraryBindersTab.test.tsx
@@ -473,7 +473,9 @@ describe('LibraryBindersTab', () => {
     await waitFor(() => expect(mockCollections).toHaveBeenCalled())
 
     await openNewMenu(/collection/i)
-    fireEvent.change(screen.getByPlaceholderText('Trade binder'), {
+    // The new collection dialog (#723) uses a richer placeholder; with no
+    // binders yet and no inline binder named, it creates a loose collection.
+    fireEvent.change(screen.getByPlaceholderText('Base Set holos'), {
       target: { value: 'Trade pile' },
     })
     fireEvent.click(screen.getByRole('button', { name: /^create$/i }))

--- a/web/src/components/LibraryBindersTab.tsx
+++ b/web/src/components/LibraryBindersTab.tsx
@@ -38,6 +38,7 @@ import type { BinderSummary, CollectionSummary, WishlistSummary } from '../api/c
 import { useAppStore } from '../store'
 import { BinderModal } from './BinderModal'
 import { BinderInventory } from './BinderInventory'
+import { CollectionCreateDialog } from './CollectionCreateDialog'
 import { NameCreateDialog } from './NameCreateDialog'
 import { BINDER_TYPE_OPTIONS, coverSwatch } from './binderIdentity'
 import { CollectionInsights } from './CollectionInsights'
@@ -92,7 +93,6 @@ export function LibraryBindersTab() {
     error: cError,
     refresh: refreshCollections,
     remove: removeCollection,
-    create: createCollection,
     update: updateCollection,
   } = useCollections()
   const { binders, refresh: refreshBinders } = useBinders()
@@ -305,15 +305,9 @@ export function LibraryBindersTab() {
         // binder's real mode.
         smartOnly={editingBinder === null}
       />
-      <NameCreateDialog
+      <CollectionCreateDialog
         open={createDialog === 'collection'}
         onOpenChange={(o) => !o && setCreateDialog(null)}
-        title="New collection"
-        placeholder="Trade binder"
-        submitLabel="Create"
-        onSubmit={async (name) => {
-          await createCollection(name)
-        }}
       />
       <NameCreateDialog
         open={createDialog === 'wishlist'}


### PR DESCRIPTION
Closes #723

## What

Two related polish items now that binders are a first-class inventory unit (#702) that own the cover color and hold many collections:

1. **Dropped the cover-color picker from BinderModal** (smart + physical, create + edit). Color lives on the binder inventory unit now, not on a collection/rule. The inventory "Add binder" form keeps its color picker.
2. **Reworked New ▾ → Collection** so it connects to the binder inventory. When binders exist, the dialog offers to file the new collection into one — each shown with its **available slots** (capacity minus filed cards; empty binders show full capacity). When none exist, you can **create a binder inline** and the collection drops straight into it. Filing stays optional.

## Why

Keeps a single home for cover color (the physical binder) and makes the collection-create flow aware of the inventory, so new collections land where they belong instead of floating loose.

## How to verify

1. Binders tab → New ▾ → **Collection**. With a binder present, the dialog lists it with its free slots (e.g. "Empty · 360 slots"); name the collection, pick the binder, Create → it's filed into that binder.
2. With no binders, the same dialog shows an inline "create a binder" form; naming one creates the binder and files the collection into it.
3. New ▾ → **Smart binder**, and Browse → **Create binder**: no cover-color picker. The inventory **Add binder** form still has one.

Verified in the browser against the live API (default user): filing at create time updates the binder's collection list and slot counts; the smart-binder modal has no color control while "Add binder" does. No console errors. Full web suite green (514 tests). Screenshots below.

### New collection dialog — slot-aware binder picker

_attach screenshot_

## Notes

- Out of scope (kept focused): applying the binder picker to other create entry points (e.g. save-to-collection from a card) and the dismissable last-empty-binder nudge (#704).