### PR TITLE
Hide smart collections from the save/promote pickers (fix 409)

### DIFF
--- a/web/src/components/AddToCollectionButton.test.tsx
+++ b/web/src/components/AddToCollectionButton.test.tsx
@@ -82,6 +82,34 @@ describe('AddToCollectionButton', () => {
     await waitFor(() => expect(mockAdd).toHaveBeenCalledWith(7, SAMPLE_CARD, undefined))
   })
 
+  it('excludes dynamic (smart) collections from the picker — they 409 on add', async () => {
+    mockFetch.mockResolvedValue([
+      {
+        id: 7,
+        name: 'Binder candidates',
+        description: null,
+        created_at: '2026-06-06T00:00:00',
+        item_count: 0,
+        kind: 'manual',
+      },
+      {
+        id: 8,
+        name: 'SmExeggs',
+        description: null,
+        created_at: '2026-06-06T00:00:00',
+        item_count: 0,
+        kind: 'dynamic',
+        dynamic_scope: 'owned',
+        rule: { name: 'Exeggutor' },
+      },
+    ])
+    render(<AddToCollectionButton card={SAMPLE_CARD} />)
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled())
+    openMenu()
+    expect(await screen.findByText('Binder candidates')).toBeInTheDocument()
+    expect(screen.queryByText('SmExeggs')).not.toBeInTheDocument()
+  })
+
   it('creates a new collection and adds the card in one flow', async () => {
     mockFetch.mockResolvedValue([])
     mockCreate.mockResolvedValue({

--- a/web/src/components/AddToCollectionButton.tsx
+++ b/web/src/components/AddToCollectionButton.tsx
@@ -18,6 +18,10 @@ interface Props {
 
 export function AddToCollectionButton({ card }: Props) {
   const { collections, loading, error, create, addCard } = useCollections()
+  // Dynamic (smart) collections are rule-defined — membership is resolved,
+  // not hand-curated — so the API rejects manual adds with a 409. Keep them
+  // out of the save picker (mirrors BulkActionBar's filter).
+  const addable = collections.filter((c) => c.kind !== 'dynamic')
   const [open, setOpen] = useState(false)
   const [busyId, setBusyId] = useState<number | null>(null)
   const [justAdded, setJustAdded] = useState<number | null>(null)
@@ -95,12 +99,12 @@ export function AddToCollectionButton({ card }: Props) {
               {error}
             </div>
           )}
-          {!loading && !error && collections.length === 0 && (
+          {!loading && !error && addable.length === 0 && (
             <div className="px-2 py-2 text-xs text-coconut-400 dark:text-sand-300">
               No collections yet.
             </div>
           )}
-          {collections.map((c) => (
+          {addable.map((c) => (
             <DropdownMenu.Item
               key={c.id}
               onSelect={(e) => {

--- a/web/src/components/WishlistDetail.tsx
+++ b/web/src/components/WishlistDetail.tsx
@@ -53,6 +53,9 @@ function GotItPicker({
   busy: boolean
 }) {
   const { collections, loading, error, create } = useCollections()
+  // Promote can't target a dynamic (smart) collection — its membership is
+  // rule-resolved, so the items API 409s. Offer only hand-curated kinds.
+  const addable = collections.filter((c) => c.kind !== 'dynamic')
   const [open, setOpen] = useState(false)
   const [newOpen, setNewOpen] = useState(false)
   const [newName, setNewName] = useState('')
@@ -102,12 +105,12 @@ function GotItPicker({
           {error && (
             <div className="px-2 py-2 text-xs text-sun-600 dark:text-sun-300">{error}</div>
           )}
-          {!loading && !error && collections.length === 0 && (
+          {!loading && !error && addable.length === 0 && (
             <div className="px-2 py-2 text-xs text-coconut-400 dark:text-sand-300">
               No collections yet.
             </div>
           )}
-          {collections.map((c) => (
+          {addable.map((c) => (
             <DropdownMenu.Item
               key={c.id}
               onSelect={(e) => {


### PR DESCRIPTION
Closes #732

## What

Adding a card to a smart (dynamic) collection failed with `add to collection failed: 409`. A dynamic collection's membership is rule-resolved, so the items API rejects manual adds (`_reject_if_dynamic`). But the "Save to collection" picker and the want-list "Got it" promote picker still listed dynamic collections as targets.

Filter `kind === 'dynamic'` out of both pickers, mirroring `BulkActionBar`, which already excludes them with the same rationale.

## How to verify

With a smart collection present (e.g. "All Exeggutor cards"), open Save to collection on a result row — the smart collection no longer appears, so you can't trigger the 409. Manual/set/binder collections still list.

Covered by a new `AddToCollectionButton` test asserting a `dynamic` collection is excluded from the picker.