### PR TITLE
Move binder storage type onto the inventory unit

### DIFF
--- a/web/src/components/BinderInventory.test.tsx
+++ b/web/src/components/BinderInventory.test.tsx
@@ -82,6 +82,15 @@ describe('BinderInventory', () => {
     expect(screen.getByText(/Empty · 9-pocket · 360 slots/i)).toBeInTheDocument()
   })
 
+  it('shows the saved storage type in the binder metadata', async () => {
+    mockFetch.mockResolvedValue([
+      binder({ binder_type: 'graded', capacity: null, binder_format: null }),
+    ] as never)
+    render(<BinderInventory />)
+    expect(await screen.findByText('Base Set binder')).toBeInTheDocument()
+    expect(screen.getByText(/Empty · Graded slabs/i)).toBeInTheDocument()
+  })
+
   it('shows the filed collections and a live count under a binder', async () => {
     mockFetch.mockResolvedValue([
       binder({ id: 1, is_empty: false, collection_count: 2, capacity: null, binder_format: null }),

--- a/web/src/components/BinderInventory.test.tsx
+++ b/web/src/components/BinderInventory.test.tsx
@@ -158,6 +158,27 @@ describe('BinderInventory', () => {
     )
   })
 
+  it('creates a binder with the chosen storage type (#726)', async () => {
+    mockFetch.mockResolvedValue([])
+    mockCreate.mockResolvedValue(
+      binder({ id: 6, name: 'Slabs', capacity: null, binder_format: null, binder_type: 'graded' }) as never,
+    )
+    render(<BinderInventory />)
+    await screen.findByText(/Add an empty binder/i)
+
+    fireEvent.click(screen.getByRole('button', { name: /Add binder/i }))
+    fireEvent.change(screen.getByLabelText(/Binder name/i), { target: { value: 'Slabs' } })
+    fireEvent.change(screen.getByLabelText(/Storage type/i), { target: { value: 'graded' } })
+    fireEvent.click(screen.getByRole('button', { name: /^Add$/i }))
+
+    await waitFor(() =>
+      expect(mockCreate).toHaveBeenCalledWith(
+        'Slabs',
+        expect.objectContaining({ binder_type: 'graded' }),
+      ),
+    )
+  })
+
   it('deletes a binder after confirmation', async () => {
     mockFetch.mockResolvedValue([binder({ id: 9, name: 'Old binder' })] as never)
     mockDelete.mockResolvedValue(undefined)

--- a/web/src/components/BinderInventory.tsx
+++ b/web/src/components/BinderInventory.tsx
@@ -12,8 +12,8 @@
  */
 import { Check, FolderPlus, Library, Loader2, Plus, Trash2, X } from 'lucide-react'
 import { useMemo, useState } from 'react'
-import type { BinderFormat, BinderSummary, CollectionSummary } from '../api/client'
-import { BINDER_FORMAT_OPTIONS, coverSwatch } from './binderIdentity'
+import type { BinderFormat, BinderSummary, BinderType, CollectionSummary } from '../api/client'
+import { BINDER_FORMAT_OPTIONS, BINDER_TYPE_OPTIONS, coverSwatch } from './binderIdentity'
 import { BinderColorPicker } from './BinderColorPicker'
 import { NameCreateDialog } from './NameCreateDialog'
 import { useBinders } from './useBinders'
@@ -26,6 +26,7 @@ export function BinderInventory() {
   const [creating, setCreating] = useState(false)
   const [name, setName] = useState('')
   const [format, setFormat] = useState<BinderFormat | ''>('')
+  const [binderType, setBinderType] = useState<BinderType | ''>('')
   const [capacity, setCapacity] = useState('')
   const [color, setColor] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
@@ -50,6 +51,7 @@ export function BinderInventory() {
   function resetForm() {
     setName('')
     setFormat('')
+    setBinderType('')
     setCapacity('')
     setColor(null)
     setSubmitError(null)
@@ -64,6 +66,7 @@ export function BinderInventory() {
       const cap = capacity.trim() ? Number(capacity) : null
       await create(trimmed, {
         binder_format: format || null,
+        binder_type: binderType || null,
         binder_color: color,
         capacity: cap && cap > 0 ? cap : null,
       })
@@ -125,6 +128,19 @@ export function BinderInventory() {
             className="w-full rounded border border-sand-300 bg-sand-50 px-2 py-1 text-xs text-coconut-700 placeholder:text-coconut-300 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:border-coconut-500 dark:bg-husk-100 dark:text-sand-50 dark:placeholder:text-sand-500 dark:focus:ring-sun-300"
           />
           <BinderColorPicker value={color} onChange={setColor} label="Cover color" />
+          <select
+            value={binderType}
+            onChange={(e) => setBinderType(e.target.value as BinderType | '')}
+            aria-label="Storage type"
+            className="w-full rounded border border-sand-300 bg-sand-50 px-2 py-1 text-xs text-coconut-700 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:border-coconut-500 dark:bg-husk-100 dark:text-sand-50 dark:focus:ring-sun-300"
+          >
+            <option value="">Storage type</option>
+            {BINDER_TYPE_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
           <div className="flex items-center gap-1">
             <select
               value={format}

--- a/web/src/components/BinderInventory.tsx
+++ b/web/src/components/BinderInventory.tsx
@@ -203,6 +203,7 @@ export function BinderInventory() {
           {binders.map((b) => {
             const swatch = coverSwatch(b.binder_color)
             const filed = collectionsByBinder.get(b.id) ?? []
+            const storageType = BINDER_TYPE_OPTIONS.find((o) => o.value === b.binder_type)?.label
             return (
               <li
                 key={b.id}
@@ -220,6 +221,7 @@ export function BinderInventory() {
                       {filed.length === 0
                         ? 'Empty'
                         : `${filed.length} ${filed.length === 1 ? 'collection' : 'collections'}`}
+                      {storageType ? ` · ${storageType}` : ''}
                       {b.binder_format ? ` · ${b.binder_format}` : ''}
                       {b.capacity ? ` · ${b.capacity} slots` : ''}
                     </p>

--- a/web/src/components/BinderModal.test.tsx
+++ b/web/src/components/BinderModal.test.tsx
@@ -120,10 +120,11 @@ describe('BinderModal', () => {
     await waitFor(() =>
       expect(mockUpdate).toHaveBeenCalledWith(
         8,
-        expect.objectContaining({ name: 'All Eevees' }),
+        expect.objectContaining({ name: 'All Eevees', binder_type: null }),
       ),
     )
-    // The edit no longer touches cover color.
+    // The edit clears legacy collection storage type while leaving cover color
+    // on the binder inventory unit.
     const [, patch] = mockUpdate.mock.calls[0]
     expect(patch).not.toHaveProperty('binder_color')
   })
@@ -158,7 +159,7 @@ describe('BinderModal', () => {
     await waitFor(() =>
       expect(mockUpdate).toHaveBeenCalledWith(
         7,
-        expect.objectContaining({ name: 'Show binder 2' }),
+        expect.objectContaining({ name: 'Show binder 2', binder_type: null }),
       ),
     )
   })

--- a/web/src/components/BinderModal.test.tsx
+++ b/web/src/components/BinderModal.test.tsx
@@ -27,7 +27,7 @@ describe('BinderModal', () => {
     mockFetch.mockResolvedValue([])
   })
 
-  it('creates a binder with format and capacity (no cover color — that lives on the binder unit)', async () => {
+  it('creates a binder with format and capacity (no cover color / storage type — those live on the binder unit)', async () => {
     mockCreate.mockResolvedValue({
       id: 5,
       name: 'Trade binder',
@@ -36,7 +36,6 @@ describe('BinderModal', () => {
       items: [],
       kind: 'binder',
       binder_format: '9-pocket',
-      binder_type: 'toploader',
       capacity: 360,
     })
     render(<BinderModal open onOpenChange={() => {}} />)
@@ -44,13 +43,12 @@ describe('BinderModal', () => {
     fireEvent.change(screen.getByPlaceholderText('Trade binder'), {
       target: { value: 'Trade binder' },
     })
-    // The cover-color picker no longer lives here (#723).
+    // The cover-color picker (#723) and storage-type select (#726) no longer
+    // live here — they belong to the binder inventory unit.
     expect(screen.queryByRole('button', { name: 'Sky' })).not.toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: /more details/i }))
+    expect(screen.queryByRole('combobox', { name: /storage type/i })).not.toBeInTheDocument()
     fireEvent.change(screen.getByPlaceholderText('360'), { target: { value: '360' } })
-    fireEvent.change(screen.getByRole('combobox', { name: /storage type/i }), {
-      target: { value: 'toploader' },
-    })
     fireEvent.change(screen.getByRole('combobox', { name: /pocket format/i }), {
       target: { value: '9-pocket' },
     })
@@ -60,15 +58,15 @@ describe('BinderModal', () => {
       expect(mockCreate).toHaveBeenCalledWith('Trade binder', {
         kind: 'binder',
         binder_format: '9-pocket',
-        binder_type: 'toploader',
         capacity: 360,
         source_set_id: null,
         is_master_set: false,
       }),
     )
-    // Cover color isn't part of the create payload anymore.
+    // Cover color and storage type aren't part of the create payload anymore.
     const [, opts] = mockCreate.mock.calls[0]
     expect(opts).not.toHaveProperty('binder_color')
+    expect(opts).not.toHaveProperty('binder_type')
   })
 
   it('creates a smart binder carrying shared identity but no physical fields or color', async () => {

--- a/web/src/components/BinderModal.tsx
+++ b/web/src/components/BinderModal.tsx
@@ -10,8 +10,8 @@
  *
  * - **Novice path:** name it, done. The rest is tucked behind a "More
  *   details" disclosure so the simple case stays one decision.
- * - **Vendor path:** open the details to set storage type, pocket format,
- *   capacity, the set it organizes, and a master-set target.
+ * - **Vendor path:** open the details to set pocket format, capacity, the
+ *   set it organizes, and a master-set target.
  *
  * Create writes a `kind='binder'` (or `kind='dynamic'`) collection; edit
  * PATCHes an existing binder's identity. Both go through
@@ -23,12 +23,11 @@ import { ChevronDown, Loader2, Sparkles, Wallet, X } from 'lucide-react'
 import { useState } from 'react'
 import type {
   BinderFormat,
-  BinderType,
   CollectionRule,
   CollectionSummary,
   DynamicScope,
 } from '../api/client'
-import { BINDER_FORMAT_OPTIONS, BINDER_TYPE_OPTIONS } from './binderIdentity'
+import { BINDER_FORMAT_OPTIONS } from './binderIdentity'
 import { SetCombobox } from './SetCombobox'
 import { useCollections } from './useCollections'
 
@@ -97,7 +96,6 @@ export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }:
     isEdit ? editMode : smartOnly ? 'smart' : 'binder',
   )
   const [name, setName] = useState(() => editing?.name ?? prefill?.name ?? '')
-  const [binderType, setBinderType] = useState<BinderType | ''>(() => editing?.binder_type ?? '')
   const [format, setFormat] = useState<BinderFormat | ''>(() => editing?.binder_format ?? '')
   const [capacity, setCapacity] = useState(() =>
     editing?.capacity != null ? String(editing.capacity) : '',
@@ -113,7 +111,6 @@ export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }:
       editing?.binder_format ||
         editing?.capacity ||
         editing?.source_set_id ||
-        editing?.binder_type ||
         editing?.is_master_set ||
         prefill?.sourceSetId ||
         prefill?.isMasterSet,
@@ -140,17 +137,13 @@ export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }:
     setSubmitting(true)
     setError(null)
     const cap = capacity.trim() ? Number(capacity.trim()) : null
-    // Shared identity rides both kinds; physical fields ride binders only.
-    // Cover color is owned by the binder inventory unit (#702), not a
-    // collection/rule, so it isn't set here anymore (#723).
-    const shared = {
-      binder_type: binderType || null,
-    }
+    // Physical identity (cover color #723, storage type #726) lives on the
+    // binder inventory unit (#702) now, not on a collection/rule — so the
+    // only physical fields set here are the binder-kind's own format/capacity.
     try {
       if (isEdit && editing) {
         await update(editing.id, {
           name: name.trim(),
-          ...shared,
           ...(editMode === 'binder'
             ? {
                 binder_format: format || null,
@@ -164,14 +157,12 @@ export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }:
           kind: 'dynamic',
           rule: buildRule(field, value),
           dynamic_scope: scope,
-          ...shared,
           is_master_set: isMasterSet,
         })
       } else {
         const set = sourceSetId.trim()
         await create(name.trim(), {
           kind: 'binder',
-          ...shared,
           binder_format: format || null,
           capacity: cap,
           source_set_id: set || null,
@@ -208,8 +199,8 @@ export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }:
             </Dialog.Close>
           </header>
           <Dialog.Description className="sr-only">
-            Name your binder and optionally set its storage type, pocket format,
-            capacity, and the set it organizes.
+            Name your binder and optionally set its pocket format, capacity, and
+            the set it organizes.
           </Dialog.Description>
 
           <form onSubmit={handleSubmit} className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
@@ -318,25 +309,6 @@ export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }:
 
               {detailsOpen && (
                 <div className="mt-3 space-y-3 rounded-md border border-sand-200 bg-coconut-50 p-3 dark:border-husk-100 dark:bg-husk-100">
-                  {/* Storage type — shared identity. */}
-                  <label className="block space-y-1">
-                    <span className="text-[11px] font-medium text-coconut-500 dark:text-sand-300">
-                      Storage type
-                    </span>
-                    <select
-                      value={binderType}
-                      onChange={(e) => setBinderType(e.target.value as BinderType | '')}
-                      className={inputClass}
-                    >
-                      <option value="">Not set</option>
-                      {BINDER_TYPE_OPTIONS.map((opt) => (
-                        <option key={opt.value} value={opt.value}>
-                          {opt.label}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-
                   {/* Pocket format + capacity — physical binders only. */}
                   {!isSmart && (
                     <>

--- a/web/src/components/BinderModal.tsx
+++ b/web/src/components/BinderModal.tsx
@@ -144,6 +144,7 @@ export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }:
       if (isEdit && editing) {
         await update(editing.id, {
           name: name.trim(),
+          binder_type: null,
           ...(editMode === 'binder'
             ? {
                 binder_format: format || null,


### PR DESCRIPTION
Part of #726.

## What

Storage type is a physical attribute of a binder, so — like cover color in #723 — it belongs on the binder **inventory unit** (#702), not on a collection or smart-binder rule.

- Drop the storage-type control (and the `binder_type` payload) from `BinderModal`, across both kinds (physical/smart) and both create/edit.
- Add a storage-type select to the inventory **"Add binder"** form, where `binder_type` already exists on the model + API.

## Why

Keeps physical identity (cover color, storage type, format, capacity) on the binder you own, and keeps logical lists (collections, smart binders) free of physical attributes.

## Scope

This is the storage-type slice of #726. The remaining halves — filing smart binders into binders (frontend) and want-lists into binders (needs a `wishlists.binder_id` migration) — are separate PRs; #726 stays open to track them.

## How to verify

Binders tab → **Add binder** now has a Storage type select (Binder pages / Toploaders / Graded slabs / Other). New ▾ → **Smart binder** (and Browse → Create binder) no longer show a storage-type control.

Verified in the browser: Add-binder form has Storage type; the smart-binder modal does not. Lint/build green; BinderModal + BinderInventory suites pass.