### PR TITLE
feat(api): card quick-action endpoints for default want/own

### DIFF
--- a/api/db/models.py
+++ b/api/db/models.py
@@ -225,6 +225,8 @@ ADDED_VIA_WISHLIST_PROMOTE = "wishlist_promote"
 ADDED_VIA_HAUL = "haul"
 ADDED_VIA_DYNAMIC_MATCH = "dynamic_match"
 ADDED_VIA_SWIPE = "swipe"
+#: One-tap `Own` quick action against the user's default collection (#760).
+ADDED_VIA_QUICK = "quick"
 
 
 class Binder(Base):

--- a/api/routes/ownership.py
+++ b/api/routes/ownership.py
@@ -20,7 +20,8 @@ Endpoint:
 
 from __future__ import annotations
 
-from typing import Annotated
+from datetime import UTC, datetime
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
@@ -28,7 +29,19 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from ..auth.session import current_user_or_default
-from ..db.models import Collection, CollectionItem, User, Wishlist, WishlistItem
+from ..db.card_payload import extract_card_identity, extract_price_snapshot
+from ..db.defaults import (
+    get_or_create_default_collection,
+    get_or_create_default_wishlist,
+)
+from ..db.models import (
+    ADDED_VIA_QUICK,
+    Collection,
+    CollectionItem,
+    User,
+    Wishlist,
+    WishlistItem,
+)
 from ..db.session import get_db
 
 router = APIRouter()
@@ -169,3 +182,220 @@ def card_ownership(
             wishlists=list(wishlists.get(key, {}).values()),
         )
     return OwnershipOut(ownership=ownership).model_dump()
