### PR TITLE
feat(api): owning a card clears its active want by default

### DIFF
--- a/api/routes/ownership.py
+++ b/api/routes/ownership.py
@@ -271,16 +271,25 @@ def _card_state(db: Session, user_id: int, set_id: str | None, number: str | Non
     )
 
 
-def _default_wishlist_item(
-    db: Session, wishlist_id: int, set_id: str | None, number: str | None
+def _wishlist_item(
+    db: Session,
+    wishlist_id: int,
+    set_id: str | None,
+    number: str | None,
+    *,
+    acquired: bool,
 ) -> WishlistItem | None:
+    """The default-wishlist row for a card, filtered to active chases
+    (``acquired=False``) or completed ones (``acquired=True``)."""
     if set_id is None or number is None:
         return None
+    cond = WishlistItem.acquired_at.is_not(None) if acquired else WishlistItem.acquired_at.is_(None)
     return db.scalar(
         select(WishlistItem).where(
             WishlistItem.wishlist_id == wishlist_id,
             WishlistItem.card_set_id == set_id,
             WishlistItem.card_number == number,
+            cond,
         )
     )
 
@@ -309,21 +318,24 @@ def want_card(req: CardActionRequest, db: DbSession, current_user: CurrentUser) 
     path (#768)."""
     wishlist = get_or_create_default_wishlist(db, current_user.id)
     set_id, number = _identity(req.card)
-    item = _default_wishlist_item(db, wishlist.id, set_id, number)
-    if item is None:
-        price = extract_price_snapshot(req.card)
-        db.add(
-            WishlistItem(
-                wishlist_id=wishlist.id,
-                card_json=req.card,
-                price_snapshot=price,
-                priced_at=datetime.now(UTC) if price is not None else None,
-                **extract_card_identity(req.card),
+    # An active want already covers this card → nothing to do (and don't touch
+    # any acquired history row).
+    if _wishlist_item(db, wishlist.id, set_id, number, acquired=False) is None:
+        acquired = _wishlist_item(db, wishlist.id, set_id, number, acquired=True)
+        if acquired is not None:
+            acquired.acquired_at = None
+            acquired.acquired_collection_item_id = None
+        else:
+            price = extract_price_snapshot(req.card)
+            db.add(
+                WishlistItem(
+                    wishlist_id=wishlist.id,
+                    card_json=req.card,
+                    price_snapshot=price,
+                    priced_at=datetime.now(UTC) if price is not None else None,
+                    **extract_card_identity(req.card),
+                )
             )
-        )
-    elif item.acquired_at is not None:
-        item.acquired_at = None
-        item.acquired_collection_item_id = None
     db.commit()
     return _card_state(db, current_user.id, set_id, number).model_dump()
 
@@ -336,8 +348,8 @@ def unwant_card(req: CardActionRequest, db: DbSession, current_user: CurrentUser
     already completed), so this never erases the "I got it" record (#768)."""
     wishlist = get_or_create_default_wishlist(db, current_user.id)
     set_id, number = _identity(req.card)
-    item = _default_wishlist_item(db, wishlist.id, set_id, number)
-    if item is not None and item.acquired_at is None:
+    item = _wishlist_item(db, wishlist.id, set_id, number, acquired=False)
+    if item is not None:
         db.delete(item)
     db.commit()
     return _card_state(db, current_user.id, set_id, number).model_dump()

--- a/api/routes/ownership.py
+++ b/api/routes/ownership.py
@@ -166,6 +166,10 @@ def card_ownership(
         .where(
             Wishlist.user_id == current_user.id,
             WishlistItem.card_set_id.in_(set_ids),
+            # Only active chases count as "wanted" — an acquired item is a
+            # completed chase kept for history (ADR-0025), not a live want
+            # (#768).
+            WishlistItem.acquired_at.is_(None),
         )
     ).all()
     for set_id, number, wish_id, wish_name in wish_rows:
@@ -245,6 +249,9 @@ def _card_state(db: Session, user_id: int, set_id: str | None, number: str | Non
                 Wishlist.user_id == user_id,
                 WishlistItem.card_set_id == set_id,
                 WishlistItem.card_number == number,
+                # Active chases only — an acquired item is history, not a live
+                # want (#768).
+                WishlistItem.acquired_at.is_(None),
             )
         ).all()
     else:
@@ -294,11 +301,16 @@ def _default_collection_item(
 
 @router.post("/cards/want")
 def want_card(req: CardActionRequest, db: DbSession, current_user: CurrentUser) -> dict:
-    """Add a card to the user's default wishlist. Idempotent — already on it is
-    a no-op."""
+    """Want a card on the user's default wishlist — an active chase.
+
+    Idempotent for an already-active want. If the only item is an *acquired*
+    one (the card was wanted, then owned), re-wanting reactivates that row
+    rather than minting a duplicate — the explicit "I own one but want another"
+    path (#768)."""
     wishlist = get_or_create_default_wishlist(db, current_user.id)
     set_id, number = _identity(req.card)
-    if _default_wishlist_item(db, wishlist.id, set_id, number) is None:
+    item = _default_wishlist_item(db, wishlist.id, set_id, number)
+    if item is None:
         price = extract_price_snapshot(req.card)
         db.add(
             WishlistItem(
@@ -309,17 +321,23 @@ def want_card(req: CardActionRequest, db: DbSession, current_user: CurrentUser) 
                 **extract_card_identity(req.card),
             )
         )
+    elif item.acquired_at is not None:
+        item.acquired_at = None
+        item.acquired_collection_item_id = None
     db.commit()
     return _card_state(db, current_user.id, set_id, number).model_dump()
 
 
 @router.post("/cards/unwant")
 def unwant_card(req: CardActionRequest, db: DbSession, current_user: CurrentUser) -> dict:
-    """Remove a card from the user's default wishlist. No-op if not on it."""
+    """Drop a card's active chase from the user's default wishlist.
+
+    Only removes an active want — an acquired item is kept as history (its chase
+    already completed), so this never erases the "I got it" record (#768)."""
     wishlist = get_or_create_default_wishlist(db, current_user.id)
     set_id, number = _identity(req.card)
     item = _default_wishlist_item(db, wishlist.id, set_id, number)
-    if item is not None:
+    if item is not None and item.acquired_at is None:
         db.delete(item)
     db.commit()
     return _card_state(db, current_user.id, set_id, number).model_dump()

--- a/api/routes/swipe.py
+++ b/api/routes/swipe.py
@@ -114,7 +114,12 @@ def list_excluded(
         chasing_rows = db.execute(
             select(WishlistItem.card_set_id, WishlistItem.card_number)
             .join(Wishlist, WishlistItem.wishlist_id == Wishlist.id)
-            .where(Wishlist.user_id == current_user.id)
+            .where(
+                Wishlist.user_id == current_user.id,
+                # Active chases only — an acquired item is owned, not chasing,
+                # so it shouldn't be excluded under chasing alone (#768).
+                WishlistItem.acquired_at.is_(None),
+            )
         ).all()
         pairs.update((s, n) for s, n in chasing_rows if s and n)
 

--- a/tests/test_ownership.py
+++ b/tests/test_ownership.py
@@ -248,7 +248,7 @@ class QuickActionTests(_IsolatedDbMixin):
             self.assertFalse(body["owned"])
             self.assertEqual(body["collections"], [])
 
-    def test_owning_a_wanted_card_stamps_the_chase_complete(self) -> None:
+    def test_owning_a_wanted_card_clears_the_active_want(self) -> None:
         from sqlalchemy import select
 
         from api.db.models import WishlistItem
@@ -256,17 +256,30 @@ class QuickActionTests(_IsolatedDbMixin):
         with self._client() as c:
             c.post("/api/v1/cards/want", json={"card": CHARIZARD})
             body = c.post("/api/v1/cards/own", json={"card": CHARIZARD}).json()
-            # A card can be both wanted (history preserved) and owned.
+            # Owning clears the active chase by default (#768): owned, no longer
+            # an active want.
             self.assertTrue(body["owned"])
-            self.assertTrue(body["wanted"])
+            self.assertFalse(body["wanted"])
 
         sf = session_mod.get_session_factory()
         with sf() as db:
+            # The wishlist row survives as history, stamped acquired (ADR-0025).
             item = db.scalar(select(WishlistItem))
             self.assertIsNotNone(item.acquired_at)
             self.assertIsNotNone(item.acquired_collection_item_id)
 
-    def test_unowning_clears_the_chase_stamp(self) -> None:
+    def test_wanting_again_after_owning_reactivates_the_chase(self) -> None:
+        with self._client() as c:
+            c.post("/api/v1/cards/want", json={"card": CHARIZARD})
+            c.post("/api/v1/cards/own", json={"card": CHARIZARD})
+            # Explicitly wanting again (own one, chase another) reactivates the
+            # row rather than minting a duplicate.
+            body = c.post("/api/v1/cards/want", json={"card": CHARIZARD}).json()
+            self.assertTrue(body["owned"])
+            self.assertTrue(body["wanted"])
+            self.assertEqual(len(body["wishlists"]), 1)
+
+    def test_unowning_restores_the_chase(self) -> None:
         from sqlalchemy import select
 
         from api.db.models import WishlistItem
@@ -274,7 +287,10 @@ class QuickActionTests(_IsolatedDbMixin):
         with self._client() as c:
             c.post("/api/v1/cards/want", json={"card": CHARIZARD})
             c.post("/api/v1/cards/own", json={"card": CHARIZARD})
-            c.post("/api/v1/cards/unown", json={"card": CHARIZARD})
+            body = c.post("/api/v1/cards/unown", json={"card": CHARIZARD}).json()
+            # Reversing the acquisition resumes the chase.
+            self.assertFalse(body["owned"])
+            self.assertTrue(body["wanted"])
 
         sf = session_mod.get_session_factory()
         with sf() as db:

--- a/tests/test_ownership.py
+++ b/tests/test_ownership.py
@@ -298,6 +298,34 @@ class QuickActionTests(_IsolatedDbMixin):
             self.assertIsNone(item.acquired_at)
             self.assertIsNone(item.acquired_collection_item_id)
 
+    def test_want_does_not_reactivate_history_when_an_active_duplicate_exists(self) -> None:
+        # With both an acquired (history) row and a separate active duplicate
+        # for the same card, re-wanting must no-op rather than clearing the
+        # acquired row — that would dup the active want and lose history (#768).
+        from sqlalchemy import select
+
+        from api.db.models import Wishlist, WishlistItem
+
+        sf = session_mod.get_session_factory()
+        with self._client() as c:
+            c.post("/api/v1/cards/want", json={"card": CHARIZARD})
+            c.post("/api/v1/cards/own", json={"card": CHARIZARD})  # acquired row
+            with sf() as db:
+                wl_id = db.scalar(select(Wishlist).where(Wishlist.is_default)).id
+            # A separate active duplicate via the generic items endpoint.
+            c.post(f"/api/v1/wishlists/{wl_id}/items", json={"card": CHARIZARD})
+
+            body = c.post("/api/v1/cards/want", json={"card": CHARIZARD}).json()
+            self.assertTrue(body["wanted"])
+
+        with sf() as db:
+            items = db.scalars(select(WishlistItem)).all()
+            acquired = [i for i in items if i.acquired_at is not None]
+            active = [i for i in items if i.acquired_at is None]
+            # History intact, exactly one active want — no reactivation, no dup.
+            self.assertEqual(len(acquired), 1)
+            self.assertEqual(len(active), 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #768

## What

Follow-up from the quick-actions review (#761). The owned chip supersedes the chase chip in the UI, but the data didn't match — owning a wanted card left it reading as both. This makes the default flow-through correct:

- Derived `wanted` / chasing counts only **active** (unacquired) wishlist items. Owning a wanted card stamps the wishlist row acquired, so it drops off the active want-list. The row survives as history (ADR-0025).
- Owning **and** still chasing another copy is now an explicit choice: tapping Want again reactivates the acquired row (or creates one), rather than minting a duplicate.
- Unowning reverses the acquisition, so the chase resumes.
- `unwant` only removes an active want — it never erases the acquired "I got it" history.

## Why

Per review: owning a card shouldn't leave it wanted by default; that's a deliberate "always chasing another" case, not the norm. A user-specific setting to keep a card wanted after owning is noted as a possible future option.

## How to verify

- `uv run pytest tests/test_ownership.py -q` — covers own-clears-want, want-again-reactivates, unown-restores-chase, and the acquired history preservation.
- `make check` green.

No new env vars or migration — `render.yaml` unchanged.