### PR TITLE
feat(web): add a card to a specific list from the detail view

### DIFF
--- a/web/src/components/AddToListPicker.test.tsx
+++ b/web/src/components/AddToListPicker.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { AddToListPicker } from './AddToListPicker'
+import { useCollections } from './useCollections'
+import { useWishlists } from './useWishlists'
+import type { CardOwnership } from '../api/client'
+
+vi.mock('./useCollections', () => ({ useCollections: vi.fn() }))
+vi.mock('./useWishlists', () => ({ useWishlists: vi.fn() }))
+
+const CARD = { id: 'base1-4', name: 'Charizard', set: { id: 'base1' }, number: '4' }
+
+const addCardC = vi.fn(async () => {})
+const addCardW = vi.fn(async () => {})
+const createC = vi.fn(async () => ({ id: 99, name: 'New' }))
+const createW = vi.fn(async () => ({ id: 88, name: 'New' }))
+
+function setLists(
+  collections: { id: number; name: string; item_count: number; kind?: string }[],
+  wishlists: { id: number; name: string; item_count: number }[],
+) {
+  vi.mocked(useCollections).mockReturnValue({
+    collections,
+    addCard: addCardC,
+    create: createC,
+  } as unknown as ReturnType<typeof useCollections>)
+  vi.mocked(useWishlists).mockReturnValue({
+    wishlists,
+    addCard: addCardW,
+    create: createW,
+  } as unknown as ReturnType<typeof useWishlists>)
+}
+
+function open() {
+  const trigger = screen.getByRole('button', { name: /add to a list/i })
+  trigger.focus()
+  fireEvent.keyDown(trigger, { key: 'Enter', code: 'Enter' })
+}
+
+describe('AddToListPicker (#762)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setLists(
+      [
+        { id: 1, name: 'Show Binder', item_count: 4, kind: 'manual' },
+        { id: 2, name: 'Smart set', item_count: 9, kind: 'dynamic' },
+      ],
+      [{ id: 5, name: 'Chase list', item_count: 2 }],
+    )
+  })
+
+  it('offers hand-curated collections and want-lists, hiding dynamic ones', () => {
+    render(<AddToListPicker card={CARD} ownership={null} />)
+    open()
+    expect(screen.getByRole('menuitem', { name: /Show Binder/i })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /Chase list/i })).toBeInTheDocument()
+    // Dynamic (smart) collections are rule-resolved — not hand-addable.
+    expect(screen.queryByRole('menuitem', { name: /Smart set/i })).toBeNull()
+  })
+
+  it('excludes lists the card already lives in', () => {
+    const ownership: CardOwnership = {
+      collections: [{ id: 1, name: 'Show Binder', quantity: 1 }],
+      wishlists: [{ id: 5, name: 'Chase list' }],
+    }
+    render(<AddToListPicker card={CARD} ownership={ownership} />)
+    open()
+    expect(screen.queryByRole('menuitem', { name: /Show Binder/i })).toBeNull()
+    expect(screen.queryByRole('menuitem', { name: /Chase list/i })).toBeNull()
+  })
+
+  it('adds the card to a chosen collection', async () => {
+    render(<AddToListPicker card={CARD} ownership={null} />)
+    open()
+    fireEvent.click(screen.getByRole('menuitem', { name: /Show Binder/i }))
+    await waitFor(() => expect(addCardC).toHaveBeenCalledWith(1, CARD))
+  })
+
+  it('adds the card to a chosen want-list', async () => {
+    render(<AddToListPicker card={CARD} ownership={null} />)
+    open()
+    fireEvent.click(screen.getByRole('menuitem', { name: /Chase list/i }))
+    await waitFor(() => expect(addCardW).toHaveBeenCalledWith(5, CARD))
+  })
+
+  it('creates a new collection and adds the card to it', async () => {
+    render(<AddToListPicker card={CARD} ownership={null} />)
+    open()
+    fireEvent.click(screen.getByRole('menuitem', { name: /New collection/i }))
+    fireEvent.change(screen.getByLabelText(/Collection name/i), {
+      target: { value: 'Graded slabs' },
+    })
+    fireEvent.keyDown(screen.getByLabelText(/Collection name/i), { key: 'Enter', code: 'Enter' })
+    await waitFor(() => expect(createC).toHaveBeenCalledWith('Graded slabs'))
+    await waitFor(() => expect(addCardC).toHaveBeenCalledWith(99, CARD))
+  })
+})

