### PR TITLE
feat(web): move export control into search mode

### DIFF
--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -343,6 +343,9 @@ describe('App: discovery mode switcher', () => {
     resetStore()
     _resetAuthStoreForTests()
     mockBulkLookup.mockReset()
+    // jsdom doesn't implement scrollIntoView; the Tour highlights its target
+    // with it on mount, so stub it for the take-the-tour path.
+    Element.prototype.scrollIntoView = vi.fn()
   })
 
   // The Library panel's tablist now also lives in App, so scope every
@@ -391,6 +394,23 @@ describe('App: discovery mode switcher', () => {
 
     fireEvent.click(discoveryTabs().getByRole('tab', { name: /Swipe/ }))
     expect(screen.queryByRole('button', { name: /Export/i })).not.toBeInTheDocument()
+  })
+
+  it('starting the tour from Browse switches back to Search so its targets mount', async () => {
+    render(<App />)
+    fireEvent.click(discoveryTabs().getByRole('tab', { name: /Browse/ }))
+    expect(discoveryTabs().getByRole('tab', { name: /Browse/ })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /Help/i }))
+    fireEvent.click(await screen.findByRole('button', { name: /Take the tour/i }))
+
+    expect(discoveryTabs().getByRole('tab', { name: /Search/ })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    )
   })
 
   it('switching back to Search restores the editor without losing input', () => {

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -381,6 +381,18 @@ describe('App: discovery mode switcher', () => {
     ).toBeInTheDocument()
   })
 
+  it('surfaces Export in Search mode but not in Browse or Swipe', () => {
+    render(<App />)
+    // Search is the default mode — Export lives in the Results section.
+    expect(screen.getByRole('button', { name: /Export/i })).toBeInTheDocument()
+
+    fireEvent.click(discoveryTabs().getByRole('tab', { name: /Browse/ }))
+    expect(screen.queryByRole('button', { name: /Export/i })).not.toBeInTheDocument()
+
+    fireEvent.click(discoveryTabs().getByRole('tab', { name: /Swipe/ }))
+    expect(screen.queryByRole('button', { name: /Export/i })).not.toBeInTheDocument()
+  })
+
   it('switching back to Search restores the editor without losing input', () => {
     useAppStore.setState({ inputText: 'Charizard | Base Set | 4' })
     render(<App />)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,12 +3,15 @@
  *
  * Layout:
  *   ┌──────────────────────────────────┐
- *   │  Header (logo · settings · export)│
+ *   │  Header (logo · settings)         │
  *   ├──────────────────────────────────┤
  *   │  InputEditor (card list textarea) │
  *   ├──────────────────────────────────┤
- *   │  ResultsTable (streaming rows)    │
+ *   │  Results (export · streaming rows)│
  *   └──────────────────────────────────┘
+ *
+ * Export lives in the Search-mode Results section — it only applies to
+ * matched rows, so Browse and Swipe don't surface it.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -300,9 +303,6 @@ function App() {
             <img src={logoDarkUrl} alt="" aria-hidden="true" className="hidden h-8 w-auto dark:block" />
           </button>
           <div className="flex items-center gap-2">
-            <div data-tour="exports">
-              <ExportBar />
-            </div>
             <HelpModal onStartTour={() => setTourOpen(true)} />
             <div data-tour="settings">
               <SettingsDrawer />
@@ -365,9 +365,14 @@ function App() {
                 </section>
 
                 <section data-tour="results">
-                  <h2 className="mb-2 text-xs font-semibold uppercase tracking-wider text-coconut-400 dark:text-sand-300">
-                    Results
-                  </h2>
+                  <div className="mb-2 flex items-end justify-between gap-2">
+                    <h2 className="text-xs font-semibold uppercase tracking-wider text-coconut-400 dark:text-sand-300">
+                      Results
+                    </h2>
+                    <div data-tour="exports">
+                      <ExportBar />
+                    </div>
+                  </div>
                   <div className="flex flex-col gap-3">
                     <ProcessingQueue />
                     <ResultsTable onRerunLine={handleRerunLine} />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -303,7 +303,15 @@ function App() {
             <img src={logoDarkUrl} alt="" aria-hidden="true" className="hidden h-8 w-auto dark:block" />
           </button>
           <div className="flex items-center gap-2">
-            <HelpModal onStartTour={() => setTourOpen(true)} />
+            <HelpModal
+              onStartTour={() => {
+                // The tour seeds the card list and runs a lookup, and several
+                // of its steps (input, results, exports) target Search-only
+                // nodes — start it from Search so every target is mounted.
+                setMode('search')
+                setTourOpen(true)
+              }}
+            />
             <div data-tour="settings">
               <SettingsDrawer />
             </div>

--- a/web/src/components/BrowsePanel.test.tsx
+++ b/web/src/components/BrowsePanel.test.tsx
@@ -306,6 +306,13 @@ describe('BrowsePanel — pokedex view (#577)', () => {
     )
   })
 
+  it('offers the row-independent Set ID cards export in Browse (#736)', async () => {
+    render(<Harness />)
+    // Set ID cards is reachable while browsing even with no matched rows;
+    // the rest of the export menu stays in Search mode.
+    expect(await screen.findByRole('button', { name: /Set ID cards/i })).toBeInTheDocument()
+  })
+
   it('swaps a broken printing thumbnail for the placeholder', async () => {
     vi.spyOn(client, 'fetchPokedexCards').mockResolvedValue([
       { ...CHARIZARD_PRINTINGS[0], thumb: 'https://img/base1-4.png' },

--- a/web/src/components/BrowsePanel.tsx
+++ b/web/src/components/BrowsePanel.tsx
@@ -19,6 +19,7 @@ import { CardDetailModal } from './CardDetailModal'
 import { useCardOwnership } from './useCardOwnership'
 import { OwnershipBadge } from './OwnershipBadge'
 import { SaveCardActions } from './SaveCardActions'
+import { SetIdCardsButton } from './SetIdCardsButton'
 import type { CardOwnership } from '../api/client'
 import type {
   BrowseController,
@@ -143,6 +144,7 @@ export function BrowsePanel({ controller }: BrowsePanelProps) {
               Create binder
             </button>
           )}
+          <SetIdCardsButton />
           <ViewModeToggle value={viewMode} onChange={setViewMode} />
         </div>
       </header>

--- a/web/src/components/SetIdCardsButton.tsx
+++ b/web/src/components/SetIdCardsButton.tsx
@@ -1,0 +1,29 @@
+/**
+ * SetIdCardsButton — a standalone entry into the "Set ID cards…" picker.
+ *
+ * The export controls live in Search mode (#736), but Set ID cards is
+ * row-independent — it fetches the full set catalog server-side and needs no
+ * matched rows. Walking a set in Browse is exactly when you'd want to print
+ * its ID cards, so this surfaces the picker there without dragging the rest of
+ * the (row-dependent) export menu along.
+ */
+import { Tags } from 'lucide-react'
+import { useState } from 'react'
+import { SetPickerModal } from './SetPickerModal'
+
+export function SetIdCardsButton() {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="inline-flex items-center gap-1.5 rounded-md border border-sand-300 dark:border-husk-50 bg-sand-200 dark:bg-husk-100 px-2.5 py-1 text-xs text-coconut-600 dark:text-sand-200 hover:bg-sand-50 dark:hover:bg-husk-200"
+      >
+        <Tags size={14} />
+        Set ID cards…
+      </button>
+      <SetPickerModal open={open} onOpenChange={setOpen} />
+    </>
+  )
+}


### PR DESCRIPTION
Closes #736

## What

Move the Export dropdown out of the global header and into the Search-mode Results section, aligned beside the "Results" heading. It no longer renders in Browse or Swipe.

Two follow-ups from review:
- **Set ID cards stays reachable outside Search.** That export is row-independent and most useful while walking a set, so a standalone "Set ID cards…" button now lives in the Browse panel header.
- **The tour starts from Search.** Its input/results/exports steps target Search-only nodes, so launching it now switches to Search first.

## Why

Export only operates on matched search rows. Surfacing it in the header across every discovery mode put it in front of Browse and Swipe, where there's nothing to export — confusing and slightly misleading. Scoping it to Search keeps the control where its action makes sense, while Set ID cards (the one row-independent export) stays one click away in Browse.

## How to verify

1. `cd web && npm run dev`, open the app.
2. Search mode (default): Export sits at the top-right of the Results section.
3. Switch to Browse — the export menu is gone, but a "Set ID cards…" button is in the panel header. Swipe shows neither.
4. Open Help from Browse and click "Take the tour" — it switches to Search so every step has a target.

Covered by tests: App asserts Export is Search-only and the tour switches to Search; BrowsePanel asserts the Set ID cards button renders in Browse.