+
+
+# ---------------------------------------------------------------------------
+# Quick actions (#760, ADR-0027) — one-tap want / own against the user's
+# default wishlist + collection, with no picker. Idempotent: re-tapping is a
+# no-op, and each endpoint returns the card's derived state so the SPA can
+# confirm immediately.
+# ---------------------------------------------------------------------------
+
+
+class CardActionRequest(BaseModel):
+    #: The verbatim card payload, same shape the save/bulk endpoints take. The
+    #: promoted ``(set_id, number)`` identity is re-extracted from it here.
+    card: dict[str, Any]
+
+
+class CardState(BaseModel):
+    """A single card's derived library state after a quick action."""
+
+    set_id: str | None
+    number: str | None
+    #: Derived view flags (ADR-0027): on any wishlist / in any collection.
+    wanted: bool
+    owned: bool
+    collections: list[CollectionOccupancy]
+    wishlists: list[WishlistOccupancy]
+
+
+def _identity(card: dict[str, Any]) -> tuple[str | None, str | None]:
+    promoted = extract_card_identity(card)
+    return promoted.get("card_set_id"), promoted.get("card_number")
+
+
+def _card_state(db: Session, user_id: int, set_id: str | None, number: str | None) -> CardState:
+    """The card's occupancy across the user's collections + wishlists — the
+    single-card sibling of :func:`card_ownership`."""
+    collections: dict[int, CollectionOccupancy] = {}
+    if set_id is not None and number is not None:
+        coll_rows = db.execute(
+            select(Collection.id, Collection.name, CollectionItem.quantity)
+            .join(CollectionItem, CollectionItem.collection_id == Collection.id)
+            .where(
+                Collection.user_id == user_id,
+                CollectionItem.card_set_id == set_id,
+                CollectionItem.card_number == number,
+            )
+        ).all()
+        for coll_id, coll_name, quantity in coll_rows:
+            existing = collections.get(coll_id)
+            if existing is None:
+                collections[coll_id] = CollectionOccupancy(
+                    id=coll_id, name=coll_name, quantity=quantity or 0
+                )
+            else:
+                existing.quantity += quantity or 0
+
+        wish_rows = db.execute(
+            select(Wishlist.id, Wishlist.name)
+            .join(WishlistItem, WishlistItem.wishlist_id == Wishlist.id)
+            .where(
+                Wishlist.user_id == user_id,
+                WishlistItem.card_set_id == set_id,
+                WishlistItem.card_number == number,
+            )
+        ).all()
+    else:
+        wish_rows = []
+
+    wishlists: dict[int, WishlistOccupancy] = {}
+    for wish_id, wish_name in wish_rows:
+        wishlists.setdefault(wish_id, WishlistOccupancy(id=wish_id, name=wish_name))
+
+    return CardState(
+        set_id=set_id,
+        number=number,
+        wanted=bool(wishlists),
+        owned=bool(collections),
+        collections=list(collections.values()),
+        wishlists=list(wishlists.values()),
+    )
+
+
+def _default_wishlist_item(
+    db: Session, wishlist_id: int, set_id: str | None, number: str | None
+) -> WishlistItem | None:
+    if set_id is None or number is None:
+        return None
+    return db.scalar(
+        select(WishlistItem).where(
+            WishlistItem.wishlist_id == wishlist_id,
+            WishlistItem.card_set_id == set_id,
+            WishlistItem.card_number == number,
+        )
+    )
+
+
+def _default_collection_item(
+    db: Session, collection_id: int, set_id: str | None, number: str | None
+) -> CollectionItem | None:
+    if set_id is None or number is None:
+        return None
+    return db.scalar(
+        select(CollectionItem).where(
+            CollectionItem.collection_id == collection_id,
+            CollectionItem.card_set_id == set_id,
+            CollectionItem.card_number == number,
+        )
+    )
+
+
+@router.post("/cards/want")
+def want_card(req: CardActionRequest, db: DbSession, current_user: CurrentUser) -> dict:
+    """Add a card to the user's default wishlist. Idempotent — already on it is
+    a no-op."""
+    wishlist = get_or_create_default_wishlist(db, current_user.id)
+    set_id, number = _identity(req.card)
+    if _default_wishlist_item(db, wishlist.id, set_id, number) is None:
+        price = extract_price_snapshot(req.card)
+        db.add(
+            WishlistItem(
+                wishlist_id=wishlist.id,
+                card_json=req.card,
+                price_snapshot=price,
+                priced_at=datetime.now(UTC) if price is not None else None,
+                **extract_card_identity(req.card),
+            )
+        )
+    db.commit()
+    return _card_state(db, current_user.id, set_id, number).model_dump()
+
+
+@router.post("/cards/unwant")
+def unwant_card(req: CardActionRequest, db: DbSession, current_user: CurrentUser) -> dict:
+    """Remove a card from the user's default wishlist. No-op if not on it."""
+    wishlist = get_or_create_default_wishlist(db, current_user.id)
+    set_id, number = _identity(req.card)
+    item = _default_wishlist_item(db, wishlist.id, set_id, number)
+    if item is not None:
+        db.delete(item)
+    db.commit()
+    return _card_state(db, current_user.id, set_id, number).model_dump()
+
+
+@router.post("/cards/own")
+def own_card(req: CardActionRequest, db: DbSession, current_user: CurrentUser) -> dict:
+    """Add a card to the user's default personal collection. Idempotent.
+
+    Preserves the chase lifecycle (ADR-0025/0027): any unacquired wishlist item
+    for this card is stamped with ``acquired_at`` + a back-pointer to the new
+    collection item, so the want-list keeps doubling as a retrospective."""
+    collection = get_or_create_default_collection(db, current_user.id)
+    set_id, number = _identity(req.card)
+    item = _default_collection_item(db, collection.id, set_id, number)
+    if item is None:
+        price = extract_price_snapshot(req.card)
+        item = CollectionItem(
+            collection_id=collection.id,
+            card_json=req.card,
+            quantity=1,
+            added_via=ADDED_VIA_QUICK,
+            price_snapshot=price,
+            priced_at=datetime.now(UTC) if price is not None else None,
+            **extract_card_identity(req.card),
+        )
+        db.add(item)
+        db.flush()
+        _stamp_acquired(db, current_user.id, set_id, number, item.id)
+    db.commit()
+    return _card_state(db, current_user.id, set_id, number).model_dump()
+
+
+@router.post("/cards/unown")
+def unown_card(req: CardActionRequest, db: DbSession, current_user: CurrentUser) -> dict:
+    """Remove a card from the user's default collection. No-op if not in it.
+
+    Reverses any promotion stamp pointing at the removed item, so a card the
+    user had marked owned shows as chasing again."""
+    collection = get_or_create_default_collection(db, current_user.id)
+    set_id, number = _identity(req.card)
+    item = _default_collection_item(db, collection.id, set_id, number)
+    if item is not None:
+        _unstamp_acquired(db, item.id)
+        db.delete(item)
+    db.commit()
+    return _card_state(db, current_user.id, set_id, number).model_dump()
+
+
+def _stamp_acquired(
+    db: Session, user_id: int, set_id: str | None, number: str | None, collection_item_id: int
+) -> None:
+    """Mark the chase complete on every unacquired wishlist item for this card."""
+    if set_id is None or number is None:
+        return
+    now = datetime.now(UTC)
+    items = db.scalars(
+        select(WishlistItem)
+        .join(Wishlist, WishlistItem.wishlist_id == Wishlist.id)
+        .where(
+            Wishlist.user_id == user_id,
+            WishlistItem.card_set_id == set_id,
+            WishlistItem.card_number == number,
+            WishlistItem.acquired_at.is_(None),
+        )
+    ).all()
+    for wl_item in items:
+        wl_item.acquired_at = now
+        wl_item.acquired_collection_item_id = collection_item_id
+
+
+def _unstamp_acquired(db: Session, collection_item_id: int) -> None:
+    """Clear the promotion stamp on any wishlist item pointing at this item."""
+    items = db.scalars(
+        select(WishlistItem).where(WishlistItem.acquired_collection_item_id == collection_item_id)
+    ).all()
+    for wl_item in items:
+        wl_item.acquired_at = None
+        wl_item.acquired_collection_item_id = None

