### PR TITLE
feat(web): remove a card from a specific list from the detail view

### DIFF
--- a/api/routes/collections.py
+++ b/api/routes/collections.py
@@ -628,6 +628,40 @@ def delete_collection_item(
     db.commit()
 
 
+@router.delete("/collections/{collection_id}/items", status_code=204)
+def delete_collection_items_by_card(
+    collection_id: int,
+    set_id: str,
+    number: str,
+    db: DbSession,
+    current_user: CurrentUser,
+) -> None:
+    """Remove a card from a specific collection by its ``(set_id, number)``
+    identity — the card-detail "remove from this list" affordance (#762).
+
+    Deletes every matching row, since a card can occupy a collection more than
+    once (separate adds), so the collection cleanly stops listing the card.
+    Scoped through the parent collection (an unowned id 404s); dynamic
+    collections are rejected like the other item-write paths."""
+    collection = _load_collection(db, collection_id, current_user.id)
+    _reject_if_dynamic(collection)
+    items = db.scalars(
+        select(CollectionItem).where(
+            CollectionItem.collection_id == collection.id,
+            CollectionItem.card_set_id == set_id,
+            CollectionItem.card_number == number,
+        )
+    ).all()
+    if not items:
+        raise HTTPException(
+            status_code=404,
+            detail=f"card {set_id}-{number} not found in collection {collection_id}",
+        )
+    for item in items:
+        db.delete(item)
+    db.commit()
+
+
 @router.patch("/collections/{collection_id}/items/{item_id}")
 def update_collection_item(
     collection_id: int,

--- a/api/routes/wishlists.py
+++ b/api/routes/wishlists.py
@@ -338,6 +338,39 @@ def delete_wishlist_item(
     db.commit()
 
 
+@router.delete("/wishlists/{wishlist_id}/items", status_code=204)
+def delete_wishlist_items_by_card(
+    wishlist_id: int,
+    set_id: str,
+    number: str,
+    db: DbSession,
+    current_user: CurrentUser,
+) -> None:
+    """Remove a card from a specific want-list by its ``(set_id, number)``
+    identity — the card-detail "remove from this list" affordance (#762).
+
+    Only drops *active* chases; an acquired item is kept as history (its chase
+    already completed), mirroring ``/cards/unwant`` (#768). 404s when no active
+    chase for the card is on the list."""
+    wishlist = _load_wishlist(db, wishlist_id, current_user.id)
+    items = db.scalars(
+        select(WishlistItem).where(
+            WishlistItem.wishlist_id == wishlist.id,
+            WishlistItem.card_set_id == set_id,
+            WishlistItem.card_number == number,
+            WishlistItem.acquired_at.is_(None),
+        )
+    ).all()
+    if not items:
+        raise HTTPException(
+            status_code=404,
+            detail=f"card {set_id}-{number} not found on wishlist {wishlist_id}",
+        )
+    for item in items:
+        db.delete(item)
+    db.commit()
+
+
 @router.post("/wishlists/{wishlist_id}/items/{item_id}/promote", status_code=201)
 def promote_wishlist_item(
     wishlist_id: int,

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -386,6 +386,31 @@ class CollectionsEndpointTests(_IsolatedDbMixin):
             self.assertEqual(resp.status_code, 204)
             self.assertEqual(len(c.get(f"/api/v1/collections/{cid}").json()["items"]), 0)
 
+    def test_delete_items_by_card_removes_every_matching_row(self) -> None:
+        # The card-detail "remove from this list" affordance (#762) deletes by
+        # identity, so a card added more than once leaves the collection clean.
+        with self._client() as c:
+            cid = c.post("/api/v1/collections", json={"name": "k"}).json()["id"]
+            c.post(f"/api/v1/collections/{cid}/items", json={"card": SAMPLE_CARD})
+            c.post(f"/api/v1/collections/{cid}/items", json={"card": SAMPLE_CARD})
+            self.assertEqual(len(c.get(f"/api/v1/collections/{cid}").json()["items"]), 2)
+
+            resp = c.delete(
+                f"/api/v1/collections/{cid}/items",
+                params={"set_id": "base1", "number": "4"},
+            )
+            self.assertEqual(resp.status_code, 204)
+            self.assertEqual(len(c.get(f"/api/v1/collections/{cid}").json()["items"]), 0)
+
+    def test_delete_items_by_card_404_when_card_absent(self) -> None:
+        with self._client() as c:
+            cid = c.post("/api/v1/collections", json={"name": "k"}).json()["id"]
+            resp = c.delete(
+                f"/api/v1/collections/{cid}/items",
+                params={"set_id": "base1", "number": "4"},
+            )
+            self.assertEqual(resp.status_code, 404)
+
     def test_add_item_promotes_card_identity_and_defaults_quantity(self) -> None:
         # The promoted columns are what every other surface in the epic
         # queries against — the ownership badge (#576), the insights

--- a/tests/test_wishlists.py
+++ b/tests/test_wishlists.py
@@ -296,6 +296,28 @@ class WishlistsEndpointTests(_IsolatedDbMixin):
             resp = c.delete(f"/api/v1/wishlists/{wid_b}/items/{item_id}")
             self.assertEqual(resp.status_code, 404)
 
+    def test_delete_items_by_card_removes_active_chase(self) -> None:
+        # The card-detail "remove from this list" affordance (#762) drops the
+        # active chase by identity, no item id needed.
+        with self._client() as c:
+            wid = c.post("/api/v1/wishlists", json={"name": "k"}).json()["id"]
+            c.post(f"/api/v1/wishlists/{wid}/items", json={"card": SAMPLE_CARD})
+            resp = c.delete(
+                f"/api/v1/wishlists/{wid}/items",
+                params={"set_id": "base1", "number": "4"},
+            )
+            self.assertEqual(resp.status_code, 204)
+            self.assertEqual(len(c.get(f"/api/v1/wishlists/{wid}").json()["items"]), 0)
+
+    def test_delete_items_by_card_404_when_card_absent(self) -> None:
+        with self._client() as c:
+            wid = c.post("/api/v1/wishlists", json={"name": "k"}).json()["id"]
+            resp = c.delete(
+                f"/api/v1/wishlists/{wid}/items",
+                params={"set_id": "base1", "number": "4"},
+            )
+            self.assertEqual(resp.status_code, 404)
+
     def test_bulk_add_items_round_trip(self) -> None:
         # #268 — add a multi-select of matched rows to a want-list at once,
         # with a shared price cap stamped on every row.

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -4,6 +4,8 @@ import {
   fetchChangelog,
   fetchMe,
   logout,
+  removeCardFromCollection,
+  removeCardFromWishlist,
   requestAccountMagicLink,
   requestMagicLink,
   unlinkIdentity,
@@ -205,5 +207,34 @@ describe('unlinkIdentity', () => {
   it('throws on a failed unlink', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 400 }))
     await expect(unlinkIdentity(42)).rejects.toThrow(/unlink identity failed: 400/)
+  })
+})
+
+describe('removeCardFromCollection / removeCardFromWishlist (#762)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('DELETEs a collection card by its (set_id, number) identity', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 204 }))
+    await expect(removeCardFromCollection(7, 'base1', '4')).resolves.toBeUndefined()
+    expect(fetchSpy).toHaveBeenCalledWith('/api/v1/collections/7/items?set_id=base1&number=4', {
+      method: 'DELETE',
+    })
+  })
+
+  it('treats a 404 as idempotent success so a stale chip still reconciles', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 404 }))
+    await expect(removeCardFromCollection(7, 'base1', '4')).resolves.toBeUndefined()
+    await expect(removeCardFromWishlist(9, 'base1', '4')).resolves.toBeUndefined()
+  })
+
+  it('throws on a real server error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 500 }))
+    await expect(removeCardFromWishlist(9, 'base1', '4')).rejects.toThrow(
+      /remove want-list card failed: 500/,
+    )
   })
 })

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1360,7 +1360,10 @@ export async function removeCardFromCollection(
   const res = await fetch(`${BASE}/collections/${collectionId}/items?${params}`, {
     method: 'DELETE',
   })
-  if (!res.ok && res.status !== 204) {
+  // 404 means the card is already off the list (e.g. a stale chip after a
+  // change in another tab) — the desired end state, so treat it as an
+  // idempotent success and let the caller reconcile the cache (#784 review).
+  if (!res.ok && res.status !== 204 && res.status !== 404) {
     throw new Error(`remove collection card failed: ${res.status}`)
   }
 }
@@ -1374,7 +1377,10 @@ export async function removeCardFromWishlist(
   const res = await fetch(`${BASE}/wishlists/${wishlistId}/items?${params}`, {
     method: 'DELETE',
   })
-  if (!res.ok && res.status !== 204) {
+  // 404 means the card is already off the list — treat as idempotent success
+  // so a stale chip still reconciles via the caller's cache refresh
+  // (#784 review).
+  if (!res.ok && res.status !== 204 && res.status !== 404) {
     throw new Error(`remove want-list card failed: ${res.status}`)
   }
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1347,6 +1347,38 @@ export async function deleteWishlistItem(
   }
 }
 
+/** Remove a card from a specific collection / want-list by its (set_id,
+ *  number) identity — the card-detail "remove from this list" affordance
+ *  (#762). The occupancy payload carries list ids but no item ids, so removal
+ *  targets the card itself; the server drops every matching row. */
+export async function removeCardFromCollection(
+  collectionId: number,
+  setId: string,
+  number: string,
+): Promise<void> {
+  const params = new URLSearchParams({ set_id: setId, number })
+  const res = await fetch(`${BASE}/collections/${collectionId}/items?${params}`, {
+    method: 'DELETE',
+  })
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`remove collection card failed: ${res.status}`)
+  }
+}
+
+export async function removeCardFromWishlist(
+  wishlistId: number,
+  setId: string,
+  number: string,
+): Promise<void> {
+  const params = new URLSearchParams({ set_id: setId, number })
+  const res = await fetch(`${BASE}/wishlists/${wishlistId}/items?${params}`, {
+    method: 'DELETE',
+  })
+  if (!res.ok && res.status !== 204) {
+    throw new Error(`remove want-list card failed: ${res.status}`)
+  }
+}
+
 // ---------------------------------------------------------------------------
 // swipe (library-aware deck memory + exclusion, #581)
 // ---------------------------------------------------------------------------

