### PR TITLE
feat(web): let want-lists file into binders

### DIFF
--- a/api/db/models.py
+++ b/api/db/models.py
@@ -262,6 +262,12 @@ class Binder(Base):
         back_populates="binder",
         order_by="Collection.created_at",
     )
+    #: Want-lists filed into this binder (#774). A binder organizes both owned
+    #: (collections) and chasing (want-lists); deleting it detaches both.
+    wishlists: Mapped[list[Wishlist]] = relationship(
+        back_populates="binder",
+        order_by="Wishlist.created_at",
+    )
 
 
 class Collection(Base):
@@ -437,6 +443,14 @@ class Wishlist(Base):
     is_default: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default=false()
     )
+    # ---- #774: parent physical binder ----
+    #: The :class:`Binder` this want-list is filed in, or null for a loose
+    #: want-list not in any binder. Mirrors ``Collection.binder_id`` (#702):
+    #: deleting a binder detaches (``SET NULL``) its want-lists, not removes them.
+    binder_id: Mapped[int | None] = mapped_column(
+        ForeignKey("binders.id", ondelete="SET NULL"), nullable=True
+    )
+    binder: Mapped[Binder | None] = relationship(back_populates="wishlists")
 
     items: Mapped[list[WishlistItem]] = relationship(
         back_populates="wishlist",

--- a/api/migrations/versions/b8e2c1f5a3d7_wishlist_binder_id.py
+++ b/api/migrations/versions/b8e2c1f5a3d7_wishlist_binder_id.py
@@ -1,0 +1,45 @@
+"""want-lists file into binders — wishlists.binder_id
+
+Split-out half of #726 (tracked as #774): the smart-collection filing shipped
+in #726/#775; this makes the third logical list — the want-list — binder-aware
+too, so a binder can organize both owned (collections) and chasing (want-lists).
+
+Mirrors ``collections.binder_id`` from #702 (a7d3f1e0c2b5): a new nullable
+``wishlists.binder_id`` FK to ``binders``, ``ON DELETE SET NULL`` so deleting a
+binder detaches its want-lists rather than cascading them away. Existing rows
+stay null (loose, in no binder).
+
+Revision ID: b8e2c1f5a3d7
+Revises: f1a4d7c9e2b6
+Create Date: 2026-06-23
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b8e2c1f5a3d7"
+down_revision: str | Sequence[str] | None = "f1a4d7c9e2b6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("wishlists") as batch:
+        batch.add_column(sa.Column("binder_id", sa.Integer(), nullable=True))
+        batch.create_foreign_key(
+            "fk_wishlists_binder_id",
+            "binders",
+            ["binder_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("wishlists") as batch:
+        batch.drop_constraint("fk_wishlists_binder_id", type_="foreignkey")
+        batch.drop_column("binder_id")

--- a/api/routes/binders.py
+++ b/api/routes/binders.py
@@ -2,12 +2,14 @@
 
 A binder is inventory-level: a real binder you own, carrying its physical
 identity (``binder_format`` / ``binder_color`` / ``binder_type`` /
-``capacity``), that holds zero or more collections via
-``Collection.binder_id``. You can own an empty binder (one with no
-collections filed in it yet) and fill it later.
+``capacity``), that holds zero or more collections via ``Collection.binder_id``
+and zero or more want-lists via ``Wishlist.binder_id`` (#774) — both owned
+cards and chase targets. You can own an empty binder (one with nothing filed
+in it yet) and fill it later.
 
-Deleting a binder detaches its collections (the FK is ``ON DELETE SET NULL``)
-rather than removing them — the cards live on the collections, not the binder.
+Deleting a binder detaches its collections and want-lists (the FK is
+``ON DELETE SET NULL``) rather than removing them — the cards/items live on
+those, not the binder.
 """
 
 from __future__ import annotations
@@ -28,6 +30,7 @@ from ..db.models import (
     Binder,
     CollectionItem,
     User,
+    WishlistItem,
 )
 from ..db.session import get_db
 
@@ -55,6 +58,14 @@ class BinderCollectionOut(BaseModel):
     total_quantity: int
 
 
+class BinderWishlistOut(BaseModel):
+    """A want-list filed in a binder, with its item count (#774)."""
+
+    id: int
+    name: str
+    item_count: int
+
+
 class BinderSummaryOut(BaseModel):
     """Lightweight binder record for the inventory list view."""
 
@@ -66,13 +77,17 @@ class BinderSummaryOut(BaseModel):
     binder_type: str | None
     capacity: int | None
     collection_count: int
-    #: ``True`` when no collections are filed in this binder yet — the "own a
-    #: binder before you fill it" case the inventory view surfaces.
+    #: Want-lists filed into this binder (#774). A binder organizes both owned
+    #: (collections) and chasing (want-lists) now.
+    wishlist_count: int
+    #: ``True`` when nothing — no collections *and* no want-lists — is filed in
+    #: this binder yet, the "own a binder before you fill it" case (#774).
     is_empty: bool
 
 
 class BinderOut(BinderSummaryOut):
     collections: list[BinderCollectionOut]
+    wishlists: list[BinderWishlistOut]
 
 
 class BinderCreate(BaseModel):
@@ -131,7 +146,7 @@ def _load_binder(db: Session, binder_id: int, user_id: int) -> Binder:
     binder = db.scalar(
         select(Binder)
         .where(Binder.id == binder_id, Binder.user_id == user_id)
-        .options(selectinload(Binder.collections))
+        .options(selectinload(Binder.collections), selectinload(Binder.wishlists))
     )
     if binder is None:
         raise HTTPException(status_code=404, detail=f"binder {binder_id} not found")
@@ -154,8 +169,21 @@ def _fill_counts(db: Session, collection_ids: list[int]) -> dict[int, tuple[int,
     return {cid: (int(count), int(qty)) for cid, count, qty in rows}
 
 
-def _serialize(db: Session, binder: Binder, *, include_collections: bool) -> dict[str, Any]:
+def _wishlist_counts(db: Session, wishlist_ids: list[int]) -> dict[int, int]:
+    """Per-want-list item count for the given ids (#774)."""
+    if not wishlist_ids:
+        return {}
+    rows = db.execute(
+        select(WishlistItem.wishlist_id, func.count(WishlistItem.id))
+        .where(WishlistItem.wishlist_id.in_(wishlist_ids))
+        .group_by(WishlistItem.wishlist_id)
+    ).all()
+    return {wid: int(count) for wid, count in rows}
+
+
+def _serialize(db: Session, binder: Binder, *, include_contents: bool) -> dict[str, Any]:
     collections = sorted(binder.collections, key=lambda c: c.created_at)
+    wishlists = sorted(binder.wishlists, key=lambda w: w.created_at)
     base: dict[str, Any] = {
         "id": binder.id,
         "name": binder.name,
@@ -165,9 +193,10 @@ def _serialize(db: Session, binder: Binder, *, include_collections: bool) -> dic
         "binder_type": binder.binder_type,
         "capacity": binder.capacity,
         "collection_count": len(collections),
-        "is_empty": len(collections) == 0,
+        "wishlist_count": len(wishlists),
+        "is_empty": len(collections) == 0 and len(wishlists) == 0,
     }
-    if not include_collections:
+    if not include_contents:
         return base
     counts = _fill_counts(db, [c.id for c in collections])
     base["collections"] = [
@@ -178,6 +207,10 @@ def _serialize(db: Session, binder: Binder, *, include_collections: bool) -> dic
             "total_quantity": counts.get(c.id, (0, 0))[1],
         }
         for c in collections
+    ]
+    wcounts = _wishlist_counts(db, [w.id for w in wishlists])
+    base["wishlists"] = [
+        {"id": w.id, "name": w.name, "item_count": wcounts.get(w.id, 0)} for w in wishlists
     ]
     return base
 
@@ -192,10 +225,10 @@ def list_binders(db: DbSession, current_user: CurrentUser) -> dict:
     binders = db.scalars(
         select(Binder)
         .where(Binder.user_id == current_user.id)
-        .options(selectinload(Binder.collections))
+        .options(selectinload(Binder.collections), selectinload(Binder.wishlists))
         .order_by(Binder.created_at)
     ).all()
-    return {"binders": [_serialize(db, b, include_collections=False) for b in binders]}
+    return {"binders": [_serialize(db, b, include_contents=False) for b in binders]}
 
 
 @router.post("/binders", status_code=201)
@@ -212,13 +245,13 @@ def create_binder(req: BinderCreate, db: DbSession, current_user: CurrentUser) -
     db.add(binder)
     db.commit()
     db.refresh(binder)
-    return _serialize(db, binder, include_collections=True)
+    return _serialize(db, binder, include_contents=True)
 
 
 @router.get("/binders/{binder_id}")
 def get_binder(binder_id: int, db: DbSession, current_user: CurrentUser) -> dict:
     binder = _load_binder(db, binder_id, current_user.id)
-    return _serialize(db, binder, include_collections=True)
+    return _serialize(db, binder, include_contents=True)
 
 
 @router.patch("/binders/{binder_id}")
@@ -242,16 +275,18 @@ def patch_binder(
             setattr(binder, key, fields[key])
     db.commit()
     db.refresh(binder)
-    return _serialize(db, binder, include_collections=True)
+    return _serialize(db, binder, include_contents=True)
 
 
 @router.delete("/binders/{binder_id}", status_code=204)
 def delete_binder(binder_id: int, db: DbSession, current_user: CurrentUser) -> None:
     binder = _load_binder(db, binder_id, current_user.id)
-    # Detach filed collections (the cards live on them, not the binder) before
-    # the row goes — explicit so the ORM identity map agrees with the FK's
-    # ON DELETE SET NULL, regardless of backend.
+    # Detach filed collections and want-lists (the cards/items live on them,
+    # not the binder) before the row goes — explicit so the ORM identity map
+    # agrees with the FK's ON DELETE SET NULL, regardless of backend (#774).
     for collection in binder.collections:
         collection.binder_id = None
+    for wishlist in binder.wishlists:
+        wishlist.binder_id = None
     db.delete(binder)
     db.commit()

--- a/api/routes/wishlists.py
+++ b/api/routes/wishlists.py
@@ -42,7 +42,7 @@ from ..db.models import (
     WishlistItem,
 )
 from ..db.session import get_db
-from .collections import serialize_collection_item
+from .collections import _require_owned_binder, serialize_collection_item
 
 router = APIRouter()
 
@@ -63,6 +63,8 @@ class WishlistSummaryOut(BaseModel):
     description: str | None
     created_at: str
     item_count: int
+    #: The binder this want-list is filed into, or null when loose (#774).
+    binder_id: int | None
 
 
 class WishlistItemOut(BaseModel):
@@ -91,17 +93,25 @@ class WishlistOut(BaseModel):
     name: str
     description: str | None
     created_at: str
+    #: The binder this want-list is filed into, or null when loose (#774).
+    binder_id: int | None
     items: list[WishlistItemOut]
 
 
 class WishlistCreate(BaseModel):
     name: str = Field(min_length=1, max_length=200)
     description: str | None = None
+    #: File the new want-list into a binder on create (#774). Null leaves it
+    #: loose; an unowned id is a 404 (see :func:`_require_owned_binder`).
+    binder_id: int | None = None
 
 
 class WishlistPatch(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=200)
     description: str | None = None
+    #: Re-file (or, with null, unfile) the want-list (#774). Only applied when
+    #: the key is present, so omitting it leaves the current binder untouched.
+    binder_id: int | None = None
 
 
 class WishlistItemCreate(BaseModel):
@@ -182,6 +192,7 @@ def list_wishlists(db: DbSession, current_user: CurrentUser) -> dict:
             description=w.description,
             created_at=w.created_at.isoformat(),
             item_count=int(item_count),
+            binder_id=w.binder_id,
         )
         for w, item_count in db.execute(stmt).all()
     ]
@@ -190,10 +201,12 @@ def list_wishlists(db: DbSession, current_user: CurrentUser) -> dict:
 
 @router.post("/wishlists", status_code=201)
 def create_wishlist(req: WishlistCreate, db: DbSession, current_user: CurrentUser) -> dict:
+    _require_owned_binder(db, req.binder_id, current_user.id)
     wishlist = Wishlist(
         user_id=current_user.id,
         name=req.name.strip(),
         description=req.description,
+        binder_id=req.binder_id,
     )
     db.add(wishlist)
     db.commit()
@@ -222,6 +235,11 @@ def patch_wishlist(
     # from "explicitly null" since Pydantic collapses both to None.
     if "description" in req.model_fields_set:
         wishlist.description = req.description
+    # File / re-file / unfile only when the caller sends the key (#774);
+    # passing `null` detaches, mirroring the collections patch path.
+    if "binder_id" in req.model_fields_set:
+        _require_owned_binder(db, req.binder_id, current_user.id)
+        wishlist.binder_id = req.binder_id
     db.commit()
     db.refresh(wishlist)
     return _serialize_wishlist(wishlist)
@@ -424,6 +442,7 @@ def _serialize_wishlist(wishlist: Wishlist) -> dict:
         name=wishlist.name,
         description=wishlist.description,
         created_at=wishlist.created_at.isoformat(),
+        binder_id=wishlist.binder_id,
         items=[_item_out(i) for i in wishlist.items],
     ).model_dump()
 

--- a/tests/test_binders_api.py
+++ b/tests/test_binders_api.py
@@ -165,6 +165,28 @@ class BindersEndpointTests(_IsolatedDbMixin):
             still = c.get(f"/api/v1/collections/{cid}")
             self.assertEqual(still.status_code, 200)
 
+    def test_filing_a_wishlist_flips_is_empty_and_delete_detaches(self) -> None:
+        # A binder now organizes want-lists too (#774): filing one makes the
+        # binder non-empty and lists it in contents; deleting detaches it.
+        with self._client() as c:
+            bid = c.post("/api/v1/binders", json={"name": "Chase binder"}).json()["id"]
+            wid = c.post(
+                "/api/v1/wishlists",
+                json={"name": "Charizard hunt", "binder_id": bid},
+            ).json()["id"]
+
+            detail = c.get(f"/api/v1/binders/{bid}").json()
+            self.assertFalse(detail["is_empty"])
+            self.assertEqual(detail["collection_count"], 0)
+            self.assertEqual(detail["wishlist_count"], 1)
+            self.assertEqual(detail["wishlists"][0]["name"], "Charizard hunt")
+
+            self.assertEqual(c.delete(f"/api/v1/binders/{bid}").status_code, 204)
+            # The want-list survives the binder, now unfiled.
+            survived = c.get(f"/api/v1/wishlists/{wid}")
+            self.assertEqual(survived.status_code, 200)
+            self.assertIsNone(survived.json()["binder_id"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_wishlists.py
+++ b/tests/test_wishlists.py
@@ -183,6 +183,47 @@ class WishlistsEndpointTests(_IsolatedDbMixin):
                     None,
                 )
 
+    # ---- #774: filing want-lists into binders ----------------------------
+
+    def test_create_files_into_binder(self) -> None:
+        with self._client() as c:
+            bid = c.post("/api/v1/binders", json={"name": "Show binder"}).json()["id"]
+            created = c.post(
+                "/api/v1/wishlists",
+                json={"name": "Chase", "binder_id": bid},
+            )
+            self.assertEqual(created.status_code, 201)
+            self.assertEqual(created.json()["binder_id"], bid)
+            # The summary list carries binder_id too, so the SPA can group it.
+            self.assertEqual(c.get("/api/v1/wishlists").json()["items"][0]["binder_id"], bid)
+
+    def test_create_rejects_unowned_binder(self) -> None:
+        with self._client() as c:
+            resp = c.post("/api/v1/wishlists", json={"name": "Chase", "binder_id": 9999})
+            self.assertEqual(resp.status_code, 404)
+
+    def test_patch_refiles_and_unfiles(self) -> None:
+        with self._client() as c:
+            b1 = c.post("/api/v1/binders", json={"name": "B1"}).json()["id"]
+            b2 = c.post("/api/v1/binders", json={"name": "B2"}).json()["id"]
+            wid = c.post("/api/v1/wishlists", json={"name": "Chase", "binder_id": b1}).json()["id"]
+
+            refiled = c.patch(f"/api/v1/wishlists/{wid}", json={"binder_id": b2})
+            self.assertEqual(refiled.json()["binder_id"], b2)
+
+            unfiled = c.patch(f"/api/v1/wishlists/{wid}", json={"binder_id": None})
+            self.assertIsNone(unfiled.json()["binder_id"])
+
+            # Omitting binder_id leaves the current value untouched.
+            renamed = c.patch(f"/api/v1/wishlists/{wid}", json={"name": "Renamed"})
+            self.assertIsNone(renamed.json()["binder_id"])
+
+    def test_patch_rejects_unowned_binder(self) -> None:
+        with self._client() as c:
+            wid = c.post("/api/v1/wishlists", json={"name": "Chase"}).json()["id"]
+            resp = c.patch(f"/api/v1/wishlists/{wid}", json={"binder_id": 9999})
+            self.assertEqual(resp.status_code, 404)
+
     def test_add_card_persists_max_price(self) -> None:
         with self._client() as c:
             wid = c.post("/api/v1/wishlists", json={"name": "Charizard hunt"}).json()["id"]

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -866,6 +866,13 @@ export interface BinderCollection {
   total_quantity: number
 }
 
+// A want-list filed into a binder (#774).
+export interface BinderWishlist {
+  id: number
+  name: string
+  item_count: number
+}
+
 export interface BinderSummary {
   id: number
   name: string
@@ -875,11 +882,14 @@ export interface BinderSummary {
   binder_type: BinderType | null
   capacity: number | null
   collection_count: number
+  // Want-lists filed into this binder (#774).
+  wishlist_count: number
   is_empty: boolean
 }
 
 export interface Binder extends BinderSummary {
   collections: BinderCollection[]
+  wishlists: BinderWishlist[]
 }
 
 export interface BinderInput {
@@ -1135,6 +1145,8 @@ export interface WishlistSummary {
   description: string | null
   created_at: string
   item_count: number
+  // The binder this want-list is filed into, or null when loose (#774).
+  binder_id: number | null
 }
 
 export interface WishlistItem {
@@ -1163,6 +1175,8 @@ export interface Wishlist {
   name: string
   description: string | null
   created_at: string
+  // The binder this want-list is filed into, or null when loose (#774).
+  binder_id: number | null
   items: WishlistItem[]
 }
 
@@ -1211,16 +1225,50 @@ export async function promoteWishlistItem(
   return (await res.json()) as PromoteResult
 }
 
+export interface CreateWishlistOptions {
+  description?: string | null
+  // #774 — file the new want-list into this binder (binders.id).
+  binder_id?: number | null
+}
+
 export async function createWishlist(
   name: string,
-  description?: string | null,
+  options?: CreateWishlistOptions,
 ): Promise<Wishlist> {
   const res = await fetch(`${BASE}/wishlists`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name, description: description ?? null }),
+    body: JSON.stringify({
+      name,
+      description: options?.description ?? null,
+      binder_id: options?.binder_id ?? null,
+    }),
   })
   if (!res.ok) throw new Error(`create wishlist failed: ${res.status}`)
+  return (await res.json()) as Wishlist
+}
+
+/**
+ * PATCH a want-list. Only the keys present are sent, so a filing-only edit
+ * (`binder_id`) leaves name/description intact — the server reads
+ * `model_fields_set`. Pass `binder_id: null` to unfile (#774).
+ */
+export interface UpdateWishlistOptions {
+  name?: string
+  description?: string | null
+  binder_id?: number | null
+}
+
+export async function updateWishlist(
+  wishlistId: number,
+  patch: UpdateWishlistOptions,
+): Promise<Wishlist> {
+  const res = await fetch(`${BASE}/wishlists/${wishlistId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(patch),
+  })
+  if (!res.ok) throw new Error(`update wishlist failed: ${res.status}`)
   return (await res.json()) as Wishlist
 }
 

--- a/web/src/components/AddToWishlistButton.test.tsx
+++ b/web/src/components/AddToWishlistButton.test.tsx
@@ -61,6 +61,7 @@ describe('AddToWishlistButton', () => {
         description: null,
         created_at: '2026-06-06T00:00:00',
         item_count: 0,
+        binder_id: null,
       },
     ])
     mockAdd.mockResolvedValue({
@@ -90,6 +91,7 @@ describe('AddToWishlistButton', () => {
       name: 'Under $50',
       description: null,
       created_at: '2026-06-06T00:00:00',
+      binder_id: null,
       items: [],
     })
     mockAdd.mockResolvedValue({
@@ -133,6 +135,7 @@ describe('AddToWishlistButton', () => {
       name: 'No cap',
       description: null,
       created_at: '2026-06-06T00:00:00',
+      binder_id: null,
       items: [],
     })
     mockAdd.mockResolvedValue({
@@ -169,6 +172,7 @@ describe('AddToWishlistButton', () => {
         description: null,
         created_at: '2026-06-06T00:00:00',
         item_count: 0,
+        binder_id: null,
       },
     ])
     mockAdd.mockRejectedValue(new Error('boom'))

--- a/web/src/components/BinderInventory.test.tsx
+++ b/web/src/components/BinderInventory.test.tsx
@@ -3,12 +3,14 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { BinderInventory } from './BinderInventory'
 import { _resetBindersCacheForTests } from './useBinders'
 import { _resetCollectionsCacheForTests } from './useCollections'
+import { _resetWishlistsCacheForTests } from './useWishlists'
 import {
   fetchBinders,
   createBinder,
   deleteBinder,
   fetchCollections,
   createCollection,
+  fetchWishlists,
 } from '../api/client'
 
 vi.mock('../api/client', () => ({
@@ -21,6 +23,13 @@ vi.mock('../api/client', () => ({
   updateCollection: vi.fn(),
   deleteCollection: vi.fn(),
   addCardToCollection: vi.fn(),
+  // useWishlists is pulled in via BinderInventory's want-list listing (#774).
+  fetchWishlists: vi.fn(),
+  createWishlist: vi.fn(),
+  updateWishlist: vi.fn(),
+  deleteWishlist: vi.fn(),
+  addCardToWishlist: vi.fn(),
+  bulkAddToWishlist: vi.fn(),
 }))
 
 const mockFetch = vi.mocked(fetchBinders)
@@ -28,6 +37,7 @@ const mockCreate = vi.mocked(createBinder)
 const mockDelete = vi.mocked(deleteBinder)
 const mockCollections = vi.mocked(fetchCollections)
 const mockCreateCollection = vi.mocked(createCollection)
+const mockWishlists = vi.mocked(fetchWishlists)
 
 /** A filed collection summary (only the fields BinderInventory reads). */
 function filed(id: number, name: string, binderId: number) {
@@ -61,12 +71,15 @@ describe('BinderInventory', () => {
   beforeEach(() => {
     _resetBindersCacheForTests()
     _resetCollectionsCacheForTests()
+    _resetWishlistsCacheForTests()
     mockFetch.mockReset()
     mockCreate.mockReset()
     mockDelete.mockReset()
     mockCollections.mockReset()
     mockCollections.mockResolvedValue([])
     mockCreateCollection.mockReset()
+    mockWishlists.mockReset()
+    mockWishlists.mockResolvedValue([])
   })
 
   it('shows the empty state when there are no binders', async () => {
@@ -103,6 +116,20 @@ describe('BinderInventory', () => {
     expect(await screen.findByText(/2 collections/i)).toBeInTheDocument()
     expect(screen.getByText('Base holos')).toBeInTheDocument()
     expect(screen.getByText('Trainers')).toBeInTheDocument()
+  })
+
+  it('lists a filed want-list alongside collections (#774)', async () => {
+    mockFetch.mockResolvedValue([
+      binder({ id: 1, is_empty: false, collection_count: 1, capacity: null, binder_format: null }),
+    ] as never)
+    mockCollections.mockResolvedValue([filed(10, 'Base holos', 1)] as never)
+    mockWishlists.mockResolvedValue([
+      { id: 20, name: 'Mew hunt', description: null, created_at: '2026-06-06T00:00:00', item_count: 3, binder_id: 1 },
+    ])
+    render(<BinderInventory />)
+    // The summary line counts both kinds, and the want-list shows in contents.
+    expect(await screen.findByText(/1 collection · 1 want-list/i)).toBeInTheDocument()
+    expect(screen.getByText('Mew hunt')).toBeInTheDocument()
   })
 
   it('files a new collection straight into a binder', async () => {

--- a/web/src/components/BinderInventory.tsx
+++ b/web/src/components/BinderInventory.tsx
@@ -12,16 +12,34 @@
  */
 import { Check, FolderPlus, Library, Loader2, Plus, Trash2, X } from 'lucide-react'
 import { useMemo, useState } from 'react'
-import type { BinderFormat, BinderSummary, BinderType, CollectionSummary } from '../api/client'
+import type {
+  BinderFormat,
+  BinderSummary,
+  BinderType,
+  CollectionSummary,
+  WishlistSummary,
+} from '../api/client'
 import { BINDER_FORMAT_OPTIONS, BINDER_TYPE_OPTIONS, coverSwatch } from './binderIdentity'
 import { BinderColorPicker } from './BinderColorPicker'
 import { NameCreateDialog } from './NameCreateDialog'
 import { useBinders } from './useBinders'
 import { useCollections } from './useCollections'
+import { useWishlists } from './useWishlists'
+
+/** The "what's filed" line under a binder: collections and/or want-lists, or
+ *  "Empty" when nothing is filed yet (#774). */
+function filedSummary(collections: number, wishlists: number): string {
+  if (collections === 0 && wishlists === 0) return 'Empty'
+  const parts: string[] = []
+  if (collections > 0) parts.push(`${collections} ${collections === 1 ? 'collection' : 'collections'}`)
+  if (wishlists > 0) parts.push(`${wishlists} ${wishlists === 1 ? 'want-list' : 'want-lists'}`)
+  return parts.join(' · ')
+}
 
 export function BinderInventory() {
   const { binders, loading, error, create, remove, refresh } = useBinders()
   const { collections, create: createCollection } = useCollections()
+  const { wishlists } = useWishlists()
 
   const [creating, setCreating] = useState(false)
   const [name, setName] = useState('')
@@ -47,6 +65,19 @@ export function BinderInventory() {
     }
     return map
   }, [collections])
+
+  // Want-lists filed into each binder (#774), derived the same way — a binder
+  // organizes chase targets alongside owned cards.
+  const wishlistsByBinder = useMemo(() => {
+    const map = new Map<number, WishlistSummary[]>()
+    for (const w of wishlists) {
+      if (w.binder_id == null) continue
+      const list = map.get(w.binder_id)
+      if (list) list.push(w)
+      else map.set(w.binder_id, [w])
+    }
+    return map
+  }, [wishlists])
 
   function resetForm() {
     setName('')
@@ -203,6 +234,7 @@ export function BinderInventory() {
           {binders.map((b) => {
             const swatch = coverSwatch(b.binder_color)
             const filed = collectionsByBinder.get(b.id) ?? []
+            const filedWishlists = wishlistsByBinder.get(b.id) ?? []
             const storageType = BINDER_TYPE_OPTIONS.find((o) => o.value === b.binder_type)?.label
             return (
               <li
@@ -218,9 +250,7 @@ export function BinderInventory() {
                   <div className="min-w-0 flex-1">
                     <p className="truncate text-sm text-coconut-700 dark:text-sand-50">{b.name}</p>
                     <p className="text-[11px] text-coconut-400 dark:text-sand-300">
-                      {filed.length === 0
-                        ? 'Empty'
-                        : `${filed.length} ${filed.length === 1 ? 'collection' : 'collections'}`}
+                      {filedSummary(filed.length, filedWishlists.length)}
                       {storageType ? ` · ${storageType}` : ''}
                       {b.binder_format ? ` · ${b.binder_format}` : ''}
                       {b.capacity ? ` · ${b.capacity} slots` : ''}
@@ -265,17 +295,29 @@ export function BinderInventory() {
                     </button>
                   )}
                 </div>
-                {filed.length > 0 && (
+                {(filed.length > 0 || filedWishlists.length > 0) && (
                   <ul className="ml-7 mt-1 space-y-0.5">
                     {filed.map((c) => (
                       <li
-                        key={c.id}
+                        key={`c-${c.id}`}
                         className="truncate text-[11px] text-coconut-500 dark:text-sand-300"
                       >
                         {c.name}
                         <span className="text-coconut-400 dark:text-sand-400">
                           {' '}
                           · {c.item_count} {c.item_count === 1 ? 'card' : 'cards'}
+                        </span>
+                      </li>
+                    ))}
+                    {filedWishlists.map((w) => (
+                      <li
+                        key={`w-${w.id}`}
+                        className="truncate text-[11px] text-coconut-500 dark:text-sand-300"
+                      >
+                        {w.name}
+                        <span className="text-coconut-400 dark:text-sand-400">
+                          {' '}
+                          · want-list · {w.item_count} {w.item_count === 1 ? 'card' : 'cards'}
                         </span>
                       </li>
                     ))}

--- a/web/src/components/BinderModal.test.tsx
+++ b/web/src/components/BinderModal.test.tsx
@@ -39,6 +39,7 @@ function binder(over: Partial<BinderSummary> = {}): BinderSummary {
     binder_type: null,
     capacity: 360,
     collection_count: 0,
+    wishlist_count: 0,
     is_empty: true,
     ...over,
   }

--- a/web/src/components/BrowsePanel.test.tsx
+++ b/web/src/components/BrowsePanel.test.tsx
@@ -367,7 +367,7 @@ describe('BrowsePanel — pokedex view (#577)', () => {
 
     // The want-list dialog opens pre-seeded with the set's name; create it.
     const dialog = await screen.findByRole('dialog')
-    const name = within(dialog).getByPlaceholderText<HTMLInputElement>(/chasing/i).value
+    const name = within(dialog).getByPlaceholderText<HTMLInputElement>(/chase cards/i).value
     expect(name.length).toBeGreaterThan(0)
     fireEvent.click(within(dialog).getByRole('button', { name: /^create$/i }))
 

--- a/web/src/components/BrowsePanel.tsx
+++ b/web/src/components/BrowsePanel.tsx
@@ -25,14 +25,13 @@ import { pokemonSpriteUrl, setLogoUrl } from '../api/client'
 import { BAKED_POKEDEX } from '../data/pokedex'
 import { useAuth } from '../hooks/useAuth'
 import { useFavoritePokemon } from './useFavoritePokemon'
-import { useWishlists } from './useWishlists'
 import type { CardData, PokedexCard, PokedexEntry, Row, SetCard, SetInfo } from '../types'
 import { BinderModal } from './BinderModal'
 import { browseCardToPayload, browseCardToRow, type BrowseSetContext } from './browseCard'
 import { CATEGORY_LABELS, CATEGORY_ORDER } from './cardCategories'
 import { CardDetailModal } from './CardDetailModal'
 import { CollectionCreateDialog } from './CollectionCreateDialog'
-import { NameCreateDialog } from './NameCreateDialog'
+import { WishlistCreateDialog } from './WishlistCreateDialog'
 import { useCardOwnership } from './useCardOwnership'
 import { OwnershipBadge } from './OwnershipBadge'
 import { SaveCardActions } from './SaveCardActions'
@@ -136,9 +135,8 @@ export function BrowsePanel({ controller }: BrowsePanelProps) {
   // Create-from-Browse flow (#737): the New ▾ menu opens one of the three
   // canonical create dialogs (owned Collection / chasing Want-list / Smart
   // binder), seeded from the active set or species. Non-null mounts a dialog;
-  // closing clears it. Want-list seeding goes through the hook's bulkAdd so the
-  // shared ownership cache (#576) is busted and the badges/chips refresh.
-  const { create: createWishlist, bulkAdd: bulkAddWishlist } = useWishlists()
+  // closing clears it. The collection/want-list create dialogs own their seeding
+  // (via the shared bulkAdd) so the ownership cache (#576) refreshes the badges.
   const [pendingCreate, setPendingCreate] = useState<PendingCreate | null>(null)
 
   // Collection / want-list creates snapshot the loaded cards as their seed, so
@@ -315,21 +313,13 @@ export function BrowsePanel({ controller }: BrowsePanelProps) {
         />
       )}
       {pendingCreate?.kind === 'wishlist' && (
-        <NameCreateDialog
+        <WishlistCreateDialog
           open
           onOpenChange={(o) => {
             if (!o) setPendingCreate(null)
           }}
-          title="New want-list"
-          placeholder="Cards you're chasing"
-          submitLabel="Create"
-          initialName={pendingCreate.name}
-          onSubmit={async (name) => {
-            const created = await createWishlist(name)
-            if (pendingCreate.seedCards.length > 0) {
-              await bulkAddWishlist(created.id, pendingCreate.seedCards)
-            }
-          }}
+          prefillName={pendingCreate.name}
+          seedCards={pendingCreate.seedCards}
         />
       )}
       {pendingCreate?.kind === 'smart' && (

--- a/web/src/components/CollectionCreateDialog.test.tsx
+++ b/web/src/components/CollectionCreateDialog.test.tsx
@@ -62,6 +62,7 @@ describe('CollectionCreateDialog', () => {
         binder_type: null,
         capacity: 360,
         collection_count: 1,
+        wishlist_count: 0,
         is_empty: false,
       },
     ])
@@ -102,6 +103,7 @@ describe('CollectionCreateDialog', () => {
         binder_type: null,
         capacity: 360,
         collection_count: 0,
+        wishlist_count: 0,
         is_empty: true,
       },
     ])

--- a/web/src/components/LibraryBindersTab.test.tsx
+++ b/web/src/components/LibraryBindersTab.test.tsx
@@ -17,6 +17,7 @@ import {
   fetchBinders,
   createWishlist,
   updateCollection,
+  updateWishlist,
 } from '../api/client'
 
 vi.mock('../api/client', () => ({
@@ -29,7 +30,9 @@ vi.mock('../api/client', () => ({
   downloadCollectionIdCardPdf: vi.fn(),
   fetchWishlists: vi.fn(),
   createWishlist: vi.fn(),
+  updateWishlist: vi.fn(),
   addCardToWishlist: vi.fn(),
+  bulkAddToWishlist: vi.fn(),
   deleteWishlist: vi.fn(),
   fetchWishlist: vi.fn(),
   promoteWishlistItem: vi.fn(),
@@ -53,6 +56,7 @@ const mockFetchWishlist = vi.mocked(fetchWishlist)
 const mockTarget = vi.mocked(fetchCollectionTarget)
 const mockCreateWishlist = vi.mocked(createWishlist)
 const mockUpdate = vi.mocked(updateCollection)
+const mockUpdateWishlist = vi.mocked(updateWishlist)
 
 /** Open the New ▾ menu (radix opens on keyboard) and pick a menu item. */
 async function openNewMenu(itemName: RegExp) {
@@ -86,6 +90,8 @@ describe('LibraryBindersTab', () => {
     mockPrintIdCard.mockReset()
     mockFetchWishlist.mockReset()
     mockTarget.mockReset()
+    mockCreateWishlist.mockReset()
+    mockUpdateWishlist.mockReset()
     mockCollections.mockResolvedValue([])
     mockWishlists.mockResolvedValue([])
   })
@@ -115,6 +121,7 @@ describe('LibraryBindersTab', () => {
         description: null,
         created_at: '2026-06-06T00:00:00',
         item_count: 3,
+        binder_id: null,
       },
     ])
     render(<LibraryBindersTab />)
@@ -141,7 +148,7 @@ describe('LibraryBindersTab', () => {
       { id: 1, name: 'Charizard masters', description: null, created_at: '2026-06-04T00:00:00', item_count: 4 },
     ])
     mockWishlists.mockResolvedValue([
-      { id: 2, name: 'Mew hunt', description: null, created_at: '2026-06-06T00:00:00', item_count: 3 },
+      { id: 2, name: 'Mew hunt', description: null, created_at: '2026-06-06T00:00:00', item_count: 3, binder_id: null },
     ])
     render(<LibraryBindersTab />)
     await waitFor(() => expect(screen.getByText('Mew hunt')).toBeInTheDocument())
@@ -157,7 +164,7 @@ describe('LibraryBindersTab', () => {
       { id: 1, name: 'Charizard masters', description: null, created_at: '2026-06-04T00:00:00', item_count: 4 },
     ])
     mockWishlists.mockResolvedValue([
-      { id: 2, name: 'Mew hunt', description: null, created_at: '2026-06-06T00:00:00', item_count: 3 },
+      { id: 2, name: 'Mew hunt', description: null, created_at: '2026-06-06T00:00:00', item_count: 3, binder_id: null },
     ])
     render(<LibraryBindersTab />)
     await waitFor(() => expect(screen.getByText('Charizard masters')).toBeInTheDocument())
@@ -388,6 +395,7 @@ describe('LibraryBindersTab', () => {
         description: null,
         created_at: '2026-06-06T00:00:00',
         item_count: 1,
+        binder_id: null,
       },
     ])
     mockFetchWishlist.mockResolvedValue({
@@ -395,6 +403,7 @@ describe('LibraryBindersTab', () => {
       name: 'Mew hunt',
       description: null,
       created_at: '2026-06-06T00:00:00',
+      binder_id: null,
       items: [
         {
           id: 11,
@@ -448,7 +457,7 @@ describe('LibraryBindersTab', () => {
 
   it('deletes a want-list after the inline confirm', async () => {
     mockWishlists.mockResolvedValue([
-      { id: 2, name: 'Mew hunt', description: null, created_at: '2026-06-06T00:00:00', item_count: 3 },
+      { id: 2, name: 'Mew hunt', description: null, created_at: '2026-06-06T00:00:00', item_count: 3, binder_id: null },
     ])
     mockDeleteWishlist.mockResolvedValue(undefined)
     render(<LibraryBindersTab />)
@@ -536,6 +545,7 @@ describe('LibraryBindersTab', () => {
       name: 'Chase list',
       description: null,
       created_at: '2026-06-11T00:00:00',
+      binder_id: null,
       items: [],
     })
     render(<LibraryBindersTab />)
@@ -565,7 +575,7 @@ describe('LibraryBindersTab', () => {
       { id: 1, name: 'Trade pile', description: null, created_at: '2026-06-04T00:00:00', item_count: 4, kind: 'manual', binder_id: null },
     ])
     mockBinders.mockResolvedValue([
-      { id: 3, name: 'Show binder', created_at: '2026-06-01T00:00:00', binder_format: null, binder_color: null, binder_type: null, capacity: null, collection_count: 0, is_empty: true },
+      { id: 3, name: 'Show binder', created_at: '2026-06-01T00:00:00', binder_format: null, binder_color: null, binder_type: null, capacity: null, collection_count: 0, wishlist_count: 0, is_empty: true },
     ])
     mockUpdate.mockResolvedValue({
       id: 1, name: 'Trade pile', description: null, created_at: '2026-06-04T00:00:00', items: [], kind: 'manual', binder_id: 3,
@@ -596,7 +606,7 @@ describe('LibraryBindersTab', () => {
       },
     ])
     mockBinders.mockResolvedValue([
-      { id: 3, name: 'Show binder', created_at: '2026-06-01T00:00:00', binder_format: null, binder_color: null, binder_type: null, capacity: null, collection_count: 1, is_empty: false },
+      { id: 3, name: 'Show binder', created_at: '2026-06-01T00:00:00', binder_format: null, binder_color: null, binder_type: null, capacity: null, collection_count: 1, wishlist_count: 0, is_empty: false },
     ])
     mockUpdate.mockResolvedValue({
       id: 2, name: 'All Eevees', description: null, created_at: '2026-06-04T00:00:00', items: [], kind: 'dynamic', binder_id: null,
@@ -611,5 +621,52 @@ describe('LibraryBindersTab', () => {
     fireEvent.click(await screen.findByRole('menuitem', { name: /remove from binder/i }))
 
     await waitFor(() => expect(mockUpdate).toHaveBeenCalledWith(2, { binder_id: null }))
+  })
+
+  // ---- #774: want-lists file into binders --------------------------------
+
+  it('files a want-list into a binder via the row control', async () => {
+    mockWishlists.mockResolvedValue([
+      { id: 5, name: 'Mew hunt', description: null, created_at: '2026-06-06T00:00:00', item_count: 2, binder_id: null },
+    ])
+    mockBinders.mockResolvedValue([
+      { id: 3, name: 'Show binder', created_at: '2026-06-01T00:00:00', binder_format: null, binder_color: null, binder_type: null, capacity: null, collection_count: 0, wishlist_count: 0, is_empty: true },
+    ])
+    mockUpdateWishlist.mockResolvedValue({
+      id: 5, name: 'Mew hunt', description: null, created_at: '2026-06-06T00:00:00', binder_id: 3, items: [],
+    })
+    render(<LibraryBindersTab />)
+
+    const fileBtn = await screen.findByRole('button', {
+      name: /file want-list "Mew hunt" into a binder/i,
+    })
+    fileBtn.focus()
+    fireEvent.keyDown(fileBtn, { key: 'Enter' })
+    fireEvent.click(await screen.findByRole('menuitemcheckbox', { name: /show binder/i }))
+
+    await waitFor(() => expect(mockUpdateWishlist).toHaveBeenCalledWith(5, { binder_id: 3 }))
+  })
+
+  it('creates a want-list filed into a binder from the New ▾ menu', async () => {
+    mockBinders.mockResolvedValue([
+      { id: 3, name: 'Show binder', created_at: '2026-06-01T00:00:00', binder_format: null, binder_color: null, binder_type: null, capacity: 360, collection_count: 0, wishlist_count: 0, is_empty: true },
+    ])
+    mockCreateWishlist.mockResolvedValue({
+      id: 8, name: 'Chase list', description: null, created_at: '2026-06-11T00:00:00', binder_id: 3, items: [],
+    })
+    render(<LibraryBindersTab />)
+    await waitFor(() => expect(mockBinders).toHaveBeenCalled())
+
+    await openNewMenu(/want-list/i)
+    fireEvent.change(screen.getByPlaceholderText('Chase cards'), {
+      target: { value: 'Chase list' },
+    })
+    // The shared binder-file picker is offered; pick the existing binder.
+    fireEvent.click(await screen.findByRole('radio', { name: /show binder/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^create$/i }))
+
+    await waitFor(() =>
+      expect(mockCreateWishlist).toHaveBeenCalledWith('Chase list', { binder_id: 3 }),
+    )
   })
 })

--- a/web/src/components/LibraryBindersTab.tsx
+++ b/web/src/components/LibraryBindersTab.tsx
@@ -40,10 +40,10 @@ import { BinderModal } from './BinderModal'
 import { BinderInventory } from './BinderInventory'
 import { CollectionCreateDialog } from './CollectionCreateDialog'
 import { CollectionDetail } from './CollectionDetail'
-import { NameCreateDialog } from './NameCreateDialog'
 import { BINDER_TYPE_OPTIONS, coverSwatch } from './binderIdentity'
 import { CollectionInsights } from './CollectionInsights'
 import { SmartCollectionTarget } from './SmartCollectionTarget'
+import { WishlistCreateDialog } from './WishlistCreateDialog'
 import { WishlistDetail } from './WishlistDetail'
 import { useBinders } from './useBinders'
 import { useCollections } from './useCollections'
@@ -103,7 +103,7 @@ export function LibraryBindersTab() {
     error: wError,
     refresh: refreshWishlists,
     remove: removeWishlist,
-    create: createWishlist,
+    file: fileWishlistApi,
   } = useWishlists()
 
   const [filter, setFilter] = useState<BinderFilter>('all')
@@ -150,6 +150,13 @@ export function LibraryBindersTab() {
   // the binder summaries so their counts stay in sync across surfaces.
   async function fileCollection(collectionId: number, binderId: number | null) {
     await updateCollection(collectionId, { binder_id: binderId })
+    await refreshBinders()
+  }
+
+  // File a want-list into a binder (or null to unfile), then refresh the
+  // binder summaries so their fill counts stay in sync across surfaces (#774).
+  async function fileWishlist(wishlistId: number, binderId: number | null) {
+    await fileWishlistApi(wishlistId, binderId)
     await refreshBinders()
   }
 
@@ -276,8 +283,10 @@ export function LibraryBindersTab() {
               <WishlistRow
                 key={row.key}
                 wishlist={row.wishlist}
+                binders={binders}
                 onOpen={setOpenWishlist}
                 onDelete={removeWishlist}
+                onFile={fileWishlist}
               />
             ),
           )}
@@ -320,15 +329,9 @@ export function LibraryBindersTab() {
         open={createDialog === 'collection'}
         onOpenChange={(o) => !o && setCreateDialog(null)}
       />
-      <NameCreateDialog
+      <WishlistCreateDialog
         open={createDialog === 'wishlist'}
         onOpenChange={(o) => !o && setCreateDialog(null)}
-        title="New want-list"
-        placeholder="Chase cards"
-        submitLabel="Create"
-        onSubmit={async (name) => {
-          await createWishlist(name)
-        }}
       />
     </div>
   )
@@ -526,7 +529,7 @@ function CollectionRow({
           at create (#726) — can be re-filed or unfiled from the row, so it's
           never stuck on the wrong binder (#775 review). */}
       {binders.length > 0 && (
-        <FileIntoBinderControl collection={c} binders={binders} onFile={onFile} />
+        <FileIntoBinderControl item={c} noun="collection" binders={binders} onFile={onFile} />
       )}
       <PrintIdCardControl collectionId={c.id} label={`collection "${c.name}"`} />
       <DeleteBinderControl label={`collection "${c.name}"`} onDelete={() => onDelete(c.id)} />
@@ -577,12 +580,16 @@ function PrintIdCardControl({ collectionId, label }: { collectionId: number; lab
 
 function WishlistRow({
   wishlist: w,
+  binders,
   onOpen,
   onDelete,
+  onFile,
 }: {
   wishlist: WishlistSummary
+  binders: BinderSummary[]
   onOpen: (w: WishlistSummary) => void
   onDelete: (id: number) => Promise<void>
+  onFile: (wishlistId: number, binderId: number | null) => Promise<void>
 }) {
   return (
     <li className="group flex items-center gap-1">
@@ -606,25 +613,32 @@ function WishlistRow({
         </div>
         <CardCount count={w.item_count} />
       </button>
+      {/* A want-list files into a binder too (#774) — same control as a row. */}
+      {binders.length > 0 && (
+        <FileIntoBinderControl item={w} noun="want-list" binders={binders} onFile={onFile} />
+      )}
       <DeleteBinderControl label={`want-list "${w.name}"`} onDelete={() => onDelete(w.id)} />
     </li>
   )
 }
 
 /**
- * Per-row "file into binder" control (#703) — a dropdown listing the user's
- * physical binders. Picking one moves the collection into it; "Remove from
+ * Per-row "file into binder" control (#703, #774) — a dropdown listing the
+ * user's physical binders. Picking one moves the list into it; "Remove from
  * binder" unfiles it. The current binder is checked. Reveals on hover/focus
- * like the other row controls.
+ * like the other row controls. Shared by collection and want-list rows — the
+ * `noun` only colors the accessible label.
  */
 function FileIntoBinderControl({
-  collection: c,
+  item: c,
+  noun = 'collection',
   binders,
   onFile,
 }: {
-  collection: CollectionSummary
+  item: { id: number; name: string; binder_id?: number | null }
+  noun?: 'collection' | 'want-list'
   binders: BinderSummary[]
-  onFile: (collectionId: number, binderId: number | null) => Promise<void>
+  onFile: (id: number, binderId: number | null) => Promise<void>
 }) {
   const [failed, setFailed] = useState(false)
 
@@ -648,7 +662,7 @@ function FileIntoBinderControl({
         <DropdownMenu.Trigger asChild>
           <button
             type="button"
-            aria-label={`File collection "${c.name}" into a binder`}
+            aria-label={`File ${noun} "${c.name}" into a binder`}
             title="File into binder"
             className="shrink-0 rounded p-1.5 text-coconut-400 opacity-100 transition-opacity hover:bg-sand-200 hover:text-palm-600 dark:text-sand-400 dark:hover:bg-husk-100 dark:hover:text-palm-300 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
           >

--- a/web/src/components/SwipePanel.test.tsx
+++ b/web/src/components/SwipePanel.test.tsx
@@ -389,6 +389,7 @@ describe('SwipePanel', () => {
       name: 'Custom prep',
       description: null,
       created_at: '2026-06-06T00:00:00',
+      binder_id: null,
       items: [],
     })
     mockAddCardToWishlist.mockResolvedValue({

--- a/web/src/components/WishlistCreateDialog.tsx
+++ b/web/src/components/WishlistCreateDialog.tsx
@@ -1,0 +1,157 @@
+/**
+ * WishlistCreateDialog — the New ▾ → Want-list create flow (#774).
+ *
+ * Mirrors {@link CollectionCreateDialog}: a want-list can now be filed into a
+ * physical binder at create time via the shared {@link BinderFilePicker} —
+ * pick an existing binder, create one inline, or leave it loose — so all three
+ * logical lists (collection, smart collection, want-list) are binder-aware.
+ * State flows through [useWishlists](./useWishlists.ts) / [useBinders](./useBinders.ts)
+ * so every surface re-renders without a refetch.
+ */
+import * as Dialog from '@radix-ui/react-dialog'
+import { Loader2, X } from 'lucide-react'
+import { useState } from 'react'
+import type { CardData } from '../types'
+import { BinderFilePicker } from './BinderFilePicker'
+import { useBinderFiling } from './useBinderFiling'
+import { useWishlists } from './useWishlists'
+
+interface Props {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Seed the name field (e.g. opened from Browse for a set/species). */
+  prefillName?: string
+  /** When set, bulk-add these cards into the new want-list on create — the
+   *  Browse "create a want-list of this set/species" path (#737). */
+  seedCards?: CardData[]
+}
+
+export function WishlistCreateDialog({ open, onOpenChange, prefillName, seedCards }: Props) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-40 bg-coconut-700/50 backdrop-blur-sm dark:bg-husk-500/70" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 flex max-h-[88vh] w-[min(420px,92vw)] -translate-x-1/2 -translate-y-1/2 flex-col rounded-lg border border-sand-300 bg-sand-50 shadow-2xl dark:border-husk-50 dark:bg-husk-200">
+          {/* Form state only mounts while open, so each open starts fresh. */}
+          {open && (
+            <CreateForm
+              onClose={() => onOpenChange(false)}
+              prefillName={prefillName}
+              seedCards={seedCards}
+            />
+          )}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}
+
+function CreateForm({
+  onClose,
+  prefillName,
+  seedCards,
+}: {
+  onClose: () => void
+  prefillName?: string
+  seedCards?: CardData[]
+}) {
+  const { create: createWishlist, bulkAdd: bulkAddWishlist } = useWishlists()
+  const filing = useBinderFiling()
+
+  const [name, setName] = useState(prefillName ?? '')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const canSubmit = name.trim().length > 0 && !submitting && filing.settled
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!canSubmit) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      const target = await filing.resolveTarget()
+      const created = await createWishlist(
+        name.trim(),
+        target != null ? { binder_id: target } : undefined,
+      )
+      // Seeded from Browse (#737): drop the set's cards / species' printings in.
+      if (seedCards && seedCards.length > 0) {
+        await bulkAddWishlist(created.id, seedCards)
+      }
+      if (target != null) await filing.refresh()
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const inputClass =
+    'w-full rounded border border-sand-300 bg-coconut-50 px-2.5 py-1.5 text-sm text-coconut-700 placeholder:text-coconut-400 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:border-husk-100 dark:bg-husk-100 dark:text-sand-50 dark:focus:ring-sun-300'
+
+  return (
+    <>
+      <header className="flex items-center justify-between gap-3 border-b border-sand-200 px-5 py-4 dark:border-husk-100">
+        <Dialog.Title className="text-lg font-semibold text-coconut-700 dark:text-sand-50">
+          New want-list
+        </Dialog.Title>
+        <Dialog.Close asChild>
+          <button
+            aria-label="Close"
+            className="rounded p-1 text-coconut-500 hover:bg-sand-200 dark:text-sand-300 dark:hover:bg-husk-100"
+          >
+            <X size={18} />
+          </button>
+        </Dialog.Close>
+      </header>
+      <Dialog.Description className="sr-only">
+        Name the want-list and optionally file it into one of your binders.
+      </Dialog.Description>
+
+      <form onSubmit={handleSubmit} className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
+        <label className="block space-y-1">
+          <span className="text-[11px] font-medium uppercase tracking-wide text-coconut-400 dark:text-sand-300">
+            Name
+          </span>
+          <input
+            autoFocus
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Chase cards"
+            className={inputClass}
+          />
+        </label>
+
+        <BinderFilePicker filing={filing} />
+
+        {error && (
+          <div role="alert" className="text-[11px] text-sun-600 dark:text-sun-300">
+            {error}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2 border-t border-sand-200 pt-3 dark:border-husk-100">
+          <Dialog.Close asChild>
+            <button
+              type="button"
+              className="rounded px-3 py-1.5 text-xs font-medium text-coconut-500 hover:bg-sand-200 dark:text-sand-300 dark:hover:bg-husk-100"
+            >
+              Cancel
+            </button>
+          </Dialog.Close>
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className="inline-flex items-center gap-1.5 rounded bg-palm-500 px-3.5 py-1.5 text-xs font-medium text-coconut-50 hover:bg-palm-600 disabled:opacity-50 dark:text-husk-300"
+          >
+            {submitting && <Loader2 size={12} className="animate-spin" />}
+            Create
+          </button>
+        </div>
+      </form>
+    </>
+  )
+}

--- a/web/src/components/WishlistDetail.test.tsx
+++ b/web/src/components/WishlistDetail.test.tsx
@@ -36,6 +36,7 @@ const WISHLIST = {
   description: null,
   created_at: '2026-06-06T00:00:00',
   item_count: 2,
+  binder_id: null,
 }
 
 function item(overrides: Record<string, unknown>) {

--- a/web/src/components/useBinderFiling.ts
+++ b/web/src/components/useBinderFiling.ts
@@ -40,19 +40,21 @@ export interface BinderFiling {
 }
 
 export function useBinderFiling(): BinderFiling {
-  const { collections } = useCollections()
-  const { wishlists } = useWishlists()
-  const { binders, fetched, create: createBinder, refresh } = useBinders()
+  const { collections, fetched: collectionsFetched } = useCollections()
+  const { wishlists, fetched: wishlistsFetched } = useWishlists()
+  const { binders, fetched: bindersFetched, create: createBinder, refresh } = useBinders()
 
   const [target, setTarget] = useState<FileTarget>(null)
   const [newBinderName, setNewBinderName] = useState('')
   const [newBinderColor, setNewBinderColor] = useState<string | null>(null)
   const [newBinderCapacity, setNewBinderCapacity] = useState('')
 
-  // Gate on the first fetch completing, not on `!loading`: the list starts
+  // Gate on the first fetch completing, not on `!loading`: each list starts
   // empty with loading=false, so an un-fetched state would otherwise read as
   // "no binders yet" and let the create submit before binders load (#775).
-  const settled = fetched
+  // Collections *and* want-lists must also be loaded before the slot math is
+  // trusted, since both occupy a binder's slots now (#774 review).
+  const settled = bindersFetched && collectionsFetched && wishlistsFetched
   const hasBinders = binders.length > 0
 
   // Cards already filed into each binder — the sum of its collections' pocket

--- a/web/src/components/useBinderFiling.ts
+++ b/web/src/components/useBinderFiling.ts
@@ -12,6 +12,7 @@ import { useMemo, useState } from 'react'
 import type { BinderSummary } from '../api/client'
 import { useBinders } from './useBinders'
 import { useCollections } from './useCollections'
+import { useWishlists } from './useWishlists'
 
 /** What the list files into: an existing binder's id, `'new'` for the inline
  *  create form, or null for "don't file". */
@@ -40,6 +41,7 @@ export interface BinderFiling {
 
 export function useBinderFiling(): BinderFiling {
   const { collections } = useCollections()
+  const { wishlists } = useWishlists()
   const { binders, fetched, create: createBinder, refresh } = useBinders()
 
   const [target, setTarget] = useState<FileTarget>(null)
@@ -54,15 +56,20 @@ export function useBinderFiling(): BinderFiling {
   const hasBinders = binders.length > 0
 
   // Cards already filed into each binder — the sum of its collections' pocket
-  // counts (vendor multiples via total_quantity, falling back to row count).
+  // counts (vendor multiples via total_quantity, falling back to row count)
+  // plus its want-lists' item counts (#774; chase targets occupy slots too).
   const usedByBinder = useMemo(() => {
     const map = new Map<number, number>()
     for (const c of collections) {
       if (c.binder_id == null) continue
       map.set(c.binder_id, (map.get(c.binder_id) ?? 0) + (c.total_quantity ?? c.item_count))
     }
+    for (const w of wishlists) {
+      if (w.binder_id == null) continue
+      map.set(w.binder_id, (map.get(w.binder_id) ?? 0) + w.item_count)
+    }
     return map
-  }, [collections])
+  }, [collections, wishlists])
 
   async function resolveTarget(): Promise<number | null> {
     if (typeof target === 'number') return target

--- a/web/src/components/useBinders.ts
+++ b/web/src/components/useBinders.ts
@@ -78,6 +78,7 @@ export function useBinders() {
           binder_type: created.binder_type,
           capacity: created.capacity,
           collection_count: created.collection_count,
+          wishlist_count: created.wishlist_count,
           is_empty: created.is_empty,
         },
         ...state.binders,

--- a/web/src/components/useCollections.ts
+++ b/web/src/components/useCollections.ts
@@ -23,10 +23,14 @@ interface State {
   collections: CollectionSummary[]
   loading: boolean
   error: string | null
+  // True once the first fetch has resolved or failed. Callers that gate on
+  // load (e.g. binder slot math, #774) must check this, not `!loading`: the
+  // list starts empty with loading=false before the effect kicks off.
+  fetched: boolean
 }
 
 const listeners = new Set<(s: State) => void>()
-let state: State = { collections: [], loading: false, error: null }
+let state: State = { collections: [], loading: false, error: null, fetched: false }
 let inflight: Promise<void> | null = null
 
 function set(next: Partial<State>) {
@@ -40,11 +44,12 @@ async function refresh(): Promise<void> {
   inflight = (async () => {
     try {
       const collections = await fetchCollections()
-      set({ collections, loading: false })
+      set({ collections, loading: false, fetched: true })
     } catch (e) {
       set({
         loading: false,
         error: e instanceof Error ? e.message : String(e),
+        fetched: true,
       })
     } finally {
       inflight = null
@@ -200,7 +205,7 @@ export function useCollections() {
 // Test-only: reset the module-level cache between vitest runs so each
 // test starts with an empty list. Production code should not call this.
 export function _resetCollectionsCacheForTests() {
-  state = { collections: [], loading: false, error: null }
+  state = { collections: [], loading: false, error: null, fetched: false }
   inflight = null
   listeners.clear()
 }

--- a/web/src/components/useWishlists.ts
+++ b/web/src/components/useWishlists.ts
@@ -12,6 +12,8 @@ import {
   createWishlist,
   deleteWishlist,
   fetchWishlists,
+  updateWishlist,
+  type CreateWishlistOptions,
   type WishlistSummary,
 } from '../api/client'
 import { invalidateOwnership } from './useCardOwnership'
@@ -63,8 +65,8 @@ export function useWishlists() {
     }
   }, [])
 
-  const create = useCallback(async (name: string, description?: string) => {
-    const created = await createWishlist(name, description)
+  const create = useCallback(async (name: string, options?: CreateWishlistOptions) => {
+    const created = await createWishlist(name, options)
     set({
       wishlists: [
         {
@@ -73,11 +75,23 @@ export function useWishlists() {
           description: created.description,
           created_at: created.created_at,
           item_count: created.items.length,
+          binder_id: created.binder_id,
         },
         ...state.wishlists,
       ],
     })
     return created
+  }, [])
+
+  // File a want-list into a binder (or pass null to unfile) and reflect the
+  // new binder_id locally so the row + binder fill update without a refetch (#774).
+  const file = useCallback(async (wishlistId: number, binderId: number | null) => {
+    await updateWishlist(wishlistId, { binder_id: binderId })
+    set({
+      wishlists: state.wishlists.map((w) =>
+        w.id === wishlistId ? { ...w, binder_id: binderId } : w,
+      ),
+    })
   }, [])
 
   const addCard = useCallback(
@@ -131,6 +145,7 @@ export function useWishlists() {
     ...snapshot,
     refresh,
     create,
+    file,
     addCard,
     bulkAdd,
     remove,

--- a/web/src/components/useWishlists.ts
+++ b/web/src/components/useWishlists.ts
@@ -22,10 +22,13 @@ interface State {
   wishlists: WishlistSummary[]
   loading: boolean
   error: string | null
+  // True once the first fetch has resolved or failed. Callers that gate on
+  // load (e.g. binder slot math, #774) must check this, not `!loading`.
+  fetched: boolean
 }
 
 const listeners = new Set<(s: State) => void>()
-let state: State = { wishlists: [], loading: false, error: null }
+let state: State = { wishlists: [], loading: false, error: null, fetched: false }
 let inflight: Promise<void> | null = null
 
 function set(next: Partial<State>) {
@@ -39,11 +42,12 @@ async function refresh(): Promise<void> {
   inflight = (async () => {
     try {
       const wishlists = await fetchWishlists()
-      set({ wishlists, loading: false })
+      set({ wishlists, loading: false, fetched: true })
     } catch (e) {
       set({
         loading: false,
         error: e instanceof Error ? e.message : String(e),
+        fetched: true,
       })
     } finally {
       inflight = null
@@ -154,7 +158,7 @@ export function useWishlists() {
 
 // Test-only: reset the module-level cache between vitest runs.
 export function _resetWishlistsCacheForTests() {
-  state = { wishlists: [], loading: false, error: null }
+  state = { wishlists: [], loading: false, error: null, fetched: false }
   inflight = null
   listeners.clear()
 }


### PR DESCRIPTION
Closes #774

## What

Makes the third logical list binder-aware: a want-list can now be filed into a binder, the way collections and smart collections already can (#726/#775). A binder organizes both owned cards (collections) and chase targets (want-lists).

This is the backend-touching half that #726 deliberately split out as #774.

## Why

Today binders only hold `Collection` rows — `Wishlist` had no `binder_id`. Filing a want-list into a binder makes all three logical lists (collection, smart collection, want-list) binder-aware instead of only the two collection kinds.

## How

**Backend**
- Migration: nullable `wishlists.binder_id` FK → `binders.id`, `ON DELETE SET NULL`, mirroring `collections.binder_id`. Round-trips cleanly (upgrade adds column + FK, downgrade drops it).
- Want-list create/patch accept and validate `binder_id` (an unowned/missing binder is a 404, reusing the collections ownership guard). Patch only touches filing when the key is present, so `null` unfiles and omission leaves it intact.
- A binder's serialized contents now include its want-lists: a `wishlist_count`, the want-lists in the contents list, and `is_empty` considers both kinds. Deleting a binder detaches its want-lists alongside its collections.

**Web**
- The want-list create flow (Library New ▾ and Browse) reuses the shared `BinderFilePicker` / `useBinderFiling` (new `WishlistCreateDialog`).
- Want-list rows get the same file-into-binder control as collection rows (the control was generalized to either list kind).
- The binder inventory lists filed want-lists alongside collections, with a combined count line.
- Per the slot-accounting decision, want-list items count toward a binder's fill the same as collection cards.

`render.yaml` unchanged — the migration adds a column to an existing table; no new env vars or persistent state.

## How to verify

- `make check` is green; `cd web && npm run build` is green. New coverage: API (filing on create/patch, 404 on unowned binder, binder contents/counts include want-lists, delete detaches) and web (want-list create picker, row file/unfile control, inventory listing, slot math).
- Manually: Binders tab → New ▾ → Want-list now shows the binder picker. File/unfile a want-list from its row. A binder that holds a want-list shows it in the inventory and counts its cards toward the fill.

## Notes

#746 is a duplicate of this issue (same `wishlists.binder_id` work) — can be closed as superseded by #774 once this lands.