### PR TITLE
feat(web): smart collections + a shared binder-filing picker

### DIFF
--- a/web/src/components/BinderColorPicker.tsx
+++ b/web/src/components/BinderColorPicker.tsx
@@ -3,7 +3,7 @@
  * create/edit surfaces: preset color tokens (#681) plus a native custom-hex
  * picker styled as a swatch. Clicking the active preset clears it (back to
  * no color). Extracted from BinderModal so the "Add binder" inventory form
- * and the smart-binder modal share one control.
+ * and the smart-collection modal share one control.
  */
 import {
   BINDER_COLOR_OPTIONS,

--- a/web/src/components/BinderFilePicker.tsx
+++ b/web/src/components/BinderFilePicker.tsx
@@ -1,0 +1,163 @@
+/**
+ * BinderFilePicker — the shared "file this list into a binder" control (#726).
+ *
+ * Extracted from CollectionCreateDialog (#723) so the smart-binder create flow
+ * can reuse the exact same affordance: pick an existing binder (each shown with
+ * its free slots) or, when none exist yet, create one inline. Filing is always
+ * optional. State + the resolve logic live in
+ * [useBinderFiling](./useBinderFiling.ts); this is the presentation.
+ */
+import { Library, Loader2 } from 'lucide-react'
+import type { BinderSummary } from '../api/client'
+import { BinderColorPicker } from './BinderColorPicker'
+import { coverSwatch } from './binderIdentity'
+import type { BinderFiling } from './useBinderFiling'
+
+const inputClass =
+  'w-full rounded border border-sand-300 bg-coconut-50 px-2.5 py-1.5 text-sm text-coconut-700 placeholder:text-coconut-400 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:border-husk-100 dark:bg-husk-100 dark:text-sand-50 dark:focus:ring-sun-300'
+
+/** Slots still free in a binder: capacity minus the cards already filed into
+ *  it. Returns null when the binder has no capacity pinned (no slot limit). */
+function freeSlots(binder: BinderSummary, usedByBinder: Map<number, number>): number | null {
+  if (binder.capacity == null) return null
+  return Math.max(0, binder.capacity - (usedByBinder.get(binder.id) ?? 0))
+}
+
+/** The free/capacity hint under a binder option. Empty binders read "Empty",
+ *  capacity-less binders read "No slot limit". */
+function slotHint(free: number | null, capacity: number | null | undefined): string {
+  if (capacity == null) return 'No slot limit'
+  if (free === capacity) return `Empty · ${capacity} slots`
+  return `${free} of ${capacity} slots free`
+}
+
+export function BinderFilePicker({ filing }: { filing: BinderFiling }) {
+  const {
+    settled,
+    hasBinders,
+    binders,
+    usedByBinder,
+    binderId,
+    setBinderId,
+    newBinderName,
+    setNewBinderName,
+    newBinderColor,
+    setNewBinderColor,
+    newBinderCapacity,
+    setNewBinderCapacity,
+  } = filing
+
+  if (!settled) {
+    return (
+      <div className="flex items-center gap-2 text-[11px] text-coconut-400 dark:text-sand-300">
+        <Loader2 size={12} className="animate-spin" />
+        Loading your binders…
+      </div>
+    )
+  }
+
+  if (hasBinders) {
+    return (
+      <fieldset className="space-y-1.5">
+        <legend className="mb-1 text-[11px] font-medium uppercase tracking-wide text-coconut-400 dark:text-sand-300">
+          File into a binder (optional)
+        </legend>
+        <BinderRadio
+          checked={binderId === null}
+          onSelect={() => setBinderId(null)}
+          label="Don't file"
+          hint="Leave it loose."
+        />
+        {binders.map((b) => (
+          <BinderRadio
+            key={b.id}
+            checked={binderId === b.id}
+            onSelect={() => setBinderId(b.id)}
+            label={b.name}
+            hint={slotHint(freeSlots(b, usedByBinder), b.capacity)}
+            swatch={coverSwatch(b.binder_color)}
+          />
+        ))}
+      </fieldset>
+    )
+  }
+
+  return (
+    <div className="space-y-2 rounded-md border border-sand-200 bg-coconut-50 p-3 dark:border-husk-100 dark:bg-husk-100">
+      <div className="flex items-center gap-1.5 text-[11px] font-medium text-coconut-500 dark:text-sand-200">
+        <Library size={12} aria-hidden />
+        No binders yet — create one to file this into (optional)
+      </div>
+      <input
+        type="text"
+        value={newBinderName}
+        onChange={(e) => setNewBinderName(e.target.value)}
+        placeholder="Binder name, e.g. Slot 1"
+        aria-label="New binder name"
+        className={inputClass}
+      />
+      <BinderColorPicker value={newBinderColor} onChange={setNewBinderColor} label="Cover color" />
+      <label className="block space-y-1">
+        <span className="text-[11px] font-medium text-coconut-500 dark:text-sand-300">
+          Capacity (slots)
+        </span>
+        <input
+          type="number"
+          min={1}
+          value={newBinderCapacity}
+          onChange={(e) => setNewBinderCapacity(e.target.value)}
+          placeholder="360"
+          aria-label="New binder capacity (slots)"
+          className={inputClass}
+        />
+      </label>
+    </div>
+  )
+}
+
+function BinderRadio({
+  checked,
+  onSelect,
+  label,
+  hint,
+  swatch,
+}: {
+  checked: boolean
+  onSelect: () => void
+  label: string
+  hint: string
+  swatch?: { className: string; style?: { backgroundColor: string } }
+}) {
+  return (
+    <label
+      className={`flex cursor-pointer items-center gap-2 rounded border px-2.5 py-1.5 text-left transition ${
+        checked
+          ? 'border-palm-400 bg-palm-50 dark:border-palm-300 dark:bg-husk-100'
+          : 'border-sand-300 bg-coconut-50 hover:border-sand-400 dark:border-husk-100 dark:bg-husk-100'
+      }`}
+    >
+      <input
+        type="radio"
+        name="binder-file-target"
+        checked={checked}
+        onChange={onSelect}
+        className="sr-only"
+      />
+      {swatch ? (
+        <span
+          className={`h-5 w-4 shrink-0 rounded-sm ${swatch.className}`}
+          style={swatch.style}
+          aria-hidden
+        />
+      ) : (
+        <span className="h-5 w-4 shrink-0" aria-hidden />
+      )}
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-xs font-medium text-coconut-700 dark:text-sand-50">
+          {label}
+        </span>
+        <span className="block text-[10px] text-coconut-400 dark:text-sand-300">{hint}</span>
+      </span>
+    </label>
+  )
+}

--- a/web/src/components/BinderFilePicker.tsx
+++ b/web/src/components/BinderFilePicker.tsx
@@ -1,13 +1,15 @@
 /**
  * BinderFilePicker — the shared "file this list into a binder" control (#726).
  *
- * Extracted from CollectionCreateDialog (#723) so the smart-binder create flow
- * can reuse the exact same affordance: pick an existing binder (each shown with
- * its free slots) or, when none exist yet, create one inline. Filing is always
- * optional. State + the resolve logic live in
- * [useBinderFiling](./useBinderFiling.ts); this is the presentation.
+ * Extracted from CollectionCreateDialog (#723) so the smart-collection create
+ * flow can reuse the exact same affordance: pick an existing binder (each shown
+ * with its free slots), create one inline (whether or not binders already
+ * exist), or leave the list loose. Filing is always optional. State + the
+ * resolve logic live in [useBinderFiling](./useBinderFiling.ts); this is the
+ * presentation.
  */
-import { Library, Loader2 } from 'lucide-react'
+import { Library, Loader2, Plus } from 'lucide-react'
+import type { ReactNode } from 'react'
 import type { BinderSummary } from '../api/client'
 import { BinderColorPicker } from './BinderColorPicker'
 import { coverSwatch } from './binderIdentity'
@@ -32,20 +34,7 @@ function slotHint(free: number | null, capacity: number | null | undefined): str
 }
 
 export function BinderFilePicker({ filing }: { filing: BinderFiling }) {
-  const {
-    settled,
-    hasBinders,
-    binders,
-    usedByBinder,
-    binderId,
-    setBinderId,
-    newBinderName,
-    setNewBinderName,
-    newBinderColor,
-    setNewBinderColor,
-    newBinderCapacity,
-    setNewBinderCapacity,
-  } = filing
+  const { settled, hasBinders, binders, usedByBinder, target, setTarget } = filing
 
   if (!settled) {
     return (
@@ -56,38 +45,70 @@ export function BinderFilePicker({ filing }: { filing: BinderFiling }) {
     )
   }
 
-  if (hasBinders) {
+  // No binders yet — the inline create form is the only path, shown directly.
+  if (!hasBinders) {
     return (
-      <fieldset className="space-y-1.5">
-        <legend className="mb-1 text-[11px] font-medium uppercase tracking-wide text-coconut-400 dark:text-sand-300">
-          File into a binder (optional)
-        </legend>
-        <BinderRadio
-          checked={binderId === null}
-          onSelect={() => setBinderId(null)}
-          label="Don't file"
-          hint="Leave it loose."
-        />
-        {binders.map((b) => (
-          <BinderRadio
-            key={b.id}
-            checked={binderId === b.id}
-            onSelect={() => setBinderId(b.id)}
-            label={b.name}
-            hint={slotHint(freeSlots(b, usedByBinder), b.capacity)}
-            swatch={coverSwatch(b.binder_color)}
-          />
-        ))}
-      </fieldset>
+      <div className="space-y-2 rounded-md border border-sand-200 bg-coconut-50 p-3 dark:border-husk-100 dark:bg-husk-100">
+        <div className="flex items-center gap-1.5 text-[11px] font-medium text-coconut-500 dark:text-sand-200">
+          <Library size={12} aria-hidden />
+          No binders yet — create one to file this into (optional)
+        </div>
+        <NewBinderFields filing={filing} />
+      </div>
     )
   }
 
+  // Binders exist — pick one, leave it loose, or create a new one inline.
   return (
-    <div className="space-y-2 rounded-md border border-sand-200 bg-coconut-50 p-3 dark:border-husk-100 dark:bg-husk-100">
-      <div className="flex items-center gap-1.5 text-[11px] font-medium text-coconut-500 dark:text-sand-200">
-        <Library size={12} aria-hidden />
-        No binders yet — create one to file this into (optional)
-      </div>
+    <fieldset className="space-y-1.5">
+      <legend className="mb-1 text-[11px] font-medium uppercase tracking-wide text-coconut-400 dark:text-sand-300">
+        File into a binder (optional)
+      </legend>
+      <BinderRadio
+        checked={target === null}
+        onSelect={() => setTarget(null)}
+        label="Don't file"
+        hint="Leave it loose."
+      />
+      {binders.map((b) => (
+        <BinderRadio
+          key={b.id}
+          checked={target === b.id}
+          onSelect={() => setTarget(b.id)}
+          label={b.name}
+          hint={slotHint(freeSlots(b, usedByBinder), b.capacity)}
+          swatch={coverSwatch(b.binder_color)}
+        />
+      ))}
+      <BinderRadio
+        checked={target === 'new'}
+        onSelect={() => setTarget('new')}
+        label="New binder"
+        hint="Create one to file this into."
+        icon={<Plus size={12} aria-hidden />}
+      />
+      {target === 'new' && (
+        <div className="space-y-2 rounded-md border border-sand-200 bg-coconut-50 p-3 dark:border-husk-100 dark:bg-husk-100">
+          <NewBinderFields filing={filing} />
+        </div>
+      )}
+    </fieldset>
+  )
+}
+
+/** The inline new-binder fields — name, cover color, capacity. Shared by the
+ *  no-binders empty state and the "New binder" option in the radio list. */
+function NewBinderFields({ filing }: { filing: BinderFiling }) {
+  const {
+    newBinderName,
+    setNewBinderName,
+    newBinderColor,
+    setNewBinderColor,
+    newBinderCapacity,
+    setNewBinderCapacity,
+  } = filing
+  return (
+    <>
       <input
         type="text"
         value={newBinderName}
@@ -111,7 +132,7 @@ export function BinderFilePicker({ filing }: { filing: BinderFiling }) {
           className={inputClass}
         />
       </label>
-    </div>
+    </>
   )
 }
 
@@ -121,12 +142,14 @@ function BinderRadio({
   label,
   hint,
   swatch,
+  icon,
 }: {
   checked: boolean
   onSelect: () => void
   label: string
   hint: string
   swatch?: { className: string; style?: { backgroundColor: string } }
+  icon?: ReactNode
 }) {
   return (
     <label
@@ -149,6 +172,10 @@ function BinderRadio({
           style={swatch.style}
           aria-hidden
         />
+      ) : icon ? (
+        <span className="flex h-5 w-4 shrink-0 items-center justify-center text-coconut-400 dark:text-sand-300">
+          {icon}
+        </span>
       ) : (
         <span className="h-5 w-4 shrink-0" aria-hidden />
       )}

--- a/web/src/components/BinderModal.test.tsx
+++ b/web/src/components/BinderModal.test.tsx
@@ -2,8 +2,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { BinderModal } from './BinderModal'
 import { _resetCollectionsCacheForTests } from './useCollections'
-import { createCollection, updateCollection, fetchCollections } from '../api/client'
-import type { CollectionSummary } from '../api/client'
+import { _resetBindersCacheForTests } from './useBinders'
+import {
+  createCollection,
+  updateCollection,
+  fetchCollections,
+  fetchBinders,
+  createBinder,
+} from '../api/client'
+import type { BinderSummary, CollectionSummary } from '../api/client'
 
 vi.mock('../api/client', () => ({
   fetchCollections: vi.fn(),
@@ -12,19 +19,42 @@ vi.mock('../api/client', () => ({
   addCardToCollection: vi.fn(),
   bulkAddToCollection: vi.fn(),
   deleteCollection: vi.fn(),
+  fetchBinders: vi.fn(),
+  createBinder: vi.fn(),
 }))
 
 const mockCreate = vi.mocked(createCollection)
 const mockUpdate = vi.mocked(updateCollection)
 const mockFetch = vi.mocked(fetchCollections)
+const mockFetchBinders = vi.mocked(fetchBinders)
+const mockCreateBinder = vi.mocked(createBinder)
+
+function binder(over: Partial<BinderSummary> = {}): BinderSummary {
+  return {
+    id: 3,
+    name: 'Show binder',
+    created_at: '2026-06-15T00:00:00',
+    binder_format: null,
+    binder_color: null,
+    binder_type: null,
+    capacity: 360,
+    collection_count: 0,
+    is_empty: true,
+    ...over,
+  }
+}
 
 describe('BinderModal', () => {
   beforeEach(() => {
     _resetCollectionsCacheForTests()
+    _resetBindersCacheForTests()
     mockCreate.mockReset()
     mockUpdate.mockReset()
     mockFetch.mockReset()
+    mockFetchBinders.mockReset()
+    mockCreateBinder.mockReset()
     mockFetch.mockResolvedValue([])
+    mockFetchBinders.mockResolvedValue([])
   })
 
   it('creates a binder with format and capacity (no cover color / storage type — those live on the binder unit)', async () => {
@@ -86,6 +116,8 @@ describe('BinderModal', () => {
       target: { value: 'All Eevees' },
     })
     fireEvent.change(screen.getByPlaceholderText('Eevee'), { target: { value: 'Eevee' } })
+    // Wait for the binder-file picker to settle (no binders here) before submit.
+    await screen.findByText(/No binders yet/i)
     fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
 
     await waitFor(() => expect(mockCreate).toHaveBeenCalled())
@@ -95,6 +127,37 @@ describe('BinderModal', () => {
     expect(opts).not.toHaveProperty('binder_format')
     expect(opts).not.toHaveProperty('capacity')
     expect(opts).not.toHaveProperty('binder_color')
+  })
+
+  it('files a new smart binder into a chosen binder (#726)', async () => {
+    mockFetchBinders.mockResolvedValue([binder({ id: 3, name: 'Show binder' })])
+    mockCreate.mockResolvedValue({
+      id: 10,
+      name: 'All Eevees',
+      description: null,
+      created_at: '2026-06-15T00:00:00',
+      items: [],
+      kind: 'dynamic',
+      rule: { name: 'Eevee' },
+    } as never)
+    render(<BinderModal open onOpenChange={() => {}} />)
+
+    fireEvent.click(screen.getByRole('radio', { name: /smart binder/i }))
+    fireEvent.change(screen.getByPlaceholderText('All Eevees'), {
+      target: { value: 'All Eevees' },
+    })
+    fireEvent.change(screen.getByPlaceholderText('Eevee'), { target: { value: 'Eevee' } })
+
+    // The shared binder-file picker lists existing binders; pick one.
+    fireEvent.click(await screen.findByRole('radio', { name: /Show binder/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() =>
+      expect(mockCreate).toHaveBeenCalledWith(
+        'All Eevees',
+        expect.objectContaining({ kind: 'dynamic', binder_id: 3 }),
+      ),
+    )
   })
 
   it('lets you save identity edits to an existing smart binder without a rule', async () => {

--- a/web/src/components/BinderModal.test.tsx
+++ b/web/src/components/BinderModal.test.tsx
@@ -99,7 +99,7 @@ describe('BinderModal', () => {
     expect(opts).not.toHaveProperty('binder_type')
   })
 
-  it('creates a smart binder carrying shared identity but no physical fields or color', async () => {
+  it('creates a smart collection carrying shared identity but no physical fields or color', async () => {
     mockCreate.mockResolvedValue({
       id: 6,
       name: 'All Eevees',
@@ -111,7 +111,7 @@ describe('BinderModal', () => {
     })
     render(<BinderModal open onOpenChange={() => {}} />)
 
-    fireEvent.click(screen.getByRole('radio', { name: /smart binder/i }))
+    fireEvent.click(screen.getByRole('radio', { name: /smart collection/i }))
     fireEvent.change(screen.getByPlaceholderText('All Eevees'), {
       target: { value: 'All Eevees' },
     })
@@ -123,13 +123,13 @@ describe('BinderModal', () => {
     await waitFor(() => expect(mockCreate).toHaveBeenCalled())
     const [, opts] = mockCreate.mock.calls[0]
     expect(opts).toMatchObject({ kind: 'dynamic', dynamic_scope: 'owned' })
-    // A smart binder has no fixed slots and no cover color.
+    // A smart collection has no fixed slots and no cover color.
     expect(opts).not.toHaveProperty('binder_format')
     expect(opts).not.toHaveProperty('capacity')
     expect(opts).not.toHaveProperty('binder_color')
   })
 
-  it('files a new smart binder into a chosen binder (#726)', async () => {
+  it('files a new smart collection into a chosen binder (#726)', async () => {
     mockFetchBinders.mockResolvedValue([binder({ id: 3, name: 'Show binder' })])
     mockCreate.mockResolvedValue({
       id: 10,
@@ -142,7 +142,7 @@ describe('BinderModal', () => {
     } as never)
     render(<BinderModal open onOpenChange={() => {}} />)
 
-    fireEvent.click(screen.getByRole('radio', { name: /smart binder/i }))
+    fireEvent.click(screen.getByRole('radio', { name: /smart collection/i }))
     fireEvent.change(screen.getByPlaceholderText('All Eevees'), {
       target: { value: 'All Eevees' },
     })
@@ -160,7 +160,7 @@ describe('BinderModal', () => {
     )
   })
 
-  it('lets you save identity edits to an existing smart binder without a rule', async () => {
+  it('lets you save identity edits to an existing smart collection without a rule', async () => {
     const smart: CollectionSummary = {
       id: 8,
       name: 'All Eevees',

--- a/web/src/components/BinderModal.tsx
+++ b/web/src/components/BinderModal.tsx
@@ -27,6 +27,8 @@ import type {
   CollectionSummary,
   DynamicScope,
 } from '../api/client'
+import { BinderFilePicker } from './BinderFilePicker'
+import { useBinderFiling } from './useBinderFiling'
 import { BINDER_FORMAT_OPTIONS } from './binderIdentity'
 import { SetCombobox } from './SetCombobox'
 import { useCollections } from './useCollections'
@@ -89,6 +91,9 @@ interface Props {
 
 export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }: Props) {
   const { create, update } = useCollections()
+  // A smart binder being created can file into a binder, same as a plain
+  // collection (#726) — shares the picker. Edit touches identity only.
+  const filing = useBinderFiling()
   const isEdit = editing != null
   // A dynamic collection edits as a smart binder; everything else as physical.
   const editMode: BinderMode = editing?.kind === 'dynamic' ? 'smart' : 'binder'
@@ -134,7 +139,13 @@ export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }:
   // its identity (name/color/type/master-set), so the rule value isn't
   // required (and the rule editor is hidden) in edit mode.
   const editingRule = isSmart && !isEdit
-  const canSubmit = name.trim().length > 0 && (!editingRule || value.trim().length > 0)
+  // Creating a smart binder offers the binder-filing picker; wait for the
+  // binder list before allowing submit so the inline-create path is safe.
+  const smartCreate = isSmart && !isEdit
+  const canSubmit =
+    name.trim().length > 0 &&
+    (!editingRule || value.trim().length > 0) &&
+    (!smartCreate || filing.settled)
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -159,12 +170,15 @@ export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }:
             : { is_master_set: isMasterSet }),
         })
       } else if (isSmart) {
+        const target = await filing.resolveTarget()
         await create(name.trim(), {
           kind: 'dynamic',
           rule: buildRule(field, value),
           dynamic_scope: scope,
           is_master_set: isMasterSet,
+          ...(target != null ? { binder_id: target } : {}),
         })
+        if (target != null) await filing.refresh()
       } else {
         const set = sourceSetId.trim()
         await create(name.trim(), {
@@ -299,6 +313,9 @@ export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }:
                 </div>
               </div>
             )}
+
+            {/* A new smart binder can file into a physical binder (#726). */}
+            {smartCreate && <BinderFilePicker filing={filing} />}
 
             <div>
               <button

--- a/web/src/components/BinderModal.tsx
+++ b/web/src/components/BinderModal.tsx
@@ -1,9 +1,9 @@
 /**
  * BinderModal — the single create-and-edit surface for binders (#679, #681).
  *
- * Everything in the Binders tab is a binder: a **physical binder** (a bucket
+ * The Binders tab creates two things here: a **physical binder** (a bucket
  * of cards with a cover, storage style, pocket format, and capacity) or a
- * **smart binder** (a saved rule whose membership is your matching cards).
+ * **smart collection** (a saved rule whose membership is your matching cards).
  * The two share storage-type/master-set identity; pocket format and capacity
  * are physical-only, since a rule-based set has no fixed slots. Cover color
  * lives on the binder inventory unit (#702), not here (#723).
@@ -33,7 +33,7 @@ import { BINDER_FORMAT_OPTIONS } from './binderIdentity'
 import { SetCombobox } from './SetCombobox'
 import { useCollections } from './useCollections'
 
-/** The single-predicate fields the smart-binder rule builder offers. */
+/** The single-predicate fields the smart-collection rule builder offers. */
 const RULE_FIELDS = [
   { key: 'name', label: 'Name contains' },
   { key: 'types', label: 'Type is' },
@@ -46,7 +46,7 @@ type RuleField = (typeof RULE_FIELDS)[number]['key']
 
 /** Seed values for a fresh binder created from another surface (e.g. the
  * Browse set/pokedex view, #682/#737). Applied only on create, not editing.
- * `ruleField`/`ruleValue` seed the smart-binder rule builder (a set-anchored
+ * `ruleField`/`ruleValue` seed the smart-collection rule builder (a set-anchored
  * `set_id` rule from set view, a species `name` rule from pokedex view). */
 export interface BinderPrefill {
   name?: string
@@ -80,22 +80,22 @@ interface Props {
   /** Seed a fresh binder's fields (create only) — e.g. opened from Browse. */
   prefill?: BinderPrefill
   /**
-   * Smart-binder-only create (#703). The Binders tab's New ▾ → Smart binder
-   * opens the modal here: the physical/smart selector is hidden and the form
-   * builds a `kind='dynamic'` rule. Physical binders are created from "Add
-   * binder" (#702) now; the set-anchored Browse path (#682) still opens this
-   * modal without `smartOnly` for its physical create.
+   * Smart-collection-only create (#703). The Binders tab's New ▾ → Smart
+   * collection opens the modal here: the physical/smart selector is hidden and
+   * the form builds a `kind='dynamic'` rule. Physical binders are created from
+   * "Add binder" (#702) now; the set-anchored Browse path (#682) still opens
+   * this modal without `smartOnly` for its physical create.
    */
   smartOnly?: boolean
 }
 
 export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }: Props) {
   const { create, update } = useCollections()
-  // A smart binder being created can file into a binder, same as a plain
+  // A smart collection being created can file into a binder, same as a plain
   // collection (#726) — shares the picker. Edit touches identity only.
   const filing = useBinderFiling()
   const isEdit = editing != null
-  // A dynamic collection edits as a smart binder; everything else as physical.
+  // A dynamic collection edits as a smart collection; everything else as physical.
   const editMode: BinderMode = editing?.kind === 'dynamic' ? 'smart' : 'binder'
 
   // State is seeded once at mount from the binder being edited (or blank for
@@ -125,8 +125,8 @@ export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }:
         prefill?.isMasterSet,
     ),
   )
-  // Smart-binder rule state — seeded from a Browse prefill (#737) so a
-  // set-anchored / species-anchored smart binder lands with its rule filled.
+  // Smart-collection rule state — seeded from a Browse prefill (#737) so a
+  // set-anchored / species-anchored smart collection lands with its rule filled.
   const [field, setField] = useState<RuleField>(() => prefill?.ruleField ?? 'name')
   const [value, setValue] = useState(() => prefill?.ruleValue ?? '')
   const [scope, setScope] = useState<DynamicScope>('owned')
@@ -135,11 +135,11 @@ export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }:
   const [error, setError] = useState<string | null>(null)
 
   const isSmart = mode === 'smart'
-  // The rule is only authored on create — editing a smart binder touches just
+  // The rule is only authored on create — editing a smart collection touches just
   // its identity (name/color/type/master-set), so the rule value isn't
   // required (and the rule editor is hidden) in edit mode.
   const editingRule = isSmart && !isEdit
-  // Creating a smart binder offers the binder-filing picker; wait for the
+  // Creating a smart collection offers the binder-filing picker; wait for the
   // binder list before allowing submit so the inline-create path is safe.
   const smartCreate = isSmart && !isEdit
   const canSubmit =
@@ -207,7 +207,13 @@ export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }:
         <Dialog.Content className="fixed left-1/2 top-1/2 z-50 flex max-h-[88vh] w-[min(460px,92vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-sand-300 bg-sand-50 shadow-2xl dark:border-husk-50 dark:bg-husk-200">
           <header className="flex items-center justify-between gap-3 border-b border-sand-200 px-5 py-4 dark:border-husk-100">
             <Dialog.Title className="text-lg font-semibold text-coconut-700 dark:text-sand-50">
-              {isEdit ? 'Edit binder' : smartOnly ? 'New smart binder' : 'New binder'}
+              {isEdit
+                ? editMode === 'smart'
+                  ? 'Edit smart collection'
+                  : 'Edit binder'
+                : smartOnly
+                  ? 'New smart collection'
+                  : 'New binder'}
             </Dialog.Title>
             <Dialog.Close asChild>
               <button
@@ -224,9 +230,9 @@ export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }:
           </Dialog.Description>
 
           <form onSubmit={handleSubmit} className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
-            {/* Mode — physical vs. smart binder. Hidden when editing (a
+            {/* Mode — physical vs. smart collection. Hidden when editing (a
                 binder's kind is fixed) and in smartOnly create (#703), where
-                the Binders tab routes straight to the smart-binder builder. */}
+                the Binders tab routes straight to the smart-collection builder. */}
             {!isEdit && !smartOnly && (
               <div role="radiogroup" aria-label="Binder type" className="grid grid-cols-2 gap-2">
                 <TypeCard
@@ -240,7 +246,7 @@ export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }:
                   active={mode === 'smart'}
                   onClick={() => setMode('smart')}
                   icon={<Sparkles size={15} />}
-                  title="Smart binder"
+                  title="Smart collection"
                   blurb="A saved rule over the cards you already own."
                 />
               </div>
@@ -314,7 +320,7 @@ export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }:
               </div>
             )}
 
-            {/* A new smart binder can file into a physical binder (#726). */}
+            {/* A new smart collection can file into a physical binder (#726). */}
             {smartCreate && <BinderFilePicker filing={filing} />}
 
             <div>
@@ -387,7 +393,7 @@ export function BinderModal({ open, onOpenChange, editing, prefill, smartOnly }:
                   )}
 
                   {/* Master-set target — shared. A physical binder needs a set
-                      anchor; a smart binder's rule defines membership. */}
+                      anchor; a smart collection's rule defines membership. */}
                   {(isSmart || (isEdit ? editing?.source_set_id : sourceSetId.trim())) && (
                     <div className="space-y-1">
                       <label className="flex items-center gap-2 text-xs text-coconut-600 dark:text-sand-200">

--- a/web/src/components/BrowsePanel.test.tsx
+++ b/web/src/components/BrowsePanel.test.tsx
@@ -329,7 +329,7 @@ describe('BrowsePanel — pokedex view (#577)', () => {
       .mockResolvedValue({ added: [], skipped: [] } as never)
 
     render(<Harness />)
-    await openSetCreate(/collection/i)
+    await openSetCreate(/^collection/i)
 
     // The collection dialog opens pre-seeded with the set's name; create it.
     const dialog = await screen.findByRole('dialog')

--- a/web/src/components/BrowsePanel.tsx
+++ b/web/src/components/BrowsePanel.tsx
@@ -69,7 +69,7 @@ type CreateKind = 'collection' | 'wishlist' | 'smart'
 interface PendingSeed {
   name: string
   /** The set's cards / species' printings to pre-populate a collection or
-   *  want-list. A smart binder ignores these — its rule is its membership. */
+   *  want-list. A smart collection ignores these — its rule is its membership. */
   seedCards: CardData[]
   ruleField: 'set_id' | 'name'
   ruleValue: string
@@ -143,11 +143,11 @@ export function BrowsePanel({ controller }: BrowsePanelProps) {
 
   // Collection / want-list creates snapshot the loaded cards as their seed, so
   // they're only offered once the drill-in's cards have landed — otherwise we'd
-  // seed an empty list. A smart binder needs no cards, so it's always available.
+  // seed an empty list. A smart collection needs no cards, so it's always available.
   const seedLoading = viewMode === 'set' ? cardsLoading : pokedexCardsLoading
 
   // Build the seed for the current drill-in: the list name, the cards to
-  // pre-populate (the whole set / all printings), and the rule a smart binder
+  // pre-populate (the whole set / all printings), and the rule a smart collection
   // would use. Returns null when there's nothing to seed from yet.
   function buildSeed(): PendingSeed | null {
     if (viewMode === 'set' && activeSet) {
@@ -396,7 +396,7 @@ function BrowseCreateMenu({
           />
           <BrowseCreateItem
             icon={<Sparkles size={13} />}
-            label="Smart binder"
+            label="Smart collection"
             blurb={`A saved rule for this ${noun}.`}
             onSelect={() => onCreate('smart')}
           />

--- a/web/src/components/CollectionCreateDialog.test.tsx
+++ b/web/src/components/CollectionCreateDialog.test.tsx
@@ -91,6 +91,55 @@ describe('CollectionCreateDialog', () => {
     await waitFor(() => expect(mockCreate).toHaveBeenCalledWith('Base holos', { binder_id: 3 }))
   })
 
+  it('creates a new binder even when binders already exist, then files into it', async () => {
+    mockBinders.mockResolvedValue([
+      {
+        id: 3,
+        name: 'Show binder',
+        created_at: '2026-06-01T00:00:00',
+        binder_format: null,
+        binder_color: null,
+        binder_type: null,
+        capacity: 360,
+        collection_count: 0,
+        is_empty: true,
+      },
+    ])
+    mockCreateBinder.mockResolvedValue({
+      id: 20,
+      name: 'Slot 2',
+      created_at: '2026-06-21T00:00:00',
+      binder_format: null,
+      binder_color: null,
+      binder_type: null,
+      capacity: 180,
+      collection_count: 0,
+      is_empty: true,
+    } as never)
+
+    render(<CollectionCreateDialog open onOpenChange={() => {}} />)
+    // The "New binder" option is offered alongside the existing binder.
+    fireEvent.click(await screen.findByRole('radio', { name: /new binder/i }))
+    fireEvent.change(screen.getByPlaceholderText('Base Set holos'), {
+      target: { value: 'Base holos' },
+    })
+    fireEvent.change(screen.getByLabelText('New binder name'), {
+      target: { value: 'Slot 2' },
+    })
+    fireEvent.change(screen.getByLabelText('New binder capacity (slots)'), {
+      target: { value: '180' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() =>
+      expect(mockCreateBinder).toHaveBeenCalledWith('Slot 2', {
+        binder_color: null,
+        capacity: 180,
+      }),
+    )
+    await waitFor(() => expect(mockCreate).toHaveBeenCalledWith('Base holos', { binder_id: 20 }))
+  })
+
   it('creates a binder inline when none exist, then files the collection into it', async () => {
     mockCreateBinder.mockResolvedValue({
       id: 12,

--- a/web/src/components/CollectionCreateDialog.tsx
+++ b/web/src/components/CollectionCreateDialog.tsx
@@ -2,26 +2,18 @@
  * CollectionCreateDialog — the New ▾ → Collection create flow (#723).
  *
  * A plain collection lives inside a physical binder (the inventory unit from
- * #702), so this dialog connects the two at create time:
- *
- * - **Binders exist:** pick one to file the new collection into, each shown
- *   with its available slots (capacity minus what's already filed; an empty
- *   binder shows its full capacity). Filing stays optional — "Don't file"
- *   leaves the collection loose.
- * - **No binders yet:** create one inline (name + optional cover color and
- *   capacity) and the collection drops straight into it.
- *
- * Both paths go through [useCollections](./useCollections.ts) /
+ * #702), so this dialog connects the two at create time via the shared
+ * {@link BinderFilePicker} (#726): pick an existing binder (each shown with its
+ * free slots), create one inline when none exist, or leave the collection
+ * loose. Both paths go through [useCollections](./useCollections.ts) /
  * [useBinders](./useBinders.ts) so every surface re-renders without a refetch.
  */
 import * as Dialog from '@radix-ui/react-dialog'
-import { Library, Loader2, X } from 'lucide-react'
-import { useMemo, useState } from 'react'
-import type { BinderSummary } from '../api/client'
+import { Loader2, X } from 'lucide-react'
+import { useState } from 'react'
 import type { CardData } from '../types'
-import { BinderColorPicker } from './BinderColorPicker'
-import { coverSwatch } from './binderIdentity'
-import { useBinders } from './useBinders'
+import { BinderFilePicker } from './BinderFilePicker'
+import { useBinderFiling } from './useBinderFiling'
 import { useCollections } from './useCollections'
 
 interface Props {
@@ -54,13 +46,6 @@ export function CollectionCreateDialog({ open, onOpenChange, prefillName, seedCa
   )
 }
 
-/** Slots still free in a binder: capacity minus the cards already filed into
- *  it. Returns null when the binder has no capacity pinned (no slot limit). */
-function freeSlots(binder: BinderSummary, usedByBinder: Map<number, number>): number | null {
-  if (binder.capacity == null) return null
-  return Math.max(0, binder.capacity - (usedByBinder.get(binder.id) ?? 0))
-}
-
 function CreateForm({
   onClose,
   prefillName,
@@ -70,45 +55,14 @@ function CreateForm({
   prefillName?: string
   seedCards?: CardData[]
 }) {
-  const { collections, create: createCollection, bulkAdd: bulkAddCollection } = useCollections()
-  const {
-    binders,
-    loading: bindersLoading,
-    create: createBinder,
-    refresh: refreshBinders,
-  } = useBinders()
+  const { create: createCollection, bulkAdd: bulkAddCollection } = useCollections()
+  const filing = useBinderFiling()
 
   const [name, setName] = useState(prefillName ?? '')
-  // Existing-binder target: a binder id, or null for "don't file".
-  const [binderId, setBinderId] = useState<number | null>(null)
-  // Inline-binder fields (only used when no binders exist yet).
-  const [newBinderName, setNewBinderName] = useState('')
-  const [newBinderColor, setNewBinderColor] = useState<string | null>(null)
-  const [newBinderCapacity, setNewBinderCapacity] = useState('')
-
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  // Until the binder list resolves, neither branch is safe to show: an empty
-  // `binders` during the in-flight fetch would falsely read as "no binders
-  // yet" and offer the inline-create / loose-collection path even though
-  // existing binders are about to appear (#724 review). Gate on the settled
-  // state instead.
-  const bindersSettled = !bindersLoading
-  const hasBinders = binders.length > 0
-
-  // Cards already filed into each binder — the sum of its collections' pocket
-  // counts (vendor multiples via total_quantity, falling back to row count).
-  const usedByBinder = useMemo(() => {
-    const map = new Map<number, number>()
-    for (const c of collections) {
-      if (c.binder_id == null) continue
-      map.set(c.binder_id, (map.get(c.binder_id) ?? 0) + (c.total_quantity ?? c.item_count))
-    }
-    return map
-  }, [collections])
-
-  const canSubmit = name.trim().length > 0 && !submitting && bindersSettled
+  const canSubmit = name.trim().length > 0 && !submitting && filing.settled
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -116,18 +70,7 @@ function CreateForm({
     setSubmitting(true)
     setError(null)
     try {
-      // No binders yet + the user named one inline → make the binder first,
-      // then drop the collection straight into it.
-      let target = binderId
-      const inlineName = newBinderName.trim()
-      if (!hasBinders && inlineName) {
-        const cap = newBinderCapacity.trim() ? Number(newBinderCapacity.trim()) : null
-        const binder = await createBinder(inlineName, {
-          binder_color: newBinderColor,
-          capacity: cap && cap > 0 ? cap : null,
-        })
-        target = binder.id
-      }
+      const target = await filing.resolveTarget()
       const created = await createCollection(
         name.trim(),
         target != null ? { binder_id: target } : undefined,
@@ -138,7 +81,7 @@ function CreateForm({
       if (seedCards && seedCards.length > 0) {
         await bulkAddCollection(created.id, seedCards, { addedVia: 'browse' })
       }
-      if (target != null) await refreshBinders()
+      if (target != null) await filing.refresh()
       onClose()
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))
@@ -184,68 +127,7 @@ function CreateForm({
           />
         </label>
 
-        {!bindersSettled ? (
-          <div className="flex items-center gap-2 text-[11px] text-coconut-400 dark:text-sand-300">
-            <Loader2 size={12} className="animate-spin" />
-            Loading your binders…
-          </div>
-        ) : hasBinders ? (
-          <fieldset className="space-y-1.5">
-            <legend className="mb-1 text-[11px] font-medium uppercase tracking-wide text-coconut-400 dark:text-sand-300">
-              File into a binder (optional)
-            </legend>
-            <BinderRadio
-              checked={binderId === null}
-              onSelect={() => setBinderId(null)}
-              label="Don't file"
-              hint="Leave the collection loose."
-            />
-            {binders.map((b) => {
-              const free = freeSlots(b, usedByBinder)
-              const swatch = coverSwatch(b.binder_color)
-              return (
-                <BinderRadio
-                  key={b.id}
-                  checked={binderId === b.id}
-                  onSelect={() => setBinderId(b.id)}
-                  label={b.name}
-                  hint={slotHint(free, b.capacity)}
-                  swatch={swatch}
-                />
-              )
-            })}
-          </fieldset>
-        ) : (
-          <div className="space-y-2 rounded-md border border-sand-200 bg-coconut-50 p-3 dark:border-husk-100 dark:bg-husk-100">
-            <div className="flex items-center gap-1.5 text-[11px] font-medium text-coconut-500 dark:text-sand-200">
-              <Library size={12} aria-hidden />
-              No binders yet — create one to file this into (optional)
-            </div>
-            <input
-              type="text"
-              value={newBinderName}
-              onChange={(e) => setNewBinderName(e.target.value)}
-              placeholder="Binder name, e.g. Slot 1"
-              aria-label="New binder name"
-              className={inputClass}
-            />
-            <BinderColorPicker value={newBinderColor} onChange={setNewBinderColor} label="Cover color" />
-            <label className="block space-y-1">
-              <span className="text-[11px] font-medium text-coconut-500 dark:text-sand-300">
-                Capacity (slots)
-              </span>
-              <input
-                type="number"
-                min={1}
-                value={newBinderCapacity}
-                onChange={(e) => setNewBinderCapacity(e.target.value)}
-                placeholder="360"
-                aria-label="New binder capacity (slots)"
-                className={inputClass}
-              />
-            </label>
-          </div>
-        )}
+        <BinderFilePicker filing={filing} />
 
         {error && (
           <div role="alert" className="text-[11px] text-sun-600 dark:text-sun-300">
@@ -273,60 +155,5 @@ function CreateForm({
         </div>
       </form>
     </>
-  )
-}
-
-/** The free/capacity hint under a binder option. Empty binders read "Empty",
- *  capacity-less binders read "No slot limit". */
-function slotHint(free: number | null, capacity: number | null | undefined): string {
-  if (capacity == null) return 'No slot limit'
-  if (free === capacity) return `Empty · ${capacity} slots`
-  return `${free} of ${capacity} slots free`
-}
-
-function BinderRadio({
-  checked,
-  onSelect,
-  label,
-  hint,
-  swatch,
-}: {
-  checked: boolean
-  onSelect: () => void
-  label: string
-  hint: string
-  swatch?: { className: string; style?: { backgroundColor: string } }
-}) {
-  return (
-    <label
-      className={`flex cursor-pointer items-center gap-2 rounded border px-2.5 py-1.5 text-left transition ${
-        checked
-          ? 'border-palm-400 bg-palm-50 dark:border-palm-300 dark:bg-husk-100'
-          : 'border-sand-300 bg-coconut-50 hover:border-sand-400 dark:border-husk-100 dark:bg-husk-100'
-      }`}
-    >
-      <input
-        type="radio"
-        name="collection-binder"
-        checked={checked}
-        onChange={onSelect}
-        className="sr-only"
-      />
-      {swatch ? (
-        <span
-          className={`h-5 w-4 shrink-0 rounded-sm ${swatch.className}`}
-          style={swatch.style}
-          aria-hidden
-        />
-      ) : (
-        <span className="h-5 w-4 shrink-0" aria-hidden />
-      )}
-      <span className="min-w-0 flex-1">
-        <span className="block truncate text-xs font-medium text-coconut-700 dark:text-sand-50">
-          {label}
-        </span>
-        <span className="block text-[10px] text-coconut-400 dark:text-sand-300">{hint}</span>
-      </span>
-    </label>
   )
 }

--- a/web/src/components/LibraryBindersTab.test.tsx
+++ b/web/src/components/LibraryBindersTab.test.tsx
@@ -65,9 +65,9 @@ async function openNewMenu(itemName: RegExp) {
   fireEvent.click(item)
 }
 
-/** Open the New ▾ menu and pick "Smart binder" (the modal opens smart-only). */
+/** Open the New ▾ menu and pick "Smart collection" (the modal opens smart-only). */
 async function openSmartBinder() {
-  await openNewMenu(/smart binder/i)
+  await openNewMenu(/smart collection/i)
 }
 
 describe('LibraryBindersTab', () => {
@@ -492,7 +492,7 @@ describe('LibraryBindersTab', () => {
 
   // ---- #703: New ▾ menu + file-into-binder -------------------------------
 
-  it('New ▾ lists Collection / Want-list / Smart binder and no plain binder', async () => {
+  it('New ▾ lists Collection / Want-list / Smart collection and no plain binder', async () => {
     render(<LibraryBindersTab />)
     await waitFor(() => expect(mockCollections).toHaveBeenCalled())
 
@@ -500,9 +500,9 @@ describe('LibraryBindersTab', () => {
     trigger.focus()
     fireEvent.keyDown(trigger, { key: 'Enter' })
 
-    expect(await screen.findByRole('menuitem', { name: /collection/i })).toBeInTheDocument()
+    expect(await screen.findByRole('menuitem', { name: /^collection/i })).toBeInTheDocument()
     expect(screen.getByRole('menuitem', { name: /want-list/i })).toBeInTheDocument()
-    expect(screen.getByRole('menuitem', { name: /smart binder/i })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /smart collection/i })).toBeInTheDocument()
     // No standalone "binder" create — physical binders come from "Add binder".
     expect(screen.queryByRole('menuitem', { name: /^binder$/i })).not.toBeInTheDocument()
   })
@@ -519,7 +519,7 @@ describe('LibraryBindersTab', () => {
     render(<LibraryBindersTab />)
     await waitFor(() => expect(mockCollections).toHaveBeenCalled())
 
-    await openNewMenu(/collection/i)
+    await openNewMenu(/^collection/i)
     // The new collection dialog (#723) uses a richer placeholder; with no
     // binders yet and no inline binder named, it creates a loose collection.
     fireEvent.change(screen.getByPlaceholderText('Base Set holos'), {
@@ -550,7 +550,7 @@ describe('LibraryBindersTab', () => {
     await waitFor(() => expect(mockCreateWishlist).toHaveBeenCalledWith('Chase list', undefined))
   })
 
-  it('the smart-binder create has no physical/smart selector', async () => {
+  it('the smart-collection create has no physical/smart selector', async () => {
     render(<LibraryBindersTab />)
     await waitFor(() => expect(mockCollections).toHaveBeenCalled())
 

--- a/web/src/components/LibraryBindersTab.test.tsx
+++ b/web/src/components/LibraryBindersTab.test.tsx
@@ -580,4 +580,36 @@ describe('LibraryBindersTab', () => {
 
     await waitFor(() => expect(mockUpdate).toHaveBeenCalledWith(1, { binder_id: 3 }))
   })
+
+  it('lets a filed smart collection be unfiled from the row (#775 review)', async () => {
+    mockCollections.mockResolvedValue([
+      {
+        id: 2,
+        name: 'All Eevees',
+        description: null,
+        created_at: '2026-06-04T00:00:00',
+        item_count: 7,
+        kind: 'dynamic',
+        dynamic_scope: 'owned',
+        rule: { name: 'eevee' },
+        binder_id: 3,
+      },
+    ])
+    mockBinders.mockResolvedValue([
+      { id: 3, name: 'Show binder', created_at: '2026-06-01T00:00:00', binder_format: null, binder_color: null, binder_type: null, capacity: null, collection_count: 1, is_empty: false },
+    ])
+    mockUpdate.mockResolvedValue({
+      id: 2, name: 'All Eevees', description: null, created_at: '2026-06-04T00:00:00', items: [], kind: 'dynamic', binder_id: null,
+    } as never)
+    render(<LibraryBindersTab />)
+    // The filing control now shows for dynamic (smart) collections too.
+    const fileBtn = await screen.findByRole('button', {
+      name: /file collection "All Eevees" into a binder/i,
+    })
+    fileBtn.focus()
+    fireEvent.keyDown(fileBtn, { key: 'Enter' })
+    fireEvent.click(await screen.findByRole('menuitem', { name: /remove from binder/i }))
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalledWith(2, { binder_id: null }))
+  })
 })

--- a/web/src/components/LibraryBindersTab.tsx
+++ b/web/src/components/LibraryBindersTab.tsx
@@ -522,7 +522,10 @@ function CollectionRow({
           <Pencil size={14} />
         </button>
       )}
-      {c.kind !== 'dynamic' && binders.length > 0 && (
+      {/* Any collection — including a smart collection, which can now be filed
+          at create (#726) — can be re-filed or unfiled from the row, so it's
+          never stuck on the wrong binder (#775 review). */}
+      {binders.length > 0 && (
         <FileIntoBinderControl collection={c} binders={binders} onFile={onFile} />
       )}
       <PrintIdCardControl collectionId={c.id} label={`collection "${c.name}"`} />

--- a/web/src/components/LibraryBindersTab.tsx
+++ b/web/src/components/LibraryBindersTab.tsx
@@ -214,7 +214,7 @@ export function LibraryBindersTab() {
                 />
                 <NewMenuItem
                   icon={<Sparkles size={13} />}
-                  label="Smart binder"
+                  label="Smart collection"
                   blurb="A saved rule over your cards."
                   onSelect={openCreate}
                 />
@@ -311,7 +311,7 @@ export function LibraryBindersTab() {
         open={modalOpen}
         onOpenChange={setModalOpen}
         editing={editingBinder}
-        // Create from the Binders tab is smart-binder-only now (#703);
+        // Create from the Binders tab is smart-collection-only now (#703);
         // physical binders come from "Add binder" above. Edit keeps the
         // binder's real mode.
         smartOnly={editingBinder === null}
@@ -404,7 +404,8 @@ function CapacityFill({ count, capacity }: { count: number; capacity: number }) 
   )
 }
 
-/** A collection carries binder identity if it's a physical or smart binder. */
+/** A collection carries binder identity if it's a physical binder or a smart
+ * collection. */
 function hasBinderIdentity(c: CollectionSummary): boolean {
   return c.kind === 'binder' || c.kind === 'dynamic'
 }

--- a/web/src/components/NameCreateDialog.tsx
+++ b/web/src/components/NameCreateDialog.tsx
@@ -3,7 +3,7 @@
  *
  * The New ▾ menu in the Binders tab uses this for the two logical-list
  * creates that need nothing but a name: a plain collection and a want-list.
- * (Smart binders go through the richer [BinderModal](./BinderModal.tsx).)
+ * (Smart collections go through the richer [BinderModal](./BinderModal.tsx).)
  *
  * Submits on Enter or the action button; surfaces a server error inline and
  * leaves the dialog open so the user can retry. Clears the field whenever

--- a/web/src/components/useBinderFiling.ts
+++ b/web/src/components/useBinderFiling.ts
@@ -1,32 +1,38 @@
 /**
  * useBinderFiling — shared state for the "file this list into a binder" control
- * (#726), used by both the collection and smart-binder create flows.
+ * (#726), used by both the collection and smart-collection create flows.
  *
  * Owns the picker state and the binder/collection data hooks, and exposes
- * `resolveTarget()`, which creates the inline binder when one was named and
- * returns the binder id to file into (or null for "don't file"). The presentational
- * control lives in [BinderFilePicker](./BinderFilePicker.tsx).
+ * `resolveTarget()`, which creates the inline binder when the "new binder" path
+ * was chosen and named, and returns the binder id to file into (or null for
+ * "don't file"). The presentational control lives in
+ * [BinderFilePicker](./BinderFilePicker.tsx).
  */
 import { useMemo, useState } from 'react'
 import type { BinderSummary } from '../api/client'
 import { useBinders } from './useBinders'
 import { useCollections } from './useCollections'
 
+/** What the list files into: an existing binder's id, `'new'` for the inline
+ *  create form, or null for "don't file". */
+export type FileTarget = number | 'new' | null
+
 export interface BinderFiling {
   settled: boolean
   hasBinders: boolean
   binders: BinderSummary[]
   usedByBinder: Map<number, number>
-  binderId: number | null
-  setBinderId: (id: number | null) => void
+  target: FileTarget
+  setTarget: (t: FileTarget) => void
   newBinderName: string
   setNewBinderName: (v: string) => void
   newBinderColor: string | null
   setNewBinderColor: (v: string | null) => void
   newBinderCapacity: string
   setNewBinderCapacity: (v: string) => void
-  /** Resolve the binder to file into, creating an inline binder if one was
-   *  named. Returns its id, or null for "don't file". */
+  /** Resolve the binder to file into, creating an inline binder when the "new
+   *  binder" path was chosen and named. Returns its id, or null for "don't
+   *  file" (including a "new binder" path left unnamed). */
   resolveTarget: () => Promise<number | null>
   /** Refresh binder slot counts after a list was filed. */
   refresh: () => Promise<void>
@@ -36,7 +42,7 @@ export function useBinderFiling(): BinderFiling {
   const { collections } = useCollections()
   const { binders, fetched, create: createBinder, refresh } = useBinders()
 
-  const [binderId, setBinderId] = useState<number | null>(null)
+  const [target, setTarget] = useState<FileTarget>(null)
   const [newBinderName, setNewBinderName] = useState('')
   const [newBinderColor, setNewBinderColor] = useState<string | null>(null)
   const [newBinderCapacity, setNewBinderCapacity] = useState('')
@@ -59,8 +65,13 @@ export function useBinderFiling(): BinderFiling {
   }, [collections])
 
   async function resolveTarget(): Promise<number | null> {
+    if (typeof target === 'number') return target
+    // The inline create form is the active path either when explicitly chosen
+    // ('new') or when there are no binders to choose from yet. An unnamed form
+    // resolves to "don't file" — filing stays optional.
     const inlineName = newBinderName.trim()
-    if (!hasBinders && inlineName) {
+    const creatingNew = target === 'new' || !hasBinders
+    if (creatingNew && inlineName) {
       const cap = newBinderCapacity.trim() ? Number(newBinderCapacity.trim()) : null
       const created = await createBinder(inlineName, {
         binder_color: newBinderColor,
@@ -68,7 +79,7 @@ export function useBinderFiling(): BinderFiling {
       })
       return created.id
     }
-    return binderId
+    return null
   }
 
   return {
@@ -76,8 +87,8 @@ export function useBinderFiling(): BinderFiling {
     hasBinders,
     binders,
     usedByBinder,
-    binderId,
-    setBinderId,
+    target,
+    setTarget,
     newBinderName,
     setNewBinderName,
     newBinderColor,

--- a/web/src/components/useBinderFiling.ts
+++ b/web/src/components/useBinderFiling.ts
@@ -1,0 +1,89 @@
+/**
+ * useBinderFiling — shared state for the "file this list into a binder" control
+ * (#726), used by both the collection and smart-binder create flows.
+ *
+ * Owns the picker state and the binder/collection data hooks, and exposes
+ * `resolveTarget()`, which creates the inline binder when one was named and
+ * returns the binder id to file into (or null for "don't file"). The presentational
+ * control lives in [BinderFilePicker](./BinderFilePicker.tsx).
+ */
+import { useMemo, useState } from 'react'
+import type { BinderSummary } from '../api/client'
+import { useBinders } from './useBinders'
+import { useCollections } from './useCollections'
+
+export interface BinderFiling {
+  settled: boolean
+  hasBinders: boolean
+  binders: BinderSummary[]
+  usedByBinder: Map<number, number>
+  binderId: number | null
+  setBinderId: (id: number | null) => void
+  newBinderName: string
+  setNewBinderName: (v: string) => void
+  newBinderColor: string | null
+  setNewBinderColor: (v: string | null) => void
+  newBinderCapacity: string
+  setNewBinderCapacity: (v: string) => void
+  /** Resolve the binder to file into, creating an inline binder if one was
+   *  named. Returns its id, or null for "don't file". */
+  resolveTarget: () => Promise<number | null>
+  /** Refresh binder slot counts after a list was filed. */
+  refresh: () => Promise<void>
+}
+
+export function useBinderFiling(): BinderFiling {
+  const { collections } = useCollections()
+  const { binders, loading, create: createBinder, refresh } = useBinders()
+
+  const [binderId, setBinderId] = useState<number | null>(null)
+  const [newBinderName, setNewBinderName] = useState('')
+  const [newBinderColor, setNewBinderColor] = useState<string | null>(null)
+  const [newBinderCapacity, setNewBinderCapacity] = useState('')
+
+  // Until the binder list resolves, neither branch is safe to show: an empty
+  // list mid-fetch would falsely read as "no binders yet" (#724 review).
+  const settled = !loading
+  const hasBinders = binders.length > 0
+
+  // Cards already filed into each binder — the sum of its collections' pocket
+  // counts (vendor multiples via total_quantity, falling back to row count).
+  const usedByBinder = useMemo(() => {
+    const map = new Map<number, number>()
+    for (const c of collections) {
+      if (c.binder_id == null) continue
+      map.set(c.binder_id, (map.get(c.binder_id) ?? 0) + (c.total_quantity ?? c.item_count))
+    }
+    return map
+  }, [collections])
+
+  async function resolveTarget(): Promise<number | null> {
+    const inlineName = newBinderName.trim()
+    if (!hasBinders && inlineName) {
+      const cap = newBinderCapacity.trim() ? Number(newBinderCapacity.trim()) : null
+      const created = await createBinder(inlineName, {
+        binder_color: newBinderColor,
+        capacity: cap && cap > 0 ? cap : null,
+      })
+      return created.id
+    }
+    return binderId
+  }
+
+  return {
+    settled,
+    hasBinders,
+    binders,
+    usedByBinder,
+    binderId,
+    setBinderId,
+    newBinderName,
+    setNewBinderName,
+    newBinderColor,
+    setNewBinderColor,
+    newBinderCapacity,
+    setNewBinderCapacity,
+    resolveTarget,
+    refresh,
+  }
+}

--- a/web/src/components/useBinderFiling.ts
+++ b/web/src/components/useBinderFiling.ts
@@ -34,16 +34,17 @@ export interface BinderFiling {
 
 export function useBinderFiling(): BinderFiling {
   const { collections } = useCollections()
-  const { binders, loading, create: createBinder, refresh } = useBinders()
+  const { binders, fetched, create: createBinder, refresh } = useBinders()
 
   const [binderId, setBinderId] = useState<number | null>(null)
   const [newBinderName, setNewBinderName] = useState('')
   const [newBinderColor, setNewBinderColor] = useState<string | null>(null)
   const [newBinderCapacity, setNewBinderCapacity] = useState('')
 
-  // Until the binder list resolves, neither branch is safe to show: an empty
-  // list mid-fetch would falsely read as "no binders yet" (#724 review).
-  const settled = !loading
+  // Gate on the first fetch completing, not on `!loading`: the list starts
+  // empty with loading=false, so an un-fetched state would otherwise read as
+  // "no binders yet" and let the create submit before binders load (#775).
+  const settled = fetched
   const hasBinders = binders.length > 0
 
   // Cards already filed into each binder — the sum of its collections' pocket

--- a/web/src/components/useBinders.ts
+++ b/web/src/components/useBinders.ts
@@ -20,10 +20,15 @@ interface State {
   binders: BinderSummary[]
   loading: boolean
   error: string | null
+  /** True once the first fetch has resolved (success or error). Distinguishes
+   *  "no binders yet" from "haven't loaded yet" — the list starts empty with
+   *  `loading: false`, so callers that gate on load must check this, not
+   *  `!loading` (#775 review). */
+  fetched: boolean
 }
 
 const listeners = new Set<(s: State) => void>()
-let state: State = { binders: [], loading: false, error: null }
+let state: State = { binders: [], loading: false, error: null, fetched: false }
 let inflight: Promise<void> | null = null
 
 function set(next: Partial<State>) {
@@ -37,9 +42,9 @@ async function refresh(): Promise<void> {
   inflight = (async () => {
     try {
       const binders = await fetchBinders()
-      set({ binders, loading: false })
+      set({ binders, loading: false, fetched: true })
     } catch (e) {
-      set({ loading: false, error: e instanceof Error ? e.message : String(e) })
+      set({ loading: false, error: e instanceof Error ? e.message : String(e), fetched: true })
     } finally {
       inflight = null
     }
@@ -113,7 +118,7 @@ export function useBinders() {
 
 // Test-only: reset the module-level cache between vitest runs.
 export function _resetBindersCacheForTests() {
-  state = { binders: [], loading: false, error: null }
+  state = { binders: [], loading: false, error: null, fetched: false }
   inflight = null
   listeners.clear()
 }


### PR DESCRIPTION
Closes #726

## What

Finishes the binder-filing UX cleanup (#726):

- **Renames "smart binder" → "smart collection"** across every user-facing surface — the New ▾ menus (Binders tab + Browse) and the binder modal's type selector and title. A dynamic collection is a saved rule, not a physical binder, so the old name read as a contradiction. Internal identifiers (`BinderModal`, `smartOnly`, `kind='dynamic'`) are unchanged.
- **Shares the binder-filing picker** with the smart-collection create flow (the original #726 work): `CollectionCreateDialog`'s filing UI was extracted into a `useBinderFiling` hook + `BinderFilePicker` component, now used by both create flows.
- **Adds a "New binder" filing option even when binders already exist.** Previously the picker only let you create a binder inline in the no-binders empty state; once you had any binder, the choices were "pick an existing one" or "don't file". The radio list now carries a "New binder" option that reveals the same inline create form. `useBinderFiling`'s target became `number | 'new' | null`, and `resolveTarget` creates the inline binder whenever the new-binder path is chosen and named (filing stays optional).

## Out of scope (tracked separately)

- **Want-lists filing into binders** needs a `wishlists.binder_id` migration — that's #774.
- **Master-set extraction / applying it across formats.** While finishing this I confirmed `is_master_set` is a pure label today: nothing reads it to change membership, counts, or expand variants, and it only exists on binder + dynamic collections. Captured the rework as #776 rather than surfacing an inert checkbox in more places.

## How to verify

- `cd web && npm run build`, `npm run lint`, and the full vitest suite (555 tests) are green, including new coverage for filing into a freshly-created binder when binders already exist.
- Manually: Binders tab → New ▾ now reads "Smart collection". Open any create flow with at least one binder → the filing picker shows your binders plus a "New binder" option that reveals the inline create form.

No backend changes.
