### PR TITLE
fix(web): show the per-row line total so collection prices track quantity

### DIFF
--- a/web/src/components/CollectionDetail.test.tsx
+++ b/web/src/components/CollectionDetail.test.tsx
@@ -91,8 +91,10 @@ describe('CollectionDetail', () => {
 
     expect(await screen.findByText('Charizard')).toBeInTheDocument()
     expect(screen.getByText(/base1-4/)).toBeInTheDocument()
-    // Snapshot total folds in quantity (2 × $250).
-    expect(screen.getByText('$500.00')).toBeInTheDocument()
+    // The row shows the line total (unit × qty = 2 × $250) and the snapshot
+    // total folds in quantity the same way (#790).
+    expect(screen.getByLabelText('Line total')).toHaveTextContent('$500.00')
+    expect(screen.getByText(/Snapshot total/i)).toHaveTextContent('$500.00')
     expect(mockFetch).toHaveBeenCalledWith(3)
   })
 
@@ -127,6 +129,23 @@ describe('CollectionDetail', () => {
     await waitFor(() => expect(mockUpdateItem).toHaveBeenCalledWith(3, 7, 3))
     // Optimistic update bumps the displayed count.
     expect(screen.getByLabelText(/owned quantity of charizard/i)).toHaveTextContent('3')
+  })
+
+  it('updates the row line total and snapshot total after a quantity change (#790)', async () => {
+    mockFetch.mockResolvedValue(collectionWith([item({ id: 7, quantity: 2, price_snapshot: 250 })]))
+    mockUpdateItem.mockResolvedValue(item({ id: 7, quantity: 3, price_snapshot: 250 }))
+    render(<CollectionDetail collection={SUMMARY} open onOpenChange={() => {}} />)
+
+    await screen.findByText('Charizard')
+    // Before: 2 × $250 on both the row and the snapshot total.
+    expect(screen.getByLabelText('Line total')).toHaveTextContent('$500.00')
+    expect(screen.getByText(/Snapshot total/i)).toHaveTextContent('$500.00')
+
+    fireEvent.click(screen.getByRole('button', { name: /increase quantity of charizard/i }))
+
+    // After: the optimistic 3 × $250 flows into both prices, no reopen.
+    await waitFor(() => expect(screen.getByLabelText('Line total')).toHaveTextContent('$750.00'))
+    expect(screen.getByText(/Snapshot total/i)).toHaveTextContent('$750.00')
   })
 
   it('disables the stepper while a quantity update is in flight (#769 review)', async () => {

--- a/web/src/components/CollectionDetail.test.tsx
+++ b/web/src/components/CollectionDetail.test.tsx
@@ -93,7 +93,7 @@ describe('CollectionDetail', () => {
     expect(screen.getByText(/base1-4/)).toBeInTheDocument()
     // The row shows the line total (unit × qty = 2 × $250) and the snapshot
     // total folds in quantity the same way (#790).
-    expect(screen.getByLabelText('Line total')).toHaveTextContent('$500.00')
+    expect(screen.getByLabelText(/^Line total/)).toHaveTextContent('$500.00')
     expect(screen.getByText(/Snapshot total/i)).toHaveTextContent('$500.00')
     expect(mockFetch).toHaveBeenCalledWith(3)
   })
@@ -138,13 +138,13 @@ describe('CollectionDetail', () => {
 
     await screen.findByText('Charizard')
     // Before: 2 × $250 on both the row and the snapshot total.
-    expect(screen.getByLabelText('Line total')).toHaveTextContent('$500.00')
+    expect(screen.getByLabelText(/^Line total/)).toHaveTextContent('$500.00')
     expect(screen.getByText(/Snapshot total/i)).toHaveTextContent('$500.00')
 
     fireEvent.click(screen.getByRole('button', { name: /increase quantity of charizard/i }))
 
     // After: the optimistic 3 × $250 flows into both prices, no reopen.
-    await waitFor(() => expect(screen.getByLabelText('Line total')).toHaveTextContent('$750.00'))
+    await waitFor(() => expect(screen.getByLabelText(/^Line total/)).toHaveTextContent('$750.00'))
     expect(screen.getByText(/Snapshot total/i)).toHaveTextContent('$750.00')
   })
 

--- a/web/src/components/CollectionDetail.tsx
+++ b/web/src/components/CollectionDetail.tsx
@@ -268,7 +268,7 @@ function ItemRow({
         // stays available in the tooltip when there's more than one.
         <span
           className="w-16 shrink-0 text-right text-xs font-medium text-palm-600 dark:text-palm-200"
-          aria-label="Line total"
+          aria-label={`Line total ${formatMoney(item.price_snapshot * qty, 'USD')}`}
           title={qty > 1 ? `${formatMoney(item.price_snapshot, 'USD')} each` : undefined}
         >
           {formatMoney(item.price_snapshot * qty, 'USD')}

--- a/web/src/components/CollectionDetail.tsx
+++ b/web/src/components/CollectionDetail.tsx
@@ -263,8 +263,15 @@ function ItemRow({
         </span>
       )}
       {item.price_snapshot != null && (
-        <span className="w-16 shrink-0 text-right text-xs font-medium text-palm-600 dark:text-palm-200">
-          {formatMoney(item.price_snapshot, 'USD')}
+        // Line total (unit × qty), so the row reflects a quantity change and
+        // the rows visibly sum to the snapshot total (#790). The unit price
+        // stays available in the tooltip when there's more than one.
+        <span
+          className="w-16 shrink-0 text-right text-xs font-medium text-palm-600 dark:text-palm-200"
+          aria-label="Line total"
+          title={qty > 1 ? `${formatMoney(item.price_snapshot, 'USD')} each` : undefined}
+        >
+          {formatMoney(item.price_snapshot * qty, 'USD')}
         </span>
       )}
     </li>


### PR DESCRIPTION
Closes #790

## What

In the collection detail view, each card row showed only its unit `price_snapshot`. Editing a card's owned quantity (#769/#778) moved the "Snapshot total" but left the row price unchanged, and the rows didn't add up to the total. Now each row shows its **line total** (`unit × quantity`), which updates with the optimistic quantity change; the unit price stays available in the row's tooltip when quantity > 1.

## Why

The snapshot total already folds in quantity (`price_snapshot × quantity` summed), so a per-row unit price that ignores quantity is inconsistent and reads as "the price didn't update" after a stepper change.

## How to verify

1. Open a collection with a priced card whose quantity is > 1 → the row price is `unit × qty` and the rows sum to the snapshot total.
2. Increase the quantity with the stepper → the row price and the snapshot total both move immediately, no reopen.
3. Hover the row price with qty > 1 → tooltip shows the unit price ("$X each").

`cd web && npm run build` and the web test suite (588) are green; a new CollectionDetail test asserts both the row line total and the snapshot total update after a quantity change.