### PR TITLE
feat(web): surface collection insights in the nav and expand the dashboard

### DIFF
--- a/api/routes/collection_insights.py
+++ b/api/routes/collection_insights.py
@@ -128,11 +128,13 @@ def _top_labels(buckets: dict[str, set]) -> list[LabeledCount]:
     return [LabeledCount(label=label, count=len(cards)) for label, cards in ranked[:_TOP_N]]
 
 
-def _top_values(buckets: dict[str, float]) -> list[LabeledValue]:
-    """Top-N labels by summed value, ties broken alphabetically. Empty
-    (zero-value) buckets are dropped so the breakdown only shows priced rows."""
+def _top_values(pairs: list[tuple[str, float]]) -> list[LabeledValue]:
+    """Top-N (label, value) pairs by summed value, ties broken alphabetically.
+    Empty (zero-value) entries are dropped so the breakdown only shows priced
+    rows. Callers pass pre-labelled pairs so a value aggregated by a stable key
+    (e.g. collection id) can still display a non-unique name."""
     ranked = sorted(
-        ((label, value) for label, value in buckets.items() if value > 0),
+        ((label, value) for label, value in pairs if value > 0),
         key=lambda kv: (-kv[1], kv[0]),
     )
     return [LabeledValue(label=label, value=round(value, 2)) for label, value in ranked[:_TOP_N]]
@@ -149,25 +151,39 @@ def aggregate_items(rows: list) -> dict[str, Any]:
     rarity_cards: dict[str, set] = defaultdict(set)
     set_cards: dict[str, set] = defaultdict(set)
     set_value: dict[str, float] = defaultdict(float)
-    collection_value: dict[str, float] = defaultdict(float)
+    # Keyed by collection id, not name — names aren't unique, so two binders
+    # sharing a display name must stay separate bars (Codex review on #741).
+    collection_value: dict[int, float] = defaultdict(float)
+    collection_label: dict[int, str] = {}
     owned_collections: dict[tuple, set] = defaultdict(set)
     owned_quantity: dict[tuple, int] = defaultdict(int)
     owned_price: dict[tuple, float] = {}  # best per-copy snapshot per identity
     owned_meta: dict[tuple, dict] = {}
+    # Priced rows with no promoted identity can't be grouped, but they still
+    # contribute to estimated value — keep them as standalone crown-jewel
+    # candidates so an expensive legacy/custom card isn't silently dropped.
+    extra_value_cards: list[ValueCard] = []
     multiples: list[DuplicateCard] = []
 
-    for set_id, number, name, rarity, types, quantity, price, coll_name in rows:
+    for set_id, number, name, rarity, types, quantity, price, coll_id, coll_name in rows:
         qty = quantity or 0
         total_quantity += qty
+        collection_label[coll_id] = coll_name
         if price is not None:
             unit = float(price)
             estimated_value += unit * qty
-            collection_value[coll_name] += unit * qty
+            collection_value[coll_id] += unit * qty
             if set_id:
                 set_value[set_id] += unit * qty
         ident = _identity(set_id, number)
         if ident is None:
             unique_extra += 1
+            if price is not None:
+                extra_value_cards.append(
+                    ValueCard(
+                        card_name=name, card_set_id=set_id, card_number=number, price=float(price)
+                    )
+                )
         else:
             owned_collections[ident].add(coll_name)
             owned_quantity[ident] += qty
@@ -203,12 +219,11 @@ def aggregate_items(rows: list) -> dict[str, Any]:
     ]
     cross.sort(key=lambda c: (-len(c.collections), -c.total_quantity, c.card_name or ""))
 