--- a/tests/test_ownership.py
+++ b/tests/test_ownership.py
@@ -190,5 +190,98 @@ class OwnershipEndpointTests(_IsolatedDbMixin):
             self.assertEqual(set(body.keys()), {"base1::4"})
 
 
+class QuickActionTests(_IsolatedDbMixin):
+    """One-tap want / own against the user's defaults (#760, ADR-0027)."""
+
+    def _client(self) -> TestClient:
+        from api.main import app
+
+        return TestClient(app)
+
+    def test_want_adds_to_default_wishlist_and_is_idempotent(self) -> None:
+        from sqlalchemy import select
+
+        from api.db.models import Wishlist
+
+        with self._client() as c:
+            first = c.post("/api/v1/cards/want", json={"card": CHARIZARD})
+            self.assertEqual(first.status_code, 200)
+            body = first.json()
+            self.assertTrue(body["wanted"])
+            self.assertFalse(body["owned"])
+            self.assertEqual(len(body["wishlists"]), 1)
+
+            # Re-tapping is a no-op — still exactly one wishlist, one item.
+            again = c.post("/api/v1/cards/want", json={"card": CHARIZARD}).json()
+            self.assertEqual(len(again["wishlists"]), 1)
+            self.assertEqual(len(c.get("/api/v1/wishlists").json()["items"]), 1)
+
+        sf = session_mod.get_session_factory()
+        with sf() as db:
+            lists = db.scalars(select(Wishlist)).all()
+            self.assertEqual(len(lists), 1)
+            self.assertTrue(lists[0].is_default)
+
+    def test_unwant_removes_from_default_wishlist(self) -> None:
+        with self._client() as c:
+            c.post("/api/v1/cards/want", json={"card": CHARIZARD})
+            body = c.post("/api/v1/cards/unwant", json={"card": CHARIZARD}).json()
+            self.assertFalse(body["wanted"])
+            self.assertEqual(body["wishlists"], [])
+
+    def test_own_adds_to_default_collection_and_is_idempotent(self) -> None:
+        with self._client() as c:
+            body = c.post("/api/v1/cards/own", json={"card": CHARIZARD}).json()
+            self.assertTrue(body["owned"])
+            self.assertEqual(len(body["collections"]), 1)
+            self.assertEqual(body["collections"][0]["quantity"], 1)
+
+            again = c.post("/api/v1/cards/own", json={"card": CHARIZARD}).json()
+            # Idempotent — one row, quantity unchanged (quantity flows are #762).
+            self.assertEqual(len(again["collections"]), 1)
+            self.assertEqual(again["collections"][0]["quantity"], 1)
+
+    def test_unown_removes_from_default_collection(self) -> None:
+        with self._client() as c:
+            c.post("/api/v1/cards/own", json={"card": CHARIZARD})
+            body = c.post("/api/v1/cards/unown", json={"card": CHARIZARD}).json()
+            self.assertFalse(body["owned"])
+            self.assertEqual(body["collections"], [])
+
+    def test_owning_a_wanted_card_stamps_the_chase_complete(self) -> None:
+        from sqlalchemy import select
+
+        from api.db.models import WishlistItem
+
+        with self._client() as c:
+            c.post("/api/v1/cards/want", json={"card": CHARIZARD})
+            body = c.post("/api/v1/cards/own", json={"card": CHARIZARD}).json()
+            # A card can be both wanted (history preserved) and owned.
+            self.assertTrue(body["owned"])
+            self.assertTrue(body["wanted"])
+
+        sf = session_mod.get_session_factory()
+        with sf() as db:
+            item = db.scalar(select(WishlistItem))
+            self.assertIsNotNone(item.acquired_at)
+            self.assertIsNotNone(item.acquired_collection_item_id)
+
+    def test_unowning_clears_the_chase_stamp(self) -> None:
+        from sqlalchemy import select
+
+        from api.db.models import WishlistItem
+
+        with self._client() as c:
+            c.post("/api/v1/cards/want", json={"card": CHARIZARD})
+            c.post("/api/v1/cards/own", json={"card": CHARIZARD})
+            c.post("/api/v1/cards/unown", json={"card": CHARIZARD})
+
+        sf = session_mod.get_session_factory()
+        with sf() as db:
+            item = db.scalar(select(WishlistItem))
+            self.assertIsNone(item.acquired_at)
+            self.assertIsNone(item.acquired_collection_item_id)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #760

