### PR TITLE
feat(web): bring search's export options to the collection and wishlist detail views

### DIFF
--- a/web/src/components/CollectionDetail.test.tsx
+++ b/web/src/components/CollectionDetail.test.tsx
@@ -100,6 +100,15 @@ describe('CollectionDetail', () => {
     mockFetch.mockResolvedValue(collectionWith([]))
     render(<CollectionDetail collection={SUMMARY} open onOpenChange={() => {}} />)
     expect(await screen.findByText('No cards yet.')).toBeInTheDocument()
+    // No export control when there's nothing to export (#773).
+    expect(screen.queryByRole('button', { name: 'Export' })).not.toBeInTheDocument()
+  })
+
+  it('offers export when the collection has cards (#773)', async () => {
+    mockFetch.mockResolvedValue(collectionWith([item({ id: 7 })]))
+    render(<CollectionDetail collection={SUMMARY} open onOpenChange={() => {}} />)
+    await screen.findByText('Charizard')
+    expect(screen.getByRole('button', { name: 'Export' })).toBeInTheDocument()
   })
 
   it("doesn't fetch while closed", () => {

--- a/web/src/components/CollectionDetail.tsx
+++ b/web/src/components/CollectionDetail.tsx
@@ -15,9 +15,11 @@
  */
 import * as Dialog from '@radix-ui/react-dialog'
 import { ImageOff, Loader2, Minus, Plus, Wallet, X } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { fetchCollection, type CollectionItem, type CollectionSummary } from '../api/client'
 import { coverSwatch } from './binderIdentity'
+import { ExportBar } from './ExportBar'
+import { itemsToExportRows } from './exportRows'
 import { useCollections } from './useCollections'
 import { formatMoney } from '../utils/format'
 
@@ -104,6 +106,7 @@ export function CollectionDetail({ collection, open, onOpenChange }: Props) {
   }, [open, collection])
 
   const cover = coverSwatch(collection?.binder_color)
+  const exportRows = useMemo(() => itemsToExportRows(items ?? []), [items])
   const total = (items ?? []).reduce(
     (sum, it) => sum + (it.price_snapshot ?? 0) * (it.quantity ?? 1),
     0,
@@ -129,14 +132,23 @@ export function CollectionDetail({ collection, open, onOpenChange }: Props) {
                 {collection?.name ?? 'Collection'}
               </Dialog.Title>
             </div>
-            <Dialog.Close asChild>
-              <button
-                aria-label="Close"
-                className="rounded p-1 text-coconut-500 hover:bg-sand-200 dark:text-sand-300 dark:hover:bg-husk-100"
-              >
-                <X size={18} />
-              </button>
-            </Dialog.Close>
+            <div className="flex shrink-0 items-center gap-1">
+              {items && items.length > 0 && (
+                <ExportBar
+                  rows={exportRows}
+                  title={collection?.name}
+                  showSetIdCards={false}
+                />
+              )}
+              <Dialog.Close asChild>
+                <button
+                  aria-label="Close"
+                  className="rounded p-1 text-coconut-500 hover:bg-sand-200 dark:text-sand-300 dark:hover:bg-husk-100"
+                >
+                  <X size={18} />
+                </button>
+              </Dialog.Close>
+            </div>
           </header>
           <Dialog.Description className="sr-only">
             The cards in this collection, with their snapshot prices.

--- a/web/src/components/ExportBar.test.tsx
+++ b/web/src/components/ExportBar.test.tsx
@@ -236,4 +236,36 @@ describe('ExportBar', () => {
 
     expect(await screen.findByText('rate-limited')).toBeInTheDocument()
   })
+
+  // ---- #773: prop-driven export for the collection / want-list detail views ----
+
+  it('exports the rows passed as a prop over the Search store', async () => {
+    // The store has an unrelated run; the detail view supplies its own rows.
+    useAppStore.setState((s) => ({
+      rows: [makeRow(true)],
+      settings: { ...s.settings, sort: 'alpha' },
+    }))
+    const detailRows = [makeRow(true), makeRow(true)]
+
+    render(<ExportBar rows={detailRows} title="Base Set holos" showSetIdCards={false} />)
+    openDropdown()
+    fireEvent.click(screen.getByText('Download .xlsx'))
+
+    await waitFor(() => expect(mockExportFile).toHaveBeenCalledTimes(1))
+    // The provided rows + title are used; sort/etc. still come from settings.
+    expect(mockExportFile).toHaveBeenCalledWith(detailRows, 'xlsx', {
+      maxPrice: null,
+      title: 'Base Set holos',
+      sort: 'alpha',
+      noImages: true,
+      dedupe: false,
+    })
+  })
+
+  it('hides the Set ID cards item when showSetIdCards is false', () => {
+    render(<ExportBar rows={[makeRow(true)]} showSetIdCards={false} />)
+    openDropdown()
+    expect(screen.getByText('Download .xlsx')).toBeInTheDocument()
+    expect(screen.queryByText('Set ID cards…')).not.toBeInTheDocument()
+  })
 })

--- a/web/src/components/ExportBar.tsx
+++ b/web/src/components/ExportBar.tsx
@@ -27,8 +27,20 @@ import {
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { exportFile } from '../api/client'
 import { useAppStore } from '../store'
-import type { ExportFormat } from '../types'
+import type { ExportFormat, Row } from '../types'
 import { SetPickerModal } from './SetPickerModal'
+
+interface ExportBarProps {
+  /** Rows to export. Omit to use the Search store's current run (the default
+   *  results-header behavior); the collection / want-list detail views pass
+   *  their own items (#773). */
+  rows?: Row[]
+  /** Filename / sheet title. Falls back to the Search tag, then "cards". */
+  title?: string
+  /** Whether to offer the "Set ID cards…" item — search-only, since it pulls a
+   *  whole set catalog rather than the listed rows. Defaults to true. */
+  showSetIdCards?: boolean
+}
 
 const BUTTONS: { format: ExportFormat; label: string; icon: ReactNode }[] = [
   { format: 'xlsx', label: 'Download .xlsx', icon: <FileSpreadsheet size={14} /> },
@@ -37,8 +49,8 @@ const BUTTONS: { format: ExportFormat; label: string; icon: ReactNode }[] = [
   { format: 'checklist', label: 'Checklist', icon: <ListChecks size={14} /> },
 ]
 
-export function ExportBar() {
-  const { rows, settings } = useAppStore()
+export function ExportBar({ rows: rowsProp, title, showSetIdCards = true }: ExportBarProps = {}) {
+  const { rows: storeRows, settings } = useAppStore()
   const [loading, setLoading] = useState<ExportFormat | null>(null)
   const [error, setError] = useState<string | null>(null)
   // Set ID cards now opens the picker modal rather than firing an
@@ -46,7 +58,9 @@ export function ExportBar() {
   // (including the cross-fetch to /api/v1/sets).
   const [pickerOpen, setPickerOpen] = useState(false)
 
-  const matchedRows = rows.filter((r) => r.matched)
+  // Caller-supplied rows (a collection / want-list) win over the Search run.
+  const sourceRows = rowsProp ?? storeRows
+  const matchedRows = sourceRows.filter((r) => r.matched)
   const disabled = matchedRows.length === 0
   const anyLoading = loading !== null
 
@@ -55,9 +69,9 @@ export function ExportBar() {
     setLoading(format)
     setError(null)
     try {
-      await exportFile(rows, format, {
+      await exportFile(sourceRows, format, {
         maxPrice: settings.maxPrice,
-        title: settings.tag || 'cards',
+        title: title ?? (settings.tag || 'cards'),
         sort: settings.sort,
         noImages: settings.noImages,
         dedupe: settings.dedupe,
@@ -100,14 +114,18 @@ export function ExportBar() {
                 {b.label}
               </DropdownMenu.Item>
             ))}
-            <DropdownMenu.Separator className="my-1 h-px bg-sand-200 dark:bg-husk-100" />
-            <DropdownMenu.Item
-              onSelect={() => setPickerOpen(true)}
-              className="flex items-center gap-2 rounded px-2.5 py-2 text-sm text-coconut-700 dark:text-sand-50 outline-none data-[highlighted]:bg-sand-200 dark:data-[highlighted]:bg-husk-100"
-            >
-              <Tags size={14} />
-              Set ID cards…
-            </DropdownMenu.Item>
+            {showSetIdCards && (
+              <>
+                <DropdownMenu.Separator className="my-1 h-px bg-sand-200 dark:bg-husk-100" />
+                <DropdownMenu.Item
+                  onSelect={() => setPickerOpen(true)}
+                  className="flex items-center gap-2 rounded px-2.5 py-2 text-sm text-coconut-700 dark:text-sand-50 outline-none data-[highlighted]:bg-sand-200 dark:data-[highlighted]:bg-husk-100"
+                >
+                  <Tags size={14} />
+                  Set ID cards…
+                </DropdownMenu.Item>
+              </>
+            )}
             {matchedRows.length > 0 && (
               <>
                 <DropdownMenu.Separator className="my-1 h-px bg-sand-200 dark:bg-husk-100" />
@@ -122,7 +140,7 @@ export function ExportBar() {
       {/* Errors live outside the dropdown so they stay visible after the
           user picks a format and the menu closes. */}
       {error && <span className="text-xs text-ember-500 dark:text-ember-300">{error}</span>}
-      <SetPickerModal open={pickerOpen} onOpenChange={setPickerOpen} />
+      {showSetIdCards && <SetPickerModal open={pickerOpen} onOpenChange={setPickerOpen} />}
     </div>
   )
 }

--- a/web/src/components/WishlistDetail.test.tsx
+++ b/web/src/components/WishlistDetail.test.tsx
@@ -89,6 +89,8 @@ describe('WishlistDetail', () => {
     expect(screen.getByText('Charizard')).toBeInTheDocument()
     // The acquired one is struck through.
     expect(screen.getByText('Blastoise')).toHaveClass('line-through')
+    // Export is offered now that the want-list has items (#773).
+    expect(screen.getByRole('button', { name: 'Export' })).toBeInTheDocument()
   })
 
   it('promotes an item into a collection and marks it acquired', async () => {

--- a/web/src/components/WishlistDetail.tsx
+++ b/web/src/components/WishlistDetail.tsx
@@ -11,7 +11,7 @@
 import * as Dialog from '@radix-ui/react-dialog'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import { Check, Footprints, ImageOff, Loader2, Plus, Trash2, X } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
   deleteWishlistItem,
   fetchWishlist,
@@ -19,6 +19,8 @@ import {
   type WishlistItem,
   type WishlistSummary,
 } from '../api/client'
+import { ExportBar } from './ExportBar'
+import { itemsToExportRows } from './exportRows'
 import { invalidateOwnership } from './useCardOwnership'
 import { useCollections } from './useCollections'
 import { useWishlists } from './useWishlists'
@@ -313,6 +315,7 @@ export function WishlistDetail({ wishlist, open, onOpenChange }: Props) {
     return aDone - bDone
   })
   const outstanding = items.filter((i) => i.acquired_at == null).length
+  const exportRows = useMemo(() => itemsToExportRows(items), [items])
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
@@ -326,14 +329,19 @@ export function WishlistDetail({ wishlist, open, onOpenChange }: Props) {
                 {wishlist?.name ?? 'Wishlist'}
               </Dialog.Title>
             </div>
-            <Dialog.Close asChild>
-              <button
-                aria-label="Close"
-                className="rounded p-1 text-coconut-500 hover:bg-sand-200 dark:text-sand-300 dark:hover:bg-husk-100"
-              >
-                <X size={18} />
-              </button>
-            </Dialog.Close>
+            <div className="flex shrink-0 items-center gap-1">
+              {items.length > 0 && (
+                <ExportBar rows={exportRows} title={wishlist?.name} showSetIdCards={false} />
+              )}
+              <Dialog.Close asChild>
+                <button
+                  aria-label="Close"
+                  className="rounded p-1 text-coconut-500 hover:bg-sand-200 dark:text-sand-300 dark:hover:bg-husk-100"
+                >
+                  <X size={18} />
+                </button>
+              </Dialog.Close>
+            </div>
           </header>
           <Dialog.Description className="sr-only">
             Cards on this want-list. Mark one &ldquo;got it&rdquo; to move it into a

--- a/web/src/components/exportRows.test.ts
+++ b/web/src/components/exportRows.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { itemsToExportRows } from './exportRows'
+
+describe('itemsToExportRows', () => {
+  it('maps an item to a matched row carrying its payload + price', () => {
+    const rows = itemsToExportRows([
+      {
+        card: { id: 'base1-4', name: 'Charizard' },
+        card_name: 'Charizard',
+        card_number: '4',
+        card_set_id: 'base1',
+        price_snapshot: 250,
+        quantity: 1,
+      },
+    ])
+    expect(rows).toHaveLength(1)
+    expect(rows[0].matched).toBe(true)
+    expect(rows[0].card).toEqual({ id: 'base1-4', name: 'Charizard' })
+    expect(rows[0].pricing.market).toBe(250)
+    expect(rows[0].query.number).toBe('4')
+  })
+
+  it('expands a collection item into one row per owned copy (#773 review)', () => {
+    const rows = itemsToExportRows([
+      { card: { id: 'base1-4', name: 'Charizard' }, card_name: 'Charizard', quantity: 3 },
+    ])
+    // Three copies → three rows, so exports and price totals match the count.
+    expect(rows).toHaveLength(3)
+    expect(rows.every((r) => (r.card as { id: string }).id === 'base1-4')).toBe(true)
+  })
+
+  it('treats a missing quantity as a single copy (want-list items)', () => {
+    const rows = itemsToExportRows([{ card: { id: 'base1-2', name: 'Blastoise' } }])
+    expect(rows).toHaveLength(1)
+  })
+})

--- a/web/src/components/exportRows.ts
+++ b/web/src/components/exportRows.ts
@@ -1,0 +1,47 @@
+/**
+ * itemsToExportRows — adapt collection / want-list items into the `Row` shape
+ * the export endpoint and {@link ExportBar} consume (#773).
+ *
+ * A saved item carries the verbatim card payload (`card`) plus promoted
+ * identity/price columns. Export treats one item as one matched row — the same
+ * contract a Search result row uses — so the detail views can offer the same
+ * xlsx / PDF / checklist exports as Search.
+ */
+import type { CardData, Row } from '../types'
+
+interface ExportableItem {
+  card: Record<string, unknown>
+  card_name?: string | null
+  card_number?: string | null
+  card_set_id?: string | null
+  price_snapshot?: number | null
+}
+
+export function itemsToExportRows(items: ExportableItem[]): Row[] {
+  return items.map((it) => ({
+    query: {
+      raw: it.card_name ?? '',
+      name: it.card_name ?? '',
+      set_hint: it.card_set_id ?? null,
+      number: it.card_number ?? null,
+      variant_hint: null,
+      url_hint: null,
+      bulk_top: null,
+      bulk_all: false,
+      price_min: null,
+      price_max: null,
+    },
+    // The stored payload is the verbatim card JSON — exactly what export reads.
+    card: it.card as unknown as CardData,
+    pricing: {
+      market: it.price_snapshot ?? null,
+      variant: null,
+      source: null,
+      url: null,
+      currency: 'USD',
+    },
+    tag: '',
+    matched: true,
+    reason: '',
+  }))
+}

--- a/web/src/components/exportRows.ts
+++ b/web/src/components/exportRows.ts
@@ -3,9 +3,12 @@
  * the export endpoint and {@link ExportBar} consume (#773).
  *
  * A saved item carries the verbatim card payload (`card`) plus promoted
- * identity/price columns. Export treats one item as one matched row — the same
- * contract a Search result row uses — so the detail views can offer the same
- * xlsx / PDF / checklist exports as Search.
+ * identity/price columns. Export treats one card copy as one matched row — the
+ * same contract a Search result row uses — so the detail views can offer the
+ * same xlsx / PDF / checklist exports as Search. A collection item's owned
+ * `quantity` expands into that many rows so exports (and their price totals /
+ * binder slots) match the detail view; want-list items carry no quantity and
+ * stay one row each.
  */
 import type { CardData, Row } from '../types'
 
@@ -15,33 +18,40 @@ interface ExportableItem {
   card_number?: string | null
   card_set_id?: string | null
   price_snapshot?: number | null
+  quantity?: number | null
 }
 
 export function itemsToExportRows(items: ExportableItem[]): Row[] {
-  return items.map((it) => ({
-    query: {
-      raw: it.card_name ?? '',
-      name: it.card_name ?? '',
-      set_hint: it.card_set_id ?? null,
-      number: it.card_number ?? null,
-      variant_hint: null,
-      url_hint: null,
-      bulk_top: null,
-      bulk_all: false,
-      price_min: null,
-      price_max: null,
-    },
-    // The stored payload is the verbatim card JSON — exactly what export reads.
-    card: it.card as unknown as CardData,
-    pricing: {
-      market: it.price_snapshot ?? null,
-      variant: null,
-      source: null,
-      url: null,
-      currency: 'USD',
-    },
-    tag: '',
-    matched: true,
-    reason: '',
-  }))
+  return items.flatMap((it) => {
+    const row: Row = {
+      query: {
+        raw: it.card_name ?? '',
+        name: it.card_name ?? '',
+        set_hint: it.card_set_id ?? null,
+        number: it.card_number ?? null,
+        variant_hint: null,
+        url_hint: null,
+        bulk_top: null,
+        bulk_all: false,
+        price_min: null,
+        price_max: null,
+      },
+      // The stored payload is the verbatim card JSON — exactly what export reads.
+      card: it.card as unknown as CardData,
+      pricing: {
+        market: it.price_snapshot ?? null,
+        variant: null,
+        source: null,
+        url: null,
+        currency: 'USD',
+      },
+      tag: '',
+      matched: true,
+      reason: '',
+    }
+    // One row per owned copy (floored at 1), so a quantity-3 card exports as
+    // three rows / slots and its price counts thrice — matching the detail view.
+    const copies = Math.max(1, it.quantity ?? 1)
+    return Array.from({ length: copies }, () => ({ ...row }))
+  })
 }


### PR DESCRIPTION
Closes #773

## What

The collection and want-list **detail** views now offer the same export options as Search — xlsx, PDF binder, condensed PDF, and checklist — for the cards in that specific list. Today export only lives in the Search results header and the backpack list view; the detail view is exactly where a user has a list in front of them and wants to export it.

## How

- `ExportBar` gained optional `rows` / `title` / `showSetIdCards` props. Omitting them preserves the Search results-header behavior (reads the run from the store); the detail views pass their own items.
- A small `itemsToExportRows` helper maps a collection/want-list item (its verbatim card payload + promoted price) into the export `Row` shape — one item, one matched row, the same contract a Search result uses.
- The shared sort / max-price / no-images / dedupe settings still apply, so it behaves like Search.
- "Set ID cards…" stays Search-only (`showSetIdCards={false}` in the detail views), since it pulls a whole set catalog rather than the listed rows.
- Reuses the existing `/export` endpoint and `ExportBar` — no new formats, no backend change.

## How to verify

- `cd web && npm run build`, `npm run lint`, and the vitest suite (566) are green. New coverage: `ExportBar` exports prop-supplied rows over the store and hides Set ID cards when asked; the detail views surface the Export control only when the list has cards.
- Manually: open a collection or want-list with cards → an Export control sits in the header; pick a format and it downloads that list. An empty list shows no Export control.

No new env vars or migrations — `render.yaml` unchanged.