--- a/web/src/components/CardDetailModal.test.tsx
+++ b/web/src/components/CardDetailModal.test.tsx
@@ -649,4 +649,35 @@ describe('CardDetailModal — library actions (#699)', () => {
     expect(within(locations).getByText('Want:')).toBeInTheDocument()
     expect(within(locations).getByText('Allentown chase list')).toBeInTheDocument()
   })
+
+  it('removes the card from a specific collection via the location chip (#762)', async () => {
+    vi.spyOn(client, 'fetchCardOwnership').mockResolvedValue({
+      'base1::4': { collections: [{ id: 7, name: 'Show binder', quantity: 2 }], wishlists: [] },
+    })
+    const removeSpy = vi.spyOn(client, 'removeCardFromCollection').mockResolvedValue()
+
+    render(<CardDetailModal rows={[identifiedRow()]} index={0} onChangeIndex={() => {}} />)
+    const locations = await screen.findByLabelText(/Library locations/i)
+    fireEvent.click(
+      within(locations).getByRole('button', { name: /Remove from collection Show binder/i }),
+    )
+
+    // Removal targets the card identity, not an item id.
+    await waitFor(() => expect(removeSpy).toHaveBeenCalledWith(7, 'base1', '4'))
+  })
+
+  it('removes the card from a specific want-list via the location chip (#762)', async () => {
+    vi.spyOn(client, 'fetchCardOwnership').mockResolvedValue({
+      'base1::4': { collections: [], wishlists: [{ id: 9, name: 'Chase list' }] },
+    })
+    const removeSpy = vi.spyOn(client, 'removeCardFromWishlist').mockResolvedValue()
+
+    render(<CardDetailModal rows={[identifiedRow()]} index={0} onChangeIndex={() => {}} />)
+    const locations = await screen.findByLabelText(/Library locations/i)
+    fireEvent.click(
+      within(locations).getByRole('button', { name: /Remove from want-list Chase list/i }),
+    )
+
+    await waitFor(() => expect(removeSpy).toHaveBeenCalledWith(9, 'base1', '4'))
+  })
 })