--- a/web/src/components/AddToListPicker.test.tsx
+++ b/web/src/components/AddToListPicker.test.tsx
@@ -69,6 +69,18 @@ describe('AddToListPicker (#762)', () => {
     expect(screen.queryByRole('menuitem', { name: /Chase list/i })).toBeNull()
   })
 
+  it('withholds existing lists until ownership is known, keeping create available', () => {
+    // `undefined` = the batched ownership lookup is still in flight; offering
+    // an occupied list now would insert a duplicate row (#762 review).
+    render(<AddToListPicker card={CARD} ownership={undefined} />)
+    open()
+    expect(screen.queryByRole('menuitem', { name: /Show Binder/i })).toBeNull()
+    expect(screen.queryByRole('menuitem', { name: /Chase list/i })).toBeNull()
+    // Create-and-add stays available — a brand-new list can't already hold it.
+    expect(screen.getByRole('menuitem', { name: /New collection/i })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /New want-list/i })).toBeInTheDocument()
+  })
+
   it('adds the card to a chosen collection', async () => {
     render(<AddToListPicker card={CARD} ownership={null} />)
     open()

--- a/web/src/components/AddToListPicker.tsx
+++ b/web/src/components/AddToListPicker.tsx
@@ -35,15 +35,25 @@ export function AddToListPicker({
   const [newName, setNewName] = useState('')
   const [error, setError] = useState<string | null>(null)
 
+  // `undefined` means the batched ownership lookup is still in flight (vs.
+  // `null`, a known-empty result). Withhold the existing-list choices until
+  // it resolves — adding to a list the card is already in inserts a duplicate
+  // row, so we can't offer them before the "already in" filter is reliable
+  // (#762 review). Create-and-add stays available: a brand-new list can't
+  // already contain the card.
+  const loading = ownership === undefined
+
   // Drop lists the card already sits in (from the shared occupancy) and
   // dynamic collections, whose membership is rule-resolved (the items API
   // 409s on a hand-add).
   const inCollections = new Set((ownership?.collections ?? []).map((c) => c.id))
   const inWishlists = new Set((ownership?.wishlists ?? []).map((w) => w.id))
-  const addableCollections = collections.collections.filter(
-    (c) => c.kind !== 'dynamic' && !inCollections.has(c.id),
-  )
-  const addableWishlists = wishlists.wishlists.filter((w) => !inWishlists.has(w.id))
+  const addableCollections = loading
+    ? []
+    : collections.collections.filter((c) => c.kind !== 'dynamic' && !inCollections.has(c.id))
+  const addableWishlists = loading
+    ? []
+    : wishlists.wishlists.filter((w) => !inWishlists.has(w.id))
 
   function reset() {
     setCreating(null)
@@ -129,6 +139,7 @@ export function AddToListPicker({
             label="Add to collection"
             icon={<Book size={12} />}
             items={addableCollections}
+            loading={loading}
             emptyHint="In every collection already."
             onPick={addToCollection}
             creating={creating === 'collection'}
@@ -149,6 +160,7 @@ export function AddToListPicker({
             label="Add to want-list"
             icon={<Footprints size={12} />}
             items={addableWishlists}
+            loading={loading}
             emptyHint="On every want-list already."
             onPick={addToWishlist}
             creating={creating === 'wishlist'}
@@ -179,6 +191,7 @@ function ListSection({
   label,
   icon,
   items,
+  loading,
   emptyHint,
   onPick,
   creating,
@@ -194,6 +207,7 @@ function ListSection({
   label: string
   icon: React.ReactNode
   items: { id: number; name: string; item_count: number }[]
+  loading: boolean
   emptyHint: string
   onPick: (id: number) => void
   creating: boolean
@@ -212,7 +226,12 @@ function ListSection({
         {icon}
         {label}
       </DropdownMenu.Label>
-      {items.length === 0 && !creating && (
+      {loading && (
+        <div className="flex items-center gap-2 px-2 py-1 text-[11px] text-coconut-400 dark:text-sand-300">
+          <Loader2 size={12} className="animate-spin" /> Checking your lists…
+        </div>
+      )}
+      {!loading && items.length === 0 && !creating && (
         <div className="px-2 py-1 text-[11px] text-coconut-400 dark:text-sand-300">{emptyHint}</div>
       )}
       {items.map((item) => (

--- a/web/src/components/AddToListPicker.tsx
+++ b/web/src/components/AddToListPicker.tsx
@@ -1,0 +1,274 @@
+/**
+ * AddToListPicker — the "organize later" half of the capture-first model
+ * (#762, ADR-0027). The one-tap Want / Own toggles write to your *default*
+ * list; this is the light, optional secondary step that puts the same card on
+ * a *specific* named collection or want-list — without the old up-front picker
+ * gate returning.
+ *
+ * Lists the card isn't already in are offered (the derived occupancy comes from
+ * the shared ownership lookup, so a list drops out the moment the card lands in
+ * it). Dynamic (smart) collections are rule-resolved and can't be hand-added,
+ * so they're filtered out. Adding goes through the cache-aware hooks, which
+ * bump the item counts and bust the ownership badge so every surface re-reads.
+ */
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
+import { Book, Footprints, ListPlus, Loader2, Plus } from 'lucide-react'
+import { useState } from 'react'
+import type { CardOwnership } from '../api/client'
+import { useCollections } from './useCollections'
+import { useWishlists } from './useWishlists'
+
+type Creating = 'collection' | 'wishlist' | null
+
+export function AddToListPicker({
+  card,
+  ownership,
+}: {
+  card: Record<string, unknown>
+  ownership: CardOwnership | null | undefined
+}) {
+  const collections = useCollections()
+  const wishlists = useWishlists()
+  const [open, setOpen] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [creating, setCreating] = useState<Creating>(null)
+  const [newName, setNewName] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  // Drop lists the card already sits in (from the shared occupancy) and
+  // dynamic collections, whose membership is rule-resolved (the items API
+  // 409s on a hand-add).
+  const inCollections = new Set((ownership?.collections ?? []).map((c) => c.id))
+  const inWishlists = new Set((ownership?.wishlists ?? []).map((w) => w.id))
+  const addableCollections = collections.collections.filter(
+    (c) => c.kind !== 'dynamic' && !inCollections.has(c.id),
+  )
+  const addableWishlists = wishlists.wishlists.filter((w) => !inWishlists.has(w.id))
+
+  function reset() {
+    setCreating(null)
+    setNewName('')
+    setError(null)
+  }
+
+  async function addToCollection(id: number) {
+    setBusy(true)
+    setError(null)
+    try {
+      await collections.addCard(id, card)
+      setOpen(false)
+      reset()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function addToWishlist(id: number) {
+    setBusy(true)
+    setError(null)
+    try {
+      await wishlists.addCard(id, card)
+      setOpen(false)
+      reset()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function createAndAdd() {
+    const name = newName.trim()
+    if (!name || !creating) return
+    setBusy(true)
+    setError(null)
+    try {
+      if (creating === 'collection') {
+        const created = await collections.create(name)
+        await collections.addCard(created.id, card)
+      } else {
+        const created = await wishlists.create(name)
+        await wishlists.addCard(created.id, card)
+      }
+      setOpen(false)
+      reset()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <DropdownMenu.Root
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next)
+        if (!next) reset()
+      }}
+    >
+      <DropdownMenu.Trigger asChild>
+        <button
+          type="button"
+          disabled={busy}
+          className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium text-coconut-500 hover:bg-sand-200 disabled:opacity-50 dark:text-sand-300 dark:hover:bg-husk-100"
+        >
+          {busy ? <Loader2 size={13} className="animate-spin" /> : <ListPlus size={13} />}
+          Add to a list…
+        </button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Portal>
+        <DropdownMenu.Content
+          align="end"
+          sideOffset={4}
+          className="z-[60] w-60 rounded-md border border-sand-300 bg-sand-50 p-1 shadow-lg dark:border-husk-50 dark:bg-husk-200"
+        >
+          <ListSection
+            label="Add to collection"
+            icon={<Book size={12} />}
+            items={addableCollections}
+            emptyHint="In every collection already."
+            onPick={addToCollection}
+            creating={creating === 'collection'}
+            onStartCreate={() => {
+              setCreating('collection')
+              setNewName('')
+            }}
+            createLabel="New collection…"
+            placeholder="Collection name"
+            newName={newName}
+            onNewName={setNewName}
+            onSubmit={createAndAdd}
+            onCancel={reset}
+            busy={busy}
+          />
+          <DropdownMenu.Separator className="my-1 h-px bg-sand-200 dark:bg-husk-100" />
+          <ListSection
+            label="Add to want-list"
+            icon={<Footprints size={12} />}
+            items={addableWishlists}
+            emptyHint="On every want-list already."
+            onPick={addToWishlist}
+            creating={creating === 'wishlist'}
+            onStartCreate={() => {
+              setCreating('wishlist')
+              setNewName('')
+            }}
+            createLabel="New want-list…"
+            placeholder="Want-list name"
+            newName={newName}
+            onNewName={setNewName}
+            onSubmit={createAndAdd}
+            onCancel={reset}
+            busy={busy}
+          />
+          {error && (
+            <div role="alert" className="px-2 py-1 text-[11px] text-ember-500 dark:text-ember-300">
+              {error}
+            </div>
+          )}
+        </DropdownMenu.Content>
+      </DropdownMenu.Portal>
+    </DropdownMenu.Root>
+  )
+}
+
+function ListSection({
+  label,
+  icon,
+  items,
+  emptyHint,
+  onPick,
+  creating,
+  onStartCreate,
+  createLabel,
+  placeholder,
+  newName,
+  onNewName,
+  onSubmit,
+  onCancel,
+  busy,
+}: {
+  label: string
+  icon: React.ReactNode
+  items: { id: number; name: string; item_count: number }[]
+  emptyHint: string
+  onPick: (id: number) => void
+  creating: boolean
+  onStartCreate: () => void
+  createLabel: string
+  placeholder: string
+  newName: string
+  onNewName: (v: string) => void
+  onSubmit: () => void
+  onCancel: () => void
+  busy: boolean
+}) {
+  return (
+    <>
+      <DropdownMenu.Label className="flex items-center gap-1 px-2 py-1 text-xs font-semibold uppercase tracking-wider text-coconut-400 dark:text-sand-300">
+        {icon}
+        {label}
+      </DropdownMenu.Label>
+      {items.length === 0 && !creating && (
+        <div className="px-2 py-1 text-[11px] text-coconut-400 dark:text-sand-300">{emptyHint}</div>
+      )}
+      {items.map((item) => (
+        <DropdownMenu.Item
+          key={item.id}
+          disabled={busy}
+          onSelect={(e) => {
+            e.preventDefault()
+            onPick(item.id)
+          }}
+          className="flex cursor-pointer items-center justify-between rounded px-2 py-1.5 text-sm text-coconut-700 outline-none data-[highlighted]:bg-sand-200 dark:text-sand-50 dark:data-[highlighted]:bg-husk-100"
+        >
+          <span className="truncate">{item.name}</span>
+          <span className="text-xs text-coconut-400 dark:text-sand-300">{item.item_count}</span>
+        </DropdownMenu.Item>
+      ))}
+      {creating ? (
+        <div className="flex items-center gap-1 px-1 py-1">
+          <input
+            autoFocus
+            value={newName}
+            onChange={(e) => onNewName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                onSubmit()
+              } else if (e.key === 'Escape') {
+                e.preventDefault()
+                onCancel()
+              }
+            }}
+            placeholder={placeholder}
+            aria-label={placeholder}
+            className="flex-1 rounded border border-sand-300 bg-sand-50 px-2 py-1 text-xs text-coconut-700 placeholder:text-coconut-300 focus:outline-none focus:ring-1 focus:ring-palm-400 dark:border-coconut-500 dark:bg-husk-100 dark:text-sand-50"
+          />
+          <button
+            type="button"
+            onClick={onSubmit}
+            disabled={busy || !newName.trim()}
+            className="rounded bg-palm-500 px-2 py-1 text-xs font-medium text-coconut-50 hover:bg-palm-600 disabled:opacity-50 dark:text-husk-300"
+          >
+            {busy ? <Loader2 size={12} className="animate-spin" /> : 'Add'}
+          </button>
+        </div>
+      ) : (
+        <DropdownMenu.Item
+          disabled={busy}
+          onSelect={(e) => {
+            e.preventDefault()
+            onStartCreate()
+          }}
+          className="flex cursor-pointer items-center gap-1.5 rounded px-2 py-1.5 text-sm text-palm-600 outline-none data-[highlighted]:bg-sand-200 dark:text-palm-300 dark:data-[highlighted]:bg-husk-100"
+        >
+          <Plus size={13} /> {createLabel}
+        </DropdownMenu.Item>
+      )}
+    </>
+  )
+}

--- a/web/src/components/CardDetailModal.tsx
+++ b/web/src/components/CardDetailModal.tsx
@@ -31,6 +31,7 @@ import {
 } from './cardCategories'
 import { EbaySparkline } from './EbaySparkline'
 import { hasEbayData, soldPriceSeries } from './ebayComps'
+import { AddToListPicker } from './AddToListPicker'
 import { OwnershipBadge } from './OwnershipBadge'
 import { SaveCardActions } from './SaveCardActions'
 import { useCardOwnership } from './useCardOwnership'
@@ -262,6 +263,15 @@ function CardDetailBody({
                   show={showActions}
                   variant="primary"
                 />
+                {/* The light "organize later" step (#762): the toggles above
+                    write to your default list; this drops the card onto a
+                    specific named collection / want-list. */}
+                <div className="mt-2 flex justify-end">
+                  <AddToListPicker
+                    card={card as unknown as Record<string, unknown>}
+                    ownership={ownership}
+                  />
+                </div>
               </section>
             )}
             <CategoryBadges card={card} />


### PR DESCRIPTION
Part of #762 (does not close it — see "Remaining" below).

## What

The first slice of the post-capture "organize later" flow (#762, ADR-0027). The one-tap Want / Own toggles write to your *default* list; this adds a light, optional secondary step in the card detail's **Library actions** that drops the same card onto a *specific* named collection or want-list — without re-introducing the old up-front picker gate.

- New `AddToListPicker`: an "Add to a list…" menu grouped into collections and want-lists, with inline "New collection… / New want-list…" create-and-add.
- Lists the card already lives in fall out of the menu (derived from the shared ownership occupancy), and dynamic smart collections are hidden since their membership is rule-resolved (a hand-add 409s).
- Adds route through the cache-aware `useCollections` / `useWishlists` hooks, so item counts bump and the ownership badge / "In: / Want:" locations update live.

## Why

#761 moved the primary save to the frictionless default toggles and deferred "organize into a specific binder" to #762. This lands that secondary path on the card itself, where the derived state and the lists a card already sits in are already shown.

## Scope / Remaining

This slice is intentionally focused on **adding** to a specific list — fully client-side on existing endpoints. The other #762 requirements are follow-up slices because they need backend support first:

- **Quantity / remove per specific list** — the ownership payload carries collection/wishlist ids but no item ids, and a card can span multiple summed items in one collection. Editing/removing by card needs item ids surfaced on the occupancy (small API change) plus a multi-item decision.
- **Condition** — no condition field on collection items yet.
- **Default-row rename/delete + "default" marker** — the web client doesn't surface the default flag yet (backend exists per #759).

I'll leave #762 open and tackle these next.

## How to verify

1. Sign in, run a Look up, open a matched card's detail.
2. Under **Library actions**, click **Add to a list…** — pick a collection or want-list, or create a new one inline.
3. The card's "In: / Want:" locations and the ownership badge update immediately, and the list you added it to drops out of the menu.

`make check` and `cd web && npm run build` are green. New `AddToListPicker.test.tsx` covers the dynamic-collection / already-in filtering, add-to-collection, add-to-want-list, and create-and-add paths.