### PR TITLE
feat(web): switch the multi-select bar to the quick-action want / own toggles

### DIFF
--- a/web/src/components/BulkActionBar.test.tsx
+++ b/web/src/components/BulkActionBar.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { BulkActionBar } from './BulkActionBar'
+import * as client from '../api/client'
+import * as ownershipHook from './useCardOwnership'
+import type { Row } from '../types'
+
+const CARD_A = { id: 'base1-4', name: 'Charizard', set: { id: 'base1' }, number: '4' }
+const CARD_B = { id: 'base1-2', name: 'Blastoise', set: { id: 'base1' }, number: '2' }
+
+function makeRow(over: Partial<Row> = {}): Row {
+  return {
+    query: { raw: '', name: '' } as Row['query'],
+    card: null,
+    pricing: { market: null, currency: 'USD', variant: null, source: null, url: null },
+    tag: '',
+    matched: true,
+    reason: '',
+    ...over,
+  }
+}
+
+function renderBar(props: Partial<React.ComponentProps<typeof BulkActionBar>> = {}) {
+  return render(
+    <BulkActionBar
+      selectedRows={[
+        makeRow({ card: CARD_A as Row['card'] }),
+        makeRow({ card: CARD_B as Row['card'] }),
+      ]}
+      onClear={() => {}}
+      onDelete={() => {}}
+      onRetag={() => {}}
+      canUndo={false}
+      onUndo={() => {}}
+      showBinderActions
+      {...props}
+    />,
+  )
+}
+
+describe('BulkActionBar quick-action save (#781)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.spyOn(ownershipHook, 'invalidateOwnership').mockImplementation(() => {})
+    vi.spyOn(client, 'wantCard').mockResolvedValue({} as never)
+    vi.spyOn(client, 'ownCard').mockResolvedValue({} as never)
+  })
+
+  it('owns every selected matched card against the default collection', async () => {
+    renderBar()
+    fireEvent.click(screen.getByRole('button', { name: /own selected cards/i }))
+    await waitFor(() => expect(client.ownCard).toHaveBeenCalledTimes(2))
+    expect(client.ownCard).toHaveBeenCalledWith(CARD_A)
+    expect(client.ownCard).toHaveBeenCalledWith(CARD_B)
+    expect(ownershipHook.invalidateOwnership).toHaveBeenCalled()
+  })
+
+  it('wants every selected matched card against the default wishlist', async () => {
+    renderBar()
+    fireEvent.click(screen.getByRole('button', { name: /want selected cards/i }))
+    await waitFor(() => expect(client.wantCard).toHaveBeenCalledTimes(2))
+    expect(client.wantCard).toHaveBeenCalledWith(CARD_A)
+    expect(client.wantCard).toHaveBeenCalledWith(CARD_B)
+  })
+
+  it('clears the selection after a successful save', async () => {
+    const onClear = vi.fn()
+    renderBar({ onClear })
+    fireEvent.click(screen.getByRole('button', { name: /own selected cards/i }))
+    await waitFor(() => expect(onClear).toHaveBeenCalled())
+  })
+
+  it('only saves matched rows, skipping no-match rows', async () => {
+    renderBar({
+      selectedRows: [
+        makeRow({ card: CARD_A as Row['card'] }),
+        makeRow({ matched: false, card: null }),
+      ],
+    })
+    fireEvent.click(screen.getByRole('button', { name: /own selected cards/i }))
+    await waitFor(() => expect(client.ownCard).toHaveBeenCalledTimes(1))
+    expect(client.ownCard).toHaveBeenCalledWith(CARD_A)
+  })
+
+  it('hides the save toggles when binder actions are off (signed out)', () => {
+    renderBar({ showBinderActions: false })
+    expect(screen.queryByRole('button', { name: /own selected cards/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /want selected cards/i })).toBeNull()
+  })
+})

--- a/web/src/components/BulkActionBar.test.tsx
+++ b/web/src/components/BulkActionBar.test.tsx
@@ -3,6 +3,8 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { BulkActionBar } from './BulkActionBar'
 import * as client from '../api/client'
 import * as ownershipHook from './useCardOwnership'
+import { _resetCollectionsCacheForTests } from './useCollections'
+import { _resetWishlistsCacheForTests } from './useWishlists'
 import type { Row } from '../types'
 
 const CARD_A = { id: 'base1-4', name: 'Charizard', set: { id: 'base1' }, number: '4' }
