### PR TITLE
feat(api): provision a default wishlist and collection per user

### DIFF
--- a/api/db/defaults.py
+++ b/api/db/defaults.py
@@ -1,0 +1,125 @@
+"""Per-user default wishlist + collection (ADR-0027, #759).
+
+The one-tap ``Want`` / ``Own`` quick actions need a write target that exists
+without asking the user to pick or create a list first. Every user gets exactly
+one default wishlist and one default personal collection — ordinary
+``wishlists`` / ``collections`` rows flagged ``is_default``, not a parallel
+store. They're provisioned lazily here on first use; a partial unique index
+(``uq_<table>_user_default``) keeps the one-default-per-user invariant even
+under a concurrent first call.
+
+Lifecycle (ADR-0027): the flag is the invariant, not the row. Renaming a
+default keeps it the default (nothing here touches it). Deleting a default
+leaves the user without one, so the next ``get_or_create_*`` call re-establishes
+it. :func:`set_default_wishlist` / :func:`set_default_collection` reassign the
+flag to another existing row rather than duplicating storage.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from .models import COLLECTION_KIND_MANUAL, Collection, Wishlist
+
+#: Names a freshly provisioned default gets. Plain and renameable — the user can
+#: change them without losing default status.
+DEFAULT_WISHLIST_NAME = "My wishlist"
+DEFAULT_COLLECTION_NAME = "My collection"
+
+
+def get_or_create_default_wishlist(db: Session, user_id: int) -> Wishlist:
+    """Return the user's default wishlist, provisioning one if absent.
+
+    Idempotent and safe against a concurrent first call: the partial unique
+    index turns the losing insert into an ``IntegrityError`` we recover from by
+    re-reading the now-present row."""
+    existing = _default_wishlist(db, user_id)
+    if existing is not None:
+        return existing
+
+    wishlist = Wishlist(user_id=user_id, name=DEFAULT_WISHLIST_NAME, is_default=True)
+    db.add(wishlist)
+    try:
+        db.flush()
+    except IntegrityError:
+        db.rollback()
+        won = _default_wishlist(db, user_id)
+        if won is None:  # pragma: no cover — the index guarantees a winner
+            raise
+        return won
+    return wishlist
+
+
+def get_or_create_default_collection(db: Session, user_id: int) -> Collection:
+    """Return the user's default personal collection, provisioning one if absent.
+
+    A plain ``manual`` collection (no binder, no rule). Same idempotency and
+    race-recovery contract as :func:`get_or_create_default_wishlist`."""
+    existing = _default_collection(db, user_id)
+    if existing is not None:
+        return existing
+
+    collection = Collection(
+        user_id=user_id,
+        name=DEFAULT_COLLECTION_NAME,
+        kind=COLLECTION_KIND_MANUAL,
+        is_default=True,
+    )
+    db.add(collection)
+    try:
+        db.flush()
+    except IntegrityError:
+        db.rollback()
+        won = _default_collection(db, user_id)
+        if won is None:  # pragma: no cover — the index guarantees a winner
+            raise
+        return won
+    return collection
+
+
+def set_default_wishlist(db: Session, user_id: int, wishlist_id: int) -> Wishlist:
+    """Promote ``wishlist_id`` to the user's default, clearing the prior one.
+
+    Clears the old default before setting the new one so the partial unique
+    index never sees two defaults mid-flush. Raises ``ValueError`` if the
+    wishlist isn't the user's."""
+    target = db.get(Wishlist, wishlist_id)
+    if target is None or target.user_id != user_id:
+        raise ValueError(f"wishlist {wishlist_id} not found for user {user_id}")
+    current = _default_wishlist(db, user_id)
+    if current is not None and current.id != wishlist_id:
+        current.is_default = False
+        db.flush()
+    target.is_default = True
+    db.flush()
+    return target
+
+
+def set_default_collection(db: Session, user_id: int, collection_id: int) -> Collection:
+    """Promote ``collection_id`` to the user's default, clearing the prior one.
+
+    Mirror of :func:`set_default_wishlist` for collections."""
+    target = db.get(Collection, collection_id)
+    if target is None or target.user_id != user_id:
+        raise ValueError(f"collection {collection_id} not found for user {user_id}")
+    current = _default_collection(db, user_id)
+    if current is not None and current.id != collection_id:
+        current.is_default = False
+        db.flush()
+    target.is_default = True
+    db.flush()
+    return target
+
+
+def _default_wishlist(db: Session, user_id: int) -> Wishlist | None:
+    return db.scalars(
+        select(Wishlist).where(Wishlist.user_id == user_id, Wishlist.is_default)
+    ).first()
+
+
+def _default_collection(db: Session, user_id: int) -> Collection | None:
+    return db.scalars(
+        select(Collection).where(Collection.user_id == user_id, Collection.is_default)
+    ).first()

--- a/api/db/models.py
+++ b/api/db/models.py
@@ -28,6 +28,7 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    false,
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
@@ -312,6 +313,13 @@ class Collection(Base):
         ForeignKey("binders.id", ondelete="SET NULL"), nullable=True
     )
     binder: Mapped[Binder | None] = relationship(back_populates="collections")
+    # ---- #759: the user's default personal collection for one-tap `Own` (ADR-0027) ----
+    #: Exactly one row per user may be the default (a partial unique index on
+    #: ``user_id WHERE is_default`` enforces it). The flag is the invariant, not
+    #: the row: renaming keeps it, deleting re-establishes one lazily.
+    is_default: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=false()
+    )
 
     items: Mapped[list[CollectionItem]] = relationship(
         back_populates="collection",
@@ -420,6 +428,13 @@ class Wishlist(Base):
     #: post-show retrospectives in the insights dashboard. Route plumbing
     #: rides on #504.
     target_date: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # ---- #759: the user's default wishlist for one-tap `Want` (ADR-0027) ----
+    #: Exactly one row per user may be the default (a partial unique index on
+    #: ``user_id WHERE is_default`` enforces it). The flag is the invariant, not
+    #: the row: renaming keeps it, deleting re-establishes one lazily.
+    is_default: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=false()
+    )
 
     items: Mapped[list[WishlistItem]] = relationship(
         back_populates="wishlist",

--- a/api/migrations/versions/f1a4d7c9e2b6_default_wishlist_and_collection.py
+++ b/api/migrations/versions/f1a4d7c9e2b6_default_wishlist_and_collection.py
@@ -1,0 +1,56 @@
+"""default wishlist + collection per user — one-tap want/own (#759, ADR-0027)
+
+Adds an ``is_default`` flag to ``wishlists`` and ``collections`` so a user's
+one-tap ``Want`` / ``Own`` quick actions always have a write target without a
+picker. The flag is the invariant, not the row: a partial unique index on
+``user_id WHERE is_default`` allows at most one default of each kind per user,
+while leaving non-default rows unconstrained. Existing rows backfill to
+``false`` (no default yet); the find-or-create helper provisions one lazily on
+the first quick action.
+
+Revision ID: f1a4d7c9e2b6
+Revises: e9a1c3f7b2d8
+Create Date: 2026-06-22
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "f1a4d7c9e2b6"
+down_revision: str | Sequence[str] | None = "e9a1c3f7b2d8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    for table in ("wishlists", "collections"):
+        op.add_column(
+            table,
+            sa.Column(
+                "is_default",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            ),
+        )
+        # At most one default of each kind per user. Partial so the many
+        # non-default rows stay unconstrained; the per-user fetch of "the
+        # default" rides the same index.
+        op.create_index(
+            f"uq_{table}_user_default",
+            table,
+            ["user_id"],
+            unique=True,
+            sqlite_where=sa.text("is_default = 1"),
+            postgresql_where=sa.text("is_default"),
+        )
+
+
+def downgrade() -> None:
+    for table in ("collections", "wishlists"):
+        op.drop_index(f"uq_{table}_user_default", table_name=table)
+        op.drop_column(table, "is_default")

--- a/tests/test_defaults.py
+++ b/tests/test_defaults.py
@@ -1,0 +1,183 @@
+"""Tests for per-user default wishlist + collection (ADR-0027, #759).
+
+Covers the find-or-create helpers, the one-default-per-user invariant enforced
+by the partial unique index, the default-row lifecycle rules from ADR-0027
+(rename keeps the default, delete re-establishes one), and flag reassignment.
+
+Reuses the isolated-tempfile-DB pattern from `tests/test_collections.py`.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sqlalchemy.exc import IntegrityError
+
+from api.db import session as session_mod
+from api.db.defaults import (
+    DEFAULT_COLLECTION_NAME,
+    DEFAULT_WISHLIST_NAME,
+    get_or_create_default_collection,
+    get_or_create_default_wishlist,
+    set_default_collection,
+    set_default_wishlist,
+)
+from api.db.migrate import upgrade_head
+from api.db.models import DEFAULT_USER_ID, Collection, User, Wishlist
+
+
+class _IsolatedDbMixin(unittest.TestCase):
+    """Point MGZ_PKMN_DATABASE_URL at a fresh sqlite file per test."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self._db_path = Path(self._tmp.name) / "test.db"
+        self._old_url = os.environ.get("MGZ_PKMN_DATABASE_URL")
+        os.environ["MGZ_PKMN_DATABASE_URL"] = f"sqlite:///{self._db_path}"
+        session_mod.reset_engine()
+        upgrade_head(session_mod.get_engine())
+        self._Session = session_mod.get_session_factory()
+
+    def tearDown(self) -> None:
+        session_mod.reset_engine()
+        if self._old_url is None:
+            os.environ.pop("MGZ_PKMN_DATABASE_URL", None)
+        else:
+            os.environ["MGZ_PKMN_DATABASE_URL"] = self._old_url
+        self._tmp.cleanup()
+
+
+class DefaultWishlistTests(_IsolatedDbMixin):
+    def test_creates_one_default_then_returns_it(self) -> None:
+        with self._Session() as db:
+            first = get_or_create_default_wishlist(db, DEFAULT_USER_ID)
+            db.commit()
+            self.assertTrue(first.is_default)
+            self.assertEqual(first.name, DEFAULT_WISHLIST_NAME)
+
+        with self._Session() as db:
+            second = get_or_create_default_wishlist(db, DEFAULT_USER_ID)
+            db.commit()
+            self.assertEqual(second.id, first.id)
+            count = db.query(Wishlist).filter_by(user_id=DEFAULT_USER_ID, is_default=True).count()
+            self.assertEqual(count, 1)
+
+    def test_partial_unique_index_blocks_a_second_default(self) -> None:
+        with self._Session() as db:
+            get_or_create_default_wishlist(db, DEFAULT_USER_ID)
+            db.commit()
+            db.add(Wishlist(user_id=DEFAULT_USER_ID, name="sneaky", is_default=True))
+            with self.assertRaises(IntegrityError):
+                db.flush()
+
+    def test_rename_keeps_default_status(self) -> None:
+        with self._Session() as db:
+            wl = get_or_create_default_wishlist(db, DEFAULT_USER_ID)
+            wl.name = "Allentown chase"
+            db.commit()
+
+        with self._Session() as db:
+            again = get_or_create_default_wishlist(db, DEFAULT_USER_ID)
+            self.assertEqual(again.name, "Allentown chase")
+            self.assertTrue(again.is_default)
+
+    def test_delete_re_establishes_a_default(self) -> None:
+        with self._Session() as db:
+            original = get_or_create_default_wishlist(db, DEFAULT_USER_ID)
+            db.delete(original)
+            db.commit()
+            # Deleting the default leaves the user without one.
+            self.assertEqual(
+                db.query(Wishlist).filter_by(user_id=DEFAULT_USER_ID, is_default=True).count(), 0
+            )
+
+        with self._Session() as db:
+            fresh = get_or_create_default_wishlist(db, DEFAULT_USER_ID)
+            db.commit()
+            # The next quick action provisions a fresh default.
+            self.assertTrue(fresh.is_default)
+            self.assertEqual(fresh.name, DEFAULT_WISHLIST_NAME)
+            self.assertEqual(
+                db.query(Wishlist).filter_by(user_id=DEFAULT_USER_ID, is_default=True).count(), 1
+            )
+
+    def test_set_default_reassigns_the_flag(self) -> None:
+        with self._Session() as db:
+            old = get_or_create_default_wishlist(db, DEFAULT_USER_ID)
+            other = Wishlist(user_id=DEFAULT_USER_ID, name="Trade pile")
+            db.add(other)
+            db.flush()
+            promoted = set_default_wishlist(db, DEFAULT_USER_ID, other.id)
+            db.commit()
+            self.assertTrue(promoted.is_default)
+            self.assertFalse(db.get(Wishlist, old.id).is_default)
+            count = db.query(Wishlist).filter_by(user_id=DEFAULT_USER_ID, is_default=True).count()
+            self.assertEqual(count, 1)
+
+    def test_set_default_rejects_another_users_wishlist(self) -> None:
+        with self._Session() as db:
+            stranger = User(name="stranger")
+            db.add(stranger)
+            db.flush()
+            theirs = Wishlist(user_id=stranger.id, name="not mine")
+            db.add(theirs)
+            db.flush()
+            with self.assertRaises(ValueError):
+                set_default_wishlist(db, DEFAULT_USER_ID, theirs.id)
+
+
+class DefaultCollectionTests(_IsolatedDbMixin):
+    def test_creates_one_default_then_returns_it(self) -> None:
+        with self._Session() as db:
+            first = get_or_create_default_collection(db, DEFAULT_USER_ID)
+            db.commit()
+            self.assertTrue(first.is_default)
+            self.assertEqual(first.name, DEFAULT_COLLECTION_NAME)
+            self.assertEqual(first.kind, "manual")
+
+        with self._Session() as db:
+            second = get_or_create_default_collection(db, DEFAULT_USER_ID)
+            db.commit()
+            self.assertEqual(second.id, first.id)
+
+    def test_partial_unique_index_blocks_a_second_default(self) -> None:
+        with self._Session() as db:
+            get_or_create_default_collection(db, DEFAULT_USER_ID)
+            db.commit()
+            db.add(Collection(user_id=DEFAULT_USER_ID, name="sneaky", is_default=True))
+            with self.assertRaises(IntegrityError):
+                db.flush()
+
+    def test_set_default_reassigns_the_flag(self) -> None:
+        with self._Session() as db:
+            old = get_or_create_default_collection(db, DEFAULT_USER_ID)
+            other = Collection(user_id=DEFAULT_USER_ID, name="Graded slabs")
+            db.add(other)
+            db.flush()
+            promoted = set_default_collection(db, DEFAULT_USER_ID, other.id)
+            db.commit()
+            self.assertTrue(promoted.is_default)
+            self.assertFalse(db.get(Collection, old.id).is_default)
+
+    def test_defaults_are_per_user(self) -> None:
+        with self._Session() as db:
+            second_user = User(name="second")
+            db.add(second_user)
+            db.flush()
+            mine = get_or_create_default_collection(db, DEFAULT_USER_ID)
+            theirs = get_or_create_default_collection(db, second_user.id)
+            db.commit()
+            self.assertNotEqual(mine.id, theirs.id)
+            self.assertEqual(mine.user_id, DEFAULT_USER_ID)
+            self.assertEqual(theirs.user_id, second_user.id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_favorite_pokemon_api.py
+++ b/tests/test_favorite_pokemon_api.py
@@ -75,7 +75,10 @@ class FavoriteSpeciesMigrationTests(_IsolatedDbMixin):
         from alembic.config import Config
 
         cfg = Config(str(Path(__file__).resolve().parents[1] / "api" / "alembic.ini"))
-        downgrade(cfg, "-1")
+        # Downgrade to favorite_species' parent so this stays valid as later
+        # migrations stack on top — a relative "-1" only drops favorite_species
+        # while it's the head, which it no longer is (#759 added one above it).
+        downgrade(cfg, "c8b4e1f6a2d7")
         insp = inspect(session_mod.get_engine())
         self.assertNotIn("favorite_species", insp.get_table_names())
         self.assertNotIn(


### PR DESCRIPTION
Closes #759

## What

Foundation for ADR-0027's one-tap `Want` / `Own` quick actions: every user gets exactly one default wishlist and one default personal collection, so a quick action always has a write target without a picker or setup step.

- `is_default` flag on `wishlists` and `collections` — ordinary rows, not a parallel store.
- Migration `f1a4d7c9e2b6` adds the column plus a **partial unique index** (`uq_<table>_user_default` on `user_id WHERE is_default`) enforcing one default of each kind per user; existing rows backfill to `false`.
- `api/db/defaults.py`: `get_or_create_default_{wishlist,collection}` (lazy, idempotent, race-safe via the index) and `set_default_{wishlist,collection}` for reassigning the flag.

## Why

Per ADR-0027 the default flag is the invariant, not the row: renaming a default keeps it, deleting it re-establishes one on the next call, and promotion reassigns the flag rather than duplicating storage. This unblocks the quick-action API (#760) and UI (#761).

## How to verify

- `uv run pytest tests/test_defaults.py -q` — covers create/idempotency, the one-default invariant, the rename/delete lifecycle, flag reassignment, and per-user isolation.
- `make check` green (incl. the migration up/down round-trip; the favorite_species downgrade test was pinned to a fixed revision since this migration now sits above it).

No new env vars or disk — the migration runs on deploy via the existing startup migrate, so `render.yaml` is unchanged.