### PR TITLE
Open a collection to view its cards (collection detail view)

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -600,6 +600,16 @@ export interface CollectionItem {
   card: Record<string, unknown>
   notes: string | null
   added_at: string
+  // Promoted identity + snapshot fields (#574). Optional so partial fixtures
+  // stay valid — the wire always carries them (null when absent).
+  quantity?: number
+  card_set_id?: string | null
+  card_number?: string | null
+  card_name?: string | null
+  card_rarity?: string | null
+  card_types?: string[] | null
+  card_image_url?: string | null
+  price_snapshot?: number | null
 }
 
 export interface Collection {
@@ -620,6 +630,12 @@ export interface Collection {
   binder_type?: BinderType | null
   capacity?: number | null
   is_master_set?: boolean | null
+}
+
+export async function fetchCollection(collectionId: number): Promise<Collection> {
+  const res = await fetch(`${BASE}/collections/${collectionId}`)
+  if (!res.ok) throw new Error(`collection failed: ${res.status}`)
+  return (await res.json()) as Collection
 }
 
 export async function fetchCollections(): Promise<CollectionSummary[]> {

--- a/web/src/components/CollectionDetail.test.tsx
+++ b/web/src/components/CollectionDetail.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { CollectionDetail } from './CollectionDetail'
+import { fetchCollection } from '../api/client'
+import type { Collection, CollectionSummary } from '../api/client'
+
+vi.mock('../api/client', () => ({
+  fetchCollection: vi.fn(),
+}))
+
+const mockFetch = vi.mocked(fetchCollection)
+
+const SUMMARY: CollectionSummary = {
+  id: 3,
+  name: 'Base Set holos',
+  description: null,
+  created_at: '2026-06-21T00:00:00',
+  item_count: 1,
+  kind: 'manual',
+}
+
+function collectionWith(items: Collection['items']): Collection {
+  return {
+    id: 3,
+    name: 'Base Set holos',
+    description: null,
+    created_at: '2026-06-21T00:00:00',
+    items,
+    kind: 'manual',
+  }
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+})
+
+describe('CollectionDetail', () => {
+  it('lists the collection cards with their snapshot price', async () => {
+    mockFetch.mockResolvedValue(
+      collectionWith([
+        {
+          id: 1,
+          card: { name: 'Charizard', images: { small: 'https://img/base1-4.png' } },
+          notes: null,
+          added_at: '2026-06-21T00:00:00',
+          quantity: 2,
+          card_set_id: 'base1',
+          card_number: '4',
+          card_name: 'Charizard',
+          card_rarity: 'Rare Holo',
+          card_image_url: 'https://img/base1-4.png',
+          price_snapshot: 250,
+        },
+      ]),
+    )
+
+    render(<CollectionDetail collection={SUMMARY} open onOpenChange={() => {}} />)
+
+    expect(await screen.findByText('Charizard')).toBeInTheDocument()
+    expect(screen.getByText(/base1-4/)).toBeInTheDocument()
+    // Snapshot total folds in quantity (2 × $250).
+    expect(screen.getByText('$500.00')).toBeInTheDocument()
+    expect(mockFetch).toHaveBeenCalledWith(3)
+  })
+
+  it('shows an empty state for a freshly created collection', async () => {
+    mockFetch.mockResolvedValue(collectionWith([]))
+    render(<CollectionDetail collection={SUMMARY} open onOpenChange={() => {}} />)
+    expect(await screen.findByText('No cards yet.')).toBeInTheDocument()
+  })
+
+  it("doesn't fetch while closed", () => {
+    render(<CollectionDetail collection={SUMMARY} open={false} onOpenChange={() => {}} />)
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/components/CollectionDetail.tsx
+++ b/web/src/components/CollectionDetail.tsx
@@ -1,0 +1,188 @@
+/**
+ * CollectionDetail — the detail view for a collection (#723).
+ *
+ * Opens from any owned row in [LibraryBindersTab](./LibraryBindersTab.tsx)
+ * that isn't a catalog-scope target (those open
+ * [SmartCollectionTarget](./SmartCollectionTarget.tsx) instead). Lists the
+ * cards in the collection with their snapshot price, and surfaces an empty
+ * state for a freshly-created collection so it's never a dead end.
+ *
+ * Read-only for now: cards are added from Browse / Search via the save
+ * buttons, and seeded placeholder slots are a separate effort (#725).
+ */
+import * as Dialog from '@radix-ui/react-dialog'
+import { ImageOff, Loader2, Wallet, X } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { fetchCollection, type CollectionItem, type CollectionSummary } from '../api/client'
+import { coverSwatch } from './binderIdentity'
+import { formatMoney } from '../utils/format'
+
+interface Props {
+  collection: CollectionSummary | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+function cardImage(item: CollectionItem): string | undefined {
+  if (item.card_image_url) return item.card_image_url
+  const images = item.card.images as { small?: string; large?: string } | undefined
+  return images?.small ?? images?.large
+}
+
+function cardLabel(item: CollectionItem): string {
+  return item.card_name ?? (item.card.name as string | undefined) ?? 'Unknown card'
+}
+
+export function CollectionDetail({ collection, open, onOpenChange }: Props) {
+  const [items, setItems] = useState<CollectionItem[] | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open || !collection) return
+    let cancelled = false
+    // Reset + fetch inside an async load (not synchronously in the effect
+    // body) — mirrors SmartCollectionTarget and avoids the cascading-render
+    // lint on set-state-in-effect.
+    const load = async () => {
+      setItems(null)
+      setError(null)
+      setLoading(true)
+      try {
+        const c = await fetchCollection(collection.id)
+        if (!cancelled) setItems(c.items)
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e))
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [open, collection])
+
+  const cover = coverSwatch(collection?.binder_color)
+  const total = (items ?? []).reduce(
+    (sum, it) => sum + (it.price_snapshot ?? 0) * (it.quantity ?? 1),
+    0,
+  )
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-coconut-700/50 backdrop-blur-sm dark:bg-husk-500/70" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-[min(640px,92vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-sand-300 bg-sand-50 shadow-2xl dark:border-husk-50 dark:bg-husk-200">
+          <header className="flex items-center justify-between gap-3 border-b border-sand-200 px-5 py-4 dark:border-husk-100">
+            <div className="flex min-w-0 items-center gap-2">
+              {collection?.binder_color ? (
+                <span
+                  className={`h-4 w-4 shrink-0 rounded-full ${cover.className}`}
+                  style={cover.style}
+                  aria-hidden
+                />
+              ) : (
+                <Wallet size={18} className="shrink-0 text-coconut-600 dark:text-sand-200" />
+              )}
+              <Dialog.Title className="truncate text-lg font-semibold text-coconut-700 dark:text-sand-50">
+                {collection?.name ?? 'Collection'}
+              </Dialog.Title>
+            </div>
+            <Dialog.Close asChild>
+              <button
+                aria-label="Close"
+                className="rounded p-1 text-coconut-500 hover:bg-sand-200 dark:text-sand-300 dark:hover:bg-husk-100"
+              >
+                <X size={18} />
+              </button>
+            </Dialog.Close>
+          </header>
+          <Dialog.Description className="sr-only">
+            The cards in this collection, with their snapshot prices.
+          </Dialog.Description>
+
+          <div className="flex-1 overflow-y-auto px-5 py-4">
+            {loading ? (
+              <div className="flex items-center gap-2 text-xs text-coconut-400 dark:text-sand-300">
+                <Loader2 size={14} className="animate-spin" />
+                Loading cards…
+              </div>
+            ) : error ? (
+              <div role="alert" className="text-xs text-sun-600 dark:text-sun-300">
+                {error}
+              </div>
+            ) : items && items.length > 0 ? (
+              <>
+                <div className="mb-3 flex items-baseline justify-between text-xs text-coconut-500 dark:text-sand-300">
+                  <span>
+                    {items.length} {items.length === 1 ? 'card' : 'cards'}
+                  </span>
+                  {total > 0 && (
+                    <span>
+                      Snapshot total{' '}
+                      <span className="font-medium text-coconut-700 dark:text-sand-50">
+                        {formatMoney(total, 'USD')}
+                      </span>
+                    </span>
+                  )}
+                </div>
+                <ul className="divide-y divide-sand-200 dark:divide-husk-100">
+                  {items.map((it) => (
+                    <ItemRow key={it.id} item={it} />
+                  ))}
+                </ul>
+              </>
+            ) : (
+              <div className="rounded-md border border-dashed border-sand-300 px-4 py-8 text-center dark:border-husk-100">
+                <p className="text-sm text-coconut-600 dark:text-sand-200">No cards yet.</p>
+                <p className="mt-1 text-xs text-coconut-400 dark:text-sand-300">
+                  Add cards from Browse or Search with the save-to-collection button.
+                </p>
+              </div>
+            )}
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+function ItemRow({ item }: { item: CollectionItem }) {
+  const [broken, setBroken] = useState(false)
+  const img = cardImage(item)
+  const qty = item.quantity ?? 1
+  return (
+    <li className="flex items-center gap-3 py-2">
+      <div className="flex h-12 w-9 shrink-0 items-center justify-center overflow-hidden rounded bg-sand-200 dark:bg-husk-100">
+        {img && !broken ? (
+          <img
+            src={img}
+            alt={cardLabel(item)}
+            loading="lazy"
+            onError={() => setBroken(true)}
+            className="h-full w-full object-contain"
+          />
+        ) : (
+          <ImageOff size={14} className="text-coconut-400 dark:text-sand-300" />
+        )}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-xs font-medium text-coconut-700 dark:text-sand-50">
+          {cardLabel(item)}
+          {qty > 1 && <span className="text-coconut-400 dark:text-sand-300"> · {qty}x</span>}
+        </div>
+        <div className="truncate text-[11px] text-coconut-400 dark:text-sand-300">
+          {item.card_set_id}
+          {item.card_number ? `-${item.card_number}` : ''}
+          {item.card_rarity ? ` · ${item.card_rarity}` : ''}
+        </div>
+      </div>
+      {item.price_snapshot != null && (
+        <span className="shrink-0 text-xs font-medium text-palm-600 dark:text-palm-200">
+          {formatMoney(item.price_snapshot, 'USD')}
+        </span>
+      )}
+    </li>
+  )
+}

--- a/web/src/components/LibraryBindersTab.test.tsx
+++ b/web/src/components/LibraryBindersTab.test.tsx
@@ -6,6 +6,7 @@ import { _resetWishlistsCacheForTests } from './useWishlists'
 import { _resetBindersCacheForTests } from './useBinders'
 import {
   fetchCollections,
+  fetchCollection,
   createCollection,
   deleteCollection,
   downloadCollectionIdCardPdf,
@@ -20,6 +21,7 @@ import {
 
 vi.mock('../api/client', () => ({
   fetchCollections: vi.fn(),
+  fetchCollection: vi.fn(),
   createCollection: vi.fn(),
   updateCollection: vi.fn(),
   addCardToCollection: vi.fn(),
@@ -40,6 +42,7 @@ vi.mock('../api/client', () => ({
 }))
 
 const mockCollections = vi.mocked(fetchCollections)
+const mockFetchCollection = vi.mocked(fetchCollection)
 const mockWishlists = vi.mocked(fetchWishlists)
 const mockBinders = vi.mocked(fetchBinders)
 const mockCreate = vi.mocked(createCollection)
@@ -75,6 +78,7 @@ describe('LibraryBindersTab', () => {
     mockBinders.mockReset()
     mockBinders.mockResolvedValue([])
     mockCollections.mockReset()
+    mockFetchCollection.mockReset()
     mockWishlists.mockReset()
     mockCreate.mockReset()
     mockDeleteCollection.mockReset()
@@ -331,6 +335,49 @@ describe('LibraryBindersTab', () => {
     expect(
       screen.getByRole('button', { name: /add 2 missing to want-list/i }),
     ).toBeInTheDocument()
+  })
+
+  it('opens a plain collection card-list detail when its row is clicked (#723)', async () => {
+    mockCollections.mockResolvedValue([
+      {
+        id: 4,
+        name: 'Base holos',
+        description: null,
+        created_at: '2026-06-06T00:00:00',
+        item_count: 1,
+        kind: 'manual',
+      },
+    ])
+    mockFetchCollection.mockResolvedValue({
+      id: 4,
+      name: 'Base holos',
+      description: null,
+      created_at: '2026-06-06T00:00:00',
+      kind: 'manual',
+      items: [
+        {
+          id: 1,
+          card: { name: 'Charizard' },
+          notes: null,
+          added_at: '2026-06-06T00:00:00',
+          card_set_id: 'base1',
+          card_number: '4',
+          card_name: 'Charizard',
+          card_rarity: 'Rare Holo',
+          price_snapshot: 250,
+        },
+      ],
+    })
+    render(<LibraryBindersTab />)
+    await waitFor(() => expect(screen.getByText('Base holos')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByText('Base holos'))
+
+    await waitFor(() => expect(mockFetchCollection).toHaveBeenCalledWith(4))
+    const dialog = await screen.findByRole('dialog')
+    expect(within(dialog).getByText('Charizard')).toBeInTheDocument()
+    // $250.00 shows for the item and the snapshot total.
+    expect(within(dialog).getAllByText('$250.00').length).toBeGreaterThanOrEqual(1)
   })
 
   it('opens the detail modal when a want-list row is clicked', async () => {

--- a/web/src/components/LibraryBindersTab.tsx
+++ b/web/src/components/LibraryBindersTab.tsx
@@ -39,6 +39,7 @@ import { useAppStore } from '../store'
 import { BinderModal } from './BinderModal'
 import { BinderInventory } from './BinderInventory'
 import { CollectionCreateDialog } from './CollectionCreateDialog'
+import { CollectionDetail } from './CollectionDetail'
 import { NameCreateDialog } from './NameCreateDialog'
 import { BINDER_TYPE_OPTIONS, coverSwatch } from './binderIdentity'
 import { CollectionInsights } from './CollectionInsights'
@@ -118,6 +119,8 @@ export function LibraryBindersTab() {
   const [modalKey, setModalKey] = useState(0)
   // The catalog-scope target collection whose detail modal is open.
   const [targetCollection, setTargetCollection] = useState<CollectionSummary | null>(null)
+  // The (non-target) collection whose card-list detail modal is open.
+  const [openCollection, setOpenCollection] = useState<CollectionSummary | null>(null)
   // The want-list whose detail modal is open.
   const [openWishlist, setOpenWishlist] = useState<WishlistSummary | null>(null)
   // The aggregate insights dashboard.
@@ -264,6 +267,7 @@ export function LibraryBindersTab() {
                 collection={row.collection}
                 binders={binders}
                 onOpenTarget={setTargetCollection}
+                onOpenCollection={setOpenCollection}
                 onEdit={openEdit}
                 onDelete={removeCollection}
                 onFile={fileCollection}
@@ -285,6 +289,13 @@ export function LibraryBindersTab() {
         open={targetCollection !== null}
         onOpenChange={(o) => {
           if (!o) setTargetCollection(null)
+        }}
+      />
+      <CollectionDetail
+        collection={openCollection}
+        open={openCollection !== null}
+        onOpenChange={(o) => {
+          if (!o) setOpenCollection(null)
         }}
       />
       <WishlistDetail
@@ -431,6 +442,7 @@ function CollectionRow({
   collection: c,
   binders,
   onOpenTarget,
+  onOpenCollection,
   onEdit,
   onDelete,
   onFile,
@@ -438,6 +450,7 @@ function CollectionRow({
   collection: CollectionSummary
   binders: BinderSummary[]
   onOpenTarget: (c: CollectionSummary) => void
+  onOpenCollection: (c: CollectionSummary) => void
   onEdit: (c: CollectionSummary) => void
   onDelete: (id: number) => Promise<void>
   onFile: (collectionId: number, binderId: number | null) => Promise<void>
@@ -446,9 +459,10 @@ function CollectionRow({
   const isBinder = c.kind === 'binder'
   const identity = hasBinderIdentity(c)
   const cover = coverSwatch(c.binder_color)
-  // A catalog-scope target opens its progress detail; everything else is
-  // a static row.
-  const openable = isCatalogTarget(c)
+  // A catalog-scope target opens its progress detail; every other collection
+  // opens its card-list detail — both are clickable so a row is never a dead
+  // end (#723).
+  const isTarget = isCatalogTarget(c)
   const body = (
     <>
       <div className="min-w-0">
@@ -489,17 +503,13 @@ function CollectionRow({
   )
   return (
     <li className="group flex items-center gap-1">
-      {openable ? (
-        <button
-          type="button"
-          onClick={() => onOpenTarget(c)}
-          className="flex flex-1 items-center justify-between rounded py-2 text-left hover:bg-sand-100 dark:hover:bg-husk-100"
-        >
-          {body}
-        </button>
-      ) : (
-        <div className="flex flex-1 items-center justify-between py-2">{body}</div>
-      )}
+      <button
+        type="button"
+        onClick={() => (isTarget ? onOpenTarget(c) : onOpenCollection(c))}
+        className="flex flex-1 items-center justify-between rounded py-2 text-left hover:bg-sand-100 dark:hover:bg-husk-100"
+      >
+        {body}
+      </button>
       {identity && (
         <button
           type="button"


### PR DESCRIPTION
Closes #730

## What

Clicking a collection in the Binders tab was a dead end — only catalog-scope smart collections opened (their progress target). Every other collection (manual, set, owned-scope smart, binder) rendered as a static row. This adds a `CollectionDetail` modal and makes every collection row open: catalog targets keep their progress view; everything else opens a card list.

## Detail view

- Lists each card with thumb, identity (set-number · rarity), quantity, and snapshot price.
- Shows a snapshot total.
- Empty state for a freshly created collection ("No cards yet — add from Browse or Search").
- Read-only; adds a `fetchCollection(id)` client wrapper over the existing `GET /collections/{id}`.

## Why

The new create flow (#719/#723) makes collections easy to create, but they led nowhere. This closes the loop. Read-only on purpose — priced placeholder seeding is tracked separately (#725).

## How to verify

Binders tab → click any collection → its card list opens (empty state for a fresh one); a catalog-scope smart collection still opens its progress target.

Verified in the browser (default user): clicking a collection opens the detail with the empty state, no console errors. Lint/build green; 24 tests in the two touched suites pass.