### PR TITLE
web: show card library locations in detail modal

### DIFF
--- a/web/src/components/CardDetailModal.test.tsx
+++ b/web/src/components/CardDetailModal.test.tsx
@@ -647,4 +647,25 @@ describe('CardDetailModal — library actions (#699)', () => {
     expect(await screen.findByText(/owned ×2/i)).toBeInTheDocument()
     expect(screen.getByTitle(/Chasing on Chase list/i)).toBeInTheDocument()
   })
+
+  it('surfaces the named collections and want-lists a card belongs to', async () => {
+    vi.spyOn(client, 'fetchCardOwnership').mockResolvedValue({
+      'base1::4': {
+        collections: [
+          { id: 1, name: 'Base Set masters', quantity: 1 },
+          { id: 2, name: 'Trade binder', quantity: 3 },
+        ],
+        wishlists: [{ id: 3, name: 'Allentown chase list' }],
+      },
+    })
+
+    render(<CardDetailModal rows={[identifiedRow()]} index={0} onChangeIndex={() => {}} />)
+
+    const locations = await screen.findByLabelText(/Library locations/i)
+    expect(within(locations).getByText('In:')).toBeInTheDocument()
+    expect(within(locations).getByText('Base Set masters')).toBeInTheDocument()
+    expect(within(locations).getByText('Trade binder ×3')).toBeInTheDocument()
+    expect(within(locations).getByText('Want:')).toBeInTheDocument()
+    expect(within(locations).getByText('Allentown chase list')).toBeInTheDocument()
+  })
 })

--- a/web/src/components/CardDetailModal.tsx
+++ b/web/src/components/CardDetailModal.tsx
@@ -255,6 +255,7 @@ function CardDetailBody({
                   </h3>
                   <OwnershipBadge ownership={ownership} />
                 </div>
+                <LibraryLocations ownership={ownership} />
                 <SaveCardActions
                   card={card as unknown as Record<string, unknown>}
                   show={showActions}
@@ -330,6 +331,51 @@ function CardDetailBody({
         </div>
       </div>
     </>
+  )
+}
+
+function LibraryLocations({
+  ownership,
+}: {
+  ownership: CardOwnership | null | undefined
+}) {
+  if (!ownership) return null
+  const { collections, wishlists } = ownership
+  if (collections.length === 0 && wishlists.length === 0) return null
+
+  return (
+    <div
+      aria-label="Library locations"
+      className="mb-3 space-y-1.5 rounded-md bg-sand-100 px-2.5 py-2 text-xs text-coconut-500 dark:bg-husk-300 dark:text-sand-200"
+    >
+      {collections.length > 0 && (
+        <LocationLine
+          label="In:"
+          names={collections.map((c) =>
+            c.quantity > 1 ? `${c.name} ×${c.quantity}` : c.name,
+          )}
+        />
+      )}
+      {wishlists.length > 0 && (
+        <LocationLine label="Want:" names={wishlists.map((w) => w.name)} />
+      )}
+    </div>
+  )
+}
+
+function LocationLine({ label, names }: { label: string; names: string[] }) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <span className="font-semibold text-coconut-600 dark:text-sand-100">{label}</span>
+      {names.map((name) => (
+        <span
+          key={name}
+          className="rounded-full bg-sand-200 px-1.5 py-0.5 text-coconut-600 dark:bg-husk-100 dark:text-sand-100"
+        >
+          {name}
+        </span>
+      ))}
+    </div>
   )
 }
 


### PR DESCRIPTION
Closes #739

## What

- Shows visible `In:` collection chips and `Want:` want-list chips in the card detail modal's Library actions section.
- Includes collection quantities when the card appears more than once in a collection.
- Adds coverage for rendering named collections and want-lists from the existing ownership lookup.

## Why

The modal already showed owned/chasing badges, but the specific collection or want-list names were only available in tooltips. This makes the modal directly answer where the card already lives or where it is being chased.

## How to verify

- `make check`
- `cd web && npm run build`
- In the web UI, sign in, add a card to a collection and a want-list, then open that card's detail modal and confirm the Library actions section lists the collection under `In:` and the want-list under `Want:`.

## Preview

Screenshot to be attached by the developer before requesting review.