### PR TITLE
Clarify card detail save actions

### DIFF
--- a/web/src/components/AddToCollectionButton.tsx
+++ b/web/src/components/AddToCollectionButton.tsx
@@ -14,9 +14,10 @@ import { useCollections } from './useCollections'
 
 interface Props {
   card: Record<string, unknown>
+  variant?: 'icon' | 'primary'
 }
 
-export function AddToCollectionButton({ card }: Props) {
+export function AddToCollectionButton({ card, variant = 'icon' }: Props) {
   const { collections, loading, error, create, addCard } = useCollections()
   // Dynamic (smart) collections are rule-defined — membership is resolved,
   // not hand-curated — so the API rejects manual adds with a 409. Keep them
@@ -28,6 +29,7 @@ export function AddToCollectionButton({ card }: Props) {
   const [newOpen, setNewOpen] = useState(false)
   const [newName, setNewName] = useState('')
   const [submitError, setSubmitError] = useState<string | null>(null)
+  const isPrimary = variant === 'primary'
 
   async function handleAdd(collectionId: number) {
     setBusyId(collectionId)
@@ -73,11 +75,16 @@ export function AddToCollectionButton({ card }: Props) {
       <DropdownMenu.Trigger asChild>
         <button
           type="button"
-          aria-label="Save to collection"
-          title="Save to collection"
-          className="rounded p-1 text-coconut-400 hover:text-palm-500 dark:text-sand-300 dark:hover:text-sun-300 transition-colors"
+          aria-label={isPrimary ? 'Add as owned' : 'Save to collection'}
+          title={isPrimary ? 'Add as owned' : 'Save to collection'}
+          className={
+            isPrimary
+              ? 'inline-flex min-h-11 items-center justify-center gap-2 rounded-md bg-palm-500 px-3 py-2 text-sm font-semibold text-coconut-50 shadow-sm transition-colors hover:bg-palm-600 focus:outline-none focus:ring-2 focus:ring-palm-400 disabled:opacity-50 dark:bg-palm-400 dark:text-husk-500 dark:hover:bg-palm-300'
+              : 'rounded p-1 text-coconut-400 hover:text-palm-500 dark:text-sand-300 dark:hover:text-sun-300 transition-colors'
+          }
         >
-          <Book size={13} aria-hidden />
+          <Book size={isPrimary ? 16 : 13} aria-hidden />
+          {isPrimary && <span>Add as owned</span>}
         </button>
       </DropdownMenu.Trigger>
       <DropdownMenu.Portal>

--- a/web/src/components/AddToWishlistButton.tsx
+++ b/web/src/components/AddToWishlistButton.tsx
@@ -14,9 +14,10 @@ import { useWishlists } from './useWishlists'
 
 interface Props {
   card: Record<string, unknown>
+  variant?: 'icon' | 'primary'
 }
 
-export function AddToWishlistButton({ card }: Props) {
+export function AddToWishlistButton({ card, variant = 'icon' }: Props) {
   const { wishlists, loading, error, create, addCard } = useWishlists()
   const [open, setOpen] = useState(false)
   const [busyId, setBusyId] = useState<number | null>(null)
@@ -25,6 +26,7 @@ export function AddToWishlistButton({ card }: Props) {
   const [newName, setNewName] = useState('')
   const [capInput, setCapInput] = useState('')
   const [submitError, setSubmitError] = useState<string | null>(null)
+  const isPrimary = variant === 'primary'
 
   function parseCap(): number | null {
     const trimmed = capInput.trim()
@@ -78,11 +80,16 @@ export function AddToWishlistButton({ card }: Props) {
       <DropdownMenu.Trigger asChild>
         <button
           type="button"
-          aria-label="Save to wishlist"
-          title="Save to wishlist"
-          className="rounded p-1 text-coconut-400 hover:text-palm-500 dark:text-sand-300 dark:hover:text-sun-300 transition-colors"
+          aria-label={isPrimary ? 'Add as chasing' : 'Save to wishlist'}
+          title={isPrimary ? 'Add as chasing' : 'Save to wishlist'}
+          className={
+            isPrimary
+              ? 'inline-flex min-h-11 items-center justify-center gap-2 rounded-md bg-sun-300 px-3 py-2 text-sm font-semibold text-husk-500 shadow-sm transition-colors hover:bg-sun-200 focus:outline-none focus:ring-2 focus:ring-sun-300 disabled:opacity-50 dark:bg-sun-300 dark:text-husk-500 dark:hover:bg-sun-200'
+              : 'rounded p-1 text-coconut-400 hover:text-palm-500 dark:text-sand-300 dark:hover:text-sun-300 transition-colors'
+          }
         >
-          <Footprints size={13} />
+          <Footprints size={isPrimary ? 16 : 13} aria-hidden />
+          {isPrimary && <span>Add as chasing</span>}
         </button>
       </DropdownMenu.Trigger>
       <DropdownMenu.Portal>

--- a/web/src/components/CardDetailModal.test.tsx
+++ b/web/src/components/CardDetailModal.test.tsx
@@ -595,12 +595,13 @@ describe('CardDetailModal — library actions (#699)', () => {
     vi.spyOn(client, 'fetchCardOwnership').mockResolvedValue({})
   })
 
-  it('renders the save-to-collection and save-to-wishlist actions when signed in', async () => {
+  it('renders prominent owned/chasing actions when signed in', async () => {
     render(<CardDetailModal rows={[identifiedRow()]} index={0} onChangeIndex={() => {}} />)
+    expect(await screen.findByRole('region', { name: /Library actions/i })).toBeInTheDocument()
     expect(
-      await screen.findByRole('button', { name: /Save to collection/i }),
+      screen.getByRole('button', { name: /Add as owned/i }),
     ).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /Save to wishlist/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Add as chasing/i })).toBeInTheDocument()
   })
 
   it('does not navigate when arrowing through save-action inputs', async () => {
@@ -611,7 +612,7 @@ describe('CardDetailModal — library actions (#699)', () => {
     const onChange = vi.fn()
     render(<CardDetailModal rows={rows} index={0} onChangeIndex={onChange} />)
 
-    const trigger = await screen.findByRole('button', { name: /Save to collection/i })
+    const trigger = await screen.findByRole('button', { name: /Add as owned/i })
     trigger.focus()
     fireEvent.keyDown(trigger, { key: 'Enter', code: 'Enter' })
     fireEvent.click(
@@ -629,7 +630,8 @@ describe('CardDetailModal — library actions (#699)', () => {
     render(<CardDetailModal rows={[identifiedRow()]} index={0} onChangeIndex={() => {}} />)
     // Let the auth probe settle, then assert the actions never mounted.
     await waitFor(() => expect(client.fetchMe).toHaveBeenCalled())
-    expect(screen.queryByRole('button', { name: /Save to collection/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /Add as owned/i })).toBeNull()
+    expect(screen.queryByRole('region', { name: /Library actions/i })).toBeNull()
   })
 
   it('shows owned (with quantity) and chasing badges from the ownership lookup', async () => {
@@ -641,6 +643,6 @@ describe('CardDetailModal — library actions (#699)', () => {
     })
     render(<CardDetailModal rows={[identifiedRow()]} index={0} onChangeIndex={() => {}} />)
     expect(await screen.findByText(/owned ×2/i)).toBeInTheDocument()
-    expect(screen.getByText(/chasing/i)).toBeInTheDocument()
+    expect(screen.getByTitle(/Chasing on Chase list/i)).toBeInTheDocument()
   })
 })

--- a/web/src/components/CardDetailModal.tsx
+++ b/web/src/components/CardDetailModal.tsx
@@ -245,14 +245,22 @@ function CardDetailBody({
                 Signed-in + matched cards only; both pieces self-hide when
                 there's nothing to show. */}
             {showActions && card && (
-              <div className="flex items-center gap-3">
-                <OwnershipBadge ownership={ownership} />
+              <section
+                aria-label="Library actions"
+                className="rounded-md border border-sand-300 bg-sand-50 p-3 shadow-sm dark:border-husk-50 dark:bg-husk-400"
+              >
+                <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+                  <h3 className="text-xs font-semibold uppercase tracking-wider text-coconut-400 dark:text-sand-300">
+                    Library actions
+                  </h3>
+                  <OwnershipBadge ownership={ownership} />
+                </div>
                 <SaveCardActions
                   card={card as unknown as Record<string, unknown>}
                   show={showActions}
-                  className="ml-auto"
+                  variant="primary"
                 />
-              </div>
+              </section>
             )}
             <CategoryBadges card={card} />
             <div className="grid gap-4 sm:grid-cols-2">

--- a/web/src/components/SaveCardActions.tsx
+++ b/web/src/components/SaveCardActions.tsx
@@ -10,17 +10,21 @@ import { AddToWishlistButton } from './AddToWishlistButton'
 export function SaveCardActions({
   card,
   show,
+  variant = 'icon',
   className = '',
 }: {
   card: Record<string, unknown>
   show: boolean
+  variant?: 'icon' | 'primary'
   className?: string
 }) {
   if (!show) return null
+  const layout =
+    variant === 'primary' ? 'grid grid-cols-1 gap-2 sm:grid-cols-2' : 'flex items-center gap-1'
   return (
-    <div className={`flex items-center gap-1 ${className}`}>
-      <AddToCollectionButton card={card} />
-      <AddToWishlistButton card={card} />
+    <div className={`${layout} ${className}`}>
+      <AddToCollectionButton card={card} variant={variant} />
+      <AddToWishlistButton card={card} variant={variant} />
     </div>
   )
 }


### PR DESCRIPTION
Closes #740

## What

- Promotes the card detail modal's owned/chasing save controls into a named **Library actions** panel.
- Adds a primary/labeled variant for the shared save controls: **Add as owned** and **Add as chasing**.
- Leaves the compact icon-only controls unchanged for result rows, Browse, and Swipe.

## Why

The modal's existing save-to-collection and add-to-want-list controls were compact icon buttons, making two high-value actions easy to miss. The detail modal now presents them as clear primary actions while preserving the existing dropdown flows.

## How to verify

- Open a matched card detail modal while signed in.
- Confirm the **Library actions** panel shows **Add as owned** and **Add as chasing** as large labeled buttons.
- Confirm each button still opens the existing collection / want-list picker.
- Confirm result rows, Browse cards, and Swipe cards still use compact icon controls.

Verified locally:

```bash
npm --prefix web test -- CardDetailModal.test.tsx AddToCollectionButton.test.tsx AddToWishlistButton.test.tsx
npm --prefix web run lint
npm --prefix web run build
make check
```

## Preview

Screenshot to be attached by the developer before review.