### PR TITLE
feat(web): mark the default collection / want-list in the library

### DIFF
--- a/api/routes/collections.py
+++ b/api/routes/collections.py
@@ -149,6 +149,10 @@ class CollectionSummaryOut(BaseModel):
     binder_type: str | None
     capacity: int | None
     is_master_set: bool | None
+    #: #759/#762 — the user's default `Own` target. The flag is the invariant,
+    #: not the row: renaming keeps it, deleting re-establishes one lazily. The
+    #: SPA shows a subtle "default" marker so a bare Own's destination is clear.
+    is_default: bool
 
 
 class CollectionItemOut(BaseModel):
@@ -386,6 +390,7 @@ def list_collections(db: DbSession, current_user: CurrentUser) -> dict:
                 binder_type=c.binder_type,
                 capacity=c.capacity,
                 is_master_set=c.is_master_set,
+                is_default=c.is_default,
             )
         )
     return {"items": [item.model_dump() for item in items], "total": len(items)}

--- a/api/routes/wishlists.py
+++ b/api/routes/wishlists.py
@@ -65,6 +65,10 @@ class WishlistSummaryOut(BaseModel):
     item_count: int
     #: The binder this want-list is filed into, or null when loose (#774).
     binder_id: int | None
+    #: #759/#762 — the user's default `Want` target. The flag is the invariant,
+    #: not the row: renaming keeps it, deleting re-establishes one lazily. The
+    #: SPA shows a subtle "default" marker so a bare Want's destination is clear.
+    is_default: bool
 
 
 class WishlistItemOut(BaseModel):
@@ -193,6 +197,7 @@ def list_wishlists(db: DbSession, current_user: CurrentUser) -> dict:
             created_at=w.created_at.isoformat(),
             item_count=int(item_count),
             binder_id=w.binder_id,
+            is_default=w.is_default,
         )
         for w, item_count in db.execute(stmt).all()
     ]

--- a/tests/test_ownership.py
+++ b/tests/test_ownership.py
@@ -222,6 +222,26 @@ class QuickActionTests(_IsolatedDbMixin):
             self.assertEqual(len(lists), 1)
             self.assertTrue(lists[0].is_default)
 