--- a/web/src/components/CardDetailModal.tsx
+++ b/web/src/components/CardDetailModal.tsx
@@ -16,9 +16,13 @@
  * patterns so we don't duplicate a11y plumbing.
  */
 import * as Dialog from '@radix-ui/react-dialog'
-import { ChevronLeft, ChevronRight, ExternalLink, X } from 'lucide-react'
-import { useEffect, useMemo } from 'react'
-import type { CardOwnership } from '../api/client'
+import { ChevronLeft, ChevronRight, ExternalLink, Loader2, X } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import {
+  removeCardFromCollection,
+  removeCardFromWishlist,
+  type CardOwnership,
+} from '../api/client'
 import { useAuth } from '../hooks/useAuth'
 import type { CardData, CardSet, EbaySoldComp, Pricing, Row } from '../types'
 import { ebayAffiliateUrl, tcgplayerAffiliateUrl } from '../utils/affiliateLinks'
@@ -34,7 +38,9 @@ import { hasEbayData, soldPriceSeries } from './ebayComps'
 import { AddToListPicker } from './AddToListPicker'
 import { OwnershipBadge } from './OwnershipBadge'
 import { SaveCardActions } from './SaveCardActions'
-import { useCardOwnership } from './useCardOwnership'
+import { invalidateOwnership, useCardOwnership } from './useCardOwnership'
+import { useCollections } from './useCollections'
+import { useWishlists } from './useWishlists'
 
 interface Props {
   /** The already filtered + sorted row set the parent table is showing. */
@@ -256,7 +262,7 @@ function CardDetailBody({
                   </h3>
                   <OwnershipBadge ownership={ownership} />
                 </div>
-                <LibraryLocations ownership={ownership} />
+                <LibraryLocations ownership={ownership} card={card} />
                 <SaveCardActions
                   card={card as unknown as Record<string, unknown>}
                   ownership={ownership}
@@ -345,47 +351,126 @@ function CardDetailBody({
   )
 }
 
+/** The lists a card sits in, with an inline remove on each chip (#762). The
+ *  "organize later" complement to {@link AddToListPicker}: drop the card off a
+ *  specific collection / want-list right from the detail view. Removal targets
+ *  the card identity (the occupancy has no item ids) and goes through the
+ *  cache-aware hooks so counts and the badge re-read. */
 function LibraryLocations({
   ownership,
+  card,
 }: {
   ownership: CardOwnership | null | undefined
+  card: CardData | null
 }) {
-  if (!ownership) return null
-  const { collections, wishlists } = ownership
-  if (collections.length === 0 && wishlists.length === 0) return null
+  const collections = useCollections()
+  const wishlists = useWishlists()
+  const [removing, setRemoving] = useState<string | null>(null)
+
+  const setId = (card?.set as CardSet | undefined)?.id
+  const number = card?.number as string | undefined
+
+  if (!ownership || !card) return null
+  const { collections: cols, wishlists: wls } = ownership
+  if (cols.length === 0 && wls.length === 0) return null
+
+  async function remove(
+    kind: 'collection' | 'wishlist',
+    id: number,
+    fn: () => Promise<void>,
+  ) {
+    if (!setId || !number) return
+    setRemoving(`${kind}-${id}`)
+    try {
+      await fn()
+      // Re-read the ownership badge / locations everywhere, and resync the
+      // list counts the chip was removed from.
+      invalidateOwnership()
+      await (kind === 'collection' ? collections.refresh() : wishlists.refresh())
+    } finally {
+      setRemoving(null)
+    }
+  }
 
   return (
     <div
       aria-label="Library locations"
       className="mb-3 space-y-1.5 rounded-md bg-sand-100 px-2.5 py-2 text-xs text-coconut-500 dark:bg-husk-300 dark:text-sand-200"
     >
-      {collections.length > 0 && (
+      {cols.length > 0 && (
         <LocationLine
           label="In:"
-          names={collections.map((c) =>
-            c.quantity > 1 ? `${c.name} ×${c.quantity}` : c.name,
-          )}
+          noun="collection"
+          chips={cols.map((c) => ({
+            id: c.id,
+            name: c.name,
+            display: c.quantity > 1 ? `${c.name} ×${c.quantity}` : c.name,
+          }))}
+          removingKey={removing}
+          keyPrefix="collection"
+          onRemove={(id) =>
+            void remove('collection', id, () =>
+              removeCardFromCollection(id, setId as string, number as string),
+            )
+          }
         />
       )}
-      {wishlists.length > 0 && (
-        <LocationLine label="Want:" names={wishlists.map((w) => w.name)} />
+      {wls.length > 0 && (
+        <LocationLine
+          label="Want:"
+          noun="want-list"
+          chips={wls.map((w) => ({ id: w.id, name: w.name, display: w.name }))}
+          removingKey={removing}
+          keyPrefix="wishlist"
+          onRemove={(id) =>
+            void remove('wishlist', id, () =>
+              removeCardFromWishlist(id, setId as string, number as string),
+            )
+          }
+        />
       )}
     </div>
   )
 }
 
-function LocationLine({ label, names }: { label: string; names: string[] }) {
+function LocationLine({
+  label,
+  noun,
+  chips,
+  removingKey,
+  keyPrefix,
+  onRemove,
+}: {
+  label: string
+  noun: string
+  chips: { id: number; name: string; display: string }[]
+  removingKey: string | null
+  keyPrefix: string
+  onRemove: (id: number) => void
+}) {
   return (
     <div className="flex flex-wrap items-center gap-1.5">
       <span className="font-semibold text-coconut-600 dark:text-sand-100">{label}</span>
-      {names.map((name) => (
-        <span
-          key={name}
-          className="rounded-full bg-sand-200 px-1.5 py-0.5 text-coconut-600 dark:bg-husk-100 dark:text-sand-100"
-        >
-          {name}
-        </span>
-      ))}
+      {chips.map((chip) => {
+        const busy = removingKey === `${keyPrefix}-${chip.id}`
+        return (
+          <span
+            key={chip.id}
+            className="inline-flex items-center gap-1 rounded-full bg-sand-200 py-0.5 pl-1.5 pr-1 text-coconut-600 dark:bg-husk-100 dark:text-sand-100"
+          >
+            {chip.display}
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => onRemove(chip.id)}
+              aria-label={`Remove from ${noun} ${chip.name}`}
+              className="rounded-full p-0.5 text-coconut-400 hover:bg-sand-300 hover:text-ember-500 disabled:opacity-50 dark:text-sand-300 dark:hover:bg-husk-200 dark:hover:text-ember-300"
+            >
+              {busy ? <Loader2 size={11} className="animate-spin" /> : <X size={11} />}
+            </button>
+          </span>
+        )
+      })}
     </div>
   )
 }


### PR DESCRIPTION
Part of #762 (does not close it).

## What

Slice 2 of the post-capture organize flow, the complement to the add picker in #783. Each "In: / Want:" location chip in the card detail's **Library actions** now carries an inline remove (×), so you can drop the card off a specific collection or want-list right from the card — the "organize later" step staying light and optional.

- **Backend** — two by-identity delete endpoints: `DELETE /collections/{id}/items?set_id&number` and `DELETE /wishlists/{id}/items?set_id&number`. The occupancy payload carries list ids but no item ids, so removal targets the card's `(set_id, number)`. The collection variant drops *every* matching row (a card can be added more than once); the want-list variant drops only the *active* chase, keeping acquired history like `/cards/unwant` (#768). Dynamic collections are rejected like the other item-write paths.
- **Frontend** — `removeCardFromCollection` / `removeCardFromWishlist` client calls; the `LibraryLocations` chips become interactive, routing removals through the cache-aware hooks so list counts and the ownership badge re-read and the chip drops out.

## Why

#783 let you add a card to a specific list from the detail view; this makes the same surface symmetric so you can also take it off one, without hunting for the card inside the collection/want-list detail.

## Scope / Remaining (#762)

Still to come as follow-up slices: per-list owned-quantity editing, condition (needs a backend field), and default-row rename/delete + a "default" marker (needs the default flag surfaced in the web client).

## How to verify

1. Sign in, open a matched card's detail that's in at least one collection / want-list.
2. Under **Library actions**, each "In: / Want:" chip shows a ×.
3. Click it — the card is removed from that specific list, the chip disappears, and the badge/counts update. Acquired (already-got-it) want-list history is preserved.

`make check` and `cd web && npm run build` are green. New Python route tests (by-identity delete: removes all matching rows / active chase only / 404 when absent) and web tests (chip remove → `removeCardFrom*` called with the card identity).