## What

ADR-0027's one-tap actions, building on the per-user defaults (#759). Four endpoints under `/api/v1/cards`:

- `POST /cards/want` / `POST /cards/unwant` — add/remove the card on the default wishlist.
- `POST /cards/own` / `POST /cards/unown` — add/remove the card in the default personal collection.

Each takes the verbatim card payload, writes to the user's default (no picker), and returns the card's **derived state** — `wanted` / `owned` booleans plus the named lists/collections it sits in — so the SPA can confirm immediately.

## Behavior

- **Idempotent** — re-tapping `want` / `own` is a no-op (no duplicate rows; quantity bumps are #762).
- **Promotion lifecycle (ADR-0025/0027)** — owning a card stamps any unacquired wishlist item with `acquired_at` + a back-pointer to the new collection item, so the want-list keeps doubling as a "got it" retrospective. Unowning reverses the stamp so the card reads as chasing again.
- Adds an `ADDED_VIA_QUICK` provenance tag for one-tap collection adds.

Unblocks the web quick actions (#761).

## How to verify

- `uv run pytest tests/test_ownership.py -q` — covers want/own idempotency, unwant/unown, the derived-state response, and the acquire/un-acquire stamp round-trip.
- `make check` green.

No new env vars, no migration (uses the `is_default` foundation already on main), so `render.yaml` is unchanged.