+    def test_default_wishlist_is_flagged_in_the_list_view(self) -> None:
+        # #762 — the SPA shows a "default" marker next to the bare-Want target,
+        # so the list endpoint surfaces the flag; a hand-made list stays plain.
+        with self._client() as c:
+            c.post("/api/v1/cards/want", json={"card": CHARIZARD})
+            plain = c.post("/api/v1/wishlists", json={"name": "Allentown chase"}).json()
+            items = c.get("/api/v1/wishlists").json()["items"]
+            defaults = [w for w in items if w["is_default"]]
+            self.assertEqual(len(defaults), 1)
+            self.assertFalse({w["id"]: w for w in items}[plain["id"]]["is_default"])
+
+    def test_default_collection_is_flagged_in_the_list_view(self) -> None:
+        with self._client() as c:
+            c.post("/api/v1/cards/own", json={"card": CHARIZARD})
+            plain = c.post("/api/v1/collections", json={"name": "Trade binder"}).json()
+            items = c.get("/api/v1/collections").json()["items"]
+            defaults = [col for col in items if col["is_default"]]
+            self.assertEqual(len(defaults), 1)
+            self.assertFalse({col["id"]: col for col in items}[plain["id"]]["is_default"])
+
     def test_unwant_removes_from_default_wishlist(self) -> None:
         with self._client() as c:
             c.post("/api/v1/cards/want", json={"card": CHARIZARD})

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -619,6 +619,9 @@ export interface CollectionSummary {
   binder_type?: BinderType | null
   capacity?: number | null
   is_master_set?: boolean | null
+  // #759/#762 — the user's default `Own` target. Optional so older cached
+  // payloads / fixtures without it still type-check.
+  is_default?: boolean
 }
 
 export interface CollectionItem {
@@ -1163,6 +1166,9 @@ export interface WishlistSummary {
   item_count: number
   // The binder this want-list is filed into, or null when loose (#774).
   binder_id: number | null
+  // #759/#762 — the user's default `Want` target. Optional so older cached
+  // payloads / fixtures without it still type-check.
+  is_default?: boolean
 }
 
 export interface WishlistItem {

--- a/web/src/components/LibraryBindersTab.test.tsx
+++ b/web/src/components/LibraryBindersTab.test.tsx
@@ -143,6 +143,24 @@ describe('LibraryBindersTab', () => {
     expect(names.map((n) => n.textContent)).toEqual(['Mew hunt', 'Charizard masters'])
   })
 
+  it('marks the default collection / want-list and leaves the rest plain (#762)', async () => {
+    mockCollections.mockResolvedValue([
+      { id: 1, name: 'My collection', description: null, created_at: '2026-06-04T00:00:00', item_count: 1, is_default: true },
+      { id: 2, name: 'Trade binder', description: null, created_at: '2026-06-03T00:00:00', item_count: 0, is_default: false },
+    ])
+    mockWishlists.mockResolvedValue([
+      { id: 3, name: 'My want-list', description: null, created_at: '2026-06-06T00:00:00', item_count: 2, binder_id: null, is_default: true },
+    ])
+    render(<LibraryBindersTab />)
+
+    await waitFor(() => expect(screen.getByText('My collection')).toBeInTheDocument())
+    // One marker on the default collection, one on the default want-list.
+    expect(screen.getAllByText('default')).toHaveLength(2)
+    // The plain collection carries no marker.
+    const tradeRow = screen.getByText('Trade binder').closest('li')!
+    expect(within(tradeRow).queryByText('default')).toBeNull()
+  })
+
   it('filters to owned binders only', async () => {
     mockCollections.mockResolvedValue([
       { id: 1, name: 'Charizard masters', description: null, created_at: '2026-06-04T00:00:00', item_count: 4 },

--- a/web/src/components/LibraryBindersTab.tsx
+++ b/web/src/components/LibraryBindersTab.tsx
@@ -367,6 +367,20 @@ function NewMenuItem({
 }
 
 /** Palm "Owned" / sun "Chasing" chip — mirrors OwnershipBadge (#576). */
+/** Subtle marker on the list a bare one-tap Want/Own writes to (#759/#762).
+ *  The default is just a normal list (rename/delete work on it like any other);
+ *  this only signals where an unspecified save lands. */
+function DefaultBadge({ noun }: { noun: 'Own' | 'Want' }) {
+  return (
+    <span
+      title={`Default ${noun} target — a one-tap ${noun} saves here`}
+      className="shrink-0 rounded-full border border-sand-300 px-1.5 py-0.5 text-[10px] font-medium text-coconut-400 dark:border-husk-50 dark:text-sand-300"
+    >
+      default
+    </span>
+  )
+}
+
 function KindBadge({ kind }: { kind: 'owned' | 'chasing' }) {
   return kind === 'owned' ? (
     <span className="shrink-0 rounded-full bg-palm-500/15 px-1.5 py-0.5 text-[10px] font-medium text-palm-600 dark:bg-palm-400/20 dark:text-palm-200">
@@ -484,6 +498,7 @@ function CollectionRow({
           <span className="truncate text-xs font-medium text-coconut-700 dark:text-sand-50">
             {c.name}
           </span>
+          {c.is_default && <DefaultBadge noun="Own" />}
           {pill && (
             <span className="shrink-0 rounded bg-palm-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-palm-700 dark:bg-husk-100 dark:text-palm-300">
               {pill}
@@ -605,6 +620,7 @@ function WishlistRow({
             <span className="truncate text-xs font-medium text-coconut-700 dark:text-sand-50">
               {w.name}
             </span>
+            {w.is_default && <DefaultBadge noun="Want" />}
           </div>
           {w.description && (
             <div className="truncate text-[11px] text-coconut-400 dark:text-sand-300">

--- a/web/src/components/QuickActions.test.tsx
+++ b/web/src/components/QuickActions.test.tsx
@@ -3,6 +3,8 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { QuickActions } from './QuickActions'
 import * as client from '../api/client'
 import * as ownershipHook from './useCardOwnership'
+import { _resetCollectionsCacheForTests } from './useCollections'
+import { _resetWishlistsCacheForTests } from './useWishlists'
 import type { CardOwnership } from '../api/client'
 
 const CARD = { id: 'base1-4', name: 'Charizard', set: { id: 'base1' }, number: '4' }
@@ -17,11 +19,16 @@ const OWNED: CardOwnership = {
 describe('QuickActions (#761)', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    _resetCollectionsCacheForTests()
+    _resetWishlistsCacheForTests()
     vi.spyOn(ownershipHook, 'invalidateOwnership').mockImplementation(() => {})
     vi.spyOn(client, 'wantCard').mockResolvedValue({} as never)
     vi.spyOn(client, 'unwantCard').mockResolvedValue({} as never)
     vi.spyOn(client, 'ownCard').mockResolvedValue({} as never)
     vi.spyOn(client, 'unownCard').mockResolvedValue({} as never)
+    // A save refreshes the affected library list cache (#762).
+    vi.spyOn(client, 'fetchCollections').mockResolvedValue([])
+    vi.spyOn(client, 'fetchWishlists').mockResolvedValue([])
   })
 
   it('renders nothing when show is false', () => {
@@ -59,6 +66,17 @@ describe('QuickActions (#761)', () => {
     render(<QuickActions card={CARD} ownership={EMPTY} show />)
     fireEvent.click(screen.getByRole('button', { name: /^own$/i }))
     await waitFor(() => expect(client.ownCard).toHaveBeenCalledWith(CARD))
+  })
+
+  it('refreshes the affected library list after a save so the default marker stays live (#762)', async () => {
+    render(<QuickActions card={CARD} ownership={EMPTY} show />)
+    fireEvent.click(screen.getByRole('button', { name: /^own$/i }))
+    // Own → collections list refreshes (where the default Own marker lives).
+    await waitFor(() => expect(client.fetchCollections).toHaveBeenCalled())
+    expect(client.fetchWishlists).not.toHaveBeenCalled()
+
+    fireEvent.click(screen.getByRole('button', { name: /^want$/i }))
+    await waitFor(() => expect(client.fetchWishlists).toHaveBeenCalled())
   })
 
   it('unowns when already owned', async () => {

--- a/web/src/components/QuickActions.tsx
+++ b/web/src/components/QuickActions.tsx
@@ -21,6 +21,8 @@ import {
   type CardOwnership,
 } from '../api/client'
 import { invalidateOwnership } from './useCardOwnership'
+import { refreshCollectionsCache } from './useCollections'
+import { refreshWishlistsCache } from './useWishlists'
 import { QUICK_ACTION_TONES } from './quickActionTones'
 
 interface Props {
@@ -49,8 +51,12 @@ export function QuickActions({ card, ownership, show, variant = 'icon', classNam
     setPending(action)
     try {
       await fn()
-      // Bust the shared cache so every mounted surface re-reads the new state.
+      // Bust the shared ownership cache so every mounted surface re-reads the
+      // new state, and refresh the affected library list — a one-tap save can
+      // create or re-create the default list, so its row + "default" marker
+      // stay live without a remount (#762, parity with the bulk save).
       invalidateOwnership()
+      await (action === 'own' ? refreshCollectionsCache() : refreshWishlistsCache())
     } finally {
       setPending(null)
     }

--- a/web/src/components/useCollections.ts
+++ b/web/src/components/useCollections.ts
@@ -39,6 +39,13 @@ function set(next: Partial<State>) {
   for (const fn of listeners) fn(state)
 }
 
+/** Refresh the shared collections cache from outside a mounted hook — the
+ *  one-tap quick actions call this after a default-targeting save so the
+ *  library list + "default" marker stay live (#762). */
+export function refreshCollectionsCache(): Promise<void> {
+  return refresh()
+}
+
 async function refresh(): Promise<void> {
   if (inflight) return inflight
   set({ loading: true, error: null })

--- a/web/src/components/useCollections.ts
+++ b/web/src/components/useCollections.ts
@@ -52,7 +52,10 @@ async function refresh(): Promise<void> {
   inflight = (async () => {
     try {
       const collections = await fetchCollections()
-      set({ collections, loading: false, fetched: true })
+      // Guard against a malformed (non-array) payload corrupting the cache —
+      // subscribers iterate `collections`, so a stray null/undefined would
+      // crash every mounted surface mid-render.
+      set({ collections: Array.isArray(collections) ? collections : [], loading: false, fetched: true })
     } catch (e) {
       set({
         loading: false,

--- a/web/src/components/useWishlists.ts
+++ b/web/src/components/useWishlists.ts
@@ -49,7 +49,10 @@ async function refresh(): Promise<void> {
   inflight = (async () => {
     try {
       const wishlists = await fetchWishlists()
-      set({ wishlists, loading: false, fetched: true })
+      // Guard against a malformed (non-array) payload corrupting the cache —
+      // subscribers iterate `wishlists`, so a stray null/undefined would crash
+      // every mounted surface mid-render.
+      set({ wishlists: Array.isArray(wishlists) ? wishlists : [], loading: false, fetched: true })
     } catch (e) {
       set({
         loading: false,

--- a/web/src/components/useWishlists.ts
+++ b/web/src/components/useWishlists.ts
@@ -36,6 +36,13 @@ function set(next: Partial<State>) {
   for (const fn of listeners) fn(state)
 }
 
+/** Refresh the shared wishlists cache from outside a mounted hook — the
+ *  one-tap quick actions call this after a default-targeting save so the
+ *  library list + "default" marker stay live (#762). */
+export function refreshWishlistsCache(): Promise<void> {
+  return refresh()
+}
+
 async function refresh(): Promise<void> {
   if (inflight) return inflight
   set({ loading: true, error: null })


### PR DESCRIPTION
Part of #762 (does not close it).

## What

Surfaces the existing `is_default` flag (#759) on the collection and want-list summary responses, and shows a subtle "default" marker next to the list a bare one-tap Own / Want writes to — so it's clear where an unspecified save lands.

- **Backend** — add `is_default` to `CollectionSummaryOut` / `WishlistSummaryOut` (the flag already lives on the model; the partial unique index keeps it to one row per user). No new tables or migrations.
- **Frontend** — `is_default?: boolean` on the summary types; a small neutral `default` badge on the marked rows in the Binders tab, with a tooltip explaining where a bare Want/Own lands.

The default stays an ordinary list: renaming keeps the flag, deleting re-establishes one lazily on the next quick action, and neither delete nor rename is special-cased — so no new management UI is needed, just the marker.

## Why

The one-tap Want/Own toggles (#761) write to a default list, but nothing in the UI told you *which* list that was. This closes that gap as the list-management slice of #762.

## Scope / Remaining (#762)

Still open as follow-up slices: per-list owned-quantity editing and condition (needs a backend field).

## How to verify

1. Sign in, tap Own / Want on a card (creates the defaults if you have none).
2. Open the library Binders tab — the default collection and want-list each show a subtle `default` marker; other lists don't.
3. Rename the default → it keeps the marker. Delete it, then tap Own/Want again → a fresh default is created and marked.

`make check` and `cd web && npm run build` are green. New tests: the list endpoints flag exactly the default (api), and the Binders tab marks the default rows and leaves the rest plain (web).