### PR TITLE
feat(web): unify library delete affordances on the saved-search pattern

### DIFF
--- a/web/src/components/BinderInventory.tsx
+++ b/web/src/components/BinderInventory.tsx
@@ -271,7 +271,7 @@ export function BinderInventory() {
                         type="button"
                         onClick={() => void handleDelete(b.id)}
                         aria-label={`Confirm delete ${b.name}`}
-                        className="rounded p-1 text-sun-600 hover:bg-sun-50 dark:text-sun-300 dark:hover:bg-husk-100"
+                        className="rounded p-1 text-ember-600 hover:bg-ember-500/10 dark:text-ember-300 dark:hover:bg-husk-100"
                       >
                         <Check size={13} />
                       </button>
@@ -289,7 +289,7 @@ export function BinderInventory() {
                       type="button"
                       onClick={() => setConfirmingId(b.id)}
                       aria-label={`Delete ${b.name}`}
-                      className="rounded p-1 text-coconut-400 hover:text-sun-600 dark:text-sand-300 dark:hover:text-sun-300"
+                      className="rounded p-1 text-coconut-400 hover:text-ember-500 dark:text-sand-300 dark:hover:text-ember-300"
                     >
                       <Trash2 size={13} />
                     </button>

--- a/web/src/components/LibraryBindersTab.test.tsx
+++ b/web/src/components/LibraryBindersTab.test.tsx
@@ -446,8 +446,8 @@ describe('LibraryBindersTab', () => {
     render(<LibraryBindersTab />)
     await waitFor(() => expect(screen.getByText('Charizard masters')).toBeInTheDocument())
 
-    fireEvent.click(screen.getByRole('button', { name: /delete collection "Charizard masters"/i }))
-    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^delete collection "Charizard masters"/i }))
+    fireEvent.click(screen.getByRole('button', { name: /confirm delete collection "Charizard masters"/i }))
 
     await waitFor(() => expect(mockDeleteCollection).toHaveBeenCalledWith(1))
     await waitFor(() =>
@@ -463,8 +463,8 @@ describe('LibraryBindersTab', () => {
     render(<LibraryBindersTab />)
     await waitFor(() => expect(screen.getByText('Mew hunt')).toBeInTheDocument())
 
-    fireEvent.click(screen.getByRole('button', { name: /delete want-list "Mew hunt"/i }))
-    fireEvent.click(screen.getByRole('button', { name: /^delete$/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^delete want-list "Mew hunt"/i }))
+    fireEvent.click(screen.getByRole('button', { name: /confirm delete want-list "Mew hunt"/i }))
 
     await waitFor(() => expect(mockDeleteWishlist).toHaveBeenCalledWith(2))
     await waitFor(() => expect(screen.queryByText('Mew hunt')).not.toBeInTheDocument())
@@ -492,8 +492,8 @@ describe('LibraryBindersTab', () => {
     render(<LibraryBindersTab />)
     await waitFor(() => expect(screen.getByText('Charizard masters')).toBeInTheDocument())
 
-    fireEvent.click(screen.getByRole('button', { name: /delete collection "Charizard masters"/i }))
-    fireEvent.click(screen.getByRole('button', { name: /^cancel$/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^delete collection "Charizard masters"/i }))
+    fireEvent.click(screen.getByRole('button', { name: /cancel delete/i }))
 
     expect(mockDeleteCollection).not.toHaveBeenCalled()
     expect(screen.getByText('Charizard masters')).toBeInTheDocument()

--- a/web/src/components/LibraryBindersTab.tsx
+++ b/web/src/components/LibraryBindersTab.tsx
@@ -31,6 +31,7 @@ import {
   Sparkles,
   Star,
   Trash2,
+  X,
 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { downloadCollectionIdCardPdf } from '../api/client'
@@ -708,10 +709,10 @@ function FileIntoBinderControl({
 }
 
 /**
- * Two-step delete affordance for a binder row. The trash icon reveals on
- * hover/focus (mirrors the Recent tab); clicking it swaps in an inline
- * "Delete / Cancel" confirm, since removing a binder cascade-deletes its
- * cards and can't be undone.
+ * Two-step delete affordance for a collection/want-list row. The trash icon is
+ * always visible; clicking it swaps in an inline check/x confirm, since
+ * deleting cascade-removes the row's cards and can't be undone. Mirrors the
+ * saved-search delete (#772).
  */
 function DeleteBinderControl({
   label,
@@ -738,7 +739,7 @@ function DeleteBinderControl({
 
   if (confirming) {
     return (
-      <div className="flex shrink-0 items-center gap-1">
+      <span className="flex shrink-0 items-center gap-1">
         {failed && (
           <span role="alert" className="text-[10px] text-ember-500 dark:text-ember-300">
             Couldn&apos;t delete
@@ -748,10 +749,10 @@ function DeleteBinderControl({
           type="button"
           onClick={() => void handleConfirm()}
           disabled={busy}
-          className="inline-flex items-center gap-1 rounded bg-ember-500 px-2 py-1 text-[11px] font-medium text-coconut-50 hover:bg-ember-600 disabled:opacity-50"
+          aria-label={`Confirm delete ${label}`}
+          className="rounded p-1 text-ember-600 hover:bg-ember-500/10 disabled:opacity-50 dark:text-ember-300 dark:hover:bg-husk-100"
         >
-          {busy && <Loader2 size={11} className="animate-spin" />}
-          Delete
+          {busy ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />}
         </button>
         <button
           type="button"
@@ -760,11 +761,12 @@ function DeleteBinderControl({
             setFailed(false)
           }}
           disabled={busy}
-          className="rounded px-2 py-1 text-[11px] font-medium text-coconut-500 hover:bg-sand-200 disabled:opacity-50 dark:text-sand-300 dark:hover:bg-husk-100"
+          aria-label="Cancel delete"
+          className="rounded p-1 text-coconut-400 hover:bg-sand-200 disabled:opacity-50 dark:text-sand-300 dark:hover:bg-husk-100"
         >
-          Cancel
+          <X size={14} />
         </button>
-      </div>
+      </span>
     )
   }
 
@@ -773,7 +775,7 @@ function DeleteBinderControl({
       type="button"
       onClick={() => setConfirming(true)}
       aria-label={`Delete ${label}`}
-      className="shrink-0 rounded p-1.5 text-coconut-400 opacity-100 transition-opacity hover:bg-sand-200 hover:text-ember-500 focus-visible:opacity-100 dark:text-sand-400 dark:hover:bg-husk-100 dark:hover:text-ember-300 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
+      className="shrink-0 rounded p-1.5 text-coconut-400 hover:bg-sand-200 hover:text-ember-500 dark:text-sand-400 dark:hover:bg-husk-100 dark:hover:text-ember-300"
     >
       <Trash2 size={14} />
     </button>

--- a/web/src/components/LibrarySearchesTab.tsx
+++ b/web/src/components/LibrarySearchesTab.tsx
@@ -279,7 +279,7 @@ function SavedSearchRow({
               }}
               disabled={deleting}
               aria-label={`Confirm delete saved search ${label}`}
-              className="rounded p-1 text-sun-600 hover:bg-sun-50 disabled:opacity-50 dark:text-sun-300 dark:hover:bg-husk-100"
+              className="rounded p-1 text-ember-600 hover:bg-ember-500/10 disabled:opacity-50 dark:text-ember-300 dark:hover:bg-husk-100"
             >
               <Check size={13} />
             </button>
@@ -298,7 +298,7 @@ function SavedSearchRow({
             onClick={() => setConfirming(true)}
             disabled={deleting}
             aria-label={`Delete saved search ${label}`}
-            className="shrink-0 rounded p-1 text-coconut-400 hover:text-sun-600 disabled:opacity-50 dark:text-sand-300 dark:hover:text-sun-300"
+            className="shrink-0 rounded p-1 text-coconut-400 hover:text-ember-500 disabled:opacity-50 dark:text-sand-300 dark:hover:text-ember-300"
           >
             <Trash2 size={13} />
           </button>


### PR DESCRIPTION
Closes #772

## What

Brings the collection and want-list deletes in line with the saved-search delete so every destructive delete in the library reads and behaves the same:

- **Always-visible trigger.** The collection / want-list trash icon no longer hides until hover — it's always shown, matching the saved-search and binder-inventory deletes.
- **Inline check / x confirm.** Clicking the trash flips to an inline check (confirm) / x (cancel) pair instead of a text "Delete / Cancel" button, so a delete always takes a deliberate second click. The "Couldn't delete" inline error and busy spinner are preserved.
- **Consistent destructive red.** The confirm action and the trash-hover hint now use the `ember` destructive token across all three deletes — saved-search and binder-inventory were the outliers still tinted `sun`.

Pure UX-consistency pass — no data-model or API change.

## Why

The trash / delete controls across the library had drifted: saved-search used an always-visible icon with a check/x confirm tinted `sun`, while collection and want-list deletes were hover-only with a text confirm. Unifying them on the saved-search pattern and a single destructive color makes "delete" predictable everywhere.

Scope note: the recent-searches X is a non-destructive "dismiss from history" and the open detail-view per-card removes are a different interaction class, so both are intentionally left as-is. The audit covered the three container-level deletes plus the binder-inventory delete.

## How to verify

1. Open the library Binders tab with at least one collection and one want-list.
2. Confirm each row's trash icon is visible without hovering.
3. Click a trash icon — it flips to a red check (confirm) and a neutral x (cancel); cancel restores the trash, confirm deletes the row.
4. Repeat on a saved search (Searches tab) and a binder in the binder inventory — the confirm reads the same red.

`make check` and `cd web && npm run build` are green; the LibraryBindersTab / LibrarySearchesTab / BinderInventory component tests cover the confirm flow.