-    top_value_cards = [
-        ValueCard(price=round(owned_price[ident], 2), **owned_meta[ident])
-        for ident in sorted(
-            owned_price, key=lambda i: (-owned_price[i], owned_meta[i]["card_name"] or "")
-        )[:_TOP_N]
-    ]
+    value_cards = [
+        ValueCard(price=round(owned_price[ident], 2), **owned_meta[ident]) for ident in owned_price
+    ] + extra_value_cards
+    value_cards.sort(key=lambda c: (-c.price, c.card_name or ""))
+    top_value_cards = value_cards[:_TOP_N]
 
     return {
         "total_quantity": total_quantity,
@@ -218,8 +233,10 @@ def aggregate_items(rows: list) -> dict[str, Any]:
         "top_rarities": _top_labels(rarity_cards),
         "top_sets": _top_labels(set_cards),
         "top_value_cards": top_value_cards,
-        "value_by_set": _top_values(set_value),
-        "value_by_collection": _top_values(collection_value),
+        "value_by_set": _top_values(list(set_value.items())),
+        "value_by_collection": _top_values(
+            [(collection_label[cid], v) for cid, v in collection_value.items()]
+        ),
         "duplicate_multiples": multiples[:_LIST_CAP],
         "cross_collection": cross[:_LIST_CAP],
         "owned_collections": owned_collections,

--- a/api/routes/collection_insights.py
+++ b/api/routes/collection_insights.py
@@ -1,0 +1,261 @@
+"""Aggregate "your collection at a glance" dashboard (#575, expanded in #741).
+
+The response shapes and the pure rollup that backs ``GET
+/collections/insights`` live here so [collections.py](./collections.py) keeps
+to CRUD + binder routing. The route handler itself (the SQL read + assembly)
+stays in that module next to the rest of the collections API.
+
+Every breakdown is computed live from the promoted card-identity columns —
+indexed SQL plus a small in-Python rollup, not a ``card_json`` scan. Dynamic
+collections own no rows, so they never appear here; their owned-scope
+membership is a filtered view of cards already counted, and double-counting
+them would inflate every total.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any
+
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..db.models import Wishlist, WishlistItem
+
+
+class InsightsTotals(BaseModel):
+    """Headline counters across every collection the user owns."""
+
+    collections: int
+    #: Distinct ``(set_id, number)`` identities, plus each identity-less row.
+    unique_cards: int
+    #: Sum of ``quantity`` — counts vendor multiples.
+    total_quantity: int
+    #: Sum of ``price_snapshot * quantity`` over priced rows. Live per-card
+    #: snapshots, not a ``collection_snapshots`` read — that table's writer
+    #: is #508, so value-over-time stays out of this slice.
+    estimated_value: float
+
+
+class LabeledCount(BaseModel):
+    """One bar in a top-N breakdown — a label and its distinct-card count."""
+
+    label: str
+    count: int
+
+
+class DuplicateCard(BaseModel):
+    """A row a vendor holds in multiples within a single collection."""
+
+    card_name: str | None
+    card_set_id: str | None
+    card_number: str | None
+    quantity: int
+    collection_name: str
+
+
+class CrossCollectionCard(BaseModel):
+    """One card identity that shows up in two or more collections."""
+
+    card_name: str | None
+    card_set_id: str | None
+    card_number: str | None
+    total_quantity: int
+    collections: list[str]
+
+
+class AlreadyOwnedChase(BaseModel):
+    """A want-list card the user already owns in a collection — a cleanup
+    nudge (wishlist ∩ collection)."""
+
+    card_name: str | None
+    card_set_id: str | None
+    card_number: str | None
+    wishlist_id: int
+    wishlist_name: str
+    collections: list[str]
+
+
+class ValueCard(BaseModel):
+    """A single owned card identity ranked by its per-copy price snapshot —
+    the collection's "crown jewels" list."""
+
+    card_name: str | None
+    card_set_id: str | None
+    card_number: str | None
+    price: float
+
+
+class LabeledValue(BaseModel):
+    """One bar in a value breakdown — a label and its summed estimated value
+    (``price_snapshot * quantity``)."""
+
+    label: str
+    value: float
+
+
+class CollectionInsightsOut(BaseModel):
+    totals: InsightsTotals
+    top_types: list[LabeledCount]
+    top_rarities: list[LabeledCount]
+    top_sets: list[LabeledCount]
+    top_value_cards: list[ValueCard]
+    value_by_set: list[LabeledValue]
+    value_by_collection: list[LabeledValue]
+    duplicate_multiples: list[DuplicateCard]
+    cross_collection: list[CrossCollectionCard]
+    already_owned_chasing: list[AlreadyOwnedChase]
+
+
+#: How many bars each top-N breakdown returns, and how many cards the
+#: duplicate / cleanup lists cap at, so the payload stays bounded.
+_TOP_N = 8
+_LIST_CAP = 25
+
+
+def _identity(set_id: str | None, number: str | None) -> tuple[str, str] | None:
+    """The ``(set_id, number)`` handle, or None when the row predates the
+    promoted-identity backfill and can't be grouped."""
+    if set_id is None or number is None:
+        return None
+    return (set_id, number)
+
+
+def _top_labels(buckets: dict[str, set]) -> list[LabeledCount]:
+    """Top-N labels by distinct-card count, ties broken alphabetically."""
+    ranked = sorted(buckets.items(), key=lambda kv: (-len(kv[1]), kv[0]))
+    return [LabeledCount(label=label, count=len(cards)) for label, cards in ranked[:_TOP_N]]
+
+
+def _top_values(buckets: dict[str, float]) -> list[LabeledValue]:
+    """Top-N labels by summed value, ties broken alphabetically. Empty
+    (zero-value) buckets are dropped so the breakdown only shows priced rows."""
+    ranked = sorted(
+        ((label, value) for label, value in buckets.items() if value > 0),
+        key=lambda kv: (-kv[1], kv[0]),
+    )
+    return [LabeledValue(label=label, value=round(value, 2)) for label, value in ranked[:_TOP_N]]
+
+
+def aggregate_items(rows: list) -> dict[str, Any]:
+    """Roll the user's materialized collection items up into the dashboard's
+    breakdowns. See the module docstring for why dynamic collections are
+    absent from ``rows`` and must stay that way."""
+    total_quantity = 0
+    unique_extra = 0  # identity-less rows, each its own "unique" card
+    estimated_value = 0.0
+    type_cards: dict[str, set] = defaultdict(set)
+    rarity_cards: dict[str, set] = defaultdict(set)
+    set_cards: dict[str, set] = defaultdict(set)
+    set_value: dict[str, float] = defaultdict(float)
+    collection_value: dict[str, float] = defaultdict(float)
+    owned_collections: dict[tuple, set] = defaultdict(set)
+    owned_quantity: dict[tuple, int] = defaultdict(int)
+    owned_price: dict[tuple, float] = {}  # best per-copy snapshot per identity
+    owned_meta: dict[tuple, dict] = {}
+    multiples: list[DuplicateCard] = []
+
+    for set_id, number, name, rarity, types, quantity, price, coll_name in rows:
+        qty = quantity or 0
+        total_quantity += qty
+        if price is not None:
+            unit = float(price)
+            estimated_value += unit * qty
+            collection_value[coll_name] += unit * qty
+            if set_id:
+                set_value[set_id] += unit * qty
+        ident = _identity(set_id, number)
+        if ident is None:
+            unique_extra += 1
+        else:
+            owned_collections[ident].add(coll_name)
+            owned_quantity[ident] += qty
+            owned_meta[ident] = {"card_name": name, "card_set_id": set_id, "card_number": number}
+            if price is not None:
+                owned_price[ident] = max(owned_price.get(ident, 0.0), float(price))
+            if set_id:
+                set_cards[set_id].add(ident)
+            if rarity:
+                rarity_cards[rarity].add(ident)
+            for t in types or []:
+                type_cards[t].add(ident)
+        if qty > 1:
+            multiples.append(
+                DuplicateCard(
+                    card_name=name,
+                    card_set_id=set_id,
+                    card_number=number,
+                    quantity=qty,
+                    collection_name=coll_name,
+                )
+            )
+
+    multiples.sort(key=lambda d: (-d.quantity, d.card_name or ""))
+    cross = [
+        CrossCollectionCard(
+            total_quantity=owned_quantity[ident],
+            collections=sorted(names),
+            **owned_meta[ident],
+        )
+        for ident, names in owned_collections.items()
+        if len(names) >= 2
+    ]
+    cross.sort(key=lambda c: (-len(c.collections), -c.total_quantity, c.card_name or ""))
+
+    top_value_cards = [
+        ValueCard(price=round(owned_price[ident], 2), **owned_meta[ident])
+        for ident in sorted(
+            owned_price, key=lambda i: (-owned_price[i], owned_meta[i]["card_name"] or "")
+        )[:_TOP_N]
+    ]
+
+    return {
+        "total_quantity": total_quantity,
+        "unique_cards": len(owned_meta) + unique_extra,
+        "estimated_value": round(estimated_value, 2),
+        "top_types": _top_labels(type_cards),
+        "top_rarities": _top_labels(rarity_cards),
+        "top_sets": _top_labels(set_cards),
+        "top_value_cards": top_value_cards,
+        "value_by_set": _top_values(set_value),
+        "value_by_collection": _top_values(collection_value),
+        "duplicate_multiples": multiples[:_LIST_CAP],
+        "cross_collection": cross[:_LIST_CAP],
+        "owned_collections": owned_collections,
+    }
+
+
+def already_owned_chasing(
+    db: Session, user_id: int, owned_collections: dict[tuple, set]
+) -> list[AlreadyOwnedChase]:
+    """Want-list cards the user already owns — the quiet cleanup nudge.
+    Acquired (``got it``) rows are excluded: they're intentionally kept as a
+    retrospective, not stale chases."""
+    rows = db.execute(
+        select(
+            WishlistItem.card_set_id,
+            WishlistItem.card_number,
+            WishlistItem.card_name,
+            Wishlist.id,
+            Wishlist.name,
+        )
+        .join(Wishlist, WishlistItem.wishlist_id == Wishlist.id)
+        .where(Wishlist.user_id == user_id, WishlistItem.acquired_at.is_(None))
+    ).all()
+    out: list[AlreadyOwnedChase] = []
+    for set_id, number, name, wl_id, wl_name in rows:
+        ident = _identity(set_id, number)
+        if ident is None or ident not in owned_collections:
+            continue
+        out.append(
+            AlreadyOwnedChase(
+                card_name=name,
+                card_set_id=set_id,
+                card_number=number,
+                wishlist_id=wl_id,
+                wishlist_name=wl_name,
+                collections=sorted(owned_collections[ident]),
+            )
+        )
+    return out[:_LIST_CAP]

--- a/api/routes/collections.py
+++ b/api/routes/collections.py
@@ -35,7 +35,6 @@ import hashlib
 import io
 import re
 import tempfile
-from collections import defaultdict
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Annotated, Any
@@ -80,6 +79,12 @@ from ..db.models import (
     WishlistItem,
 )
 from ..db.session import get_db
+from .collection_insights import (
+    CollectionInsightsOut,
+    InsightsTotals,
+    aggregate_items,
+    already_owned_chasing,
+)
 
 #: The kinds a caller may create. Mirrors the model constants; kept here so
 #: the create/patch validators reject an unknown kind with a 422.
@@ -317,72 +322,6 @@ class BulkAddResult(BaseModel):
     items: list[CollectionItemOut]
 
 
-# ---- #575: aggregate insights dashboard ----------------------------------
-
-
-class InsightsTotals(BaseModel):
-    """Headline counters across every collection the user owns."""
-
-    collections: int
-    #: Distinct ``(set_id, number)`` identities, plus each identity-less row.
-    unique_cards: int
-    #: Sum of ``quantity`` — counts vendor multiples.
-    total_quantity: int
-    #: Sum of ``price_snapshot * quantity`` over priced rows. Live per-card
-    #: snapshots, not a ``collection_snapshots`` read — that table's writer
-    #: is #508, so value-over-time stays out of this slice.
-    estimated_value: float
-
-
-class LabeledCount(BaseModel):
-    """One bar in a top-N breakdown — a label and its distinct-card count."""
-
-    label: str
-    count: int
-
-
-class DuplicateCard(BaseModel):
-    """A row a vendor holds in multiples within a single collection."""
-
-    card_name: str | None
-    card_set_id: str | None
-    card_number: str | None
-    quantity: int
-    collection_name: str
-
-
-class CrossCollectionCard(BaseModel):
-    """One card identity that shows up in two or more collections."""
-
-    card_name: str | None
-    card_set_id: str | None
-    card_number: str | None
-    total_quantity: int
-    collections: list[str]
-
-
-class AlreadyOwnedChase(BaseModel):
-    """A want-list card the user already owns in a collection — a cleanup
-    nudge (wishlist ∩ collection)."""
-
-    card_name: str | None
-    card_set_id: str | None
-    card_number: str | None
-    wishlist_id: int
-    wishlist_name: str
-    collections: list[str]
-
-
-class CollectionInsightsOut(BaseModel):
-    totals: InsightsTotals
-    top_types: list[LabeledCount]
-    top_rarities: list[LabeledCount]
-    top_sets: list[LabeledCount]
-    duplicate_multiples: list[DuplicateCard]
-    cross_collection: list[CrossCollectionCard]
-    already_owned_chasing: list[AlreadyOwnedChase]
-
-
 # ---------------------------------------------------------------------------
 # Routes
 # ---------------------------------------------------------------------------
@@ -445,131 +384,6 @@ def list_collections(db: DbSession, current_user: CurrentUser) -> dict:
     return {"items": [item.model_dump() for item in items], "total": len(items)}
 
 
-#: How many bars each top-N breakdown returns, and how many cards the
-#: duplicate / cleanup lists cap at, so the payload stays bounded.
-_TOP_N = 8
-_LIST_CAP = 25
-
-
-def _identity(set_id: str | None, number: str | None) -> tuple[str, str] | None:
-    """The ``(set_id, number)`` handle, or None when the row predates the
-    promoted-identity backfill and can't be grouped."""
-    if set_id is None or number is None:
-        return None
-    return (set_id, number)
-
-
-def _top_labels(buckets: dict[str, set]) -> list[LabeledCount]:
-    """Top-N labels by distinct-card count, ties broken alphabetically."""
-    ranked = sorted(buckets.items(), key=lambda kv: (-len(kv[1]), kv[0]))
-    return [LabeledCount(label=label, count=len(cards)) for label, cards in ranked[:_TOP_N]]
-
-
-def _aggregate_items(rows: list) -> dict[str, Any]:
-    """Roll the user's materialized collection items up into the dashboard's
-    breakdowns. Dynamic collections own no rows, so they never appear here —
-    their owned-scope membership is just a filtered view of cards already
-    counted, and double-counting them would inflate every total."""
-    total_quantity = 0
-    unique_extra = 0  # identity-less rows, each its own "unique" card
-    estimated_value = 0.0
-    type_cards: dict[str, set] = defaultdict(set)
-    rarity_cards: dict[str, set] = defaultdict(set)
-    set_cards: dict[str, set] = defaultdict(set)
-    owned_collections: dict[tuple, set] = defaultdict(set)
-    owned_quantity: dict[tuple, int] = defaultdict(int)
-    owned_meta: dict[tuple, dict] = {}
-    multiples: list[DuplicateCard] = []
-
-    for set_id, number, name, rarity, types, quantity, price, coll_name in rows:
-        qty = quantity or 0
-        total_quantity += qty
-        if price is not None:
-            estimated_value += float(price) * qty
-        ident = _identity(set_id, number)
-        if ident is None:
-            unique_extra += 1
-        else:
-            owned_collections[ident].add(coll_name)
-            owned_quantity[ident] += qty
-            owned_meta[ident] = {"card_name": name, "card_set_id": set_id, "card_number": number}
-            if set_id:
-                set_cards[set_id].add(ident)
-            if rarity:
-                rarity_cards[rarity].add(ident)
-            for t in types or []:
-                type_cards[t].add(ident)
-        if qty > 1:
-            multiples.append(
-                DuplicateCard(
-                    card_name=name,
-                    card_set_id=set_id,
-                    card_number=number,
-                    quantity=qty,
-                    collection_name=coll_name,
-                )
-            )
-
-    multiples.sort(key=lambda d: (-d.quantity, d.card_name or ""))
-    cross = [
-        CrossCollectionCard(
-            total_quantity=owned_quantity[ident],
-            collections=sorted(names),
-            **owned_meta[ident],
-        )
-        for ident, names in owned_collections.items()
-        if len(names) >= 2
-    ]
-    cross.sort(key=lambda c: (-len(c.collections), -c.total_quantity, c.card_name or ""))
-
-    return {
-        "total_quantity": total_quantity,
-        "unique_cards": len(owned_meta) + unique_extra,
-        "estimated_value": round(estimated_value, 2),
-        "top_types": _top_labels(type_cards),
-        "top_rarities": _top_labels(rarity_cards),
-        "top_sets": _top_labels(set_cards),
-        "duplicate_multiples": multiples[:_LIST_CAP],
-        "cross_collection": cross[:_LIST_CAP],
-        "owned_collections": owned_collections,
-    }
-
-
-def _already_owned_chasing(
-    db: Session, user_id: int, owned_collections: dict[tuple, set]
-) -> list[AlreadyOwnedChase]:
-    """Want-list cards the user already owns — the quiet cleanup nudge.
-    Acquired (``got it``) rows are excluded: they're intentionally kept as a
-    retrospective, not stale chases."""
-    rows = db.execute(
-        select(
-            WishlistItem.card_set_id,
-            WishlistItem.card_number,
-            WishlistItem.card_name,
-            Wishlist.id,
-            Wishlist.name,
-        )
-        .join(Wishlist, WishlistItem.wishlist_id == Wishlist.id)
-        .where(Wishlist.user_id == user_id, WishlistItem.acquired_at.is_(None))
-    ).all()
-    out: list[AlreadyOwnedChase] = []
-    for set_id, number, name, wl_id, wl_name in rows:
-        ident = _identity(set_id, number)
-        if ident is None or ident not in owned_collections:
-            continue
-        out.append(
-            AlreadyOwnedChase(
-                card_name=name,
-                card_set_id=set_id,
-                card_number=number,
-                wishlist_id=wl_id,
-                wishlist_name=wl_name,
-                collections=sorted(owned_collections[ident]),
-            )
-        )
-    return out[:_LIST_CAP]
-
-
 @router.get("/collections/insights")
 def collection_insights(db: DbSession, current_user: CurrentUser) -> dict:
     """Aggregate "your collection at a glance" across all of a user's
@@ -596,7 +410,7 @@ def collection_insights(db: DbSession, current_user: CurrentUser) -> dict:
         .where(Collection.user_id == current_user.id)
     ).all()
 
-    agg = _aggregate_items(rows)
+    agg = aggregate_items(rows)
     out = CollectionInsightsOut(
         totals=InsightsTotals(
             collections=int(collection_count),
@@ -607,9 +421,12 @@ def collection_insights(db: DbSession, current_user: CurrentUser) -> dict:
         top_types=agg["top_types"],
         top_rarities=agg["top_rarities"],
         top_sets=agg["top_sets"],
+        top_value_cards=agg["top_value_cards"],
+        value_by_set=agg["value_by_set"],
+        value_by_collection=agg["value_by_collection"],
         duplicate_multiples=agg["duplicate_multiples"],
         cross_collection=agg["cross_collection"],
-        already_owned_chasing=_already_owned_chasing(db, current_user.id, agg["owned_collections"]),
+        already_owned_chasing=already_owned_chasing(db, current_user.id, agg["owned_collections"]),
     )
     return out.model_dump()
 

--- a/api/routes/collections.py
+++ b/api/routes/collections.py
@@ -404,6 +404,7 @@ def collection_insights(db: DbSession, current_user: CurrentUser) -> dict:
             CollectionItem.card_types_json,
             CollectionItem.quantity,
             CollectionItem.price_snapshot,
+            Collection.id,
             Collection.name,
         )
         .join(Collection, CollectionItem.collection_id == Collection.id)

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -1057,6 +1057,36 @@ class CollectionInsightsTests(_IsolatedDbMixin):
             colls = {b["label"]: b["value"] for b in body["value_by_collection"]}
             self.assertEqual(colls, {"Owned": 510.0, "Trade Stock": 30.0})
 
+    def test_insights_value_by_collection_keys_by_id_not_name(self) -> None:
+        # Two binders share a display name; their values must stay separate.
+        priced = {**SAMPLE_CARD, "market_price": 100.0}
+        with self._client() as c:
+            a = c.post("/api/v1/collections", json={"name": "Trade Stock"}).json()["id"]
+            b = c.post("/api/v1/collections", json={"name": "Trade Stock"}).json()["id"]
+            c.post(f"/api/v1/collections/{a}/items", json={"card": priced})
+            c.post(f"/api/v1/collections/{b}/items", json={"card": priced, "quantity": 2})
+
+            bars = c.get("/api/v1/collections/insights").json()["value_by_collection"]
+            # Two bars, not one merged $300 bar.
+            self.assertEqual(len(bars), 2)
+            self.assertEqual(sorted(b["value"] for b in bars), [100.0, 200.0])
+            self.assertEqual({b["label"] for b in bars}, {"Trade Stock"})
+
+    def test_insights_crown_jewels_include_identity_less_priced_rows(self) -> None:
+        # A pricey card with no promoted (set, number) identity still counts.
+        custom = {"name": "Custom Slab", "market_price": 999.0}
+        with self._client() as c:
+            cid = c.post("/api/v1/collections", json={"name": "Owned"}).json()["id"]
+            c.post(f"/api/v1/collections/{cid}/items", json={"card": custom})
+            c.post(
+                f"/api/v1/collections/{cid}/items",
+                json={"card": {**SAMPLE_CARD, "market_price": 50.0}},
+            )
+
+            jewels = c.get("/api/v1/collections/insights").json()["top_value_cards"]
+            self.assertEqual(jewels[0]["card_name"], "Custom Slab")
+            self.assertEqual(jewels[0]["price"], 999.0)
+
     def test_insights_flags_vendor_multiples(self) -> None:
         with self._client() as c:
             cid = c.post("/api/v1/collections", json={"name": "Trade Stock"}).json()["id"]

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -997,6 +997,9 @@ class CollectionInsightsTests(_IsolatedDbMixin):
                 {"collections": 0, "unique_cards": 0, "total_quantity": 0, "estimated_value": 0.0},
             )
             self.assertEqual(body["top_types"], [])
+            self.assertEqual(body["top_value_cards"], [])
+            self.assertEqual(body["value_by_set"], [])
+            self.assertEqual(body["value_by_collection"], [])
             self.assertEqual(body["duplicate_multiples"], [])
             self.assertEqual(body["cross_collection"], [])
             self.assertEqual(body["already_owned_chasing"], [])
@@ -1027,6 +1030,32 @@ class CollectionInsightsTests(_IsolatedDbMixin):
             self.assertEqual(types, {"Fire": 1, "Colorless": 1, "Water": 1})
             rarities = {b["label"]: b["count"] for b in body["top_rarities"]}
             self.assertEqual(rarities["Rare Holo"], 1)
+
+    def test_insights_value_breakdowns(self) -> None:
+        charizard = {**SAMPLE_CARD, "market_price": 250.0}  # base1, Charizard
+        eevee = {**EEVEE_CARD, "market_price": 10.0}  # sv1
+        with self._client() as c:
+            owned = c.post("/api/v1/collections", json={"name": "Owned"}).json()["id"]
+            trade = c.post("/api/v1/collections", json={"name": "Trade Stock"}).json()["id"]
+            c.post(f"/api/v1/collections/{owned}/items", json={"card": charizard, "quantity": 2})
+            c.post(f"/api/v1/collections/{owned}/items", json={"card": eevee})
+            c.post(f"/api/v1/collections/{trade}/items", json={"card": eevee, "quantity": 3})
+
+            body = c.get("/api/v1/collections/insights").json()
+
+            # Crown jewels ranked by per-copy snapshot, not summed value.
+            jewels = body["top_value_cards"]
+            self.assertEqual(jewels[0]["card_name"], "Charizard")
+            self.assertEqual(jewels[0]["price"], 250.0)
+            self.assertEqual(jewels[1]["price"], 10.0)
+
+            # Value by set: base1 = 250*2 = 500; sv1 = 10*1 + 10*3 = 40.
+            sets = {b["label"]: b["value"] for b in body["value_by_set"]}
+            self.assertEqual(sets, {"base1": 500.0, "sv1": 40.0})
+
+            # Value by collection: Owned = 500 + 10 = 510; Trade Stock = 30.
+            colls = {b["label"]: b["value"] for b in body["value_by_collection"]}
+            self.assertEqual(colls, {"Owned": 510.0, "Trade Stock": 30.0})
 
     def test_insights_flags_vendor_multiples(self) -> None:
         with self._client() as c:

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -44,6 +44,9 @@ vi.mock('./api/client', () => ({
   // SwipePanel's "Build prep list" CTA depends on `useWishlists`, which
   // mounts its own GET on the first hook subscriber.
   fetchWishlists: vi.fn(() => Promise.resolve([])),
+  // InsightsNavButton mounts in the header and reads useCollections on its
+  // first subscriber; stub the list so the gate resolves to 0 (button hidden).
+  fetchCollections: vi.fn(() => Promise.resolve([])),
   createWishlist: vi.fn(),
   addCardToWishlist: vi.fn(),
   setLogoUrl: vi.fn(() => ''),

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -24,6 +24,7 @@ import { LibraryPanel } from './components/LibraryPanel'
 import { ResultsTable } from './components/ResultsTable'
 import { consumePendingSaveSearch, type PendingSaveSearch } from './components/pendingSaveSearch'
 import { ExportBar } from './components/ExportBar'
+import { InsightsNavButton } from './components/InsightsNavButton'
 import { ProcessingQueue } from './components/ProcessingQueue'
 import { SettingsDrawer } from './components/SettingsDrawer'
 import { HelpModal } from './components/HelpModal'
@@ -300,6 +301,7 @@ function App() {
             <img src={logoDarkUrl} alt="" aria-hidden="true" className="hidden h-8 w-auto dark:block" />
           </button>
           <div className="flex items-center gap-2">
+            <InsightsNavButton />
             <div data-tour="exports">
               <ExportBar />
             </div>

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1027,6 +1027,20 @@ export interface AlreadyOwnedChase {
   collections: string[]
 }
 
+/** One owned card identity ranked by its per-copy price snapshot. */
+export interface ValueCard {
+  card_name: string | null
+  card_set_id: string | null
+  card_number: string | null
+  price: number
+}
+
+/** One bar in a value breakdown — a label and its summed estimated value. */
+export interface LabeledValue {
+  label: string
+  value: number
+}
+
 /** Aggregate "your collection at a glance" across all of the user's
  * collections (#575). */
 export interface CollectionInsights {
@@ -1034,6 +1048,9 @@ export interface CollectionInsights {
   top_types: LabeledCount[]
   top_rarities: LabeledCount[]
   top_sets: LabeledCount[]
+  top_value_cards: ValueCard[]
+  value_by_set: LabeledValue[]
+  value_by_collection: LabeledValue[]
   duplicate_multiples: DuplicateCard[]
   cross_collection: CrossCollectionCard[]
   already_owned_chasing: AlreadyOwnedChase[]

--- a/web/src/components/CollectionInsights.test.tsx
+++ b/web/src/components/CollectionInsights.test.tsx
@@ -18,6 +18,9 @@ function insights(overrides: Partial<Insights> = {}): Insights {
     ],
     top_rarities: [{ label: 'Rare Holo', count: 1 }],
     top_sets: [{ label: 'base1', count: 2 }],
+    top_value_cards: [],
+    value_by_set: [],
+    value_by_collection: [],
     duplicate_multiples: [],
     cross_collection: [],
     already_owned_chasing: [],
@@ -96,6 +99,27 @@ describe('CollectionInsights', () => {
     const nudge = screen.getByText('Already in a binder').closest('section')!
     expect(within(nudge).getByText('Blastoise')).toBeInTheDocument()
     expect(within(nudge).getByText('Chase')).toBeInTheDocument()
+  })
+
+  it('renders the most-valuable cards and value breakdowns (#741)', async () => {
+    mockFetch.mockResolvedValue(
+      insights({
+        top_value_cards: [
+          { card_name: 'Charizard', card_set_id: 'base1', card_number: '4', price: 250 },
+          { card_name: 'Blastoise', card_set_id: 'base1', card_number: '2', price: 80 },
+        ],
+        value_by_set: [{ label: 'base1', value: 330 }],
+        value_by_collection: [{ label: 'Show Binder', value: 330 }],
+      }),
+    )
+    render(<CollectionInsights open onOpenChange={() => {}} />)
+
+    await waitFor(() => expect(screen.getByText('Most valuable cards')).toBeInTheDocument())
+    const jewels = screen.getByText('Most valuable cards').closest('section')!
+    expect(within(jewels).getByText('Charizard')).toBeInTheDocument()
+    expect(within(jewels).getByText('$250.00')).toBeInTheDocument()
+    expect(screen.getByText('Value by set')).toBeInTheDocument()
+    expect(screen.getByText('Value by binder')).toBeInTheDocument()
   })
 
   it('does not fetch while closed', () => {

--- a/web/src/components/CollectionInsights.tsx
+++ b/web/src/components/CollectionInsights.tsx
@@ -4,19 +4,21 @@
  * [LibraryBindersTab](./LibraryBindersTab.tsx).
  *
  * Reads one rollup from `GET /collections/insights`: headline totals, the
- * top types / rarities / sets as bars, a vendor-facing duplicates view
+ * top types / rarities / sets as bars, the most valuable cards plus value
+ * broken down by set and by binder (#741), a vendor-facing duplicates view
  * (multiples + cards spanning more than one binder), and a quiet cleanup
  * nudge for want-list cards you already own. Value-over-time is deliberately
  * out — that chart needs the `collection_snapshots` writer (#508), which
  * hasn't landed.
  */
 import * as Dialog from '@radix-ui/react-dialog'
-import { BarChart3, Copy, Loader2, Sparkles, X } from 'lucide-react'
+import { BarChart3, Copy, Gem, Loader2, Sparkles, X } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import {
   fetchCollectionInsights,
   type CollectionInsights as Insights,
   type LabeledCount,
+  type LabeledValue,
 } from '../api/client'
 import { formatMoney } from '../utils/format'
 
@@ -68,6 +70,69 @@ function BarList({ title, items }: { title: string; items: LabeledCount[] }) {
             </div>
             <span className="text-right tabular-nums text-coconut-400 dark:text-sand-300">
               {i.count}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+/** A top-N value breakdown as horizontal bars, widths relative to the group
+ * max. Mirrors {@link BarList} but the trailing figure is money, not a count. */
+function ValueBarList({ title, items }: { title: string; items: LabeledValue[] }) {
+  if (items.length === 0) return null
+  const max = Math.max(...items.map((i) => i.value))
+  return (
+    <section>
+      <h3 className="mb-2 text-[11px] font-medium uppercase tracking-wide text-coconut-400 dark:text-sand-300">
+        {title}
+      </h3>
+      <ul className="space-y-1.5">
+        {items.map((i) => (
+          <li
+            key={i.label}
+            className="grid grid-cols-[5.5rem_1fr_3.5rem] items-center gap-2 text-xs"
+          >
+            <span className="truncate text-coconut-600 dark:text-sand-200" title={i.label}>
+              {i.label}
+            </span>
+            <div className="h-2 overflow-hidden rounded-full bg-sand-200 dark:bg-husk-200">
+              <div
+                className="h-full rounded-full bg-sun-500"
+                style={{ width: `${Math.max((i.value / max) * 100, 4)}%` }}
+              />
+            </div>
+            <span className="text-right tabular-nums text-coconut-400 dark:text-sand-300">
+              {formatMoney(i.value)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+/** The collection's "crown jewels" — owned cards ranked by per-copy price. */
+function TopValueCards({ data }: { data: Insights }) {
+  const cards = data.top_value_cards
+  if (cards.length === 0) return null
+  return (
+    <section>
+      <h3 className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-coconut-400 dark:text-sand-300">
+        <Gem size={12} /> Most valuable cards
+      </h3>
+      <ul className="mt-2 divide-y divide-sand-200 dark:divide-husk-100">
+        {cards.map((c, idx) => (
+          <li
+            key={`${c.card_set_id}-${c.card_number}-${idx}`}
+            className="flex items-center justify-between gap-2 py-1.5 text-xs"
+          >
+            <span className="min-w-0 truncate text-coconut-700 dark:text-sand-50">
+              {c.card_name ?? cardRef(c.card_set_id, c.card_number)}
+            </span>
+            <span className="shrink-0 tabular-nums font-medium text-coconut-600 dark:text-sand-200">
+              {formatMoney(c.price)}
             </span>
           </li>
         ))}
@@ -220,8 +285,9 @@ export function CollectionInsights({ open, onOpenChange }: Props) {
             </Dialog.Close>
           </header>
           <Dialog.Description className="sr-only">
-            Headline totals, top types, rarities and sets, duplicates, and want-list cards you
-            already own, across all your collections.
+            Headline totals, top types, rarities and sets, your most valuable cards, value by set
+            and binder, duplicates, and want-list cards you already own, across all your
+            collections.
           </Dialog.Description>
 
           <div className="flex-1 space-y-5 overflow-y-auto px-5 py-4">
@@ -252,6 +318,13 @@ export function CollectionInsights({ open, onOpenChange }: Props) {
                   <BarList title="Top types" items={data.top_types} />
                   <BarList title="Top rarities" items={data.top_rarities} />
                   <BarList title="Top sets" items={data.top_sets} />
+                </div>
+
+                <TopValueCards data={data} />
+
+                <div className="grid gap-5 sm:grid-cols-2">
+                  <ValueBarList title="Value by set" items={data.value_by_set} />
+                  <ValueBarList title="Value by binder" items={data.value_by_collection} />
                 </div>
 
                 <DuplicatesSection data={data} />

--- a/web/src/components/InsightsNavButton.test.tsx
+++ b/web/src/components/InsightsNavButton.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { InsightsNavButton, INSIGHTS_NAV_THRESHOLD } from './InsightsNavButton'
+import { fetchCollections, type CollectionSummary } from '../api/client'
+import { _resetCollectionsCacheForTests } from './useCollections'
+
+vi.mock('../api/client', () => ({
+  fetchCollections: vi.fn(),
+  // CollectionInsights (rendered by the button) reads this when opened; the
+  // gate tests never open the dialog, so a stub is enough.
+  fetchCollectionInsights: vi.fn(() => Promise.resolve({})),
+}))
+
+const mockFetch = vi.mocked(fetchCollections)
+
+function summary(overrides: Partial<CollectionSummary>): CollectionSummary {
+  return {
+    id: 1,
+    name: 'Binder',
+    description: null,
+    created_at: '2026-01-01T00:00:00Z',
+    item_count: 0,
+    total_quantity: 0,
+    kind: 'manual',
+    ...overrides,
+  }
+}
+
+describe('InsightsNavButton (#741)', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+    _resetCollectionsCacheForTests()
+  })
+
+  it('stays hidden below the 25-card threshold', async () => {
+    mockFetch.mockResolvedValue([summary({ total_quantity: INSIGHTS_NAV_THRESHOLD - 1 })])
+    render(<InsightsNavButton />)
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled())
+    expect(screen.queryByRole('button', { name: /Collection insights/i })).not.toBeInTheDocument()
+  })
+
+  it('surfaces once 25+ cards are collected', async () => {
+    mockFetch.mockResolvedValue([
+      summary({ id: 1, total_quantity: 20 }),
+      summary({ id: 2, total_quantity: 5 }),
+    ])
+    render(<InsightsNavButton />)
+    expect(
+      await screen.findByRole('button', { name: /Collection insights/i }),
+    ).toBeInTheDocument()
+  })
+
+  it('excludes dynamic collections from the count', async () => {
+    mockFetch.mockResolvedValue([
+      summary({ id: 1, total_quantity: 10, kind: 'manual' }),
+      summary({ id: 2, total_quantity: 100, kind: 'dynamic' }),
+    ])
+    render(<InsightsNavButton />)
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled())
+    expect(screen.queryByRole('button', { name: /Collection insights/i })).not.toBeInTheDocument()
+  })
+})

--- a/web/src/components/InsightsNavButton.tsx
+++ b/web/src/components/InsightsNavButton.tsx
@@ -1,0 +1,45 @@
+/**
+ * InsightsNavButton — the top-nav entry point into the Collection insights
+ * dashboard (#741). Hidden until the user has a meaningful library so it
+ * doesn't clutter the header for newcomers; it surfaces once 25+ cards are
+ * collected.
+ *
+ * The collected count reuses the already-loaded `useCollections` cache (sum
+ * of vendor multiples), so the gate costs no extra round-trip. Dynamic
+ * collections are excluded — they own no rows, and their resolved membership
+ * either double-counts owned cards or reflects an un-owned catalog, so
+ * counting them would misrepresent how much you actually hold.
+ */
+import { BarChart3 } from 'lucide-react'
+import { useState } from 'react'
+import { useCollections } from './useCollections'
+import { CollectionInsights } from './CollectionInsights'
+
+/** How many collected cards before the insights entry point appears. */
+export const INSIGHTS_NAV_THRESHOLD = 25
+
+export function InsightsNavButton() {
+  const { collections } = useCollections()
+  const [open, setOpen] = useState(false)
+
+  const collected = collections
+    .filter((c) => c.kind !== 'dynamic')
+    .reduce((n, c) => n + (c.total_quantity ?? c.item_count), 0)
+
+  if (collected < INSIGHTS_NAV_THRESHOLD) return null
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label="Collection insights"
+        className="flex items-center gap-1.5 rounded-md border border-sand-300 bg-sand-100 px-3 py-1.5 text-sm text-coconut-700 hover:bg-sand-200 hover:border-sand-400 dark:border-husk-50 dark:bg-husk-200 dark:text-sand-50 dark:hover:bg-husk-100 dark:hover:border-coconut-400 transition-colors"
+      >
+        <BarChart3 size={14} />
+        Insights
+      </button>
+      <CollectionInsights open={open} onOpenChange={setOpen} />
+    </>
+  )
+}


### PR DESCRIPTION
Closes #741

## What

Two changes to the Collection insights surface:

1. **Top-nav entry point.** Insights was reachable only from inside the Binders tab. A new `InsightsNavButton` in the header appears once the library is meaningful — 25+ cards collected — and opens the existing dashboard. Below the threshold it stays hidden so it doesn't clutter the header for newcomers.
2. **Expanded dashboard.** Three new value-oriented breakdowns: **Most valuable cards** (crown jewels ranked by per-copy price snapshot), **Value by set**, and **Value by binder**.

It also moves the insights response models + the pure rollup into a new `api/routes/collection_insights.py`, leaving the route handler in `collections.py`. That keeps `collections.py` focused on CRUD + binder routing and lifts its maintainability index back above the gate (A 26.4, was trending down as insights grew).

## Why

A collector with a real library wants their stats one click away, not buried a tab deep. And "at a glance" should answer the questions collectors actually ask — *what's my best card, where's my value concentrated* — not just counts.

## How it works

- The 25-card gate reads the already-loaded `useCollections` cache (sum of vendor multiples), so it costs no extra round-trip. Dynamic collections are excluded from the count — they own no rows, and their resolved membership would either double-count owned cards or reflect an un-owned catalog.
- The new breakdowns are computed in the same single SQL read + in-Python rollup that already backed the dashboard — no new query, no migration.

## How to verify

- `make check` and `cd web && npm run build` are green.
- Backend: `test_insights_value_breakdowns` covers crown jewels + value-by-set + value-by-collection; the empty-state test covers the new empty fields.
- Frontend: `InsightsNavButton.test.tsx` covers the 25-card gate (hidden below, shown at/above, dynamic collections excluded); `CollectionInsights.test.tsx` covers the new sections rendering.
- Manual: with a signed-in account holding 25+ collected cards, the Insights button shows in the header and opens the dashboard with the new sections.