### PR TITLE
feat(web): let users pick favorite Pokémon (pokedex + onboarding)

### DIFF
--- a/api/auth/routes.py
+++ b/api/auth/routes.py
@@ -7,7 +7,7 @@ routes once they land."""
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
@@ -15,7 +15,15 @@ from pydantic import BaseModel, Field
 from sqlalchemy import func, select
 
 from ..db.models import DEFAULT_USER_ID, User, UserIdentity
-from .session import CurrentUserRequired, DbSession, auth_enabled, get_current_user
+from .session import (
+    CurrentUserRequired,
+    DbSession,
+    auth_enabled,
+    current_user_or_default,
+    get_current_user,
+)
+
+CurrentUserOrDefault = Annotated[User, Depends(current_user_or_default)]
 
 router = APIRouter()
 
@@ -47,6 +55,9 @@ class MeUser(BaseModel):
     email: str | None
     display_name: str | None
     identities: list[MeIdentity] = Field(default_factory=list)
+    #: Whether the user has finished (or skipped) the first-login onboarding
+    #: survey (#742) — the SPA shows the favorite-Pokémon pop-up when false.
+    onboarding_completed: bool = False
 
 
 class MeOut(BaseModel):
@@ -91,6 +102,7 @@ def me(user: CurrentUser, db: DbSession) -> MeOut:
                     email=default.email,
                     display_name=default.display_name,
                     identities=[],
+                    onboarding_completed=default.onboarding_completed_at is not None,
                 ),
                 auth_enabled=False,
             )
@@ -117,12 +129,26 @@ def me(user: CurrentUser, db: DbSession) -> MeOut:
                 email=user.email,
                 display_name=user.display_name,
                 identities=identities,
+                onboarding_completed=user.onboarding_completed_at is not None,
             )
             if user is not None
             else None
         ),
         auth_enabled=enabled,
     )
+
+
+@router.post("/me/onboarding/complete", status_code=204)
+def complete_onboarding(db: DbSession, user: CurrentUserOrDefault) -> Response:
+    """Mark the first-login onboarding survey done (#742).
+
+    Idempotent — re-completing leaves the original timestamp in place, so a
+    double-submit (or a "Skip" after a "Done") never re-opens the pop-up. Works
+    in self-host mode too: the sentinel default user can finish onboarding."""
+    if user.onboarding_completed_at is None:
+        user.onboarding_completed_at = datetime.now(UTC)
+        db.commit()
+    return Response(status_code=204)
 
 
 @router.post("/auth/logout", status_code=204)

--- a/api/db/models.py
+++ b/api/db/models.py
@@ -74,6 +74,12 @@ class User(Base):
         DateTime(timezone=True), nullable=True
     )
     display_name: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    #: When the user finished (or skipped) the first-login onboarding survey
+    #: (#742). Null = never seen it, so the SPA shows the favorite-Pokémon
+    #: pop-up; a timestamp suppresses it across devices.
+    onboarding_completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     runs: Mapped[list[Run]] = relationship(back_populates="user")
     identities: Mapped[list[UserIdentity]] = relationship(
@@ -540,6 +546,37 @@ class FavoriteSet(Base):
         index=True,
     )
     set_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    pinned_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_utcnow, nullable=False
+    )
+
+
+class FavoriteSpecies(Base):
+    """One Pokémon species a user has pinned as a favorite (#742).
+
+    The species-level sibling of :class:`FavoriteSet`: a durable, per-user,
+    server-side "I love this Pokémon" signal that Swipe / Browse lean toward.
+    Keyed by national Pokédex number — the same key Browse's pokedex view and
+    ``GET /pokedex/{number}/cards`` use — so a card's
+    ``nationalPokedexNumbers`` matches it directly.
+
+    Append-only and idempotent: the unique constraint on
+    ``(user_id, dex_number)`` makes re-pinning a no-op rather than a duplicate
+    row, mirroring :class:`FavoriteSet`."""
+
+    __tablename__ = "favorite_species"
+    __table_args__ = (
+        UniqueConstraint("user_id", "dex_number", name="uq_favorite_species_user_dex"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"),
+        default=DEFAULT_USER_ID,
+        nullable=False,
+        index=True,
+    )
+    dex_number: Mapped[int] = mapped_column(Integer, nullable=False)
     pinned_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=_utcnow, nullable=False
     )

--- a/api/main.py
+++ b/api/main.py
@@ -49,6 +49,7 @@ from .routes import (
     collections,
     ebay,
     export,
+    favorite_pokemon,
     favorite_sets,
     lookup,
     overrides,
@@ -547,6 +548,7 @@ app.include_router(binders.router, prefix="/api/v1", tags=["binders"])
 app.include_router(wishlists.router, prefix="/api/v1", tags=["wishlists"])
 app.include_router(swipe.router, prefix="/api/v1", tags=["swipe"])
 app.include_router(favorite_sets.router, prefix="/api/v1", tags=["favorite-sets"])
+app.include_router(favorite_pokemon.router, prefix="/api/v1", tags=["favorite-pokemon"])
 app.include_router(ownership.router, prefix="/api/v1", tags=["ownership"])
 app.include_router(cache_route.router, prefix="/api/v1", tags=["cache"])
 app.include_router(ebay.router, prefix="/api/v1", tags=["ebay"])

--- a/api/migrations/versions/e9a1c3f7b2d8_favorite_species_and_onboarding.py
+++ b/api/migrations/versions/e9a1c3f7b2d8_favorite_species_and_onboarding.py
@@ -1,0 +1,60 @@
+"""favorite_species + users.onboarding_completed_at — favorite Pokémon (#742)
+
+Species-level sibling of ``favorite_sets`` (#712): an explicit, durable "I love
+this Pokémon" signal, keyed by national Pokédex number — the same key Browse's
+pokedex view and ``GET /pokedex/{number}/cards`` use — so a card's
+``nationalPokedexNumbers`` matches it directly across Swipe / Browse.
+
+Also adds ``users.onboarding_completed_at``: a server-side gate for the
+first-login favorite-Pokémon survey, so it suppresses across devices once the
+user finishes (or skips) it.
+
+Append-only and idempotent: the unique constraint on ``(user_id, dex_number)``
+makes re-pinning a no-op, mirroring ``favorite_sets``.
+
+Revision ID: e9a1c3f7b2d8
+Revises: c8b4e1f6a2d7
+Create Date: 2026-06-22
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e9a1c3f7b2d8"
+down_revision: str | Sequence[str] | None = "c8b4e1f6a2d7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "favorite_species",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("dex_number", sa.Integer(), nullable=False),
+        sa.Column("pinned_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "dex_number", name="uq_favorite_species_user_dex"),
+    )
+    # Every read filters by user_id first; a leading-user_id index keeps the
+    # per-user fetch and the idempotent-insert conflict check off a scan.
+    op.create_index(
+        "ix_favorite_species_user_id",
+        "favorite_species",
+        ["user_id"],
+    )
+    op.add_column(
+        "users",
+        sa.Column("onboarding_completed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "onboarding_completed_at")
+    op.drop_index("ix_favorite_species_user_id", table_name="favorite_species")
+    op.drop_table("favorite_species")

--- a/api/routes/favorite_pokemon.py
+++ b/api/routes/favorite_pokemon.py
@@ -1,0 +1,120 @@
+"""`/api/v1/favorite-pokemon` — per-user pinned favorite Pokémon (#742).
+
+The species-level sibling of ``/favorite-sets`` (#712), part of turning swipe
+into a personalization surface (#701). A favorite Pokémon is an explicit,
+durable "I love this species" signal — distinct from the localStorage swipe
+taste profile — that other surfaces (Browse's pokedex view, swipe candidate
+weighting) can read across devices.
+
+Species are referenced by their national Pokédex number — the same key Browse's
+pokedex view and ``GET /pokedex/{number}/cards`` use — so a card's
+``nationalPokedexNumbers`` matches a favorite directly. The friendly name is
+resolved client-side from the baked Pokédex, so it isn't stored or returned
+here.
+
+Endpoints:
+
+- ``GET    /favorite-pokemon``                 the user's pinned dex numbers
+- ``POST   /favorite-pokemon``                 pin a species (idempotent)
+- ``DELETE /favorite-pokemon/{dex_number}``    unpin a species
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Response
+from pydantic import BaseModel, Field
+from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from ..auth.session import current_user_or_default
+from ..db.models import FavoriteSpecies, User
+from ..db.session import get_db
+
+router = APIRouter()
+
+DbSession = Annotated[Session, Depends(get_db)]
+CurrentUser = Annotated[User, Depends(current_user_or_default)]
+
+#: National Pokédex ceiling — the highest dex number a pin can reference. Kept
+#: in step with the baked Pokédex's top generation boundary.
+_MAX_DEX_NUMBER = 1025
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+
+class FavoritePokemonOut(BaseModel):
+    dex_number: int
+    pinned_at: str
+
+
+class FavoritePokemonListOut(BaseModel):
+    pokemon: list[FavoritePokemonOut]
+
+
+class FavoritePokemonCreate(BaseModel):
+    dex_number: int = Field(ge=1, le=_MAX_DEX_NUMBER)
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@router.get("/favorite-pokemon")
+def list_favorites(db: DbSession, current_user: CurrentUser) -> dict:
+    """The user's pinned Pokémon, newest first."""
+    rows = db.execute(
+        select(FavoriteSpecies.dex_number, FavoriteSpecies.pinned_at)
+        .where(FavoriteSpecies.user_id == current_user.id)
+        .order_by(FavoriteSpecies.pinned_at.desc())
+    ).all()
+    pokemon = [FavoritePokemonOut(dex_number=n, pinned_at=p.isoformat()) for n, p in rows]
+    return FavoritePokemonListOut(pokemon=pokemon).model_dump()
+
+
+@router.post("/favorite-pokemon", status_code=204)
+def pin_favorite(
+    req: FavoritePokemonCreate,
+    db: DbSession,
+    current_user: CurrentUser,
+) -> Response:
+    """Pin a species. Idempotent: re-pinning is a no-op.
+
+    The unique constraint on ``(user_id, dex_number)`` is the source of truth —
+    a concurrent duplicate insert raises ``IntegrityError``, which we swallow so
+    the call still reports success (the species is already pinned)."""
+    row = FavoriteSpecies(
+        user_id=current_user.id,
+        dex_number=req.dex_number,
+        pinned_at=datetime.now(UTC),
+    )
+    db.add(row)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+    return Response(status_code=204)
+
+
+@router.delete("/favorite-pokemon/{dex_number}", status_code=204)
+def unpin_favorite(
+    dex_number: int,
+    db: DbSession,
+    current_user: CurrentUser,
+) -> Response:
+    """Unpin a species. A no-op (still 204) when it wasn't pinned."""
+    db.execute(
+        delete(FavoriteSpecies).where(
+            FavoriteSpecies.user_id == current_user.id,
+            FavoriteSpecies.dex_number == dex_number,
+        )
+    )
+    db.commit()
+    return Response(status_code=204)

--- a/api/routes/sets.py
+++ b/api/routes/sets.py
@@ -186,6 +186,12 @@ def _trim_card(card: dict[str, Any]) -> dict[str, Any]:
         "subtypes": card.get("subtypes") or [],
         "thumb": thumb,
         "market": pricing.market,
+        # National Pokédex numbers (usually one; a couple for multi-species
+        # cards). Lets the SPA match a card to a favorite species (#742) for
+        # swipe weighting without re-deriving the species from the name.
+        # camelCase to match the rest of the SPA-facing card shape (the SPA
+        # casts the JSON straight to `SetCard`, no key remap).
+        "dexNumbers": card.get("nationalPokedexNumbers") or [],
     }
 
 

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -690,9 +690,11 @@ class SetCardsRouteTests(unittest.TestCase):
             "images": {"small": "https://example/c.png", "large": "x"},
             "tcgplayer": {"prices": {"holofoil": {"market": 42.5}}},
             "attacks": [{"name": "Fire Spin"}],
+            "nationalPokedexNumbers": [6],
         }
         slim = _trim_card(raw)
         self.assertEqual(slim["id"], "sv8-99")
+        self.assertEqual(slim["dexNumbers"], [6])
         self.assertEqual(slim["name"], "Charizard")
         self.assertEqual(slim["number"], "99")
         self.assertEqual(slim["rarity"], "Rare Holo")
@@ -714,6 +716,7 @@ class SetCardsRouteTests(unittest.TestCase):
         self.assertIsNone(slim["market"])
         self.assertIsNone(slim["thumb"])
         self.assertEqual(slim["subtypes"], [])
+        self.assertEqual(slim["dexNumbers"], [])
 
     def test_404_when_set_has_no_cards(self) -> None:
         with patch("api.routes.sets._fetch_set_cards", return_value=([], "MISS")):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -193,6 +193,28 @@ class MeEndpointAnonymousTests(_IsolatedDbMixin):
             self.assertEqual(body["user"]["id"], 1)
 
 
+class OnboardingTests(_IsolatedDbMixin):
+    """First-login onboarding gate (#742): ``/me`` reports completion and
+    ``POST /me/onboarding/complete`` flips it, idempotently. Exercised in
+    self-host mode against the sentinel default user."""
+
+    def test_onboarding_starts_incomplete_then_completes(self) -> None:
+        from api.main import app
+
+        with TestClient(app) as c:
+            self.assertFalse(c.get("/api/v1/me").json()["user"]["onboarding_completed"])
+            self.assertEqual(c.post("/api/v1/me/onboarding/complete").status_code, 204)
+            self.assertTrue(c.get("/api/v1/me").json()["user"]["onboarding_completed"])
+
+    def test_completing_onboarding_is_idempotent(self) -> None:
+        from api.main import app
+
+        with TestClient(app) as c:
+            self.assertEqual(c.post("/api/v1/me/onboarding/complete").status_code, 204)
+            self.assertEqual(c.post("/api/v1/me/onboarding/complete").status_code, 204)
+            self.assertTrue(c.get("/api/v1/me").json()["user"]["onboarding_completed"])
+
+
 class MeEndpointAuthOnTests(_IsolatedDbMixin):
     """End-to-end cookie sign-in is covered by the provider sub-issues
     (#408 GitHub / #409 magic-link / #410 Google) — those wire the routes

--- a/tests/test_auth_identities.py
+++ b/tests/test_auth_identities.py
@@ -26,7 +26,7 @@ from unittest.mock import patch
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from sqlalchemy import func, inspect, select
+from sqlalchemy import func, inspect, select, text
 from sqlalchemy.exc import IntegrityError
 
 from api.auth.identity import resolve_or_link_identity
@@ -126,37 +126,41 @@ class UserIdentitiesBackfillTests(_IsolatedDbMixin):
         cfg = migrate_mod._alembic_config()
         cfg.set_main_option("sqlalchemy.url", str(engine.url))
         command.upgrade(cfg, "4a1c7b1e9b22")
-        with session_mod.get_session_factory()() as s:
-            # The `default` sentinel is seeded by the initial migration;
-            # it should NOT get an identity row.
-            s.add(
-                User(
-                    name="gh:alice",
-                    email="alice@example.com",
-                    email_verified_at=datetime.now(UTC),
-                    display_name="Alice",
+        # Seed via raw SQL listing only the columns that exist at this old
+        # revision — the live ``User`` model carries columns added by later
+        # migrations (e.g. #742's ``onboarding_completed_at``) that aren't in
+        # this schema yet, so an ORM insert would reference a missing column.
+        now = datetime.now(UTC)
+        rows = [
+            # The `default` sentinel is seeded by the initial migration; it
+            # should NOT get an identity row.
+            ("gh:alice", "alice@example.com", now, "Alice"),
+            ("google:11223344", "bob@example.com", now, "Bob"),
+            # Magic-link's stored name is a sha256(email) prefix; the backfill
+            # recovers the subject from ``users.email``, not the name suffix.
+            (
+                "magic:abcdef0123456789abcdef0123456789abcdef0123456789",
+                "carol@example.com",
+                now,
+                None,
+            ),
+        ]
+        with engine.begin() as conn:
+            for name, email, verified_at, display_name in rows:
+                conn.execute(
+                    text(
+                        "INSERT INTO users (name, created_at, email, email_verified_at,"
+                        " display_name) VALUES (:name, :created_at, :email,"
+                        " :email_verified_at, :display_name)"
+                    ),
+                    {
+                        "name": name,
+                        "created_at": now,
+                        "email": email,
+                        "email_verified_at": verified_at,
+                        "display_name": display_name,
+                    },
                 )
-            )
-            s.add(
-                User(
-                    name="google:11223344",
-                    email="bob@example.com",
-                    email_verified_at=datetime.now(UTC),
-                    display_name="Bob",
-                )
-            )
-            # Magic-link's stored name is a sha256(email) prefix; the
-            # backfill recovers the subject from ``users.email``, not
-            # from the name suffix.
-            s.add(
-                User(
-                    name="magic:abcdef0123456789abcdef0123456789abcdef0123456789",
-                    email="carol@example.com",
-                    email_verified_at=datetime.now(UTC),
-                    display_name=None,
-                )
-            )
-            s.commit()
 
     def test_backfill_mints_one_identity_per_prefixed_user(self) -> None:
         self._seed_at_pre_491_schema()

--- a/tests/test_favorite_pokemon_api.py
+++ b/tests/test_favorite_pokemon_api.py
@@ -1,0 +1,136 @@
+"""Tests for `/api/v1/favorite-pokemon` — per-user pinned favorite Pokémon (#742).
+
+Covers:
+
+- Alembic migration up/down round-trip for the `favorite_species` table and the
+  `users.onboarding_completed_at` column.
+- CRUD: list, idempotent pin, unpin (including unpin-of-unpinned no-op), and the
+  dex-number range validation.
+
+Mirrors the per-test tempfile DB isolation from `tests/test_favorite_sets_api.py`.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+from sqlalchemy import inspect
+
+from api.db import session as session_mod
+from api.db.migrate import upgrade_head
+
+CHARIZARD = 6
+BLASTOISE = 9
+MEW = 151
+
+
+class _IsolatedDbMixin(unittest.TestCase):
+    """Point MGZ_PKMN_DATABASE_URL at a fresh sqlite file per test."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._db_path = Path(self._tmp.name) / "test.db"
+        self._old_url = os.environ.get("MGZ_PKMN_DATABASE_URL")
+        os.environ["MGZ_PKMN_DATABASE_URL"] = f"sqlite:///{self._db_path}"
+        session_mod.reset_engine()
+
+    def tearDown(self) -> None:
+        session_mod.reset_engine()
+        if self._old_url is None:
+            os.environ.pop("MGZ_PKMN_DATABASE_URL", None)
+        else:
+            os.environ["MGZ_PKMN_DATABASE_URL"] = self._old_url
+        self._tmp.cleanup()
+
+    def _client(self) -> TestClient:
+        from api.main import app
+
+        return TestClient(app)
+
+
+class FavoriteSpeciesMigrationTests(_IsolatedDbMixin):
+    def test_upgrade_creates_table_then_downgrade_drops_it(self) -> None:
+        engine = session_mod.get_engine()
+        upgrade_head(engine)
+        insp = inspect(engine)
+        self.assertIn("favorite_species", insp.get_table_names())
+        cols = {c["name"] for c in insp.get_columns("favorite_species")}
+        self.assertEqual(cols, {"id", "user_id", "dex_number", "pinned_at"})
+        self.assertIn(
+            "ix_favorite_species_user_id",
+            {i["name"] for i in insp.get_indexes("favorite_species")},
+        )
+        user_cols = {c["name"] for c in insp.get_columns("users")}
+        self.assertIn("onboarding_completed_at", user_cols)
+
+        from alembic.command import downgrade
+        from alembic.config import Config
+
+        cfg = Config(str(Path(__file__).resolve().parents[1] / "api" / "alembic.ini"))
+        downgrade(cfg, "-1")
+        insp = inspect(session_mod.get_engine())
+        self.assertNotIn("favorite_species", insp.get_table_names())
+        self.assertNotIn(
+            "onboarding_completed_at",
+            {c["name"] for c in insp.get_columns("users")},
+        )
+
+
+class FavoritePokemonCrudTests(_IsolatedDbMixin):
+    def test_list_is_empty_initially(self) -> None:
+        with self._client() as c:
+            resp = c.get("/api/v1/favorite-pokemon")
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.json(), {"pokemon": []})
+
+    def test_pin_then_list(self) -> None:
+        with self._client() as c:
+            self.assertEqual(
+                c.post("/api/v1/favorite-pokemon", json={"dex_number": CHARIZARD}).status_code,
+                204,
+            )
+            body = c.get("/api/v1/favorite-pokemon").json()
+            self.assertEqual([p["dex_number"] for p in body["pokemon"]], [CHARIZARD])
+            self.assertIn("pinned_at", body["pokemon"][0])
+
+    def test_pin_is_idempotent(self) -> None:
+        with self._client() as c:
+            c.post("/api/v1/favorite-pokemon", json={"dex_number": CHARIZARD})
+            c.post("/api/v1/favorite-pokemon", json={"dex_number": CHARIZARD})
+            body = c.get("/api/v1/favorite-pokemon").json()
+            self.assertEqual(len(body["pokemon"]), 1)
+
+    def test_pin_rejects_out_of_range_dex_number(self) -> None:
+        with self._client() as c:
+            self.assertEqual(
+                c.post("/api/v1/favorite-pokemon", json={"dex_number": 0}).status_code, 422
+            )
+            self.assertEqual(
+                c.post("/api/v1/favorite-pokemon", json={"dex_number": 99999}).status_code, 422
+            )
+
+    def test_unpin_removes_only_that_species(self) -> None:
+        with self._client() as c:
+            c.post("/api/v1/favorite-pokemon", json={"dex_number": CHARIZARD})
+            c.post("/api/v1/favorite-pokemon", json={"dex_number": MEW})
+            self.assertEqual(c.delete(f"/api/v1/favorite-pokemon/{CHARIZARD}").status_code, 204)
+            remaining = [
+                p["dex_number"] for p in c.get("/api/v1/favorite-pokemon").json()["pokemon"]
+            ]
+            self.assertEqual(remaining, [MEW])
+
+    def test_unpin_unpinned_is_a_noop(self) -> None:
+        with self._client() as c:
+            self.assertEqual(c.delete(f"/api/v1/favorite-pokemon/{BLASTOISE}").status_code, 204)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_favorite_sets_api.py
+++ b/tests/test_favorite_sets_api.py
@@ -91,7 +91,10 @@ class FavoriteSetsMigrationTests(_IsolatedDbMixin):
         from alembic.config import Config
 
         cfg = Config(str(Path(__file__).resolve().parents[1] / "api" / "alembic.ini"))
-        downgrade(cfg, "-1")
+        # Downgrade to favorite_sets' parent so this stays valid as later
+        # migrations stack on top — a relative "-1" only drops favorite_sets
+        # while it's the head, which it no longer is (#742 added one above it).
+        downgrade(cfg, "a7d3f1e0c2b5")
         self.assertNotIn("favorite_sets", inspect(session_mod.get_engine()).get_table_names())
 
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,7 +16,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { GalleryHorizontalEnd, Heart, Search } from 'lucide-react'
-import { bulkLookup, listRuns, lookupLine, saveRun } from './api/client'
+import { bulkLookup, completeOnboarding, listRuns, lookupLine, saveRun } from './api/client'
 import { AnnouncementBanner } from './components/AnnouncementBanner'
 import { SaveSearchNameDialog } from './components/SaveSearchNameDialog'
 import { BrowsePanel } from './components/BrowsePanel'
@@ -30,6 +30,7 @@ import { ExportBar } from './components/ExportBar'
 import { InsightsNavButton } from './components/InsightsNavButton'
 import { ProcessingQueue } from './components/ProcessingQueue'
 import { SettingsDrawer } from './components/SettingsDrawer'
+import { FavoritePokemonOnboarding } from './components/FavoritePokemonOnboarding'
 import { HelpModal } from './components/HelpModal'
 import { SignInChip } from './components/SignInChip'
 import { ThemeToggle } from './components/ThemeToggle'
@@ -72,7 +73,23 @@ function App() {
   const abortRef = useRef<AbortController | null>(null)
   const [tourOpen, setTourOpen] = useState(false)
   const [mode, setMode] = useState<DiscoveryMode>('search')
-  const { user: authedUser } = useAuth()
+  const { user: authedUser, refresh: refreshAuth } = useAuth()
+
+  // First-login onboarding survey (#742): the favorite-Pokémon pop-up shows
+  // once per account, gated server-side via `onboardingCompleted`. Dismissing
+  // (Done or Skip) marks it complete and re-polls `/me` so it never re-nags;
+  // the local flag hides it immediately, ahead of the round-trip.
+  const [onboardingDismissed, setOnboardingDismissed] = useState(false)
+  const showOnboarding =
+    authedUser != null && authedUser.onboardingCompleted === false && !onboardingDismissed
+  const closeOnboarding = useCallback(() => {
+    setOnboardingDismissed(true)
+    void completeOnboarding()
+      .then(() => refreshAuth())
+      .catch(() => {
+        // Best-effort — the local flag already hid the pop-up for this session.
+      })
+  }, [refreshAuth])
   // `active` flips when the user switches into browse mode so the
   // controller's reset effect fires.
   const browseController = useBrowseController(mode === 'browse')
@@ -409,6 +426,8 @@ function App() {
       {tourOpen && (
         <Tour onClose={() => setTourOpen(false)} onRun={handleRun} onStop={handleStop} />
       )}
+
+      <FavoritePokemonOnboarding open={showOnboarding} onClose={closeOnboarding} />
 
       <SaveSearchNameDialog
         open={pendingSave !== null}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -463,6 +463,10 @@ export interface Me {
   email: string | null
   display_name: string | null
   identities?: MeIdentity[]
+  /** Whether the user has finished (or skipped) the first-login onboarding
+   *  survey (#742). Falsy (incl. absent) opens the favorite-Pokémon pop-up;
+   *  `fetchMe` always populates it from the `/me` envelope. */
+  onboardingCompleted?: boolean
 }
 
 /**
@@ -477,11 +481,33 @@ export interface MeEnvelope {
   authEnabled: boolean
 }
 
+interface RawMe {
+  id: number
+  email: string | null
+  display_name: string | null
+  identities?: MeIdentity[]
+  onboarding_completed: boolean
+}
+
 export async function fetchMe(): Promise<MeEnvelope> {
   const res = await fetch(`${BASE}/me`, { credentials: 'same-origin' })
   if (!res.ok) throw new Error(`me failed: ${res.status}`)
-  const body = (await res.json()) as { user: Me | null; auth_enabled: boolean }
-  return { user: body.user, authEnabled: body.auth_enabled }
+  const body = (await res.json()) as { user: RawMe | null; auth_enabled: boolean }
+  const user: Me | null = body.user
+    ? { ...body.user, onboardingCompleted: body.user.onboarding_completed }
+    : null
+  return { user, authEnabled: body.auth_enabled }
+}
+
+/** Mark the first-login onboarding survey done (#742) so it never re-opens. */
+export async function completeOnboarding(): Promise<void> {
+  const res = await fetch(`${BASE}/me/onboarding/complete`, {
+    method: 'POST',
+    credentials: 'same-origin',
+  })
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`complete onboarding failed: ${res.status}`)
+  }
 }
 
 export async function logout(): Promise<void> {
@@ -953,6 +979,43 @@ export async function fetchFavoriteSetSuggestions(): Promise<FavoriteSetSuggesti
   if (!res.ok) throw new Error(`favorite set suggestions failed: ${res.status}`)
   const data = await res.json()
   return data.suggestions as FavoriteSetSuggestion[]
+}
+
+// ---------------------------------------------------------------------------
+// Favorite Pokémon (#742) — durable per-user pinned species, keyed by national
+// Pokédex number. The species-level sibling of favorite sets.
+// ---------------------------------------------------------------------------
+
+export interface FavoritePokemon {
+  dex_number: number
+  pinned_at: string
+}
+
+export async function fetchFavoritePokemon(): Promise<FavoritePokemon[]> {
+  const res = await fetch(`${BASE}/favorite-pokemon`)
+  if (!res.ok) throw new Error(`favorite pokemon failed: ${res.status}`)
+  const data = await res.json()
+  return data.pokemon as FavoritePokemon[]
+}
+
+export async function pinFavoritePokemon(dexNumber: number): Promise<void> {
+  const res = await fetch(`${BASE}/favorite-pokemon`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ dex_number: dexNumber }),
+  })
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`pin favorite pokemon failed: ${res.status}`)
+  }
+}
+
+export async function unpinFavoritePokemon(dexNumber: number): Promise<void> {
+  const res = await fetch(`${BASE}/favorite-pokemon/${dexNumber}`, {
+    method: 'DELETE',
+  })
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`unpin favorite pokemon failed: ${res.status}`)
+  }
 }
 
 /**

--- a/web/src/components/BrowsePanel.test.tsx
+++ b/web/src/components/BrowsePanel.test.tsx
@@ -92,6 +92,12 @@ describe('BrowsePanel — pokedex view (#577)', () => {
     const pin = vi.spyOn(client, 'pinFavoritePokemon').mockResolvedValue(undefined)
     render(<Harness />)
     fireEvent.click(screen.getByRole('button', { name: 'By Pokédex #' }))
+    // Filter to a single species first so the grid renders one tile, not the
+    // whole 1025-entry dex — the star click re-renders the list, and re-running
+    // that over every tile blows the test timeout under CI contention.
+    fireEvent.change(screen.getByLabelText('Find a Pokémon'), {
+      target: { value: 'bulbasaur' },
+    })
 
     // Bulbasaur is national dex #1 — its star toggle pins that number.
     const star = await screen.findByRole('button', { name: 'Add Bulbasaur to favorites' })

--- a/web/src/components/BrowsePanel.test.tsx
+++ b/web/src/components/BrowsePanel.test.tsx
@@ -6,6 +6,7 @@ import { useAppStore } from '../store'
 import { _resetAuthStoreForTests } from '../hooks/useAuth'
 import { _resetCollectionsCacheForTests } from './useCollections'
 import { _resetWishlistsCacheForTests } from './useWishlists'
+import { _resetFavoritePokemonCacheForTests } from './useFavoritePokemon'
 import * as client from '../api/client'
 import type { PokedexCard, SetCard } from '../types'
 
@@ -24,6 +25,7 @@ const CHARIZARD_PRINTINGS: PokedexCard[] = [
     subtypes: ['Stage 2'],
     thumb: null,
     market: 250,
+    dexNumbers: [6],
     setId: 'base1',
     setName: 'Base',
     releaseDate: '1999/01/09',
@@ -48,9 +50,15 @@ describe('BrowsePanel — pokedex view (#577)', () => {
     })
     vi.spyOn(client, 'fetchCollections').mockResolvedValue([])
     vi.spyOn(client, 'fetchWishlists').mockResolvedValue([])
+    // Favorite-Pokémon star toggles (#742) read the per-user pin list; keep it
+    // empty + inert so the stars render unfilled without a real request.
+    vi.spyOn(client, 'fetchFavoritePokemon').mockResolvedValue([])
+    vi.spyOn(client, 'pinFavoritePokemon').mockResolvedValue(undefined)
+    vi.spyOn(client, 'unpinFavoritePokemon').mockResolvedValue(undefined)
     _resetAuthStoreForTests()
     _resetCollectionsCacheForTests()
     _resetWishlistsCacheForTests()
+    _resetFavoritePokemonCacheForTests()
   })
 
   it('toggles to pokedex view and lists species from the national dex', async () => {
@@ -78,6 +86,17 @@ describe('BrowsePanel — pokedex view (#577)', () => {
 
     expect(await screen.findByText('Charizard')).toBeInTheDocument()
     expect(screen.queryByText('Bulbasaur')).not.toBeInTheDocument()
+  })
+
+  it('favorites a species from its pokedex tile (#742)', async () => {
+    const pin = vi.spyOn(client, 'pinFavoritePokemon').mockResolvedValue(undefined)
+    render(<Harness />)
+    fireEvent.click(screen.getByRole('button', { name: 'By Pokédex #' }))
+
+    // Bulbasaur is national dex #1 — its star toggle pins that number.
+    const star = await screen.findByRole('button', { name: 'Add Bulbasaur to favorites' })
+    fireEvent.click(star)
+    await waitFor(() => expect(pin).toHaveBeenCalledWith(1))
   })
 
   it('drills into a species, fetches every printing, and opens the card detail modal', async () => {
@@ -121,6 +140,7 @@ describe('BrowsePanel — pokedex view (#577)', () => {
         subtypes: ['Stage 2'],
         thumb: 'https://img/base1-4.png',
         market: 250,
+        dexNumbers: [6],
       },
     ]
     const fetchCards = vi
@@ -197,6 +217,7 @@ describe('BrowsePanel — pokedex view (#577)', () => {
         subtypes: ['Basic'],
         thumb: null,
         market: 40,
+        dexNumbers: [380],
       },
       {
         id: 'base1-4',
@@ -207,6 +228,7 @@ describe('BrowsePanel — pokedex view (#577)', () => {
         subtypes: ['Stage 2'],
         thumb: null,
         market: 250,
+        dexNumbers: [6],
       },
     ]
     vi.spyOn(client, 'fetchSetCards').mockResolvedValue(SET_CARDS)

--- a/web/src/components/BrowsePanel.tsx
+++ b/web/src/components/BrowsePanel.tsx
@@ -6,11 +6,21 @@
  * Pokémon across every set). State + effects live in
  * [useBrowseController](./useBrowseController.ts).
  */
-import { ArrowLeft, GalleryHorizontalEnd, ImageOff, Loader2, Search, Wallet } from 'lucide-react'
+import {
+  ArrowLeft,
+  GalleryHorizontalEnd,
+  ImageOff,
+  Loader2,
+  Search,
+  Star,
+  Wallet,
+} from 'lucide-react'
 import { useMemo, useState } from 'react'
 import type { ReactNode } from 'react'
 import { pokemonSpriteUrl, setLogoUrl } from '../api/client'
+import { BAKED_POKEDEX } from '../data/pokedex'
 import { useAuth } from '../hooks/useAuth'
+import { useFavoritePokemon } from './useFavoritePokemon'
 import type { PokedexCard, PokedexEntry, Row, SetCard, SetInfo } from '../types'
 import { BinderModal, type BinderPrefill } from './BinderModal'
 import { browseCardToPayload, browseCardToRow, type BrowseSetContext } from './browseCard'
@@ -35,6 +45,10 @@ function releaseYear(date: string): string | null {
   const match = /^(\d{4})/.exec(date || '')
   return match ? match[1] : null
 }
+
+/** dex number → species, resolved once so favorited numbers (#742) render as
+ *  the same tiles as the generation groups. */
+const DEX_BY_NUMBER = new Map(BAKED_POKEDEX.map((e) => [e.number, e]))
 
 interface BrowsePanelProps {
   controller: BrowseController
@@ -79,6 +93,22 @@ export function BrowsePanel({ controller }: BrowsePanelProps) {
   // render save buttons", matching ResultsTable's row pattern.
   const { user } = useAuth()
   const showSavedActions = user !== null
+
+  // Favorite Pokémon (#742) — the inline star toggle on the pokedex tiles and
+  // the pinned "Your favorites" group. Signed-in only; a signed-out visitor
+  // reads an empty list without hitting the per-user endpoint.
+  const { favorites, pin, unpin, isFavorite } = useFavoritePokemon({
+    enabled: showSavedActions,
+  })
+  const favoriteEntries = useMemo<PokedexEntry[]>(
+    () =>
+      favorites
+        .map((f) => DEX_BY_NUMBER.get(f.dex_number))
+        .filter((e): e is PokedexEntry => e !== undefined),
+    [favorites],
+  )
+  const toggleFavorite = (number: number) =>
+    isFavorite(number) ? void unpin(number) : void pin(number)
 
   // A fresh binder pre-anchored to the set you're walking (#682). Non-null
   // mounts the modal; closing clears it so the next open re-seeds cleanly.
@@ -132,6 +162,14 @@ export function BrowsePanel({ controller }: BrowsePanelProps) {
           )}
         </div>
         <div className="flex flex-none items-center gap-2">
+          {viewMode === 'pokedex' && activePokemon && showSavedActions && (
+            <FavoriteToggle
+              favorited={isFavorite(activePokemon.number)}
+              name={activePokemon.name}
+              onToggle={() => toggleFavorite(activePokemon.number)}
+              withLabel
+            />
+          )}
           {viewMode === 'set' && activeSet && showSavedActions && (
             <button
               type="button"
@@ -193,6 +231,10 @@ export function BrowsePanel({ controller }: BrowsePanelProps) {
           filter={pokedexFilter}
           onFilter={setPokedexFilter}
           onPick={(p) => setActivePokemon(p)}
+          favoriteEntries={favoriteEntries}
+          showFavoriteControls={showSavedActions}
+          isFavorite={isFavorite}
+          onToggleFavorite={toggleFavorite}
         />
       )}
 
@@ -514,9 +556,30 @@ interface PokedexListProps {
   filter: string
   onFilter: (v: string) => void
   onPick: (species: PokedexEntry) => void
+  /** Favorited species, newest first — pinned in a "Your favorites" group at
+   *  the top while no search filter is active (#742). */
+  favoriteEntries: PokedexEntry[]
+  /** Whether to render the favorite star toggle (signed-in only). */
+  showFavoriteControls: boolean
+  isFavorite: (number: number) => boolean
+  onToggleFavorite: (number: number) => void
 }
 
-function PokedexListView({ groups, filter, onFilter, onPick }: PokedexListProps) {
+function PokedexListView({
+  groups,
+  filter,
+  onFilter,
+  onPick,
+  favoriteEntries,
+  showFavoriteControls,
+  isFavorite,
+  onToggleFavorite,
+}: PokedexListProps) {
+  // The pinned favorites group only makes sense as a "jump to what I love"
+  // shortcut on the unfiltered list — once you're searching, the matching
+  // generation groups already surface the species.
+  const showFavorites =
+    showFavoriteControls && favoriteEntries.length > 0 && filter.trim() === ''
   return (
     <>
       <div className="flex flex-wrap items-center gap-2 border-b border-sand-200 dark:border-husk-100 px-5 py-3">
@@ -537,26 +600,32 @@ function PokedexListView({ groups, filter, onFilter, onPick }: PokedexListProps)
         </label>
       </div>
       <div className="flex-1 overflow-y-auto px-5 py-3">
-        {groups.length === 0 ? (
+        {groups.length === 0 && !showFavorites ? (
           <p className="text-sm text-coconut-400 dark:text-sand-400">
             No Pokémon match “{filter}”.
           </p>
         ) : (
           <ul className="space-y-4">
+            {showFavorites && (
+              <PokedexGroupSection
+                label="Your favorites"
+                species={favoriteEntries}
+                onPick={onPick}
+                showFavoriteControls={showFavoriteControls}
+                isFavorite={isFavorite}
+                onToggleFavorite={onToggleFavorite}
+              />
+            )}
             {groups.map((group) => (
-              <li key={group.label}>
-                <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-coconut-600 dark:text-sand-200">
-                  {group.label}
-                  <span className="ml-1 font-normal normal-case tracking-normal text-coconut-400 dark:text-sand-400">
-                    ({group.species.length})
-                  </span>
-                </div>
-                <ul className="grid grid-cols-2 gap-1 sm:grid-cols-3 lg:grid-cols-4">
-                  {group.species.map((s) => (
-                    <SpeciesTile key={s.number} species={s} onPick={() => onPick(s)} />
-                  ))}
-                </ul>
-              </li>
+              <PokedexGroupSection
+                key={group.label}
+                label={group.label}
+                species={group.species}
+                onPick={onPick}
+                showFavoriteControls={showFavoriteControls}
+                isFavorite={isFavorite}
+                onToggleFavorite={onToggleFavorite}
+              />
             ))}
           </ul>
         )}
@@ -565,20 +634,67 @@ function PokedexListView({ groups, filter, onFilter, onPick }: PokedexListProps)
   )
 }
 
+function PokedexGroupSection({
+  label,
+  species,
+  onPick,
+  showFavoriteControls,
+  isFavorite,
+  onToggleFavorite,
+}: {
+  label: string
+  species: PokedexEntry[]
+  onPick: (species: PokedexEntry) => void
+  showFavoriteControls: boolean
+  isFavorite: (number: number) => boolean
+  onToggleFavorite: (number: number) => void
+}) {
+  return (
+    <li>
+      <div className="mb-2 text-xs font-semibold uppercase tracking-wider text-coconut-600 dark:text-sand-200">
+        {label}
+        <span className="ml-1 font-normal normal-case tracking-normal text-coconut-400 dark:text-sand-400">
+          ({species.length})
+        </span>
+      </div>
+      <ul className="grid grid-cols-2 gap-1 sm:grid-cols-3 lg:grid-cols-4">
+        {species.map((s) => (
+          <SpeciesTile
+            key={s.number}
+            species={s}
+            onPick={() => onPick(s)}
+            showFavoriteControl={showFavoriteControls}
+            favorited={isFavorite(s.number)}
+            onToggleFavorite={() => onToggleFavorite(s.number)}
+          />
+        ))}
+      </ul>
+    </li>
+  )
+}
+
 function SpeciesTile({
   species,
   onPick,
+  showFavoriteControl,
+  favorited,
+  onToggleFavorite,
 }: {
   species: PokedexEntry
   onPick: () => void
+  showFavoriteControl: boolean
+  favorited: boolean
+  onToggleFavorite: () => void
 }) {
   const [spriteFailed, setSpriteFailed] = useState(false)
   return (
-    <li>
+    <li className="relative">
       <button
         type="button"
         onClick={onPick}
-        className="flex w-full items-center gap-2 rounded-md border border-sand-200 dark:border-husk-100 bg-sand-50 dark:bg-husk-400/40 px-3 py-2 text-left hover:border-sand-300 dark:hover:border-husk-50 hover:bg-sand-50 dark:hover:bg-husk-200 focus:outline-none focus:ring-2 focus:ring-sand-300 dark:ring-husk-50"
+        className={`flex w-full items-center gap-2 rounded-md border border-sand-200 dark:border-husk-100 bg-sand-50 dark:bg-husk-400/40 py-2 pl-3 text-left hover:border-sand-300 dark:hover:border-husk-50 hover:bg-sand-50 dark:hover:bg-husk-200 focus:outline-none focus:ring-2 focus:ring-sand-300 dark:ring-husk-50 ${
+          showFavoriteControl ? 'pr-9' : 'pr-3'
+        }`}
       >
         <span className="flex h-9 w-9 flex-none items-center justify-center rounded bg-sand-50 dark:bg-husk-400">
           {spriteFailed ? (
@@ -600,7 +716,68 @@ function SpeciesTile({
           {species.name}
         </span>
       </button>
+      {showFavoriteControl && (
+        <div className="absolute right-1.5 top-1/2 -translate-y-1/2">
+          <FavoriteToggle
+            favorited={favorited}
+            name={species.name}
+            onToggle={onToggleFavorite}
+          />
+        </div>
+      )}
     </li>
+  )
+}
+
+/** Star toggle for pinning a favorite Pokémon (#742). `withLabel` renders the
+ *  bordered header variant; bare is the icon-only tile overlay. */
+function FavoriteToggle({
+  favorited,
+  name,
+  onToggle,
+  withLabel = false,
+}: {
+  favorited: boolean
+  name: string
+  onToggle: () => void
+  withLabel?: boolean
+}) {
+  const label = favorited ? `Remove ${name} from favorites` : `Add ${name} to favorites`
+  const star = (
+    <Star
+      size={withLabel ? 14 : 16}
+      className={
+        favorited
+          ? 'fill-sun-400 text-sun-500 dark:fill-sun-300 dark:text-sun-300'
+          : 'text-coconut-400 dark:text-sand-300'
+      }
+      aria-hidden
+    />
+  )
+  if (withLabel) {
+    return (
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-pressed={favorited}
+        aria-label={label}
+        className="inline-flex items-center gap-1.5 rounded-md border border-sand-300 dark:border-husk-50 bg-sand-200 dark:bg-husk-100 px-2.5 py-1 text-xs text-coconut-600 dark:text-sand-200 hover:bg-sand-50 dark:hover:bg-husk-200"
+      >
+        {star}
+        {favorited ? 'Favorited' : 'Favorite'}
+      </button>
+    )
+  }
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-pressed={favorited}
+      aria-label={label}
+      className="rounded-full p-1 hover:bg-sand-200 dark:hover:bg-husk-100 focus:outline-none focus:ring-2 focus:ring-sand-300 dark:ring-husk-50"
+    >
+      {star}
+    </button>
   )
 }
 

--- a/web/src/components/FavoritePokemonOnboarding.test.tsx
+++ b/web/src/components/FavoritePokemonOnboarding.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import {
+  fetchFavoritePokemon,
+  pinFavoritePokemon,
+  unpinFavoritePokemon,
+  pokemonSpriteUrl,
+} from '../api/client'
+import { FavoritePokemonOnboarding } from './FavoritePokemonOnboarding'
+import { _resetFavoritePokemonCacheForTests } from './useFavoritePokemon'
+
+vi.mock('../api/client', () => ({
+  fetchFavoritePokemon: vi.fn(),
+  pinFavoritePokemon: vi.fn(),
+  unpinFavoritePokemon: vi.fn(),
+  pokemonSpriteUrl: vi.fn((n: number) => `https://sprite/${n}.png`),
+}))
+
+const mockFetch = vi.mocked(fetchFavoritePokemon)
+const mockPin = vi.mocked(pinFavoritePokemon)
+const mockUnpin = vi.mocked(unpinFavoritePokemon)
+
+describe('FavoritePokemonOnboarding', () => {
+  beforeEach(() => {
+    _resetFavoritePokemonCacheForTests()
+    mockFetch.mockReset().mockResolvedValue([])
+    mockPin.mockReset().mockResolvedValue(undefined)
+    mockUnpin.mockReset().mockResolvedValue(undefined)
+    vi.mocked(pokemonSpriteUrl).mockClear()
+  })
+
+  it('renders nothing when closed', () => {
+    render(<FavoritePokemonOnboarding open={false} onClose={vi.fn()} />)
+    expect(screen.queryByText('Pick your favorite Pokémon')).not.toBeInTheDocument()
+  })
+
+  it('shows the survey with the crowd-favorites quick picks when open', () => {
+    render(<FavoritePokemonOnboarding open onClose={vi.fn()} />)
+    expect(screen.getByText('Pick your favorite Pokémon')).toBeInTheDocument()
+    expect(screen.getByText('Crowd favorites')).toBeInTheDocument()
+    // Pikachu (25) leads the curated quick-pick row.
+    expect(screen.getByRole('button', { name: 'Add Pikachu to favorites' })).toBeInTheDocument()
+  })
+
+  it('pins a Pokémon when its tile is tapped', async () => {
+    render(<FavoritePokemonOnboarding open onClose={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Add Pikachu to favorites' }))
+    await waitFor(() => expect(mockPin).toHaveBeenCalledWith(25))
+  })
+
+  it('searches the baked Pokédex by name', () => {
+    render(<FavoritePokemonOnboarding open onClose={vi.fn()} />)
+    fireEvent.change(screen.getByRole('searchbox', { name: 'Search for a Pokémon' }), {
+      target: { value: 'bulbasaur' },
+    })
+    expect(screen.getByRole('button', { name: 'Add Bulbasaur to favorites' })).toBeInTheDocument()
+  })
+
+  it('marks onboarding complete via onClose on both Done and Skip', () => {
+    const onClose = vi.fn()
+    render(<FavoritePokemonOnboarding open onClose={onClose} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+    fireEvent.click(screen.getByRole('button', { name: 'Skip for now' }))
+    expect(onClose).toHaveBeenCalledTimes(2)
+  })
+})

--- a/web/src/components/FavoritePokemonOnboarding.tsx
+++ b/web/src/components/FavoritePokemonOnboarding.tsx
@@ -1,0 +1,212 @@
+/**
+ * FavoritePokemonOnboarding — the first-login pop-up survey that asks a new
+ * user which Pokémon they love, seeding the favorite-species signal that
+ * Swipe / Browse lean toward (#742, epic #701).
+ *
+ * Shows once per account: the gate is the server-side
+ * `onboarding_completed_at` exposed as `user.onboardingCompleted`. Both
+ * "Done" and "Skip" mark onboarding complete (via the parent's `onClose`), so
+ * the pop-up never re-nags — picks are saved live through
+ * {@link useFavoritePokemon}, so there's nothing to "submit".
+ *
+ * Picking is the same as the inline pokedex tiles: a curated quick-pick row of
+ * crowd favorites for a one-tap start, plus a search over the baked Pokédex.
+ */
+import * as Dialog from '@radix-ui/react-dialog'
+import { ImageOff, Search, Star, X } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { pokemonSpriteUrl } from '../api/client'
+import { BAKED_POKEDEX } from '../data/pokedex'
+import type { PokedexEntry } from '../types'
+import { useFavoritePokemon } from './useFavoritePokemon'
+
+/** Crowd favorites — a one-tap start so the survey is never a blank search. */
+const QUICK_PICK_NUMBERS = [25, 6, 150, 133, 94, 448, 658, 384, 282, 445, 143, 149]
+
+/** How many search matches to render — enough to find a species, short of a
+ *  scroll marathon. */
+const MAX_RESULTS = 24
+
+const DEX_BY_NUMBER = new Map(BAKED_POKEDEX.map((e) => [e.number, e]))
+
+const QUICK_PICKS: PokedexEntry[] = QUICK_PICK_NUMBERS.map((n) => DEX_BY_NUMBER.get(n)).filter(
+  (e): e is PokedexEntry => e !== undefined,
+)
+
+function matches(entry: PokedexEntry, query: string): boolean {
+  const q = query.trim().toLowerCase()
+  if (!q) return false
+  return entry.name.toLowerCase().includes(q) || String(entry.number) === q
+}
+
+interface Props {
+  open: boolean
+  onClose: () => void
+}
+
+export function FavoritePokemonOnboarding({ open, onClose }: Props) {
+  const { favorites, isFavorite, pin, unpin } = useFavoritePokemon({ enabled: open })
+  const [query, setQuery] = useState('')
+
+  const results = useMemo<PokedexEntry[]>(() => {
+    if (query.trim() === '') return []
+    return BAKED_POKEDEX.filter((e) => matches(e, query)).slice(0, MAX_RESULTS)
+  }, [query])
+
+  const toggle = (number: number) =>
+    isFavorite(number) ? void unpin(number) : void pin(number)
+
+  const list = query.trim() === '' ? QUICK_PICKS : results
+  const pickedCount = favorites.length
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(o) => !o && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-coconut-700/50 backdrop-blur-sm dark:bg-husk-500/70" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 flex max-h-[88vh] w-[min(520px,92vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-sand-300 bg-sand-50 shadow-2xl dark:border-husk-50 dark:bg-husk-200">
+          <header className="flex items-start justify-between gap-3 border-b border-sand-200 px-5 py-4 dark:border-husk-100">
+            <div className="min-w-0">
+              <Dialog.Title className="text-lg font-semibold text-coconut-700 dark:text-sand-50">
+                Pick your favorite Pokémon
+              </Dialog.Title>
+              <Dialog.Description className="mt-1 text-sm text-coconut-400 dark:text-sand-300">
+                Tap a few you love and we’ll lean Swipe and Browse toward them. You can
+                always change these later.
+              </Dialog.Description>
+            </div>
+            <Dialog.Close asChild>
+              <button
+                type="button"
+                aria-label="Close"
+                className="rounded p-1 text-coconut-500 hover:bg-sand-200 dark:text-sand-300 dark:hover:bg-husk-100"
+              >
+                <X size={18} aria-hidden />
+              </button>
+            </Dialog.Close>
+          </header>
+
+          <div className="border-b border-sand-200 px-5 py-3 dark:border-husk-100">
+            <label className="relative block">
+              <Search
+                size={14}
+                className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-coconut-400 dark:text-sand-400"
+                aria-hidden
+              />
+              <input
+                type="search"
+                placeholder="Search for a Pokémon by name or dex #…"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                className="w-full rounded-md border border-sand-300 bg-sand-50 py-1.5 pl-8 pr-2 text-sm text-coconut-700 placeholder:text-coconut-400 focus:border-sand-400 focus:outline-none dark:border-husk-50 dark:bg-husk-400 dark:text-sand-50 dark:placeholder:text-sand-400 dark:focus:border-coconut-400"
+                aria-label="Search for a Pokémon"
+              />
+            </label>
+          </div>
+
+          <div className="flex-1 overflow-y-auto px-5 py-3">
+            <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-coconut-600 dark:text-sand-200">
+              {query.trim() === '' ? 'Crowd favorites' : `Results for “${query.trim()}”`}
+            </p>
+            {list.length === 0 ? (
+              <p className="text-sm text-coconut-400 dark:text-sand-400">
+                No Pokémon match “{query.trim()}”.
+              </p>
+            ) : (
+              <ul className="grid grid-cols-2 gap-1 sm:grid-cols-3">
+                {list.map((entry) => (
+                  <OnboardingSpeciesTile
+                    key={entry.number}
+                    species={entry}
+                    favorited={isFavorite(entry.number)}
+                    onToggle={() => toggle(entry.number)}
+                  />
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <footer className="flex items-center justify-between gap-3 border-t border-sand-200 px-5 py-3 dark:border-husk-100">
+            <span className="text-xs text-coconut-400 dark:text-sand-300" role="status">
+              {pickedCount === 0
+                ? 'Nothing picked yet'
+                : `${pickedCount} favorite${pickedCount === 1 ? '' : 's'} picked`}
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-md px-3 py-1.5 text-sm text-coconut-500 hover:bg-sand-200 dark:text-sand-300 dark:hover:bg-husk-100"
+              >
+                Skip for now
+              </button>
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-md bg-palm-500 px-3 py-1.5 text-sm font-medium text-sand-50 hover:bg-palm-600 dark:bg-palm-400 dark:text-husk-500 dark:hover:bg-palm-300"
+              >
+                Done
+              </button>
+            </div>
+          </footer>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+function OnboardingSpeciesTile({
+  species,
+  favorited,
+  onToggle,
+}: {
+  species: PokedexEntry
+  favorited: boolean
+  onToggle: () => void
+}) {
+  const [spriteFailed, setSpriteFailed] = useState(false)
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-pressed={favorited}
+        aria-label={
+          favorited
+            ? `Remove ${species.name} from favorites`
+            : `Add ${species.name} to favorites`
+        }
+        className={`flex w-full items-center gap-2 rounded-md border px-2.5 py-2 text-left focus:outline-none focus:ring-2 focus:ring-sand-300 dark:ring-husk-50 ${
+          favorited
+            ? 'border-sun-400 bg-sun-400/15 dark:border-sun-300 dark:bg-sun-300/20'
+            : 'border-sand-200 bg-sand-50 hover:border-sand-300 hover:bg-sand-50 dark:border-husk-100 dark:bg-husk-400/40 dark:hover:border-husk-50 dark:hover:bg-husk-200'
+        }`}
+      >
+        <span className="flex h-9 w-9 flex-none items-center justify-center rounded bg-sand-50 dark:bg-husk-400">
+          {spriteFailed ? (
+            <ImageOff size={14} className="text-coconut-300 dark:text-sand-500" aria-hidden />
+          ) : (
+            <img
+              src={pokemonSpriteUrl(species.number)}
+              alt=""
+              className="h-9 w-9 object-contain"
+              loading="lazy"
+              onError={() => setSpriteFailed(true)}
+            />
+          )}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-sm font-medium text-coconut-700 dark:text-sand-50">
+          {species.name}
+        </span>
+        <Star
+          size={16}
+          className={
+            favorited
+              ? 'flex-none fill-sun-400 text-sun-500 dark:fill-sun-300 dark:text-sun-300'
+              : 'flex-none text-coconut-300 dark:text-sand-500'
+          }
+          aria-hidden
+        />
+      </button>
+    </li>
+  )
+}

--- a/web/src/components/FavoriteSetsPanel.test.tsx
+++ b/web/src/components/FavoriteSetsPanel.test.tsx
@@ -44,6 +44,7 @@ function card(setId: string): SetCard {
     subtypes: ['Basic'],
     thumb: null,
     market: 1,
+    dexNumbers: [],
   }
 }
 

--- a/web/src/components/SwipePanel.test.tsx
+++ b/web/src/components/SwipePanel.test.tsx
@@ -40,6 +40,11 @@ vi.mock('../api/client', () => ({
   resetSwipeSeen: vi.fn(),
   // Cross-collection ownership badge (#576): default to "nothing owned".
   fetchCardOwnership: vi.fn(async () => ({})),
+  // Favorite-Pokémon candidate weighting (#742): signed-in only; default to
+  // an empty pin list so the deck isn't biased and no real request fires.
+  fetchFavoritePokemon: vi.fn(async () => []),
+  pinFavoritePokemon: vi.fn(),
+  unpinFavoritePokemon: vi.fn(),
 }))
 
 const mockFetchSets = vi.mocked(fetchSets)
@@ -63,6 +68,7 @@ function card(overrides: Partial<SetCard> = {}): SetCard {
     subtypes: ['Basic'],
     thumb: null,
     market: 5,
+    dexNumbers: [],
     ...overrides,
   }
 }

--- a/web/src/components/SwipePanel.tsx
+++ b/web/src/components/SwipePanel.tsx
@@ -33,6 +33,8 @@ import type { RarityFloor, Row, SetCard } from '../types'
 import { browseCardToPayload, browseCardToRow } from './browseCard'
 import { CardDetailModal } from './CardDetailModal'
 import { FavoriteSetsPanel } from './FavoriteSetsPanel'
+import { favoriteSpeciesBoost } from './favoriteSpeciesBoost'
+import { useFavoritePokemon } from './useFavoritePokemon'
 import { useFavoriteSets } from './useFavoriteSets'
 import { useCardOwnership } from './useCardOwnership'
 import { OwnershipBadge } from './OwnershipBadge'
@@ -86,15 +88,24 @@ export function SwipePanel({ active }: SwipePanelProps) {
   // user (they're per-user) so a signed-out deck isn't biased by — and doesn't
   // hit the endpoint as — the default user.
   const { isPinned } = useFavoriteSets({ enabled: showSavedActions })
+  // Favorite Pokémon (#742) feed the card weighting the same way pinned sets
+  // feed the set weighting; same signed-in gate.
+  const { isFavorite } = useFavoritePokemon({ enabled: showSavedActions })
 
   // Profile-weighted candidate selection (#713). `setScore` biases which set
   // is walked next — the learned per-set lean plus a strong bonus for pinned
   // favorites; `cardScore` biases the card within it via the full taste
-  // profile. Both fall back to a flat 0 (the unbiased walk) before any signal.
+  // profile plus a bonus when the card is a favorite Pokémon (#742). Both fall
+  // back to a flat 0 (the unbiased walk) before any signal.
   const setScore = useCallback(
     (setId: string) =>
       (profile.set[setId] ?? 0) + (isPinned(setId) ? FAVORITE_SET_BONUS : 0),
     [profile.set, isPinned],
+  )
+  const cardScore = useCallback(
+    (card: SetCard, setId: string) =>
+      scoreCard(card, setId) + favoriteSpeciesBoost(card, isFavorite),
+    [scoreCard, isFavorite],
   )
   const { excludedKeys, recordSeen, resetDeck } = useSwipeExclusions({
     excludeOwned: settings.swipeExcludeOwned,
@@ -107,7 +118,7 @@ export function SwipePanel({ active }: SwipePanelProps) {
       excludedKeys,
       rarityFloor: settings.swipeRarityFloor,
       setScore,
-      cardScore: scoreCard,
+      cardScore,
     })
 
   // Cross-collection ownership badge (#576). Prefetch the current card plus

--- a/web/src/components/SwipeProfilePanel.test.tsx
+++ b/web/src/components/SwipeProfilePanel.test.tsx
@@ -17,6 +17,7 @@ function card(overrides: Partial<SetCard> = {}): SetCard {
     subtypes: ['Basic'],
     thumb: null,
     market: 12,
+    dexNumbers: [],
     ...overrides,
   }
 }

--- a/web/src/components/browseCard.test.ts
+++ b/web/src/components/browseCard.test.ts
@@ -11,6 +11,7 @@ const POKEDEX_CARD: PokedexCard = {
   subtypes: ['Stage 2'],
   thumb: 'https://img/base1-4.png',
   market: 250,
+  dexNumbers: [6],
   setId: 'base1',
   setName: 'Base',
   releaseDate: '1999/01/09',
@@ -27,6 +28,7 @@ const BARE_SET_CARD: SetCard = {
   subtypes: [],
   thumb: null,
   market: null,
+  dexNumbers: [],
 }
 
 describe('browseCard adapters', () => {

--- a/web/src/components/favoriteSpeciesBoost.test.ts
+++ b/web/src/components/favoriteSpeciesBoost.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { favoriteSpeciesBoost } from './favoriteSpeciesBoost'
+
+describe('favoriteSpeciesBoost (#742)', () => {
+  const isFavorite = (n: number) => n === 6 // Charizard favorited
+
+  it('boosts a card that prints a favorite species', () => {
+    expect(favoriteSpeciesBoost({ dexNumbers: [6] }, isFavorite)).toBeGreaterThan(0)
+  })
+
+  it('boosts a multi-species card when any of its numbers is favorited', () => {
+    expect(favoriteSpeciesBoost({ dexNumbers: [25, 6] }, isFavorite)).toBeGreaterThan(0)
+  })
+
+  it('gives no boost to a non-favorite species', () => {
+    expect(favoriteSpeciesBoost({ dexNumbers: [25] }, isFavorite)).toBe(0)
+  })
+
+  it('gives no boost when the card carries no dex numbers', () => {
+    expect(favoriteSpeciesBoost({ dexNumbers: [] }, isFavorite)).toBe(0)
+  })
+
+  it('a favorited card outscores an identical non-favorite via the boost', () => {
+    const favorited = favoriteSpeciesBoost({ dexNumbers: [6] }, isFavorite)
+    const plain = favoriteSpeciesBoost({ dexNumbers: [1] }, isFavorite)
+    expect(favorited).toBeGreaterThan(plain)
+  })
+})

--- a/web/src/components/favoriteSpeciesBoost.ts
+++ b/web/src/components/favoriteSpeciesBoost.ts
@@ -1,0 +1,27 @@
+/**
+ * favoriteSpeciesBoost — the extra swipe candidate-draw weight a card earns
+ * when it prints a favorite Pokémon (#742, epic #701).
+ *
+ * The species-level sibling of the pinned-favorite-set bonus: folded into the
+ * swipe `cardScore` on top of the learned taste profile so the deck leans
+ * toward the Pokémon a user explicitly loves, without ever collapsing the feed
+ * onto one species (the bounded `profileMultiplier` in `useSwipeCandidates`
+ * clamps it).
+ */
+import type { SetCard } from '../types'
+
+/** Profile-score bonus a card of a favorite Pokémon adds to its in-set draw
+ *  weight. Sized like the pinned-favorite-set bonus so an explicit "I love
+ *  this Pokémon" lands the card near the multiplier cap. */
+export const FAVORITE_SPECIES_BONUS = 12
+
+/**
+ * {@link FAVORITE_SPECIES_BONUS} when any of the card's national dex numbers is
+ * favorited, else 0.
+ */
+export function favoriteSpeciesBoost(
+  card: Pick<SetCard, 'dexNumbers'>,
+  isFavorite: (dexNumber: number) => boolean,
+): number {
+  return card.dexNumbers?.some(isFavorite) ? FAVORITE_SPECIES_BONUS : 0
+}

--- a/web/src/components/useFavoritePokemon.test.ts
+++ b/web/src/components/useFavoritePokemon.test.ts
@@ -67,6 +67,29 @@ describe('useFavoritePokemon', () => {
     expect(result.current.error).toBe('boom')
   })
 
+  it('keeps an optimistic pin when a slow initial GET resolves afterward', async () => {
+    // The mount GET is still in flight when the user stars a Pokémon; it then
+    // resolves with a snapshot that predates the pin. The optimistic favorite
+    // must survive (the pin's own POST persisted it) — not get clobbered.
+    let resolveGet: (v: never[]) => void = () => {}
+    mockFetch.mockReset().mockImplementation(
+      () => new Promise((res) => { resolveGet = res as (v: never[]) => void }),
+    )
+    const { result } = renderHook(() => useFavoritePokemon())
+
+    await act(async () => {
+      await result.current.pin(6)
+    })
+    expect(result.current.isFavorite(6)).toBe(true)
+
+    // The stale initial GET (empty) lands after the optimistic pin.
+    await act(async () => {
+      resolveGet([])
+      await Promise.resolve()
+    })
+    expect(result.current.isFavorite(6)).toBe(true)
+  })
+
   it('unpins a Pokémon', async () => {
     mockFetch.mockResolvedValue([{ dex_number: 6, pinned_at: '2026-06-22T00:00:00Z' }])
     const { result } = renderHook(() => useFavoritePokemon())

--- a/web/src/components/useFavoritePokemon.test.ts
+++ b/web/src/components/useFavoritePokemon.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import {
+  fetchFavoritePokemon,
+  pinFavoritePokemon,
+  unpinFavoritePokemon,
+} from '../api/client'
+import {
+  useFavoritePokemon,
+  _resetFavoritePokemonCacheForTests,
+} from './useFavoritePokemon'
+
+vi.mock('../api/client', () => ({
+  fetchFavoritePokemon: vi.fn(),
+  pinFavoritePokemon: vi.fn(),
+  unpinFavoritePokemon: vi.fn(),
+}))
+
+const mockFetch = vi.mocked(fetchFavoritePokemon)
+const mockPin = vi.mocked(pinFavoritePokemon)
+const mockUnpin = vi.mocked(unpinFavoritePokemon)
+
+describe('useFavoritePokemon', () => {
+  beforeEach(() => {
+    _resetFavoritePokemonCacheForTests()
+    mockFetch.mockReset().mockResolvedValue([])
+    mockPin.mockReset().mockResolvedValue(undefined)
+    mockUnpin.mockReset().mockResolvedValue(undefined)
+  })
+
+  it('loads pinned Pokémon on mount', async () => {
+    mockFetch.mockResolvedValue([{ dex_number: 6, pinned_at: '2026-06-22T00:00:00Z' }])
+    const { result } = renderHook(() => useFavoritePokemon())
+    await waitFor(() => expect(result.current.favorites.length).toBe(1))
+    expect(result.current.favorites[0].dex_number).toBe(6)
+    expect(result.current.isFavorite(6)).toBe(true)
+    expect(result.current.isFavorite(25)).toBe(false)
+  })
+
+  it('skips the fetch when disabled', async () => {
+    renderHook(() => useFavoritePokemon({ enabled: false }))
+    // Give any stray effect a tick; the per-user endpoint must stay untouched.
+    await Promise.resolve()
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('pins optimistically', async () => {
+    const { result } = renderHook(() => useFavoritePokemon())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await act(async () => {
+      await result.current.pin(25)
+    })
+    expect(result.current.isFavorite(25)).toBe(true)
+    expect(mockPin).toHaveBeenCalledWith(25)
+  })
+
+  it('rolls back a pin when the request fails', async () => {
+    mockPin.mockRejectedValue(new Error('boom'))
+    const { result } = renderHook(() => useFavoritePokemon())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await act(async () => {
+      await result.current.pin(25)
+    })
+    expect(result.current.isFavorite(25)).toBe(false)
+    expect(result.current.error).toBe('boom')
+  })
+
+  it('unpins a Pokémon', async () => {
+    mockFetch.mockResolvedValue([{ dex_number: 6, pinned_at: '2026-06-22T00:00:00Z' }])
+    const { result } = renderHook(() => useFavoritePokemon())
+    await waitFor(() => expect(result.current.favorites.length).toBe(1))
+
+    await act(async () => {
+      await result.current.unpin(6)
+    })
+    expect(result.current.isFavorite(6)).toBe(false)
+    expect(mockUnpin).toHaveBeenCalledWith(6)
+  })
+})

--- a/web/src/components/useFavoritePokemon.ts
+++ b/web/src/components/useFavoritePokemon.ts
@@ -1,0 +1,110 @@
+/**
+ * useFavoritePokemon — shared fetcher + cache for the `/api/v1/favorite-pokemon`
+ * pinned-species list (#742, epic #701).
+ *
+ * The species-level sibling of {@link useFavoriteSets}: favorite Pokémon are
+ * the durable, server-side half of the swipe taste profile — an explicit "I
+ * love this Pokémon" the user curates, kept in the DB (keyed by national
+ * Pokédex number) so Browse and Swipe can read it across devices.
+ *
+ * Mirrors the module-level-store pattern so a pin in one surface (the pokedex
+ * tiles, the onboarding survey) lights up every consumer without a refetch.
+ * Pins and unpins are optimistic.
+ */
+import { useCallback, useEffect, useState } from 'react'
+import {
+  fetchFavoritePokemon,
+  pinFavoritePokemon,
+  unpinFavoritePokemon,
+  type FavoritePokemon,
+} from '../api/client'
+
+interface State {
+  favorites: FavoritePokemon[]
+  loading: boolean
+  error: string | null
+}
+
+const listeners = new Set<(s: State) => void>()
+let state: State = { favorites: [], loading: false, error: null }
+let inflight: Promise<void> | null = null
+
+function set(next: Partial<State>) {
+  state = { ...state, ...next }
+  for (const fn of listeners) fn(state)
+}
+
+async function refresh(): Promise<void> {
+  if (inflight) return inflight
+  set({ loading: true, error: null })
+  inflight = (async () => {
+    try {
+      const favorites = await fetchFavoritePokemon()
+      set({ favorites, loading: false })
+    } catch (e) {
+      set({ loading: false, error: e instanceof Error ? e.message : String(e) })
+    } finally {
+      inflight = null
+    }
+  })()
+  return inflight
+}
+
+/**
+ * @param enabled When false, skip the auto-fetch on mount — favorite Pokémon
+ *   are per-user, so a signed-out consumer reads an empty list instead of
+ *   hitting the endpoint as the default user. Defaults to true.
+ */
+export function useFavoritePokemon({ enabled = true }: { enabled?: boolean } = {}) {
+  const [snapshot, setSnapshot] = useState<State>(state)
+
+  useEffect(() => {
+    listeners.add(setSnapshot)
+    if (enabled && state.favorites.length === 0 && !state.loading) {
+      void refresh()
+    }
+    return () => {
+      listeners.delete(setSnapshot)
+    }
+  }, [enabled])
+
+  const pin = useCallback(async (dexNumber: number) => {
+    if (state.favorites.some((f) => f.dex_number === dexNumber)) return
+    const previous = state.favorites
+    set({
+      favorites: [
+        { dex_number: dexNumber, pinned_at: new Date().toISOString() },
+        ...state.favorites,
+      ],
+    })
+    try {
+      await pinFavoritePokemon(dexNumber)
+    } catch (e) {
+      set({ favorites: previous, error: e instanceof Error ? e.message : String(e) })
+    }
+  }, [])
+
+  const unpin = useCallback(async (dexNumber: number) => {
+    const previous = state.favorites
+    set({ favorites: state.favorites.filter((f) => f.dex_number !== dexNumber) })
+    try {
+      await unpinFavoritePokemon(dexNumber)
+    } catch (e) {
+      set({ favorites: previous, error: e instanceof Error ? e.message : String(e) })
+    }
+  }, [])
+
+  const isFavorite = useCallback(
+    (dexNumber: number) => snapshot.favorites.some((f) => f.dex_number === dexNumber),
+    [snapshot.favorites],
+  )
+
+  return { ...snapshot, refresh, pin, unpin, isFavorite }
+}
+
+// Test-only: reset the module-level cache between vitest runs.
+export function _resetFavoritePokemonCacheForTests() {
+  state = { favorites: [], loading: false, error: null }
+  inflight = null
+  listeners.clear()
+}

--- a/web/src/components/useFavoritePokemon.ts
+++ b/web/src/components/useFavoritePokemon.ts
@@ -28,6 +28,9 @@ interface State {
 const listeners = new Set<(s: State) => void>()
 let state: State = { favorites: [], loading: false, error: null }
 let inflight: Promise<void> | null = null
+// Bumped on every optimistic pin/unpin so an in-flight refresh can tell its
+// server snapshot predates a mutation and must not clobber it.
+let mutationRev = 0
 
 function set(next: Partial<State>) {
   state = { ...state, ...next }
@@ -37,10 +40,15 @@ function set(next: Partial<State>) {
 async function refresh(): Promise<void> {
   if (inflight) return inflight
   set({ loading: true, error: null })
+  const revAtStart = mutationRev
   inflight = (async () => {
     try {
       const favorites = await fetchFavoritePokemon()
-      set({ favorites, loading: false })
+      // If a pin/unpin landed while this GET was in flight, its snapshot may
+      // predate that change — keep the optimistic state (the mutation's own
+      // POST already persisted it) and only clear the loading flag.
+      if (mutationRev === revAtStart) set({ favorites, loading: false })
+      else set({ loading: false })
     } catch (e) {
       set({ loading: false, error: e instanceof Error ? e.message : String(e) })
     } finally {
@@ -70,6 +78,7 @@ export function useFavoritePokemon({ enabled = true }: { enabled?: boolean } = {
 
   const pin = useCallback(async (dexNumber: number) => {
     if (state.favorites.some((f) => f.dex_number === dexNumber)) return
+    mutationRev++
     const previous = state.favorites
     set({
       favorites: [
@@ -85,6 +94,7 @@ export function useFavoritePokemon({ enabled = true }: { enabled?: boolean } = {
   }, [])
 
   const unpin = useCallback(async (dexNumber: number) => {
+    mutationRev++
     const previous = state.favorites
     set({ favorites: state.favorites.filter((f) => f.dex_number !== dexNumber) })
     try {
@@ -106,5 +116,6 @@ export function useFavoritePokemon({ enabled = true }: { enabled?: boolean } = {
 export function _resetFavoritePokemonCacheForTests() {
   state = { favorites: [], loading: false, error: null }
   inflight = null
+  mutationRev = 0
   listeners.clear()
 }

--- a/web/src/components/useSwipeCandidates.test.ts
+++ b/web/src/components/useSwipeCandidates.test.ts
@@ -141,6 +141,7 @@ function card(id: string, rarity: string | null = 'Common'): SetCard {
     subtypes: ['Basic'],
     thumb: null,
     market: 1,
+    dexNumbers: [],
   }
 }
 

--- a/web/src/components/useSwipeProfile.test.ts
+++ b/web/src/components/useSwipeProfile.test.ts
@@ -16,6 +16,7 @@ function card(overrides: Partial<SetCard> = {}): SetCard {
     subtypes: ['Basic'],
     thumb: null,
     market: 5,
+    dexNumbers: [],
     ...overrides,
   }
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -241,6 +241,9 @@ export interface SetCard {
   subtypes: string[]
   thumb: string | null
   market: number | null
+  /** National Pokédex numbers this card prints (usually one; a couple for
+   *  multi-species cards). Drives favorite-species swipe weighting (#742). */
+  dexNumbers: number[]
 }
 
 /**


### PR DESCRIPTION
Closes #742

## What

The species-level sibling of favorite **sets** (#712): a durable, per-user "these are my Pokémon" signal that Swipe and Browse lean toward. Favorite Pokémon are stored server-side keyed by national Pokédex number — the same key Browse's pokedex view and `GET /pokedex/{n}/cards` already use — so a card's `nationalPokedexNumbers` matches a favorite directly.

Two picking surfaces plus the personalization payoff (all in one PR, per the issue):

- **Inline (Browse pokedex view):** a star toggle on every species tile and on the species detail header, plus a pinned **"Your favorites"** group at the top of the unfiltered list.
- **First-login onboarding survey:** a pop-up that asks a new user which Pokémon they love — a curated crowd-favorites quick-pick row plus a search over the baked Pokédex. Gated server-side by a new `users.onboarding_completed_at` column surfaced through `/me`; both **Done** and **Skip** mark it complete so it never re-nags (cross-device).
- **Personalization:** each trimmed card now carries `dexNumbers`, and the swipe `cardScore` adds a bonus when a card prints a favorite species — sized like the pinned-favorite-set bonus and clamped by the existing `profileMultiplier`, so a loved species surfaces more without collapsing the feed.

### Backend
- `favorite_species` table + `users.onboarding_completed_at` (one alembic migration on top of the favorite-sets head).
- `/api/v1/favorite-pokemon` GET/POST/DELETE (idempotent, dex-range validated) and `POST /api/v1/me/onboarding/complete`, mirroring the favorite-sets route shapes.
- `_trim_card` projects `nationalPokedexNumbers` as `dexNumbers`.

## Why

"To personalize Swipe/Browse suggestions" — an explicit, durable favorite-species signal is the species-level half of the swipe taste profile, and the onboarding survey gives a cold account a one-tap way to seed it. Mirrors the favorite-sets model so the two signals stay consistent.

## How to verify

1. `make check` (ruff + 999 py tests + web ESLint) — green. `cd web && npm run build` — green. `alembic upgrade head` then `downgrade -1` round-trips cleanly.
2. Run `make dev-api` + `make dev-web`, open the SPA fresh: the **Pick your favorite Pokémon** pop-up appears (the default user starts with `onboarding_completed: false`). Tap a few favorites → **Done** → modal closes and does **not** reappear on reload.
3. Browse → **By Pokédex #**: a **Your favorites** group sits at the top with filled stars; every species tile has a star toggle that pins/unpins live.
4. Swipe (signed in): cards of a favorited species surface more often.

Verified end-to-end locally via the dev server (onboarding POST 204 → complete POST 204 → no re-nag; Browse stars + favorites group rendering); screenshots in the thread.

## Out of scope / follow-up

Owned-signal favorite-species *suggestions* (like favorite sets' owned-count suggestions) need dex numbers on `collection_items`, so they're deferred.