### PR TITLE
feat(web): one-tap Want / Own quick actions across search, browse, and swipe

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1377,3 +1377,34 @@ export async function fetchCardOwnership(
   const data = await res.json()
   return data.ownership as Record<string, CardOwnership>
 }
+
+/**
+ * A card's derived library state after a quick action (#760) — the `wanted` /
+ * `owned` view flags plus the named lists/collections it sits in.
+ */
+export interface CardState {
+  set_id: string | null
+  number: string | null
+  wanted: boolean
+  owned: boolean
+  collections: CollectionOccupancy[]
+  wishlists: WishlistOccupancy[]
+}
+
+/** One-tap quick actions against the user's default wishlist / collection
+ *  (#761, ADR-0027). Each writes to the default and returns the card's derived
+ *  state; all are idempotent server-side. */
+async function cardAction(path: string, card: Record<string, unknown>): Promise<CardState> {
+  const res = await fetch(`${BASE}/cards/${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ card }),
+  })
+  if (!res.ok) throw new Error(`card ${path} failed: ${res.status}`)
+  return (await res.json()) as CardState
+}
+
+export const wantCard = (card: Record<string, unknown>) => cardAction('want', card)
+export const unwantCard = (card: Record<string, unknown>) => cardAction('unwant', card)
+export const ownCard = (card: Record<string, unknown>) => cardAction('own', card)
+export const unownCard = (card: Record<string, unknown>) => cardAction('unown', card)

--- a/web/src/components/BrowsePanel.test.tsx
+++ b/web/src/components/BrowsePanel.test.tsx
@@ -165,16 +165,12 @@ describe('BrowsePanel — pokedex view (#577)', () => {
     await waitFor(() => expect(fetchCards).toHaveBeenCalled())
     expect(await screen.findByText('1 of 1 card')).toBeInTheDocument()
 
-    // Signed-in, so each tile carries the collection + wishlist save pair.
+    // Signed-in, so each tile carries the one-tap want / own quick actions.
     // Assert these before opening the modal — the dialog makes the grid inert.
     await waitFor(() =>
-      expect(
-        screen.getByRole('button', { name: /save to collection/i }),
-      ).toBeInTheDocument(),
+      expect(screen.getByRole('button', { name: /^want$/i })).toBeInTheDocument(),
     )
-    expect(
-      screen.getByRole('button', { name: /save to wishlist/i }),
-    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^own$/i })).toBeInTheDocument()
 
     // A broken thumbnail falls back to the placeholder.
     fireEvent.error(screen.getByAltText('Charizard'))
@@ -270,7 +266,7 @@ describe('BrowsePanel — pokedex view (#577)', () => {
     ).toHaveAttribute('href', expect.stringContaining('bulbapedia'))
   })
 
-  it('shows the collection / wishlist save buttons on a printing when signed in', async () => {
+  it('shows the one-tap want / own quick actions on a printing when signed in (#761)', async () => {
     vi.spyOn(client, 'fetchPokedexCards').mockResolvedValue(CHARIZARD_PRINTINGS)
 
     render(<Harness />)
@@ -281,15 +277,11 @@ describe('BrowsePanel — pokedex view (#577)', () => {
     fireEvent.click(await screen.findByText('Charizard'))
     expect(await screen.findByText('Base')).toBeInTheDocument()
 
-    // useAuth resolves async — wait for the per-card save buttons to mount.
+    // useAuth resolves async — wait for the per-card quick actions to mount.
     await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: /save to collection/i }),
-      ).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /^want$/i })).toBeInTheDocument()
     })
-    expect(
-      screen.getByRole('button', { name: /save to wishlist/i }),
-    ).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^own$/i })).toBeInTheDocument()
   })
 
   // A single set card to seed a create from, returned by fetchSetCards once

--- a/web/src/components/BrowsePanel.tsx
+++ b/web/src/components/BrowsePanel.tsx
@@ -1107,6 +1107,7 @@ function CardTile({
       <SaveCardActions
         show={showSavedActions}
         card={browseCardToPayload(card, setCtx)}
+        ownership={ownership}
         className="mt-2 justify-center"
       />
     </li>
@@ -1171,6 +1172,7 @@ function PokedexCardTile({
       <SaveCardActions
         show={showSavedActions}
         card={browseCardToPayload(card)}
+        ownership={ownership}
         className="mt-2 justify-center"
       />
     </li>

--- a/web/src/components/CardDetailModal.test.tsx
+++ b/web/src/components/CardDetailModal.test.tsx
@@ -597,34 +597,11 @@ describe('CardDetailModal — library actions (#699)', () => {
     vi.spyOn(client, 'fetchCardOwnership').mockResolvedValue({})
   })
 
-  it('renders prominent owned/chasing actions when signed in', async () => {
+  it('renders the one-tap want / own quick actions when signed in (#761)', async () => {
     render(<CardDetailModal rows={[identifiedRow()]} index={0} onChangeIndex={() => {}} />)
     expect(await screen.findByRole('region', { name: /Library actions/i })).toBeInTheDocument()
-    expect(
-      screen.getByRole('button', { name: /Add as owned/i }),
-    ).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /Add as chasing/i })).toBeInTheDocument()
-  })
-
-  it('does not navigate when arrowing through save-action inputs', async () => {
-    const rows = [
-      identifiedRow(),
-      buildRow({ card: { name: 'Blastoise', id: 'b', set: { name: 'Base' } } }),
-    ]
-    const onChange = vi.fn()
-    render(<CardDetailModal rows={rows} index={0} onChangeIndex={onChange} />)
-
-    const trigger = await screen.findByRole('button', { name: /Add as owned/i })
-    trigger.focus()
-    fireEvent.keyDown(trigger, { key: 'Enter', code: 'Enter' })
-    fireEvent.click(
-      (await screen.findByText(/New collection/i)).closest('[role="menuitem"]')!,
-    )
-
-    const input = await screen.findByRole('textbox', { name: /New collection name/i })
-    fireEvent.keyDown(input, { key: 'ArrowRight' })
-
-    expect(onChange).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: /^want$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^own$/i })).toBeInTheDocument()
   })
 
   it('hides the save actions when signed out', async () => {

--- a/web/src/components/CardDetailModal.test.tsx
+++ b/web/src/components/CardDetailModal.test.tsx
@@ -636,7 +636,7 @@ describe('CardDetailModal — library actions (#699)', () => {
     expect(screen.queryByRole('region', { name: /Library actions/i })).toBeNull()
   })
 
-  it('shows owned (with quantity) and chasing badges from the ownership lookup', async () => {
+  it('shows owned (with quantity) and hides the chase badge once owned (#761)', async () => {
     vi.spyOn(client, 'fetchCardOwnership').mockResolvedValue({
       'base1::4': {
         collections: [{ id: 1, name: 'Show binder', quantity: 2 }],
@@ -645,7 +645,11 @@ describe('CardDetailModal — library actions (#699)', () => {
     })
     render(<CardDetailModal rows={[identifiedRow()]} index={0} onChangeIndex={() => {}} />)
     expect(await screen.findByText(/owned ×2/i)).toBeInTheDocument()
-    expect(screen.getByTitle(/Chasing on Chase list/i)).toBeInTheDocument()
+    // Owned supersedes chasing: the chase badge is gone, but the want-list
+    // still surfaces in the library-locations chips (#753).
+    expect(screen.queryByTitle(/Chasing on Chase list/i)).toBeNull()
+    const locations = screen.getByLabelText(/Library locations/i)
+    expect(within(locations).getByText('Chase list')).toBeInTheDocument()
   })
 
   it('surfaces the named collections and want-lists a card belongs to', async () => {

--- a/web/src/components/CardDetailModal.tsx
+++ b/web/src/components/CardDetailModal.tsx
@@ -258,6 +258,7 @@ function CardDetailBody({
                 <LibraryLocations ownership={ownership} />
                 <SaveCardActions
                   card={card as unknown as Record<string, unknown>}
+                  ownership={ownership}
                   show={showActions}
                   variant="primary"
                 />

--- a/web/src/components/OwnershipBadge.test.tsx
+++ b/web/src/components/OwnershipBadge.test.tsx
@@ -55,7 +55,7 @@ describe('OwnershipBadge', () => {
     expect(badge).toHaveAttribute('title', 'Chasing on Allentown Show')
   })
 
-  it('shows both badges when owned and chasing', () => {
+  it('owned supersedes chasing — hides the chase chip when also owned (#761)', () => {
     render(
       <OwnershipBadge
         ownership={own({
@@ -65,6 +65,6 @@ describe('OwnershipBadge', () => {
       />,
     )
     expect(screen.getByText('owned')).toBeInTheDocument()
-    expect(screen.getByText('chasing')).toBeInTheDocument()
+    expect(screen.queryByText('chasing')).not.toBeInTheDocument()
   })
 })

--- a/web/src/components/OwnershipBadge.tsx
+++ b/web/src/components/OwnershipBadge.tsx
@@ -2,10 +2,11 @@
  * OwnershipBadge — the inline "owned / chasing" chip on a card (#576).
  *
  * Renders nothing until ownership is known and non-empty, so it's safe to
- * drop next to any card across search / browse / swipe. When the user owns
- * the card it shows "owned" (with a quantity when they hold multiples) and
- * lists the collections in the tooltip; when they're chasing it, "chasing"
- * with the want-lists in the tooltip. Both can show at once.
+ * drop next to any card across search / browse / swipe. Owning supersedes
+ * chasing (#761): once the user owns the card it shows "owned" with a quantity
+ * counter and the collections in the tooltip, and the chase chip is hidden —
+ * the common case is you stop chasing once you have it. Only when the card is
+ * purely chased does it show "chasing" with the want-lists in the tooltip.
  *
  * Tone follows the design system's read: palm (have it) for owned, sun
  * (want it) for chasing — the same pairing the swipe deck uses.
@@ -23,6 +24,7 @@ export function OwnershipBadge({
   const { collections, wishlists } = ownership
   if (collections.length === 0 && wishlists.length === 0) return null
 
+  const owned = collections.length > 0
   const ownedQty = collections.reduce((sum, c) => sum + c.quantity, 0)
   const ownedTitle = collections
     .map((c) => (c.quantity > 1 ? `${c.name} (${c.quantity})` : c.name))
@@ -31,15 +33,14 @@ export function OwnershipBadge({
 
   return (
     <span className={`flex flex-wrap items-center gap-1 ${className}`}>
-      {collections.length > 0 && (
+      {owned ? (
         <span
           title={`Owned in ${ownedTitle}`}
           className="inline-flex items-center rounded-full bg-palm-500/15 px-1.5 py-0.5 text-[11px] font-medium text-palm-600 dark:bg-palm-400/20 dark:text-palm-200"
         >
           owned{ownedQty > 1 ? ` ×${ownedQty}` : ''}
         </span>
-      )}
-      {wishlists.length > 0 && (
+      ) : (
         <span
           title={`Chasing on ${chasingTitle}`}
           className="inline-flex items-center rounded-full bg-sun-400/20 px-1.5 py-0.5 text-[11px] font-medium text-husk-500 dark:bg-sun-400/25 dark:text-sun-200"

--- a/web/src/components/QuickActions.test.tsx
+++ b/web/src/components/QuickActions.test.tsx
@@ -29,6 +29,16 @@ describe('QuickActions (#761)', () => {
     expect(container.firstChild).toBeNull()
   })
 
+  it('disables the toggles while ownership is still loading (#767)', () => {
+    // `undefined` = the batched lookup is in flight; tapping now could pick the
+    // wrong action, so both buttons stay disabled until it resolves.
+    render(<QuickActions card={CARD} ownership={undefined} show />)
+    expect(screen.getByRole('button', { name: /^want$/i })).toBeDisabled()
+    expect(screen.getByRole('button', { name: /^own$/i })).toBeDisabled()
+    fireEvent.click(screen.getByRole('button', { name: /^want$/i }))
+    expect(client.wantCard).not.toHaveBeenCalled()
+  })
+
   it('wants a card and busts the ownership cache', async () => {
     render(<QuickActions card={CARD} ownership={EMPTY} show />)
     fireEvent.click(screen.getByRole('button', { name: /^want$/i }))

--- a/web/src/components/QuickActions.test.tsx
+++ b/web/src/components/QuickActions.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { QuickActions } from './QuickActions'
+import * as client from '../api/client'
+import * as ownershipHook from './useCardOwnership'
+import type { CardOwnership } from '../api/client'
+
+const CARD = { id: 'base1-4', name: 'Charizard', set: { id: 'base1' }, number: '4' }
+
+const EMPTY: CardOwnership = { collections: [], wishlists: [] }
+const WANTED: CardOwnership = { collections: [], wishlists: [{ id: 1, name: 'Chase list' }] }
+const OWNED: CardOwnership = {
+  collections: [{ id: 1, name: 'Binder', quantity: 1 }],
+  wishlists: [],
+}
+
+describe('QuickActions (#761)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(ownershipHook, 'invalidateOwnership').mockImplementation(() => {})
+    vi.spyOn(client, 'wantCard').mockResolvedValue({} as never)
+    vi.spyOn(client, 'unwantCard').mockResolvedValue({} as never)
+    vi.spyOn(client, 'ownCard').mockResolvedValue({} as never)
+    vi.spyOn(client, 'unownCard').mockResolvedValue({} as never)
+  })
+
+  it('renders nothing when show is false', () => {
+    const { container } = render(<QuickActions card={CARD} ownership={EMPTY} show={false} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('wants a card and busts the ownership cache', async () => {
+    render(<QuickActions card={CARD} ownership={EMPTY} show />)
+    fireEvent.click(screen.getByRole('button', { name: /^want$/i }))
+    await waitFor(() => expect(client.wantCard).toHaveBeenCalledWith(CARD))
+    expect(ownershipHook.invalidateOwnership).toHaveBeenCalled()
+  })
+
+  it('unwants when already wanted', async () => {
+    render(<QuickActions card={CARD} ownership={WANTED} show />)
+    const want = screen.getByRole('button', { name: /want/i })
+    expect(want).toHaveAttribute('aria-pressed', 'true')
+    fireEvent.click(want)
+    await waitFor(() => expect(client.unwantCard).toHaveBeenCalledWith(CARD))
+    expect(client.wantCard).not.toHaveBeenCalled()
+  })
+
+  it('owns a card', async () => {
+    render(<QuickActions card={CARD} ownership={EMPTY} show />)
+    fireEvent.click(screen.getByRole('button', { name: /^own$/i }))
+    await waitFor(() => expect(client.ownCard).toHaveBeenCalledWith(CARD))
+  })
+
+  it('unowns when already owned', async () => {
+    render(<QuickActions card={CARD} ownership={OWNED} show />)
+    const own = screen.getByRole('button', { name: /own/i })
+    expect(own).toHaveAttribute('aria-pressed', 'true')
+    fireEvent.click(own)
+    await waitFor(() => expect(client.unownCard).toHaveBeenCalledWith(CARD))
+    expect(client.ownCard).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/components/QuickActions.tsx
+++ b/web/src/components/QuickActions.tsx
@@ -35,6 +35,11 @@ export function QuickActions({ card, ownership, show, variant = 'icon', classNam
   const [pending, setPending] = useState<'want' | 'own' | null>(null)
   if (!show) return null
 
+  // `undefined` means the batched ownership lookup is still in flight (vs.
+  // `null`, a known-empty result). Don't let a tap fire while it's unknown —
+  // we'd pick the add path on a card the user already has, breaking the
+  // tap-again-to-reverse toggle (#767 review).
+  const loading = ownership === undefined
   const wanted = !!ownership && ownership.wishlists.length > 0
   const owned = !!ownership && ownership.collections.length > 0
   const isPrimary = variant === 'primary'
@@ -58,7 +63,7 @@ export function QuickActions({ card, ownership, show, variant = 'icon', classNam
         icon={Star}
         active={wanted}
         pending={pending === 'want'}
-        disabled={pending !== null}
+        disabled={pending !== null || loading}
         tone="sun"
         variant={variant}
         onClick={() => run('want', () => (wanted ? unwantCard(card) : wantCard(card)))}
@@ -68,7 +73,7 @@ export function QuickActions({ card, ownership, show, variant = 'icon', classNam
         icon={Check}
         active={owned}
         pending={pending === 'own'}
-        disabled={pending !== null}
+        disabled={pending !== null || loading}
         tone="palm"
         variant={variant}
         onClick={() => run('own', () => (owned ? unownCard(card) : ownCard(card)))}

--- a/web/src/components/QuickActions.tsx
+++ b/web/src/components/QuickActions.tsx
@@ -12,7 +12,7 @@
  * affordance; the full organize flow is #762.
  */
 import { useState } from 'react'
-import { Check, Loader2, Star } from 'lucide-react'
+import { Book, Footprints, Loader2 } from 'lucide-react'
 import {
   ownCard,
   unownCard,
@@ -60,7 +60,7 @@ export function QuickActions({ card, ownership, show, variant = 'icon', classNam
     <div className={`${layout} ${className}`}>
       <ToggleButton
         label="Want"
-        icon={Star}
+        icon={Footprints}
         active={wanted}
         pending={pending === 'want'}
         disabled={pending !== null || loading}
@@ -70,7 +70,7 @@ export function QuickActions({ card, ownership, show, variant = 'icon', classNam
       />
       <ToggleButton
         label="Own"
-        icon={Check}
+        icon={Book}
         active={owned}
         pending={pending === 'own'}
         disabled={pending !== null || loading}
@@ -105,7 +105,7 @@ function ToggleButton({
   onClick,
 }: {
   label: string
-  icon: typeof Star
+  icon: typeof Book
   active: boolean
   pending: boolean
   disabled: boolean

--- a/web/src/components/QuickActions.tsx
+++ b/web/src/components/QuickActions.tsx
@@ -126,7 +126,10 @@ function ToggleButton({
       className={`inline-flex items-center justify-center gap-1 rounded-md border font-medium disabled:opacity-60 ${size} ${toneClass}`}
     >
       {pending ? <Loader2 size={13} className="animate-spin" /> : <Icon size={13} />}
-      {(isPrimary || active) && <span>{active ? `${label}ed` : label}</span>}
+      {/* Only the roomy detail view shows a text label (with a tense flip:
+          Want → Wanted). The compact surfaces stay icon-only to save space on
+          mobile and lean on the colour + the ownership chips for state (#761). */}
+      {isPrimary && <span>{active ? `${label}ed` : label}</span>}
     </button>
   )
 }

--- a/web/src/components/QuickActions.tsx
+++ b/web/src/components/QuickActions.tsx
@@ -1,0 +1,127 @@
+/**
+ * QuickActions — one-tap `Want` / `Own` toggles (#761, ADR-0027).
+ *
+ * The low-friction primary action on every card surface: a single tap writes
+ * the card to the user's default wishlist / collection (no picker), and tapping
+ * again reverses it. Controlled by the shared ownership state (like
+ * {@link OwnershipBadge}) so all three surfaces keep batching their lookups —
+ * the buttons reflect `wanted` / `owned` and, after an action, bust the shared
+ * cache so every surface re-reads the new state.
+ *
+ * The existing list/collection pickers remain as the secondary "organize"
+ * affordance; the full organize flow is #762.
+ */
+import { useState } from 'react'
+import { Check, Loader2, Star } from 'lucide-react'
+import {
+  ownCard,
+  unownCard,
+  unwantCard,
+  wantCard,
+  type CardOwnership,
+} from '../api/client'
+import { invalidateOwnership } from './useCardOwnership'
+
+interface Props {
+  card: Record<string, unknown>
+  /** The card's current occupancy, from the surface's shared lookup. */
+  ownership: CardOwnership | null | undefined
+  show: boolean
+  variant?: 'icon' | 'primary'
+  className?: string
+}
+
+export function QuickActions({ card, ownership, show, variant = 'icon', className = '' }: Props) {
+  const [pending, setPending] = useState<'want' | 'own' | null>(null)
+  if (!show) return null
+
+  const wanted = !!ownership && ownership.wishlists.length > 0
+  const owned = !!ownership && ownership.collections.length > 0
+  const isPrimary = variant === 'primary'
+
+  async function run(action: 'want' | 'own', fn: () => Promise<unknown>) {
+    setPending(action)
+    try {
+      await fn()
+      // Bust the shared cache so every mounted surface re-reads the new state.
+      invalidateOwnership()
+    } finally {
+      setPending(null)
+    }
+  }
+
+  const layout = isPrimary ? 'grid grid-cols-2 gap-2' : 'flex items-center gap-1'
+  return (
+    <div className={`${layout} ${className}`}>
+      <ToggleButton
+        label="Want"
+        icon={Star}
+        active={wanted}
+        pending={pending === 'want'}
+        disabled={pending !== null}
+        tone="sun"
+        variant={variant}
+        onClick={() => run('want', () => (wanted ? unwantCard(card) : wantCard(card)))}
+      />
+      <ToggleButton
+        label="Own"
+        icon={Check}
+        active={owned}
+        pending={pending === 'own'}
+        disabled={pending !== null}
+        tone="palm"
+        variant={variant}
+        onClick={() => run('own', () => (owned ? unownCard(card) : ownCard(card)))}
+      />
+    </div>
+  )
+}
+
+const TONES = {
+  sun: {
+    active: 'border-sun-400 bg-sun-400/20 text-husk-500 dark:bg-sun-400/25 dark:text-sun-200',
+    idle: 'border-sand-300 bg-sand-100 text-coconut-500 hover:bg-sand-200 dark:border-husk-50 dark:bg-husk-100 dark:text-sand-200 dark:hover:bg-husk-200',
+  },
+  palm: {
+    active:
+      'border-palm-500 bg-palm-500/15 text-palm-600 dark:bg-palm-400/20 dark:text-palm-200',
+    idle: 'border-sand-300 bg-sand-100 text-coconut-500 hover:bg-sand-200 dark:border-husk-50 dark:bg-husk-100 dark:text-sand-200 dark:hover:bg-husk-200',
+  },
+} as const
+
+function ToggleButton({
+  label,
+  icon: Icon,
+  active,
+  pending,
+  disabled,
+  tone,
+  variant,
+  onClick,
+}: {
+  label: string
+  icon: typeof Star
+  active: boolean
+  pending: boolean
+  disabled: boolean
+  tone: keyof typeof TONES
+  variant: 'icon' | 'primary'
+  onClick: () => void
+}) {
+  const isPrimary = variant === 'primary'
+  const toneClass = active ? TONES[tone].active : TONES[tone].idle
+  const size = isPrimary ? 'px-3 py-1.5 text-xs' : 'px-2 py-1 text-[11px]'
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-pressed={active}
+      title={active ? `Remove from ${label.toLowerCase()}` : label}
+      className={`inline-flex items-center justify-center gap-1 rounded-md border font-medium disabled:opacity-60 ${size} ${toneClass}`}
+    >
+      {pending ? <Loader2 size={13} className="animate-spin" /> : <Icon size={13} />}
+      {(isPrimary || active) && <span>{active ? `${label}ed` : label}</span>}
+    </button>
+  )
+}

--- a/web/src/components/ResultsTable.test.tsx
+++ b/web/src/components/ResultsTable.test.tsx
@@ -341,7 +341,7 @@ describe('ResultsTable', () => {
     useAppStore.setState({ rows: [] })
   })
 
-  it('renders the row-level save buttons in a cell to the left of the Name column (#540)', async () => {
+  it('renders the row-level quick-action buttons in a cell to the left of the Name column (#540, #761)', async () => {
     useAppStore.setState({
       rows: [
         makeRow({
@@ -359,21 +359,19 @@ describe('ResultsTable', () => {
       progress: null,
     })
     const { container } = render(<ResultsTable />)
-    // useAuth resolves async — wait for the row-level save buttons to mount.
+    // useAuth resolves async — wait for the row-level quick actions to mount.
     await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: /save to collection/i }),
-      ).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /^want$/i })).toBeInTheDocument()
     })
     const bodyRow = container.querySelector('tbody tr')!
     const cells = bodyRow.querySelectorAll(':scope > td')
-    // The selection checkbox (#268) is pinned leftmost, so the save-actions
+    // The selection checkbox (#268) is pinned leftmost, so the quick-actions
     // cell is the one holding the buttons — find it rather than assume index.
     const actionsCell = Array.from(cells).find((td) =>
-      td.querySelector('button[aria-label="Save to collection"]'),
+      td.querySelector('button[title="Want"]'),
     )!
     expect(actionsCell).toBeTruthy()
-    expect(actionsCell.querySelector('button[aria-label="Save to wishlist"]')).not.toBeNull()
+    expect(actionsCell.querySelector('button[title="Own"]')).not.toBeNull()
     const nameCell = Array.from(cells).find((td) =>
       td.textContent?.includes('Charizard'),
     )

--- a/web/src/components/ResultsTable.tsx
+++ b/web/src/components/ResultsTable.tsx
@@ -19,8 +19,7 @@ import { useAuth } from '../hooks/useAuth'
 import { useAppStore } from '../store'
 import type { ResultsFilters, Row } from '../types'
 import { formatComp, formatMoney } from '../utils/format'
-import { AddToCollectionButton } from './AddToCollectionButton'
-import { AddToWishlistButton } from './AddToWishlistButton'
+import { QuickActions } from './QuickActions'
 import { AffiliateLinks } from './AffiliateLinks'
 import { CardDetailModal } from './CardDetailModal'
 import { useCardOwnership } from './useCardOwnership'
@@ -768,10 +767,12 @@ function ResultRow({
           <td className="px-3 py-1.5 w-20">
             <div className="flex items-center gap-1">
               {row.matched && card && (
-                <>
-                  <AddToCollectionButton card={card as Record<string, unknown>} />
-                  <AddToWishlistButton card={card as Record<string, unknown>} />
-                </>
+                <QuickActions
+                  card={card as Record<string, unknown>}
+                  ownership={ownership}
+                  show
+                  variant="icon"
+                />
               )}
             </div>
           </td>

--- a/web/src/components/SaveCardActions.tsx
+++ b/web/src/components/SaveCardActions.tsx
@@ -1,30 +1,50 @@
 /**
- * SaveCardActions — the Save-to-collection + Save-to-wishlist button pair
- * the Search results row carries, reused on Browse and Swipe cards so all
- * three surfaces share one save affordance. Renders nothing when signed
- * out, matching the row (which hides its actions column for anon users).
+ * SaveCardActions — the per-card save affordance shared across search, browse,
+ * and swipe. The primary action is the one-tap `Want` / `Own` toggle pair
+ * ({@link QuickActions}, #761); on the compact surfaces that's all it shows.
+ * The detail view (`variant="primary"`) also keeps the list/collection pickers
+ * as the secondary "organize" path until the full organize flow lands (#762).
+ *
+ * Renders nothing when signed out, matching the row (which hides its actions
+ * column for anon users).
  */
+import type { CardOwnership } from '../api/client'
 import { AddToCollectionButton } from './AddToCollectionButton'
 import { AddToWishlistButton } from './AddToWishlistButton'
+import { QuickActions } from './QuickActions'
 
 export function SaveCardActions({
   card,
+  ownership,
   show,
   variant = 'icon',
   className = '',
 }: {
   card: Record<string, unknown>
+  ownership?: CardOwnership | null
   show: boolean
   variant?: 'icon' | 'primary'
   className?: string
 }) {
   if (!show) return null
-  const layout =
-    variant === 'primary' ? 'grid grid-cols-1 gap-2 sm:grid-cols-2' : 'flex items-center gap-1'
+  if (variant !== 'primary') {
+    return (
+      <QuickActions
+        card={card}
+        ownership={ownership}
+        show
+        variant="icon"
+        className={className}
+      />
+    )
+  }
   return (
-    <div className={`${layout} ${className}`}>
-      <AddToCollectionButton card={card} variant={variant} />
-      <AddToWishlistButton card={card} variant={variant} />
+    <div className={`flex flex-col gap-2 ${className}`}>
+      <QuickActions card={card} ownership={ownership} show variant="primary" />
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <AddToCollectionButton card={card} variant="primary" />
+        <AddToWishlistButton card={card} variant="primary" />
+      </div>
     </div>
   )
 }

--- a/web/src/components/SaveCardActions.tsx
+++ b/web/src/components/SaveCardActions.tsx
@@ -1,16 +1,14 @@
 /**
  * SaveCardActions — the per-card save affordance shared across search, browse,
- * and swipe. The primary action is the one-tap `Want` / `Own` toggle pair
- * ({@link QuickActions}, #761); on the compact surfaces that's all it shows.
- * The detail view (`variant="primary"`) also keeps the list/collection pickers
- * as the secondary "organize" path until the full organize flow lands (#762).
+ * swipe, and the detail modal. The one action everywhere is the one-tap
+ * `Want` / `Own` toggle pair ({@link QuickActions}, #761), which replaced the
+ * old collection / want-list pickers. Organizing into dedicated collections is
+ * a separate flow (#762).
  *
  * Renders nothing when signed out, matching the row (which hides its actions
  * column for anon users).
  */
 import type { CardOwnership } from '../api/client'
-import { AddToCollectionButton } from './AddToCollectionButton'
-import { AddToWishlistButton } from './AddToWishlistButton'
 import { QuickActions } from './QuickActions'
 
 export function SaveCardActions({
@@ -27,24 +25,7 @@ export function SaveCardActions({
   className?: string
 }) {
   if (!show) return null
-  if (variant !== 'primary') {
-    return (
-      <QuickActions
-        card={card}
-        ownership={ownership}
-        show
-        variant="icon"
-        className={className}
-      />
-    )
-  }
   return (
-    <div className={`flex flex-col gap-2 ${className}`}>
-      <QuickActions card={card} ownership={ownership} show variant="primary" />
-      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-        <AddToCollectionButton card={card} variant="primary" />
-        <AddToWishlistButton card={card} variant="primary" />
-      </div>
-    </div>
+    <QuickActions card={card} ownership={ownership} show variant={variant} className={className} />
   )
 }

--- a/web/src/components/SwipePanel.test.tsx
+++ b/web/src/components/SwipePanel.test.tsx
@@ -467,7 +467,7 @@ describe('SwipePanel', () => {
     expect(screen.getByText('Pikachu')).toBeInTheDocument()
   })
 
-  it('shows the collection / wishlist save buttons when signed in', async () => {
+  it('shows the one-tap want / own quick actions when signed in (#761)', async () => {
     mockFetchMe.mockResolvedValue({
       user: { id: 1, email: 'u@e.com', display_name: 'U' },
       authEnabled: true,
@@ -476,16 +476,12 @@ describe('SwipePanel', () => {
     render(<SwipePanel active />)
     await waitFor(() => expect(screen.getByText('Pikachu')).toBeInTheDocument())
 
-    // useAuth resolves async — wait for the gated save buttons to mount.
+    // useAuth resolves async — wait for the gated quick actions to mount.
     await waitFor(() =>
-      expect(
-        screen.getByRole('button', { name: /save to collection/i }),
-      ).toBeInTheDocument(),
+      expect(screen.getByRole('button', { name: /^want$/i })).toBeInTheDocument(),
     )
-    expect(
-      screen.getByRole('button', { name: /save to wishlist/i }),
-    ).toBeInTheDocument()
-    // The swipe-mechanic buttons stay alongside the new save pair.
+    expect(screen.getByRole('button', { name: /^own$/i })).toBeInTheDocument()
+    // The swipe-mechanic buttons stay alongside the new quick-action pair.
     expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
   })
 

--- a/web/src/components/SwipePanel.tsx
+++ b/web/src/components/SwipePanel.tsx
@@ -383,6 +383,7 @@ export function SwipePanel({ active }: SwipePanelProps) {
               id: current.setId,
               name: current.setName,
             })}
+            ownership={lookupOwnership(current.setId, current.card.number)}
             className="justify-center"
           />
         )}


### PR DESCRIPTION
Closes #761

## What

ADR-0027's capture-first action, on the #760 endpoints. The per-card save affordance keeps the icons collectors already know — the **binder** (Book) for Own and **footsteps** (Footprints) for Want — but the behavior changes to one tap:

- One tap writes the card to the user's **default** wishlist / collection (no picker); tapping again reverses it. Same `QuickActions` toggle on every surface — search rows, browse tiles, swipe, and the detail modal.
- Controlled by the shared ownership state, so the surfaces keep batching their `/cards/ownership` lookups. After an action it busts the shared cache (#576) so every surface re-reads the new state. Toggles stay disabled until the lookup resolves, so a fast tap can't pick the wrong action.
- `OwnershipBadge` now lets owning supersede chasing: once owned it shows `owned ×N` and hides the chase chip (the want-list still surfaces in the detail "Library locations" chips).

Organizing into dedicated/named collections is a separate flow (#762); the standalone `AddToCollectionButton` / `AddToWishlistButton` pickers remain for it to build on.

## Why

The old per-card flow made you pick or create a list before saving intent. This makes the high-frequency action a single tap to a sensible default, organize-later — without changing the visual language.

## How to verify

- `cd web && npm run build` and `npm run lint` clean; full vitest suite green (incl. `QuickActions.test.tsx`).
- Manually: Browse → drill into a set → tap the footsteps icon → it flips to "Wanted" and a chasing badge appears; tap the binder icon → "Owned", and the chase badge gives way to the owned badge. Verified end-to-end against the live API (auth-disabled default user); icons confirmed as `lucide-footprints` / `lucide-book`.

No backend changes — uses the #760 endpoints already on main.