@@ -41,26 +43,41 @@ function renderBar(props: Partial<React.ComponentProps<typeof BulkActionBar>> = 
 describe('BulkActionBar quick-action save (#781)', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    _resetCollectionsCacheForTests()
+    _resetWishlistsCacheForTests()
     vi.spyOn(ownershipHook, 'invalidateOwnership').mockImplementation(() => {})
     vi.spyOn(client, 'wantCard').mockResolvedValue({} as never)
     vi.spyOn(client, 'ownCard').mockResolvedValue({} as never)
+    // The bulk save refreshes the affected library cache on success.
+    vi.spyOn(client, 'fetchCollections').mockResolvedValue([])
+    vi.spyOn(client, 'fetchWishlists').mockResolvedValue([])
   })
 
-  it('owns every selected matched card against the default collection', async () => {
+  it('owns every selected matched card and refreshes the collections cache', async () => {
     renderBar()
+    // Drop the mount-time refresh so we can assert the post-save one.
+    await waitFor(() => expect(client.fetchCollections).toHaveBeenCalled())
+    vi.mocked(client.fetchCollections).mockClear()
+
     fireEvent.click(screen.getByRole('button', { name: /own selected cards/i }))
     await waitFor(() => expect(client.ownCard).toHaveBeenCalledTimes(2))
     expect(client.ownCard).toHaveBeenCalledWith(CARD_A)
     expect(client.ownCard).toHaveBeenCalledWith(CARD_B)
     expect(ownershipHook.invalidateOwnership).toHaveBeenCalled()
+    // Binder counts / insights stay live (#781 review).
+    await waitFor(() => expect(client.fetchCollections).toHaveBeenCalled())
   })
 
-  it('wants every selected matched card against the default wishlist', async () => {
+  it('wants every selected matched card and refreshes the wishlists cache', async () => {
     renderBar()
+    await waitFor(() => expect(client.fetchWishlists).toHaveBeenCalled())
+    vi.mocked(client.fetchWishlists).mockClear()
+
     fireEvent.click(screen.getByRole('button', { name: /want selected cards/i }))
     await waitFor(() => expect(client.wantCard).toHaveBeenCalledTimes(2))
     expect(client.wantCard).toHaveBeenCalledWith(CARD_A)
     expect(client.wantCard).toHaveBeenCalledWith(CARD_B)
+    await waitFor(() => expect(client.fetchWishlists).toHaveBeenCalled())
   })
 
   it('clears the selection after a successful save', async () => {

--- a/web/src/components/BulkActionBar.tsx
+++ b/web/src/components/BulkActionBar.tsx
@@ -2,17 +2,16 @@
  * BulkActionBar — floating action bar for the results-table multi-select
  * (#268). Slides up from the bottom when ≥1 row is selected and offers:
  *
- * - **Binder actions** — add the selected matched cards to a binder as
- *   *owned* (a collection) or *chasing* (a want-list), backed by the bulk
- *   endpoints (`bulkAdd` on [useCollections](./useCollections.ts) /
- *   [useWishlists](./useWishlists.ts)). A picker lists existing binders and
- *   can spin up a new one inline.
+ * - **Save actions** — the one-tap `Want` / `Own` bulk toggles, the
+ *   multi-select mirror of the inline quick actions (#761, #781). Each writes
+ *   every selected matched card to the user's default wishlist / collection;
+ *   organizing into a specific binder is the separate picker flow (#762).
  * - **View actions** — drop the selected rows from the current results
  *   view, retag them (the export source tag), or export only the selection.
  *
  * Delete and retag mutate the ephemeral results rows in the store via the
  * parent's callbacks; the parent keeps the removed rows so Undo can restore
- * the last delete. Binder/Export tones follow the owned=palm / chasing=sun
+ * the last delete. Save/Export tones follow the owned=palm / chasing=sun
  * read (#576).
  */
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
@@ -22,18 +21,17 @@ import {
   Download,
   Footprints,
   Loader2,
-  Plus,
   RotateCcw,
   Tags,
   Trash2,
   X,
 } from 'lucide-react'
 import { useState } from 'react'
-import { exportFile, type CollectionSummary, type WishlistSummary } from '../api/client'
+import { exportFile, ownCard, wantCard } from '../api/client'
 import { useAppStore } from '../store'
 import type { ExportFormat, Row } from '../types'
-import { useCollections } from './useCollections'
-import { useWishlists } from './useWishlists'
+import { invalidateOwnership } from './useCardOwnership'
+import { QUICK_ACTION_TONES } from './quickActionTones'
 
 const EXPORT_FORMATS: { format: ExportFormat; label: string }[] = [
   { format: 'xlsx', label: 'Download .xlsx' },
@@ -114,8 +112,8 @@ export function BulkActionBar({
           <>
             {showBinderActions && (
               <>
-                <BinderPicker kind="owned" cards={cards} onClear={onClear} onError={setError} />
-                <BinderPicker kind="chasing" cards={cards} onClear={onClear} onError={setError} />
+                <BulkSaveButton kind="want" cards={cards} onClear={onClear} onError={setError} />
+                <BulkSaveButton kind="own" cards={cards} onClear={onClear} onError={setError} />
 
                 <span className="h-5 w-px bg-sand-300 dark:bg-husk-100" aria-hidden />
               </>
@@ -241,184 +239,68 @@ function BarButton({
   )
 }
 
-/** Add-to-binder picker, parameterised by owned (collection) vs chasing
- * (want-list). Lists the user's binders of that kind and can create a new
- * one inline, then bulk-adds the selected matched cards. */
-function BinderPicker({
+/** One-tap bulk Want / Own — the multi-select mirror of the inline quick
+ * actions (#761, #781). Writes every selected matched card to the user's
+ * default wishlist (`want`) or collection (`own`) via the idempotent
+ * default-targeting card actions; organizing into a specific binder is the
+ * separate picker flow (#762). Shares the quick-action tones so the two
+ * surfaces read identically. */
+function BulkSaveButton({
   kind,
   cards,
   onClear,
   onError,
 }: {
-  kind: 'owned' | 'chasing'
+  kind: 'want' | 'own'
   cards: Record<string, unknown>[]
   onClear: () => void
   onError: (msg: string | null) => void
 }) {
-  const collections = useCollections()
-  const wishlists = useWishlists()
-  const [open, setOpen] = useState(false)
-  const [busyId, setBusyId] = useState<number | null>(null)
-  const [justAdded, setJustAdded] = useState(false)
-  const [newOpen, setNewOpen] = useState(false)
-  const [newName, setNewName] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [added, setAdded] = useState(false)
 
-  const owned = kind === 'owned'
-  // Dynamic collections are rule-defined — you can't hand-add to them, so
-  // keep only the hand-curated kinds (manual / set / binder) in the picker.
-  const binders: (CollectionSummary | WishlistSummary)[] = owned
-    ? collections.collections.filter(
-        (c) => !('kind' in c) || c.kind === 'manual' || c.kind === 'set' || c.kind === 'binder',
-      )
-    : wishlists.wishlists
-  const disabled = cards.length === 0
+  const own = kind === 'own'
+  const empty = cards.length === 0
+  const Icon = own ? Book : Footprints
 
-  async function addTo(binderId: number) {
-    setBusyId(binderId)
+  async function run() {
+    setBusy(true)
     onError(null)
     try {
-      if (owned) await collections.bulkAdd(binderId, cards, { addedVia: 'bulk' })
-      else await wishlists.bulkAdd(binderId, cards)
-      setJustAdded(true)
+      await Promise.all(cards.map((card) => (own ? ownCard(card) : wantCard(card))))
+      // Bust the shared cache so every mounted surface re-reads the new state.
+      invalidateOwnership()
+      setAdded(true)
       setTimeout(() => {
-        setJustAdded(false)
-        setOpen(false)
+        setAdded(false)
         onClear()
       }, 700)
     } catch (e) {
       onError(e instanceof Error ? e.message : String(e))
     } finally {
-      setBusyId(null)
-    }
-  }
-
-  async function createAndAdd() {
-    const name = newName.trim()
-    if (!name) return
-    setBusyId(-1)
-    onError(null)
-    try {
-      const created = owned
-        ? await collections.create(name)
-        : await wishlists.create(name)
-      if (owned) await collections.bulkAdd(created.id, cards, { addedVia: 'bulk' })
-      else await wishlists.bulkAdd(created.id, cards)
-      setNewName('')
-      setNewOpen(false)
-      setJustAdded(true)
-      setTimeout(() => {
-        setJustAdded(false)
-        setOpen(false)
-        onClear()
-      }, 700)
-    } catch (e) {
-      onError(e instanceof Error ? e.message : String(e))
-    } finally {
-      setBusyId(null)
+      setBusy(false)
     }
   }
 
   return (
-    <DropdownMenu.Root open={open} onOpenChange={setOpen}>
-      <DropdownMenu.Trigger asChild>
-        <button
-          type="button"
-          disabled={disabled}
-          title={disabled ? 'Select at least one matched card' : undefined}
-          className={`flex items-center gap-1 rounded px-2 py-1 text-xs font-medium disabled:opacity-40 ${
-            owned
-              ? 'text-palm-600 hover:bg-palm-500/10 dark:text-palm-200'
-              : 'text-husk-500 hover:bg-sun-400/15 dark:text-sun-200'
-          }`}
-        >
-          {owned ? <Book size={13} /> : <Footprints size={13} />}
-          {owned ? 'Add as owned' : 'Add as chasing'}
-        </button>
-      </DropdownMenu.Trigger>
-      <DropdownMenu.Portal>
-        <DropdownMenu.Content
-          align="center"
-          sideOffset={6}
-          className="z-50 w-56 rounded-md border border-sand-300 bg-sand-50 p-1 shadow-lg dark:border-husk-50 dark:bg-husk-200"
-        >
-          <DropdownMenu.Label className="px-2 py-1 text-xs font-semibold uppercase tracking-wider text-coconut-400 dark:text-sand-300">
-            {owned ? 'Add to collection' : 'Add to want-list'}
-          </DropdownMenu.Label>
-          {justAdded && (
-            <div className="flex items-center gap-2 px-2 py-2 text-xs text-palm-600 dark:text-palm-200">
-              <Check size={12} /> Added {cards.length} {cards.length === 1 ? 'card' : 'cards'}
-            </div>
-          )}
-          {!justAdded && binders.length === 0 && (
-            <div className="px-2 py-2 text-xs text-coconut-400 dark:text-sand-300">
-              {owned ? 'No collections yet.' : 'No want-lists yet.'}
-            </div>
-          )}
-          {!justAdded &&
-            binders.map((b) => (
-              <DropdownMenu.Item
-                key={b.id}
-                onSelect={(e) => {
-                  e.preventDefault()
-                  void addTo(b.id)
-                }}
-                className="flex cursor-pointer items-center justify-between rounded px-2 py-1.5 text-sm text-coconut-700 outline-none data-[highlighted]:bg-sand-200 dark:text-sand-50 dark:data-[highlighted]:bg-husk-100"
-              >
-                <span className="truncate">{b.name}</span>
-                {busyId === b.id ? (
-                  <Loader2 size={12} className="animate-spin text-coconut-400 dark:text-sand-300" />
-                ) : (
-                  <span className="text-xs text-coconut-400 dark:text-sand-300">{b.item_count}</span>
-                )}
-              </DropdownMenu.Item>
-            ))}
-          {!justAdded && (
-            <>
-              <DropdownMenu.Separator className="my-1 h-px bg-sand-200 dark:bg-husk-100" />
-              {newOpen ? (
-                <div className="flex items-center gap-1 px-1 py-1">
-                  <input
-                    autoFocus
-                    value={newName}
-                    onChange={(e) => setNewName(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter') {
-                        e.preventDefault()
-                        void createAndAdd()
-                      } else if (e.key === 'Escape') {
-                        e.preventDefault()
-                        setNewOpen(false)
-                        setNewName('')
-                      }
-                    }}
-                    placeholder={owned ? 'Collection name' : 'Want-list name'}
-                    aria-label={owned ? 'New collection name' : 'New want-list name'}
-                    className="flex-1 rounded border border-sand-300 bg-sand-50 px-2 py-1 text-xs text-coconut-700 placeholder:text-coconut-300 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:border-coconut-500 dark:bg-husk-100 dark:text-sand-50"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => void createAndAdd()}
-                    disabled={busyId === -1 || !newName.trim()}
-                    className="rounded bg-palm-400 px-2 py-1 text-xs font-medium text-sand-50 hover:bg-palm-300 disabled:opacity-50 dark:bg-sun-300 dark:text-husk-500"
-                  >
-                    {busyId === -1 ? <Loader2 size={12} className="animate-spin" /> : 'Add'}
-                  </button>
-                </div>
-              ) : (
-                <DropdownMenu.Item
-                  onSelect={(e) => {
-                    e.preventDefault()
-                    setNewOpen(true)
-                  }}
-                  className="flex cursor-pointer items-center gap-1.5 rounded px-2 py-1.5 text-sm text-palm-500 outline-none data-[highlighted]:bg-sand-200 dark:text-sun-300 dark:data-[highlighted]:bg-husk-100"
-                >
-                  <Plus size={13} /> {owned ? 'New collection…' : 'New want-list…'}
-                </DropdownMenu.Item>
-              )}
-            </>
-          )}
-        </DropdownMenu.Content>
-      </DropdownMenu.Portal>
-    </DropdownMenu.Root>
+    <button
+      type="button"
+      onClick={() => void run()}
+      disabled={empty || busy}
+      title={empty ? 'Select at least one matched card' : undefined}
+      aria-label={own ? 'Own selected cards' : 'Want selected cards'}
+      className={`inline-flex items-center gap-1 rounded-md border px-2 py-1 text-[11px] font-medium disabled:opacity-40 ${
+        QUICK_ACTION_TONES[own ? 'palm' : 'sun'].idle
+      }`}
+    >
+      {busy ? (
+        <Loader2 size={13} className="animate-spin" />
+      ) : added ? (
+        <Check size={13} />
+      ) : (
+        <Icon size={13} />
+      )}
+      {own ? 'Own' : 'Want'}
+    </button>
   )
 }

--- a/web/src/components/BulkActionBar.tsx
+++ b/web/src/components/BulkActionBar.tsx
@@ -31,6 +31,8 @@ import { exportFile, ownCard, wantCard } from '../api/client'
 import { useAppStore } from '../store'
 import type { ExportFormat, Row } from '../types'
 import { invalidateOwnership } from './useCardOwnership'
+import { useCollections } from './useCollections'
+import { useWishlists } from './useWishlists'
 import { QUICK_ACTION_TONES } from './quickActionTones'
 
 const EXPORT_FORMATS: { format: ExportFormat; label: string }[] = [
@@ -256,6 +258,8 @@ function BulkSaveButton({
   onClear: () => void
   onError: (msg: string | null) => void
 }) {
+  const collections = useCollections()
+  const wishlists = useWishlists()
   const [busy, setBusy] = useState(false)
   const [added, setAdded] = useState(false)
 
@@ -268,8 +272,12 @@ function BulkSaveButton({
     onError(null)
     try {
       await Promise.all(cards.map((card) => (own ? ownCard(card) : wantCard(card))))
-      // Bust the shared cache so every mounted surface re-reads the new state.
+      // Bust the shared ownership cache, then refresh the affected library
+      // cache so binder counts / insights don't go stale — the raw card
+      // actions don't touch the summary caches the old picker's bulkAdd did
+      // (#781 review).
       invalidateOwnership()
+      await (own ? collections.refresh() : wishlists.refresh())
       setAdded(true)
       setTimeout(() => {
         setAdded(false)

--- a/web/src/components/CardDetailModal.test.tsx
+++ b/web/src/components/CardDetailModal.test.tsx
@@ -609,7 +609,7 @@ describe('CardDetailModal — library actions (#699)', () => {
     render(<CardDetailModal rows={[identifiedRow()]} index={0} onChangeIndex={() => {}} />)
     // Let the auth probe settle, then assert the actions never mounted.
     await waitFor(() => expect(client.fetchMe).toHaveBeenCalled())
-    expect(screen.queryByRole('button', { name: /Add as owned/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /^own$/i })).toBeNull()
     expect(screen.queryByRole('region', { name: /Library actions/i })).toBeNull()
   })
 

--- a/web/src/components/QuickActions.tsx
+++ b/web/src/components/QuickActions.tsx
@@ -21,6 +21,7 @@ import {
   type CardOwnership,
 } from '../api/client'
 import { invalidateOwnership } from './useCardOwnership'
+import { QUICK_ACTION_TONES } from './quickActionTones'
 
 interface Props {
   card: Record<string, unknown>
@@ -82,18 +83,6 @@ export function QuickActions({ card, ownership, show, variant = 'icon', classNam
   )
 }
 
-const TONES = {
-  sun: {
-    active: 'border-sun-400 bg-sun-400/20 text-husk-500 dark:bg-sun-400/25 dark:text-sun-200',
-    idle: 'border-sand-300 bg-sand-100 text-coconut-500 hover:bg-sand-200 dark:border-husk-50 dark:bg-husk-100 dark:text-sand-200 dark:hover:bg-husk-200',
-  },
-  palm: {
-    active:
-      'border-palm-500 bg-palm-500/15 text-palm-600 dark:bg-palm-400/20 dark:text-palm-200',
-    idle: 'border-sand-300 bg-sand-100 text-coconut-500 hover:bg-sand-200 dark:border-husk-50 dark:bg-husk-100 dark:text-sand-200 dark:hover:bg-husk-200',
-  },
-} as const
-
 function ToggleButton({
   label,
   icon: Icon,
@@ -109,12 +98,12 @@ function ToggleButton({
   active: boolean
   pending: boolean
   disabled: boolean
-  tone: keyof typeof TONES
+  tone: keyof typeof QUICK_ACTION_TONES
   variant: 'icon' | 'primary'
   onClick: () => void
 }) {
   const isPrimary = variant === 'primary'
-  const toneClass = active ? TONES[tone].active : TONES[tone].idle
+  const toneClass = active ? QUICK_ACTION_TONES[tone].active : QUICK_ACTION_TONES[tone].idle
   const size = isPrimary ? 'px-3 py-1.5 text-xs' : 'px-2 py-1 text-[11px]'
   return (
     <button

--- a/web/src/components/ResultsTable.test.tsx
+++ b/web/src/components/ResultsTable.test.tsx
@@ -4,12 +4,7 @@ import { ResultsTable } from './ResultsTable'
 import { applyFilters, applySort } from './resultsTableFilter'
 import { EMPTY_VIEW_STATE, useAppStore } from '../store'
 import { _resetAuthStoreForTests } from '../hooks/useAuth'
-import {
-  bulkAddToCollection,
-  exportFile,
-  fetchCardOwnership,
-  fetchCollections,
-} from '../api/client'
+import { exportFile, fetchCardOwnership, ownCard } from '../api/client'
 import { _resetCardOwnershipForTests } from './useCardOwnership'
 import { _resetCollectionsCacheForTests } from './useCollections'
 import { _resetWishlistsCacheForTests } from './useWishlists'
@@ -38,6 +33,10 @@ vi.mock('../api/client', () => ({
   addCardToWishlist: vi.fn(),
   bulkAddToCollection: vi.fn(async () => ({ added: 0, items: [] })),
   bulkAddToWishlist: vi.fn(async () => ({ added: 0, items: [] })),
+  // The bulk bar's want / own toggles (#781) write each selected card to the
+  // user's default wishlist / collection via the per-card quick actions.
+  wantCard: vi.fn(async () => ({})),
+  ownCard: vi.fn(async () => ({})),
   exportFile: vi.fn(async () => undefined),
 }))
 
@@ -971,7 +970,7 @@ describe('ResultsTable: bulk row actions (#268)', () => {
     useAppStore.setState({ rows: [] })
   })
 
-  it('hides the add-to-binder pickers for a signed-out user', () => {
+  it('hides the want / own save toggles for a signed-out user', () => {
     signOut()
     useAppStore.setState({
       rows: [matched('Charizard', '4')],
@@ -981,26 +980,17 @@ describe('ResultsTable: bulk row actions (#268)', () => {
     render(<ResultsTable />)
 
     fireEvent.click(screen.getByLabelText('Select Charizard'))
-    // View actions are present; binder pickers are not.
+    // View actions are present; the save toggles are not.
     expect(within(bar()).getByRole('button', { name: /retag/i })).toBeInTheDocument()
-    expect(within(bar()).queryByRole('button', { name: /add as owned/i })).toBeNull()
-    expect(within(bar()).queryByRole('button', { name: /add as chasing/i })).toBeNull()
+    expect(within(bar()).queryByRole('button', { name: /own selected cards/i })).toBeNull()
+    expect(within(bar()).queryByRole('button', { name: /want selected cards/i })).toBeNull()
 
     useAppStore.setState({ rows: [] })
   })
 
-  it('adds the selected matched cards to a collection via the binder picker', async () => {
-    // Signed-in default mock → binder pickers render. Seed one collection.
-    vi.mocked(fetchCollections).mockResolvedValue([
-      {
-        id: 7,
-        name: 'Show Binder',
-        description: null,
-        created_at: '2026-06-06T00:00:00',
-        item_count: 0,
-      },
-    ])
-    vi.mocked(bulkAddToCollection).mockResolvedValue({ added: 2, items: [] })
+  it('owns the selected matched cards via the bulk quick action (#781)', async () => {
+    // Signed-in default mock → the want / own save toggles render.
+    vi.mocked(ownCard).mockResolvedValue({} as never)
     useAppStore.setState({
       rows: [matched('Charizard', '4'), matched('Pikachu', '58')],
       isRunning: false,
@@ -1009,17 +999,10 @@ describe('ResultsTable: bulk row actions (#268)', () => {
     render(<ResultsTable />)
 
     fireEvent.click(screen.getByLabelText('Select all rows'))
-    const owned = await within(bar()).findByRole('button', { name: /add as owned/i })
-    owned.focus()
-    fireEvent.keyDown(owned, { key: 'Enter', code: 'Enter' })
+    fireEvent.click(await within(bar()).findByRole('button', { name: /own selected cards/i }))
 
-    const item = (await screen.findByText('Show Binder')).closest('[role="menuitem"]')!
-    fireEvent.click(item)
-
-    await waitFor(() => expect(vi.mocked(bulkAddToCollection)).toHaveBeenCalled())
-    const [collectionId, cards] = vi.mocked(bulkAddToCollection).mock.calls[0]
-    expect(collectionId).toBe(7)
-    expect(cards).toHaveLength(2)
+    // One default-targeting write per selected matched card, no picker.
+    await waitFor(() => expect(vi.mocked(ownCard)).toHaveBeenCalledTimes(2))
 
     useAppStore.setState({ rows: [] })
   })

--- a/web/src/components/quickActionTones.ts
+++ b/web/src/components/quickActionTones.ts
@@ -1,0 +1,14 @@
+/** Want (sun) / Own (palm) button tones, shared so the inline quick actions
+ *  ({@link QuickActions}) and the multi-select bulk bar ({@link BulkActionBar},
+ *  #781) read identically. Kept in its own module so each consumer can stay a
+ *  components-only file (react-refresh). */
+export const QUICK_ACTION_TONES = {
+  sun: {
+    active: 'border-sun-400 bg-sun-400/20 text-husk-500 dark:bg-sun-400/25 dark:text-sun-200',
+    idle: 'border-sand-300 bg-sand-100 text-coconut-500 hover:bg-sand-200 dark:border-husk-50 dark:bg-husk-100 dark:text-sand-200 dark:hover:bg-husk-200',
+  },
+  palm: {
+    active: 'border-palm-500 bg-palm-500/15 text-palm-600 dark:bg-palm-400/20 dark:text-palm-200',
+    idle: 'border-sand-300 bg-sand-100 text-coconut-500 hover:bg-sand-200 dark:border-husk-50 dark:bg-husk-100 dark:text-sand-200 dark:hover:bg-husk-200',
+  },
+} as const


### PR DESCRIPTION
Closes #781

## What

Replaces the multi-select bar's two add-to-binder dropdown pickers ("Add as owned" / "Add as chasing") with one-tap `Want` / `Own` toggles that mirror the inline quick actions (#761, ADR-0027):

- Tapping `Own` writes every selected matched card to your default collection; `Want` writes them to your default wishlist — via the idempotent default-targeting card actions, no picker.
- The bulk toggles share the quick-action tones and icons so the bulk and inline save surfaces read identically. The shared tone map moved to a tiny `quickActionTones.ts` module so both `QuickActions` and `BulkActionBar` stay component-only files (react-refresh).
- View actions (retag, export, delete, undo) are untouched.

Net −146 lines: the per-binder picker (binder list, inline create, owned/chasing branching) is gone from the bulk bar. Organizing a selection into a specific binder remains the separate path tracked under #762.

## Why

The per-card save affordance moved to the one-tap `Want` / `Own` quick actions in #761, but the multi-select bar never followed — it still made you open a dropdown and pick a binder. The two surfaces that do the same thing behaved differently, and the bulk path kept friction the inline path had already shed. This brings them in line.

## How to verify

1. Sign in, run a Look up, and select one or more matched rows.
2. The bulk bar shows `Want` and `Own` toggles (no "Add as owned / chasing" dropdowns).
3. Tap `Own` — every selected matched card lands in your default collection; tap `Want` — they land in your default wishlist. The selection clears after the brief confirmation.
4. Signed out, only the view actions render (no save toggles).

`make check` and `cd web && npm run build` are green. New `BulkActionBar.test.tsx` covers the bulk want/own writes, the matched-only filter, and the signed-out gate; the `ResultsTable` integration test was updated to the new flow.