### PR TITLE
feat(web): show and edit owned quantity per card in collection detail

### DIFF
--- a/api/routes/collections.py
+++ b/api/routes/collections.py
@@ -23,6 +23,7 @@ Endpoints:
 - `DELETE /collections/{id}`                  cascade-delete items
 - `POST   /collections/{id}/items`            add a card (manual/set only)
 - `POST   /collections/{id}/items/bulk`       add many cards at once (#268/#509)
+- `PATCH  /collections/{id}/items/{item_id}`  adjust a card's owned quantity (#769)
 - `DELETE /collections/{id}/items/{item_id}`  remove a card (manual/set only)
 - `GET    /collections/{id}/target`           catalog-backed membership + ownership overlay (#631)
 - `POST   /collections/{id}/chase`            push the un-owned matches onto a want-list (#631)
@@ -299,6 +300,12 @@ class CollectionItemCreate(BaseModel):
     #: Provenance tag. Inserts default to ``manual``; callers like the
     #: wishlist promote endpoint (#504) and the haul mode (#509) override.
     added_via: str | None = None
+
+
+class CollectionItemPatch(BaseModel):
+    #: New vendor-multiple count for the item (#769). Floored at 1 — removing
+    #: the last copy is a DELETE, not a quantity-0 PATCH.
+    quantity: int = Field(ge=1)
 
 
 class BulkItemsCreate(BaseModel):
@@ -619,6 +626,37 @@ def delete_collection_item(
         )
     db.delete(item)
     db.commit()
+
+
+@router.patch("/collections/{collection_id}/items/{item_id}")
+def update_collection_item(
+    collection_id: int,
+    item_id: int,
+    req: CollectionItemPatch,
+    db: DbSession,
+    current_user: CurrentUser,
+) -> dict:
+    """Adjust a card's owned quantity in place (#769) — the editable count in
+    the collection detail view. Scoped through the parent collection so an
+    unowned id 404s; dynamic collections (rule-derived membership) are rejected
+    like the other item-write paths."""
+    collection = _load_collection(db, collection_id, current_user.id)
+    _reject_if_dynamic(collection)
+    item = db.scalar(
+        select(CollectionItem).where(
+            CollectionItem.id == item_id,
+            CollectionItem.collection_id == collection.id,
+        )
+    )
+    if item is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"item {item_id} not found in collection {collection_id}",
+        )
+    item.quantity = req.quantity
+    db.commit()
+    db.refresh(item)
+    return serialize_collection_item(item)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -425,6 +425,41 @@ class CollectionsEndpointTests(_IsolatedDbMixin):
             )
             self.assertEqual(resp.status_code, 422)
 
+    def test_patch_item_updates_quantity(self) -> None:
+        # #769 — the editable owned count in the collection detail view.
+        with self._client() as c:
+            cid = c.post("/api/v1/collections", json={"name": "k"}).json()["id"]
+            item_id = c.post(f"/api/v1/collections/{cid}/items", json={"card": SAMPLE_CARD}).json()[
+                "id"
+            ]
+
+            patched = c.patch(f"/api/v1/collections/{cid}/items/{item_id}", json={"quantity": 4})
+            self.assertEqual(patched.status_code, 200)
+            self.assertEqual(patched.json()["quantity"], 4)
+            # The change persists on the next read.
+            items = c.get(f"/api/v1/collections/{cid}").json()["items"]
+            self.assertEqual(items[0]["quantity"], 4)
+
+    def test_patch_item_rejects_zero_quantity(self) -> None:
+        # Dropping to zero is a DELETE, not a quantity-0 PATCH — 422.
+        with self._client() as c:
+            cid = c.post("/api/v1/collections", json={"name": "k"}).json()["id"]
+            item_id = c.post(f"/api/v1/collections/{cid}/items", json={"card": SAMPLE_CARD}).json()[
+                "id"
+            ]
+            resp = c.patch(f"/api/v1/collections/{cid}/items/{item_id}", json={"quantity": 0})
+            self.assertEqual(resp.status_code, 422)
+
+    def test_patch_item_404_when_wrong_collection(self) -> None:
+        with self._client() as c:
+            cid_a = c.post("/api/v1/collections", json={"name": "a"}).json()["id"]
+            cid_b = c.post("/api/v1/collections", json={"name": "b"}).json()["id"]
+            item_id = c.post(
+                f"/api/v1/collections/{cid_a}/items", json={"card": SAMPLE_CARD}
+            ).json()["id"]
+            resp = c.patch(f"/api/v1/collections/{cid_b}/items/{item_id}", json={"quantity": 2})
+            self.assertEqual(resp.status_code, 404)
+
     def test_delete_item_404_when_wrong_collection(self) -> None:
         with self._client() as c:
             cid_a = c.post("/api/v1/collections", json={"name": "a"}).json()["id"]

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -821,6 +821,22 @@ export async function addCardToCollection(
   return (await res.json()) as CollectionItem
 }
 
+/** Set a card's owned quantity in a collection (#769). Floored at 1 server-side
+ * — removing the last copy is a delete, not a quantity-0 update. */
+export async function updateCollectionItem(
+  collectionId: number,
+  itemId: number,
+  quantity: number,
+): Promise<CollectionItem> {
+  const res = await fetch(`${BASE}/collections/${collectionId}/items/${itemId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ quantity }),
+  })
+  if (!res.ok) throw new Error(`update collection item failed: ${res.status}`)
+  return (await res.json()) as CollectionItem
+}
+
 /** Result of a bulk add: the created rows plus their count (#268). */
 export interface BulkAddResult<T> {
   added: number

--- a/web/src/components/CollectionDetail.test.tsx
+++ b/web/src/components/CollectionDetail.test.tsx
@@ -1,14 +1,25 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { CollectionDetail } from './CollectionDetail'
-import { fetchCollection } from '../api/client'
-import type { Collection, CollectionSummary } from '../api/client'
+import { _resetCollectionsCacheForTests } from './useCollections'
+import { fetchCollection, fetchCollections, updateCollectionItem } from '../api/client'
+import type { Collection, CollectionItem, CollectionSummary } from '../api/client'
 
 vi.mock('../api/client', () => ({
   fetchCollection: vi.fn(),
+  // useCollections is pulled in for the editable quantity stepper (#769).
+  fetchCollections: vi.fn(),
+  createCollection: vi.fn(),
+  updateCollection: vi.fn(),
+  deleteCollection: vi.fn(),
+  addCardToCollection: vi.fn(),
+  bulkAddToCollection: vi.fn(),
+  updateCollectionItem: vi.fn(),
 }))
 
 const mockFetch = vi.mocked(fetchCollection)
+const mockFetchList = vi.mocked(fetchCollections)
+const mockUpdateItem = vi.mocked(updateCollectionItem)
 
 const SUMMARY: CollectionSummary = {
   id: 3,
@@ -30,8 +41,30 @@ function collectionWith(items: Collection['items']): Collection {
   }
 }
 
+/** One collection item with sensible defaults for the fields the row reads. */
+function item(over: Partial<CollectionItem> = {}): CollectionItem {
+  return {
+    id: 1,
+    card: { name: 'Charizard', images: { small: 'https://img/base1-4.png' } },
+    notes: null,
+    added_at: '2026-06-21T00:00:00',
+    quantity: 2,
+    card_set_id: 'base1',
+    card_number: '4',
+    card_name: 'Charizard',
+    card_rarity: 'Rare Holo',
+    card_image_url: 'https://img/base1-4.png',
+    price_snapshot: 250,
+    ...over,
+  }
+}
+
 beforeEach(() => {
+  _resetCollectionsCacheForTests()
   mockFetch.mockReset()
+  mockFetchList.mockReset()
+  mockFetchList.mockResolvedValue([])
+  mockUpdateItem.mockReset()
 })
 
 describe('CollectionDetail', () => {
@@ -72,5 +105,42 @@ describe('CollectionDetail', () => {
   it("doesn't fetch while closed", () => {
     render(<CollectionDetail collection={SUMMARY} open={false} onOpenChange={() => {}} />)
     expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('increments a card quantity from the stepper (#769)', async () => {
+    mockFetch.mockResolvedValue(collectionWith([item({ id: 7, quantity: 2 })]))
+    mockUpdateItem.mockResolvedValue(item({ id: 7, quantity: 3 }))
+    render(<CollectionDetail collection={SUMMARY} open onOpenChange={() => {}} />)
+
+    await screen.findByText('Charizard')
+    fireEvent.click(screen.getByRole('button', { name: /increase quantity of charizard/i }))
+
+    await waitFor(() => expect(mockUpdateItem).toHaveBeenCalledWith(3, 7, 3))
+    // Optimistic update bumps the displayed count.
+    expect(screen.getByLabelText(/owned quantity of charizard/i)).toHaveTextContent('3')
+  })
+
+  it('floors the stepper at 1 (decrement disabled)', async () => {
+    mockFetch.mockResolvedValue(collectionWith([item({ id: 7, quantity: 1 })]))
+    render(<CollectionDetail collection={SUMMARY} open onOpenChange={() => {}} />)
+
+    await screen.findByText('Charizard')
+    expect(screen.getByRole('button', { name: /decrease quantity of charizard/i })).toBeDisabled()
+  })
+
+  it('shows quantity read-only for a dynamic (smart) collection', async () => {
+    const dynamic: CollectionSummary = { ...SUMMARY, kind: 'dynamic' }
+    mockFetch.mockResolvedValue({
+      ...collectionWith([item({ id: 7, quantity: 4 })]),
+      kind: 'dynamic',
+    } as Collection)
+    render(<CollectionDetail collection={dynamic} open onOpenChange={() => {}} />)
+
+    await screen.findByText('Charizard')
+    // No editable stepper — the rule defines membership, so counts aren't editable.
+    expect(
+      screen.queryByRole('button', { name: /increase quantity/i }),
+    ).not.toBeInTheDocument()
+    expect(screen.getByLabelText(/owned quantity/i)).toHaveTextContent('4x')
   })
 })

--- a/web/src/components/CollectionDetail.test.tsx
+++ b/web/src/components/CollectionDetail.test.tsx
@@ -120,6 +120,31 @@ describe('CollectionDetail', () => {
     expect(screen.getByLabelText(/owned quantity of charizard/i)).toHaveTextContent('3')
   })
 
+  it('disables the stepper while a quantity update is in flight (#769 review)', async () => {
+    mockFetch.mockResolvedValue(collectionWith([item({ id: 7, quantity: 2 })]))
+    // Hold the PATCH open so we can observe the pending (disabled) state.
+    let resolvePatch!: (v: CollectionItem) => void
+    mockUpdateItem.mockReturnValue(
+      new Promise<CollectionItem>((res) => {
+        resolvePatch = res
+      }),
+    )
+    render(<CollectionDetail collection={SUMMARY} open onOpenChange={() => {}} />)
+
+    await screen.findByText('Charizard')
+    const inc = screen.getByRole('button', { name: /increase quantity of charizard/i })
+    fireEvent.click(inc)
+
+    // Both controls are gated until the in-flight request resolves, so a
+    // second click can't race an out-of-order absolute update onto the server.
+    await waitFor(() => expect(inc).toBeDisabled())
+    expect(screen.getByRole('button', { name: /decrease quantity of charizard/i })).toBeDisabled()
+    expect(mockUpdateItem).toHaveBeenCalledTimes(1)
+
+    resolvePatch(item({ id: 7, quantity: 3 }))
+    await waitFor(() => expect(inc).not.toBeDisabled())
+  })
+
   it('floors the stepper at 1 (decrement disabled)', async () => {
     mockFetch.mockResolvedValue(collectionWith([item({ id: 7, quantity: 1 })]))
     render(<CollectionDetail collection={SUMMARY} open onOpenChange={() => {}} />)

--- a/web/src/components/CollectionDetail.tsx
+++ b/web/src/components/CollectionDetail.tsx
@@ -7,14 +7,18 @@
  * cards in the collection with their snapshot price, and surfaces an empty
  * state for a freshly-created collection so it's never a dead end.
  *
- * Read-only for now: cards are added from Browse / Search via the save
- * buttons, and seeded placeholder slots are a separate effort (#725).
+ * Owned quantity per card is shown and editable here (#769) — the canonical
+ * place to manage counts. Cards are still added from Browse / Search via the
+ * save buttons; seeded placeholder slots are a separate effort (#725). Editing
+ * is gated to manual/set collections — a dynamic (smart) collection's
+ * membership is rule-derived, so its counts aren't hand-adjustable.
  */
 import * as Dialog from '@radix-ui/react-dialog'
-import { ImageOff, Loader2, Wallet, X } from 'lucide-react'
+import { ImageOff, Loader2, Minus, Plus, Wallet, X } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { fetchCollection, type CollectionItem, type CollectionSummary } from '../api/client'
 import { coverSwatch } from './binderIdentity'
+import { useCollections } from './useCollections'
 import { formatMoney } from '../utils/format'
 
 interface Props {
@@ -34,9 +38,35 @@ function cardLabel(item: CollectionItem): string {
 }
 
 export function CollectionDetail({ collection, open, onOpenChange }: Props) {
+  const { setItemQuantity } = useCollections()
   const [items, setItems] = useState<CollectionItem[] | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [editError, setEditError] = useState<string | null>(null)
+
+  // A dynamic (smart) collection's membership comes from its rule, so its
+  // counts aren't hand-editable — only manual/set collections get the stepper.
+  const editable = collection != null && collection.kind !== 'dynamic'
+
+  // Persist a card's new owned quantity, optimistically updating the row and
+  // reverting on failure (#769).
+  async function changeQuantity(item: CollectionItem, next: number) {
+    if (!collection || next < 1) return
+    const prev = item.quantity ?? 1
+    if (next === prev) return
+    setEditError(null)
+    setItems((list) =>
+      list ? list.map((i) => (i.id === item.id ? { ...i, quantity: next } : i)) : list,
+    )
+    try {
+      await setItemQuantity(collection.id, item.id, next, next - prev)
+    } catch (e) {
+      setItems((list) =>
+        list ? list.map((i) => (i.id === item.id ? { ...i, quantity: prev } : i)) : list,
+      )
+      setEditError(e instanceof Error ? e.message : String(e))
+    }
+  }
 
   useEffect(() => {
     if (!open || !collection) return
@@ -47,6 +77,7 @@ export function CollectionDetail({ collection, open, onOpenChange }: Props) {
     const load = async () => {
       setItems(null)
       setError(null)
+      setEditError(null)
       setLoading(true)
       try {
         const c = await fetchCollection(collection.id)
@@ -127,9 +158,19 @@ export function CollectionDetail({ collection, open, onOpenChange }: Props) {
                     </span>
                   )}
                 </div>
+                {editError && (
+                  <div role="alert" className="mb-2 text-[11px] text-sun-600 dark:text-sun-300">
+                    Couldn&apos;t update quantity: {editError}
+                  </div>
+                )}
                 <ul className="divide-y divide-sand-200 dark:divide-husk-100">
                   {items.map((it) => (
-                    <ItemRow key={it.id} item={it} />
+                    <ItemRow
+                      key={it.id}
+                      item={it}
+                      editable={editable}
+                      onChangeQuantity={(next) => void changeQuantity(it, next)}
+                    />
                   ))}
                 </ul>
               </>
@@ -148,7 +189,15 @@ export function CollectionDetail({ collection, open, onOpenChange }: Props) {
   )
 }
 
-function ItemRow({ item }: { item: CollectionItem }) {
+function ItemRow({
+  item,
+  editable,
+  onChangeQuantity,
+}: {
+  item: CollectionItem
+  editable: boolean
+  onChangeQuantity: (next: number) => void
+}) {
   const [broken, setBroken] = useState(false)
   const img = cardImage(item)
   const qty = item.quantity ?? 1
@@ -170,7 +219,6 @@ function ItemRow({ item }: { item: CollectionItem }) {
       <div className="min-w-0 flex-1">
         <div className="truncate text-xs font-medium text-coconut-700 dark:text-sand-50">
           {cardLabel(item)}
-          {qty > 1 && <span className="text-coconut-400 dark:text-sand-300"> · {qty}x</span>}
         </div>
         <div className="truncate text-[11px] text-coconut-400 dark:text-sand-300">
           {item.card_set_id}
@@ -178,11 +226,64 @@ function ItemRow({ item }: { item: CollectionItem }) {
           {item.card_rarity ? ` · ${item.card_rarity}` : ''}
         </div>
       </div>
+      {editable ? (
+        <QuantityStepper
+          qty={qty}
+          label={cardLabel(item)}
+          onChange={onChangeQuantity}
+        />
+      ) : (
+        <span className="shrink-0 text-xs text-coconut-500 dark:text-sand-300" aria-label="Owned quantity">
+          {qty}x
+        </span>
+      )}
       {item.price_snapshot != null && (
-        <span className="shrink-0 text-xs font-medium text-palm-600 dark:text-palm-200">
+        <span className="w-16 shrink-0 text-right text-xs font-medium text-palm-600 dark:text-palm-200">
           {formatMoney(item.price_snapshot, 'USD')}
         </span>
       )}
     </li>
+  )
+}
+
+/** The −/+ owned-quantity control for one card (#769). Floored at 1 — removing
+ *  the last copy is a separate delete, not a zero here. */
+function QuantityStepper({
+  qty,
+  label,
+  onChange,
+}: {
+  qty: number
+  label: string
+  onChange: (next: number) => void
+}) {
+  const btn =
+    'flex h-6 w-6 items-center justify-center rounded text-coconut-500 hover:bg-sand-200 disabled:opacity-40 disabled:hover:bg-transparent dark:text-sand-300 dark:hover:bg-husk-100'
+  return (
+    <div className="flex shrink-0 items-center gap-0.5">
+      <button
+        type="button"
+        onClick={() => onChange(qty - 1)}
+        disabled={qty <= 1}
+        aria-label={`Decrease quantity of ${label}`}
+        className={btn}
+      >
+        <Minus size={13} />
+      </button>
+      <span
+        className="min-w-[1.5rem] text-center text-xs font-medium tabular-nums text-coconut-700 dark:text-sand-50"
+        aria-label={`Owned quantity of ${label}`}
+      >
+        {qty}
+      </span>
+      <button
+        type="button"
+        onClick={() => onChange(qty + 1)}
+        aria-label={`Increase quantity of ${label}`}
+        className={btn}
+      >
+        <Plus size={13} />
+      </button>
+    </div>
   )
 }

--- a/web/src/components/CollectionDetail.tsx
+++ b/web/src/components/CollectionDetail.tsx
@@ -43,6 +43,10 @@ export function CollectionDetail({ collection, open, onOpenChange }: Props) {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [editError, setEditError] = useState<string | null>(null)
+  // The item whose quantity PATCH is in flight, if any. Gating per-item edits
+  // keeps the absolute updates from racing — a stale response can't land after
+  // a newer one and overwrite the server (#769).
+  const [pendingId, setPendingId] = useState<number | null>(null)
 
   // A dynamic (smart) collection's membership comes from its rule, so its
   // counts aren't hand-editable — only manual/set collections get the stepper.
@@ -53,8 +57,11 @@ export function CollectionDetail({ collection, open, onOpenChange }: Props) {
   async function changeQuantity(item: CollectionItem, next: number) {
     if (!collection || next < 1) return
     const prev = item.quantity ?? 1
-    if (next === prev) return
+    // Ignore the click if nothing changes, or while this item's edit is still
+    // saving — the stepper is disabled then, but guard the handler too.
+    if (next === prev || pendingId === item.id) return
     setEditError(null)
+    setPendingId(item.id)
     setItems((list) =>
       list ? list.map((i) => (i.id === item.id ? { ...i, quantity: next } : i)) : list,
     )
@@ -65,6 +72,8 @@ export function CollectionDetail({ collection, open, onOpenChange }: Props) {
         list ? list.map((i) => (i.id === item.id ? { ...i, quantity: prev } : i)) : list,
       )
       setEditError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setPendingId(null)
     }
   }
 
@@ -169,6 +178,7 @@ export function CollectionDetail({ collection, open, onOpenChange }: Props) {
                       key={it.id}
                       item={it}
                       editable={editable}
+                      busy={pendingId === it.id}
                       onChangeQuantity={(next) => void changeQuantity(it, next)}
                     />
                   ))}
@@ -192,10 +202,12 @@ export function CollectionDetail({ collection, open, onOpenChange }: Props) {
 function ItemRow({
   item,
   editable,
+  busy,
   onChangeQuantity,
 }: {
   item: CollectionItem
   editable: boolean
+  busy: boolean
   onChangeQuantity: (next: number) => void
 }) {
   const [broken, setBroken] = useState(false)
@@ -230,6 +242,7 @@ function ItemRow({
         <QuantityStepper
           qty={qty}
           label={cardLabel(item)}
+          busy={busy}
           onChange={onChangeQuantity}
         />
       ) : (
@@ -251,10 +264,12 @@ function ItemRow({
 function QuantityStepper({
   qty,
   label,
+  busy,
   onChange,
 }: {
   qty: number
   label: string
+  busy: boolean
   onChange: (next: number) => void
 }) {
   const btn =
@@ -264,7 +279,7 @@ function QuantityStepper({
       <button
         type="button"
         onClick={() => onChange(qty - 1)}
-        disabled={qty <= 1}
+        disabled={qty <= 1 || busy}
         aria-label={`Decrease quantity of ${label}`}
         className={btn}
       >
@@ -279,6 +294,7 @@ function QuantityStepper({
       <button
         type="button"
         onClick={() => onChange(qty + 1)}
+        disabled={busy}
         aria-label={`Increase quantity of ${label}`}
         className={btn}
       >

--- a/web/src/components/useCollections.ts
+++ b/web/src/components/useCollections.ts
@@ -13,6 +13,7 @@ import {
   deleteCollection,
   fetchCollections,
   updateCollection,
+  updateCollectionItem,
   type CollectionSummary,
   type CreateCollectionOptions,
   type UpdateCollectionOptions,
@@ -183,6 +184,27 @@ export function useCollections() {
     [],
   )
 
+  // Set a card's owned quantity (#769). `quantityDelta` (new − old) keeps the
+  // collection summary's total_quantity — binder fill / slot math — in sync
+  // without a refetch; the ownership badge (#576) is busted since counts moved.
+  const setItemQuantity = useCallback(
+    async (collectionId: number, itemId: number, quantity: number, quantityDelta: number) => {
+      const updated = await updateCollectionItem(collectionId, itemId, quantity)
+      invalidateOwnership()
+      if (quantityDelta !== 0) {
+        set({
+          collections: state.collections.map((c) =>
+            c.id === collectionId
+              ? { ...c, total_quantity: (c.total_quantity ?? c.item_count) + quantityDelta }
+              : c,
+          ),
+        })
+      }
+      return updated
+    },
+    [],
+  )
+
   const remove = useCallback(async (collectionId: number) => {
     await deleteCollection(collectionId)
     // Cascade-removed items drop the cards' ownership badges (#576) — bust
@@ -198,6 +220,7 @@ export function useCollections() {
     update,
     addCard,
     bulkAdd,
+    setItemQuantity,
     remove,
   }
 }


### PR DESCRIPTION
Closes #769

## What

Makes "how many of this card do I own" legible and editable in the canonical place — the collection detail view. Each card row gets a −/+ quantity stepper that shows the owned count and persists changes.

This is the collection-detail half of #769; the optional setting-gated quantity field in the search results table is left for a follow-up so this stays focused.

## Why

The data already existed (`collection_items.quantity`, summed into `/cards/ownership` and the binder fill math), but the detail view only hinted at it ("· 2x") and offered no way to adjust counts. The detail view is exactly where a user manages a specific list.

## How

- **Backend**: new `PATCH /collections/{id}/items/{item_id}` adjusts an item's quantity in place. Scoped through the parent collection (an unowned id 404s), dynamic collections rejected like the other item-write paths, quantity floored at 1 (dropping the last copy is a `DELETE`, not a quantity-0 patch).
- **Web**: a −/+ stepper per card row, optimistic with revert-on-failure. Editing is gated to manual/set collections — a dynamic (smart) collection's membership is rule-derived, so its rows show the count read-only. The collection summary's `total_quantity` (binder fill / slot math) stays in sync via the hook without a refetch, and the ownership cache (#576) is busted so badges refresh.

## How to verify

- `make check` green; `cd web && npm run build` green. New coverage: API (patch updates quantity, 422 on zero, 404 on wrong collection) and web (stepper increments + persists, floors at 1, read-only for dynamic collections).
- Manually: open a collection's detail → each card shows a −/+ count; adjust it and reopen to confirm it stuck. A smart collection shows the count read-only.

No new env vars or migrations — `render.yaml` unchanged.